### PR TITLE
Alter newlines from HistoryStep formatting (!history-query-json)

### DIFF
--- a/pipeline/operations/HistoryStep.cpp
+++ b/pipeline/operations/HistoryStep.cpp
@@ -25,10 +25,11 @@ void HistoryStep::execute() {
         if (commit.isHead()) {
             str += " (HEAD)";
         }
+        str += "\\n";
 
         size_t i = 0;
         for (const auto& part : commit.dataparts()) {
-            str += fmt::format(" - Part {}: {} nodes, {} edges",
+            str += fmt::format(" - Part {}: {} nodes, {} edges\\n",
                                i + 1, part->getNodeCount(), part->getEdgeCount());
             i++;
         }

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -1,6 +1,7 @@
 #include "TuringShell.h"
 
 #include <linenoise.h>
+#include <regex>
 #include <tabulate/table.hpp>
 #include <argparse.hpp>
 #include <spdlog/spdlog.h>
@@ -252,6 +253,14 @@ std::string TuringShell::composePrompt() {
 
 template <typename T>
 void tabulateWrite(tabulate::RowStream& rs, const T& value) {
+    // @_ref HistoryStep uses double escaped new line (\\n) so that it is valid JSON
+    // if the `/query -d "history"` endpoint is hit. When writing to CLI we replace double
+    // escaped with single escape so that it is rendered in terminal correctly.
+    if constexpr (std::same_as<T, std::string>) {
+        std::regex re(R"(\\n)");  
+        rs << std::regex_replace(value, re, "\n");
+        return;
+    }
     rs << value;
 }
 


### PR DESCRIPTION
Change new lines in formatting of `HistoryStep` to use double escaped newline `\\n` so that `/query -d "history'` produces valid JSON. The existing `/history` endpoint already does this, so no need to fix there.

This changes the formatting of the output of `history` in `turingdb -cli` from:
<img width="402" height="425" alt="image" src="https://github.com/user-attachments/assets/9e8ae8e7-c642-482f-9db5-fa9e44b59775" />

to:
<img width="734" height="310" alt="image" src="https://github.com/user-attachments/assets/c817b4f0-eb37-4792-a4bd-a162f6fbb5fd" />

i.e. the double escaped chars do not work in the terminal. So I also specialised the CLI function `TuringShell.cpp:255` (`tabulateWrite`) to preprocess the double escaped characters into single escaped characters which are rendered correctly in the terminal:
<img width="388" height="429" alt="image" src="https://github.com/user-attachments/assets/82f620ba-8480-4302-81e5-bce31a349b87" />


Correct JSON verified with:
```
❯ turingdb -p 6666 -load simpledb -nodemon
[2025-08-13 19:29:07] [info] Turing Directories Detected
[2025-08-13 19:29:07] [info] Server listening on address: 127.0.0.1:6666
```

```
# Standard History endpoint
❯ curl -X POST "http://127.0.0.1:6666/history?graph=simpledb" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   347    0   347    0     0   335k      0 --:--:-- --:--:-- --:--:--  338k
{
  "data": {
    "commits": [
      "Commit: 885f26417506f103\n",
      "Commit: 2ec865d507aeb62c\n - Part 1: 7 nodes, 8 edges\n",
      "Commit: c491cb2231b81387\n - Part 1: 2 nodes, 2 edges\n",
      "Commit: 719ebfdcde6b7230\n - Part 1: 2 nodes, 2 edges\n",
      "Commit: b846e8355810685\n - Part 1: 1 nodes, 1 edges\n",
      "Commit: 809b431d806a167c (HEAD)\n - Part 1: 1 nodes, 0 edges\n"
    ]
  }
}

# Query endpoint using `"history"` as payload
❯ curl -X POST "http://127.0.0.1:6666/query?graph=simpledb" -d "history" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   409    0   402  100     7   328k   5852 --:--:-- --:--:-- --:--:--  399k
{
  "header": {
    "column_names": [],
    "column_types": []
  },
  "data": [
    [
      [
        "Commit: 885f26417506f103\n",
        "Commit: 2ec865d507aeb62c\n - Part 1: 7 nodes, 8 edges\n",
        "Commit: c491cb2231b81387\n - Part 1: 2 nodes, 2 edges\n",
        "Commit: 719ebfdcde6b7230\n - Part 1: 2 nodes, 2 edges\n",
        "Commit: b846e8355810685\n - Part 1: 1 nodes, 1 edges\n",
        "Commit: 809b431d806a167c (HEAD)\n - Part 1: 1 nodes, 0 edges\n"
      ]
    ]
  ],
  "time": 0.123379
}
```
and outputs are identical.