### PR TITLE
Add LocalMemory::clear to DBServerProcessor

### DIFF
--- a/memory/LocalMemory.h
+++ b/memory/LocalMemory.h
@@ -65,6 +65,13 @@ public:
         MakeMemoryPool<ColumnSet<EdgeID>>::type
         >;
 
+    template <typename KeyT, typename ValueT>
+    struct ClearTransform {
+        void operator()(ValueT& value) const {
+            value.clear();
+        }
+    };
+
     LocalMemory(const LocalMemory&) = delete;
     LocalMemory(LocalMemory&&) = delete;
     LocalMemory& operator=(const LocalMemory&) = delete;
@@ -79,17 +86,7 @@ public:
     }
 
     void clear() {
-        _pools.get<ColumnVector<EntityID>>().clear();
-        _pools.get<ColumnVector<NodeID>>().clear();
-        _pools.get<ColumnVector<EdgeID>>().clear();
-        _pools.get<ColumnVector<PropertyType>>().clear();
-        _pools.get<ColumnVector<size_t>>().clear();
-        _pools.get<ColumnConst<EdgeTypeID>>().clear();
-        _pools.get<ColumnConst<size_t>>().clear();
-        _pools.get<ColumnVector<std::string>>().clear();
-        _pools.get<ColumnVector<std::string_view>>().clear();
-        _pools.get<ColumnVector<const CommitBuilder*>>().clear();
-        _pools.get<ColumnVector<const Change*>>().clear();
+        _pools.transform<ClearTransform>();
     }
 
 private:

--- a/memory/MemoryPool.h
+++ b/memory/MemoryPool.h
@@ -10,6 +10,8 @@ struct MemoryBlock;
 template <typename ObjectT>
 class MemoryPool {
 public:
+    using MemoryBlockT = MemoryBlock<ObjectT>;
+
     MemoryPool()
         : _first(new MemoryBlock<ObjectT>()),
         _last(_first),
@@ -23,9 +25,9 @@ public:
     MemoryPool& operator=(MemoryPool&&) = delete;
 
     ~MemoryPool() {
-        auto* block = _first;
+        MemoryBlockT* block = _first;
         while (block) {
-            auto* nextBlock = block->_next;
+            MemoryBlockT* nextBlock = block->_next;
             delete block;
             block = nextBlock;
         }
@@ -33,7 +35,7 @@ public:
 
     void clear() {
         // Invoke std::vector clear on each MemoryBlock one by one
-        auto* block = _first;
+        MemoryBlockT* block = _first;
         while (block) {
             block->_objects.clear();
             block = block->_next;
@@ -55,12 +57,12 @@ public:
     }
 
 private:
-    MemoryBlock<ObjectT>* _first {nullptr};
-    MemoryBlock<ObjectT>* _last {nullptr};
-    MemoryBlock<ObjectT>* _current {nullptr};
+    MemoryBlockT* _first {nullptr};
+    MemoryBlockT* _last {nullptr};
+    MemoryBlockT* _current {nullptr};
 
     void allocBlock() {
-        MemoryBlock<ObjectT>* newBlock = new MemoryBlock<ObjectT>();
+        MemoryBlockT* newBlock = new MemoryBlock<ObjectT>();
         _last->_next = newBlock;
         _last = newBlock;
     }
@@ -68,6 +70,7 @@ private:
 
 template <typename ObjectT>
 struct MemoryBlock {
+    // Each block is 8MB in capacity
     static constexpr size_t MEMORY_BLOCK_BYTE_CAPACITY = 8*1024*1024;
     static constexpr size_t MEMORY_BLOCK_CAPACITY = MEMORY_BLOCK_BYTE_CAPACITY/sizeof(ObjectT);
     static_assert(sizeof(ObjectT) <= MEMORY_BLOCK_BYTE_CAPACITY);

--- a/server/DBServerProcessor.cpp
+++ b/server/DBServerProcessor.cpp
@@ -49,64 +49,84 @@ void DBServerProcessor::process(net::AbstractThreadContext* abstractContext) {
 
     switch ((Endpoint)httpInfo._endpoint) {
         case Endpoint::QUERY: {
-            return query();
+             query();
         }
+        break;
         case Endpoint::LOAD_GRAPH: {
-            return load_graph();
+             load_graph();
         }
+        break;
         case Endpoint::GET_GRAPH_STATUS: {
-            return get_graph_status();
+             get_graph_status();
         }
+        break;
         case Endpoint::IS_GRAPH_LOADED: {
-            return is_graph_loaded();
+             is_graph_loaded();
         }
+        break;
         case Endpoint::IS_GRAPH_LOADING: {
-            return is_graph_loading();
+             is_graph_loading();
         }
+        break;
         case Endpoint::LIST_LOADED_GRAPHS: {
-            return list_loaded_graphs();
+             list_loaded_graphs();
         }
+        break;
         case Endpoint::LIST_AVAIL_GRAPHS: {
-            return list_avail_graphs();
+             list_avail_graphs();
         }
+        break;
         case Endpoint::LIST_LABELS: {
-            return list_labels();
+             list_labels();
         }
+        break;
         case Endpoint::LIST_PROPERTY_TYPES: {
-            return list_property_types();
+             list_property_types();
         }
+        break;
         case Endpoint::LIST_EDGE_TYPES: {
-            return list_edge_types();
+             list_edge_types();
         }
+        break;
         case Endpoint::LIST_NODES: {
-            return list_nodes();
+             list_nodes();
         }
+        break;
         case Endpoint::GET_NODE_PROPERTIES: {
-            return get_node_properties();
+             get_node_properties();
         }
+        break;
         case Endpoint::GET_NEIGHBORS: {
-            return get_neighbors();
+             get_neighbors();
         }
+        break;
         case Endpoint::GET_NODES: {
-            return get_nodes();
+             get_nodes();
         }
+        break;
         case Endpoint::GET_NODE_EDGES: {
-            return get_node_edges();
+             get_node_edges();
         }
+        break;
         case Endpoint::GET_EDGES: {
-            return get_edges();
+             get_edges();
         }
+        break;
         case Endpoint::EXPLORE_NODE_EDGES: {
-            return explore_node_edges();
+             explore_node_edges();
         }
+        break;
         case Endpoint::HISTORY: {
-            return history();
+             history();
         }
+        break;
         default: {
             _writer.writeHttpError(net::HTTP::Status::NOT_FOUND);
-            return;
         }
+        break;
     }
+
+    _threadContext->getLocalMemory().clear();
 }
 
 const Graph* DBServerProcessor::getRequestedGraph() const {


### PR DESCRIPTION
* Add a call to LocalMemory::clear in DBServerProcessor when we are sure that the current endpoint function has been processed
* Current clear will go through each MemoryBlock in each MemoryPool to do a clear
* Use TypeMap transform to automate the call to each clear for each defined MemoryPool