### PR TITLE
Create a new graph for simpledb, instead of using default (!simpledb-new-graph)

### DIFF
--- a/samples/simpledb/main.cpp
+++ b/samples/simpledb/main.cpp
@@ -41,10 +41,8 @@ int main(int argc, const char** argv) {
         auto* graph = db.getSystemManager().createGraph("simpledb");
         SimpleGraph::createSimpleGraph(graph);
 
-        const Graph* defaultGraph = db.getSystemManager().getGraph("simpledb");
-
         spdlog::info("Graph created");
-        const FrozenCommitTx tx = defaultGraph->openTransaction();
+        const FrozenCommitTx tx = graph->openTransaction();
         {
             std::stringstream sstream;
             GraphReport::getReport(tx.readGraph(), sstream);
@@ -52,7 +50,7 @@ int main(int argc, const char** argv) {
         }
 
         spdlog::info("Dump graph into {}", outDir.c_str());
-        const auto dumpRes = GraphDumper::dump(*defaultGraph, outDir);
+        const auto dumpRes = GraphDumper::dump(*graph, outDir);
         if (!dumpRes) {
             spdlog::error("{}", dumpRes.error().fmtMessage());
             return EXIT_FAILURE;


### PR DESCRIPTION
Since default graph is now dumped, the state of default graph affects the produced simplegraph. Instead, create a new graph, called "simpledb", and write simplegraph to that.