### PR TITLE
Fixed Neo4j import deadlock

### DIFF
--- a/import/neo4j/Neo4jImporter.h
+++ b/import/neo4j/Neo4jImporter.h
@@ -47,6 +47,24 @@ public:
 
 private:
     std::mutex _mutex;
+
+    bool fromUrlToJsonDirImpl(JobSystem& jobSystem,
+                              Graph* graph,
+                              std::size_t nodeCountPerQuery,
+                              std::size_t edgeCountPerQuery,
+                              const UrlToJsonDirArgs& args);
+
+    bool importJsonDirImpl(JobSystem& jobSystem,
+                           Graph* graph,
+                           std::size_t nodeCountPerFile,
+                           std::size_t edgeCountPerFile,
+                           const ImportJsonDirArgs& args);
+
+    bool fromDumpFileToJsonDirImpl(JobSystem& jobSystem,
+                                   Graph* graph,
+                                   std::size_t nodeCountPerQuery,
+                                   std::size_t edgeCountPerQuery,
+                                   const DumpFileToJsonDirArgs& args);
 };
 
 }

--- a/system/SystemManager.cpp
+++ b/system/SystemManager.cpp
@@ -22,7 +22,8 @@ using namespace db;
 
 SystemManager::SystemManager(const TuringConfig* config)
     : _config(config),
-    _changes(std::make_unique<ChangeManager>())
+    _changes(std::make_unique<ChangeManager>()),
+    _neo4JImporter(std::make_unique<Neo4jImporter>())
 {
 }
 
@@ -261,11 +262,11 @@ bool SystemManager::loadNeo4jJsonDB(const std::string& graphName,
     Neo4jImporter::ImportJsonDirArgs args;
     args._jsonDir = FileUtils::Path {dbPath.c_str()};
 
-    if (!_neo4JImporter.importJsonDir(jobsystem,
-                                      graph.get(),
-                                      db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
-                                      db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
-                                      args)) {
+    if (!_neo4JImporter->importJsonDir(jobsystem,
+                                       graph.get(),
+                                       db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
+                                       db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
+                                       args)) {
         _graphLoadStatus.removeLoadingGraph(graphName);
         return false;
     }
@@ -304,11 +305,11 @@ bool SystemManager::loadNeo4jDB(const std::string& graphName,
     dumpArgs._workDir = "/tmp";
     dumpArgs._dumpFilePath = dbPath.c_str();
 
-    if (!_neo4JImporter.fromDumpFileToJsonDir(jobsystem,
-                                              graph.get(),
-                                              db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
-                                              db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
-                                              dumpArgs)) {
+    if (!_neo4JImporter->fromDumpFileToJsonDir(jobsystem,
+                                               graph.get(),
+                                               db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
+                                               db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
+                                               dumpArgs)) {
         _graphLoadStatus.removeLoadingGraph(graphName);
         return false;
     }
@@ -316,11 +317,11 @@ bool SystemManager::loadNeo4jDB(const std::string& graphName,
     Neo4jImporter::ImportJsonDirArgs args;
     args._jsonDir = FileUtils::Path {dumpArgs._workDir / "json"};
 
-    if (!_neo4JImporter.importJsonDir(jobsystem,
-                                      graph.get(),
-                                      db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
-                                      db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
-                                      args)) {
+    if (!_neo4JImporter->importJsonDir(jobsystem,
+                                       graph.get(),
+                                       db::json::neo4j::Neo4JParserConfig::nodeCountLimit,
+                                       db::json::neo4j::Neo4JParserConfig::edgeCountLimit,
+                                       args)) {
         _graphLoadStatus.removeLoadingGraph(graphName);
         return false;
     }

--- a/system/SystemManager.h
+++ b/system/SystemManager.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <optional>
 
-#include "Neo4jImporter.h"
 #include "RWSpinLock.h"
 #include "GraphLoadStatus.h"
 #include "TuringS3Client.h"
@@ -17,6 +16,7 @@
 
 namespace db {
 
+class Neo4jImporter;
 class TuringConfig;
 class Graph;
 class ChangeManager;
@@ -91,8 +91,8 @@ private:
     std::unique_ptr<S3::TuringS3Client<S3::AwsS3ClientWrapper<>>> _s3Client {nullptr};
     std::unordered_map<std::string, std::unique_ptr<Graph>> _graphs;
     std::unique_ptr<ChangeManager> _changes;
+    std::unique_ptr<Neo4jImporter> _neo4JImporter;
     GraphLoadStatus _graphLoadStatus;
-    Neo4jImporter _neo4JImporter;
 
     bool loadNeo4jJsonDB(const std::string& graphName, const fs::Path& dbPath, JobSystem&);
     bool loadNeo4jDB(const std::string& graphName, const fs::Path& dbPath, JobSystem&);


### PR DESCRIPTION
Fixed a not too obvious deadlock that would occur when import graphs from neo4j dumps. Was caused by this stack:
- fromDumpFileToJsonDir()
- lock(_mutex)
- fromUrlToJsonDir()
- lock(_mutex) // deadlock
