### PR TITLE
Address Out of Memory issues with ChunkWriters (!oom)

### DIFF
--- a/storage/iterators/GetInEdgesIterator.cpp
+++ b/storage/iterators/GetInEdgesIterator.cpp
@@ -105,7 +105,7 @@ void GetInEdgesChunkWriter::fill(size_t maxCount) {
             const auto nodeInEdges = _partIt.get()->edgeIndexer().getNodeInEdges(*_nodeIt);
             const auto nodeInEdgesEnd = nodeInEdges.end();
             const size_t availInPart = std::distance(_edgeIt, nodeInEdgesEnd);
-            const size_t rangeSize = std::min(maxCount, availInPart);
+            const size_t rangeSize = std::min(remainingToMax, availInPart);
             const size_t prevSize = _indices->size();
             const size_t newSize = prevSize + rangeSize;
             _indices->resize(newSize);

--- a/storage/iterators/GetOutEdgesIterator.cpp
+++ b/storage/iterators/GetOutEdgesIterator.cpp
@@ -105,7 +105,7 @@ void GetOutEdgesChunkWriter::fill(size_t maxCount) {
             const auto nodeOutEdges = _partIt.get()->edgeIndexer().getNodeOutEdges(*_nodeIt);
             const auto nodeOutEdgesEnd = nodeOutEdges.end();
             const size_t availOutPart = std::distance(_edgeIt, nodeOutEdgesEnd);
-            const size_t rangeSize = std::min(maxCount, availOutPart);
+            const size_t rangeSize = std::min(remainingToMax, availOutPart);
             const size_t prevSize = _indices->size();
             const size_t newSize = prevSize + rangeSize;
             _indices->resize(newSize);

--- a/storage/iterators/ScanEdgesIterator.cpp
+++ b/storage/iterators/ScanEdgesIterator.cpp
@@ -106,7 +106,7 @@ void ScanEdgesChunkWriter::fill(size_t maxCount) {
             const auto partOutEdges = _partIt.get()->edges().getOuts();
             const auto partOutEnd = partOutEdges.end();
             const size_t availInPart = std::distance(_edgeIt, partOutEnd);
-            const size_t rangeSize = std::min(maxCount, availInPart);
+            const size_t rangeSize = std::min(remainingToMax, availInPart);
             const size_t prevSize = getPrevSize();
             const size_t newSize = prevSize + rangeSize;
 

--- a/storage/iterators/ScanNodePropertiesByLabelIterator.cpp
+++ b/storage/iterators/ScanNodePropertiesByLabelIterator.cpp
@@ -145,7 +145,7 @@ void ScanNodePropertiesByLabelChunkWriter<T>::fill(size_t maxCount) {
     const auto fill = [&]<std::array<bool, NColumns> conditions>() {
         while (this->isValid() && remainingToMax > 0) {
             const size_t availInPart = std::distance(this->_propIt, this->_props.end());
-            const size_t rangeSize = std::min(maxCount, availInPart);
+            const size_t rangeSize = std::min(remainingToMax, availInPart);
             const size_t prevSize = getPrevSize();
             const size_t newSize = prevSize + rangeSize;
 

--- a/storage/iterators/ScanNodesIterator.cpp
+++ b/storage/iterators/ScanNodesIterator.cpp
@@ -39,7 +39,7 @@ void ScanNodesIterator::fill(ColumnNodeIDs* column, size_t maxNodes) {
 
     while (isValid() && remainingToMax > 0) {
         const size_t availableInPart = _partEnd.getValue() - _currentNodeID.getValue();
-        const size_t rangeSize = std::min(maxNodes, availableInPart);
+        const size_t rangeSize = std::min(remainingToMax, availableInPart);
         const size_t prevSize = column->size();
         const size_t newSize = prevSize + rangeSize;
         column->resize(newSize);


### PR DESCRIPTION
Previously, the rangeSize calculation in GetOutEdgesChunkWriter was incorrectly calculated, causes observable integer underflows and therefore non-termination of the while loop. This commits standardises all ChunkWriters/Iterators to calculate remaining based on the remainingToMax variable (which is decremented in the loop), as opposed to the maxCount variable (which remains constant and causes underflows).


Verified with:

`valgrind --tool=massif turingdb -nodemon -load tfl`

```
turingsh:

turingdb:default> cd tfl
✓ Changed graph to tfl
turingdb:tfl> MATCH (start:Station{displayName:"Paddington"})-[e1:CONNECTED]-(s1:Station)-[e2:CONNECTED]-(s2:Station
)-[e3:CONNECTED]-(s3:Station)-[e4:CONNECTED]-(s4:Station)-[e5:CONNECTED]-(s5:Station)-[e6:CONNECTED]-(s6:Station)-[e
7:CONNECTED]-(s7:Station)-[e8:CONNECTED]-(s8:Station)-[e9:CONNECTED]-(s9:Station)-[e10:CONNECTED]-(s10:Station)-[e11
:CONNECTED]-(s11:Station)-[e12:CONNECTED]-(s12:Station)-[e13:CONNECTED]-(s13:Station)-[e14:CONNECTED]-(s14:Station)-
[e15:CONNECTED]-(end:Station{displayName="Blackfriars"}) RETURN start, start.displayName, start.Note, e1.Line, s1, s
1.displayName, s1.Note, e2.Line, s2, s2.displayName, s2.Note, e3.Line, s3, s3.displayName, s3.Note, e4.Line, s4, s4.
displayName, s4.Note, e5.Line, s5, s5.displayName, s5.Note, e6.Line, s6, s6.displayName, s6.Note, e7.Line, s7, s7.di
splayName, s7.Note, e8.Line, s8, s8.displayName, s8.Note, e9.Line, s9, s9.displayName, s9.Note, e10.Line, s10, s10.d
isplayName, s10.Note, e11.Line, s11, s11.displayName, s11.Note, e12.Line, s12, s12.displayName, s12.Note, e13.Line,
s13, s13.displayName, s13.Note, e14.Line, s14, s14.displayName, s14.Note, e15.Line, end, end.displayName, end.Note
         0           1   ...           61                                                 62
0       218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
1       218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
2       218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
3       218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
4       218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
...     ...         ...  ...          ...                                                ...
113058  218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
113059  218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
113060  218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
113061  218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...
113062  218  Paddington  ...  Blackfriars  Cross the Blackfriars Bridge to the Tate Moder...

[113063 rows x 63 columns]
Total execution time: 92194.843 milliseconds
Including query execution time: 42525.934 milliseconds
```


With massif out
```
--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 67 30,684,562,314    3,805,611,888    3,803,896,640     1,715,248            0
 68 30,685,996,036    3,805,633,488    3,803,918,240     1,715,248            0
 69 37,995,202,669    3,805,642,368    3,803,927,112     1,715,256            0
 70 54,564,007,378    3,805,639,360    3,803,924,128     1,715,232            0
```
Showing 4GB used at peak.