### PR TITLE
Add forwarding to `Pipeline::add`

### DIFF
--- a/pipeline/Pipeline.h
+++ b/pipeline/Pipeline.h
@@ -18,7 +18,7 @@ public:
 
     template <typename StepT, typename... ArgsT>
     PipelineStep& add(ArgsT&&... args) {
-        _steps.emplace_back(typename StepT::Tag {}, args...);
+        _steps.emplace_back(typename StepT::Tag {}, std::forward<ArgsT>(args)...);
         return _steps.back();
     }
 


### PR DESCRIPTION
- Allows for arguments to be properly passed to pipeline steps as the same value category as they were provided by the call to Pipeline::add.