### PR TITLE
Fix StringIndex returning an output which exceeds a chunk

### DIFF
--- a/pipeline/operations/ScanNodesStringApproxStep.cpp
+++ b/pipeline/operations/ScanNodesStringApproxStep.cpp
@@ -16,7 +16,6 @@
 using namespace db;
 using Step = ScanNodesStringApproxStep;
 
-
 Step::ScanNodesStringApproxStep(ColumnVector<NodeID>* nodes, const GraphView& view,
                                 PropertyTypeID propID, std::string_view strQuery)
     : _nodes(nodes),
@@ -32,7 +31,7 @@ Step::~ScanNodesStringApproxStep()
 
 void Step::describe(std::string& descr) const {
     std::stringstream ss;
-    ss << "ScanNodesByPropertyStep";
+    ss << "ScanNodesStringApproxStep";
     ss << " nodes=" << std::hex << _nodes;
     ss << " propID=" << std::hex << _pId;
     ss << " query=" << std::hex << _strQuery;

--- a/plan/QueryPlanner.cpp
+++ b/plan/QueryPlanner.cpp
@@ -465,9 +465,9 @@ void QueryPlanner::caseScanNodesStringConstraint(const std::vector<const BinExpr
             // TOMBSTONES: base column @ref firstStageOutput always allocd by
             // @ref planScanNodes
             _pipeline->add<ScanNodesStringApproxStep>(firstStageOutput, _view,
-                                                     propType._id, queryString);
-        break;
+                                                      propType._id, queryString);
         }
+        break;
 
         default:
             throw PlannerException("Unsupported operator for type 'String'");

--- a/storage/indexes/StringIndexUtils.h
+++ b/storage/indexes/StringIndexUtils.h
@@ -2,13 +2,16 @@
 
 #include <concepts>
 
+#include "StringIndex.h"
 #include "DataPart.h"
 #include "DataPartSpan.h"
 #include "ID.h"
-#include "TuringException.h"
 #include "indexers/StringPropertyIndexer.h"
+#include "iterators/ChunkConfig.h"
 #include "views/GraphView.h"
-#include "indexes/StringIndex.h"
+
+#include "PipelineException.h"
+#include "TuringException.h"
 
 namespace db {
 
@@ -77,6 +80,9 @@ public:
                 // Get any matches for the query string in the index
                 strIndex->query<IDT>(output, query);
             }
+        }
+        if (output.size() > ChunkConfig::CHUNK_SIZE) {
+            throw PipelineException("String Index output exceeded CHUNK_SIZE. Please try a more restrictive query.");
         }
     }
 };


### PR DESCRIPTION
Context:

```
turing:reactome> match (n{`displayName (String)`~="Trans-autophosphorylation"}) return n, n.`displayName (String)`
[2025-11-10 15:37:54] [info] Column of size: 97751  // <- StringIndexLookup exceeding a chunk
[2025-11-10 15:37:54] [info] Column of size: 65536 // <- Property step within a chunk
[2025-11-10 15:37:54] [info] Column of size: 97751  // <- StringIndexLookupStep repeated
[2025-11-10 15:37:54] [info] Column of size: 32215 // <- Property step remaining after first chunk
Thread 1 "turingdb" received signal SIGSEGV, Segmentation fault.
```
- Columns being differing sizes caused SEGFAULT on turingdb -cli and exception in Python SDK

Changes:
I have added a very quick hotfix which prevents a more meaningful error message to the user. I have an idea for an actual fix (storing all matches which exceed a chunk size in a temporary buffer), but I thought v2 should be the priority for now.

Verified with:
```
turing:reactome> match (n{`displayName (String)`~="Trans-autophosphorylation"}) return n, n.`displayName (String)`
[2025-11-10 16:07:02] [error] EXEC_ERROR: String Index output exceeded CHUNK_SIZE. Please try a more restrictive query.
```
