### PR TITLE
PipelineBuilder: remove builder pattern

### DIFF
--- a/test/v2/pipeline/PipelineTest.cpp
+++ b/test/v2/pipeline/PipelineTest.cpp
@@ -2,6 +2,7 @@
 
 #include <math.h>
 
+#include "PipelineInterface.h"
 #include "SystemManager.h"
 #include "Graph.h"
 #include "TuringDB.h"
@@ -107,9 +108,9 @@ TEST_F(PipelineTest, scanNodes) {
     ColumnTagManager tagMan;
 
     PipelineBuilder builder(&mem, &pipeline, tagMan);
-    builder.addScanNodes();
-    PipelineNodeOutputInterface* scanNodesOut = static_cast<PipelineNodeOutputInterface*>(builder.getOutput());
-    const ColumnTag scanOutNodeIDsTag = scanNodesOut->getNodeIDs()->getHeader().getTag();
+    
+    PipelineNodeOutputInterface& scanNodesOut = builder.addScanNodes();
+    const ColumnTag scanOutNodeIDsTag = scanNodesOut.getNodeIDs()->getHeader().getTag();
 
     builder.addMaterialize();
 
@@ -150,13 +151,12 @@ TEST_F(PipelineTest, scanNodesExpand1) {
     ColumnTagManager tagMan;
 
     PipelineBuilder builder(&mem, &pipeline, tagMan);
-    builder.addScanNodes();
-    PipelineNodeOutputInterface* scanNodesOut = static_cast<PipelineNodeOutputInterface*>(builder.getOutput());
-    const ColumnTag scanOutNodeIDsTag = scanNodesOut->getNodeIDs()->getHeader().getTag();
+    
+    PipelineNodeOutputInterface& scanNodesOut = builder.addScanNodes();
+    const ColumnTag scanOutNodeIDsTag = scanNodesOut.getNodeIDs()->getHeader().getTag();
 
-    builder.addGetOutEdges();
-    PipelineEdgeOutputInterface* getOutEdgesOut = static_cast<PipelineEdgeOutputInterface*>(builder.getOutput());
-    const ColumnTag getOutEdgesOutTargetNodesTag = getOutEdgesOut->getTargetNodes()->getHeader().getTag();
+    PipelineEdgeOutputInterface& getOutEdgesOut = builder.addGetOutEdges();
+    const ColumnTag getOutEdgesOutTargetNodesTag = getOutEdgesOut.getTargetNodes()->getHeader().getTag();
     
     builder.addMaterialize();
 
@@ -220,17 +220,17 @@ TEST_F(PipelineTest, scanNodesExpandGetProperties) {
     ColumnTagManager tagMan;
 
     PipelineBuilder builder(&mem, &pipeline, tagMan);
-    builder.addScanNodes();
-    PipelineNodeOutputInterface* scanNodesOut = static_cast<PipelineNodeOutputInterface*>(builder.getOutput());
-    const ColumnTag scanOutNodeIDsTag = scanNodesOut->getNodeIDs()->getHeader().getTag();
+    
+    PipelineNodeOutputInterface& scanNodesOut = builder.addScanNodes();
+    const ColumnTag scanOutNodeIDsTag = scanNodesOut.getNodeIDs()->getHeader().getTag();
 
     builder.addGetOutEdges();
 
     // Get properties
     const PropertyType namePropType = _graph->openTransaction().readGraph().getMetadata().propTypes().get("name").value();
-    builder.addGetNodeProperties<types::String>(namePropType);
-    PipelineValuesOutputInterface* getNodePropertiesOut = static_cast<PipelineValuesOutputInterface*>(builder.getOutput());
-    const ColumnTag getNodePropertiesOutValuesTag = getNodePropertiesOut->getValues()->getHeader().getTag();
+
+    PipelineValuesOutputInterface& getNodePropertiesOut = builder.addGetNodeProperties<types::String>(namePropType);
+    const ColumnTag getNodePropertiesOutValuesTag = getNodePropertiesOut.getValues()->getHeader().getTag();
 
     builder.addMaterialize();
 
@@ -288,17 +288,14 @@ TEST_F(PipelineTest, scanNodesExpand2) {
 
     PipelineBuilder builder(&mem, &pipeline, tagMan);
 
-    builder.addScanNodes();
-    PipelineNodeOutputInterface* scanNodesOut = static_cast<PipelineNodeOutputInterface*>(builder.getOutput());
-    const ColumnTag scanOutNodeIDsTag = scanNodesOut->getNodeIDs()->getHeader().getTag();
+    PipelineNodeOutputInterface& scanNodesOut = builder.addScanNodes();
+    const ColumnTag scanOutNodeIDsTag = scanNodesOut.getNodeIDs()->getHeader().getTag();
     
-    builder.addGetOutEdges();
-    PipelineEdgeOutputInterface* getOutEdges1Out = static_cast<PipelineEdgeOutputInterface*>(builder.getOutput());
-    const ColumnTag getOutEdges1OutTargetNodesTag = getOutEdges1Out->getTargetNodes()->getHeader().getTag();
+    PipelineEdgeOutputInterface& getOutEdges1Out = builder.addGetOutEdges();
+    const ColumnTag getOutEdges1OutTargetNodesTag = getOutEdges1Out.getTargetNodes()->getHeader().getTag();
     
-    builder.addGetOutEdges();
-    PipelineEdgeOutputInterface* getOutEdges2Out = static_cast<PipelineEdgeOutputInterface*>(builder.getOutput());
-    const ColumnTag getOutEdges2OutTargetNodesTag = getOutEdges2Out->getTargetNodes()->getHeader().getTag();
+    PipelineEdgeOutputInterface& getOutEdges2Out = builder.addGetOutEdges();
+    const ColumnTag getOutEdges2OutTargetNodesTag = getOutEdges2Out.getTargetNodes()->getHeader().getTag();
     
     builder.addMaterialize();
 

--- a/v2/pipeline/PipelineBuilder.cpp
+++ b/v2/pipeline/PipelineBuilder.cpp
@@ -27,7 +27,7 @@ void duplicateDataframeShape(LocalMemory* mem, Dataframe* src, Dataframe* dest) 
 
 }
 
-PipelineOutputInterface& PipelineBuilder::addScanNodes() {
+PipelineNodeOutputInterface& PipelineBuilder::addScanNodes() {
     openMaterialize();
 
     ScanNodesProcessor* proc = ScanNodesProcessor::create(_pipeline);
@@ -43,7 +43,7 @@ PipelineOutputInterface& PipelineBuilder::addScanNodes() {
     return outNodeIDs;
 }
 
-PipelineOutputInterface& PipelineBuilder::addGetOutEdges() {
+PipelineEdgeOutputInterface& PipelineBuilder::addGetOutEdges() {
     GetOutEdgesProcessor* getOutEdges = GetOutEdgesProcessor::create(_pipeline);
     _pendingOutput->connectTo(getOutEdges->inNodeIDs());
 
@@ -77,7 +77,7 @@ void PipelineBuilder::closeMaterialize() {
     _matProc = nullptr;
 }
 
-PipelineOutputInterface& PipelineBuilder::addMaterialize() {
+PipelineBlockOutputInterface& PipelineBuilder::addMaterialize() {
     _pendingOutput->connectTo(_matProc->input());
     _pendingOutput = &_matProc->output();
     closeMaterialize();
@@ -95,7 +95,7 @@ void PipelineBuilder::addLambda(const LambdaProcessor::Callback& callback) {
     _pendingOutput = nullptr;
 }
 
-PipelineOutputInterface& PipelineBuilder::addSkip(size_t count) {
+PipelineBlockOutputInterface& PipelineBuilder::addSkip(size_t count) {
     SkipProcessor* skip = SkipProcessor::create(_pipeline, count);
     _pendingOutput->connectTo(skip->input());
 
@@ -106,7 +106,7 @@ PipelineOutputInterface& PipelineBuilder::addSkip(size_t count) {
     return skip->output();
 }
 
-PipelineOutputInterface& PipelineBuilder::addLimit(size_t count) {
+PipelineBlockOutputInterface& PipelineBuilder::addLimit(size_t count) {
     LimitProcessor* limit = LimitProcessor::create(_pipeline, count);
     _pendingOutput->connectTo(limit->input());
 
@@ -117,7 +117,7 @@ PipelineOutputInterface& PipelineBuilder::addLimit(size_t count) {
     return limit->output();
 }
 
-PipelineOutputInterface& PipelineBuilder::addCount() {
+PipelineValueOutputInterface& PipelineBuilder::addCount() {
     CountProcessor* count = CountProcessor::create(_pipeline);
     _pendingOutput->connectTo(count->input());
 
@@ -128,14 +128,14 @@ PipelineOutputInterface& PipelineBuilder::addCount() {
     return count->output();
 }
 
-PipelineOutputInterface& PipelineBuilder::addLambdaSource(const LambdaSourceProcessor::Callback& callback) {
+PipelineBlockOutputInterface& PipelineBuilder::addLambdaSource(const LambdaSourceProcessor::Callback& callback) {
     LambdaSourceProcessor* source = LambdaSourceProcessor::create(_pipeline, callback);
     _pendingOutput = &source->output();
     return source->output();
 }
 
 template <db::SupportedType T>
-PipelineOutputInterface& PipelineBuilder::addGetNodeProperties(PropertyType propertyType) {
+PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties(PropertyType propertyType) {
     auto* getProps = GetNodePropertiesProcessor<T>::create(_pipeline, propertyType);
     _pendingOutput->connectTo(getProps->inIDs());
 
@@ -159,8 +159,8 @@ PipelineOutputInterface& PipelineBuilder::addGetNodeProperties(PropertyType prop
     return getProps->outValues();
 }
 
-template PipelineOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Int64>(PropertyType propertyType);
-template PipelineOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::UInt64>(PropertyType propertyType);
-template PipelineOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Double>(PropertyType propertyType);
-template PipelineOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::String>(PropertyType propertyType);
-template PipelineOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Bool>(PropertyType propertyType);
+template PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Int64>(PropertyType propertyType);
+template PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::UInt64>(PropertyType propertyType);
+template PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Double>(PropertyType propertyType);
+template PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::String>(PropertyType propertyType);
+template PipelineValuesOutputInterface& PipelineBuilder::addGetNodeProperties<db::types::Bool>(PropertyType propertyType);

--- a/v2/pipeline/PipelineBuilder.h
+++ b/v2/pipeline/PipelineBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "PipelineInterface.h"
 #include "dataframe/ColumnTagManager.h"
 #include "dataframe/Dataframe.h"
 #include "dataframe/NamedColumn.h"
@@ -30,25 +31,25 @@ public:
 
     PipelineOutputInterface* getOutput() const { return _pendingOutput; }
 
+    PipelineNodeOutputInterface& addScanNodes();
+    PipelineEdgeOutputInterface& addGetOutEdges();
+    void addLambda(const LambdaProcessor::Callback& callback);
+
+    template <SupportedType T>
+    PipelineValuesOutputInterface& addGetNodeProperties(PropertyType propertyType);
+
+    PipelineBlockOutputInterface& addSkip(size_t count);
+    PipelineBlockOutputInterface& addLimit(size_t count);
+    PipelineValueOutputInterface& addCount();
+
+    PipelineBlockOutputInterface& addLambdaSource(const LambdaSourceProcessor::Callback& callback);
+
+    PipelineBlockOutputInterface& addMaterialize();
+
     template <typename ColumnType>
     NamedColumn* addColumnToOutput(ColumnTag tag) {
         return allocColumn<ColumnType>(_pendingOutput->getDataframe(), tag);
     }
-
-    PipelineOutputInterface& addScanNodes();
-    PipelineOutputInterface& addGetOutEdges();
-    void addLambda(const LambdaProcessor::Callback& callback);
-
-    template <SupportedType T>
-    PipelineOutputInterface& addGetNodeProperties(PropertyType propertyType);
-
-    PipelineOutputInterface& addSkip(size_t count);
-    PipelineOutputInterface& addLimit(size_t count);
-    PipelineOutputInterface& addCount();
-
-    PipelineOutputInterface& addLambdaSource(const LambdaSourceProcessor::Callback& callback);
-
-    PipelineOutputInterface& addMaterialize();
 
 private:
     LocalMemory* _mem {nullptr};


### PR DESCRIPTION
Remove builder pattern in PipelineBuilder and return directly the type of the last pipeline output interface