### PR TITLE
Fixed missing evaluated type info in dummy prop expressions

### DIFF
--- a/test/v2/plan/success-reads/constraint-0
+++ b/test/v2/plan/success-reads/constraint-0
@@ -33,8 +33,8 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _c_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _c_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__
@@ -51,7 +51,7 @@ flowchart TD
     `"]
     13["`
         __VAR__
-        __name__: v2
+        __name__: v5
     `"]
     14["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/constraint-1
+++ b/test/v2/plan/success-reads/constraint-1
@@ -13,9 +13,9 @@ flowchart TD
     2["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._duration_
+        __dep__ _a_._duration_ (Integer)
         __has predicate__
-        __dep__ _a_._name_
+        __dep__ _a_._name_ (String)
     `"]
     3["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-reads/loop-0
+++ b/test/v2/plan/success-reads/loop-0
@@ -33,8 +33,8 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _b_._name_
-        __dep__ _a_._name_
+        __dep__ _b_._name_ (String)
+        __dep__ _a_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__
@@ -51,7 +51,7 @@ flowchart TD
     `"]
     13["`
         __VAR__
-        __name__: v2
+        __name__: v5
     `"]
     14["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/loop-1
+++ b/test/v2/plan/success-reads/loop-1
@@ -33,11 +33,11 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _b_._name_
-        __dep__ _a_._name_
+        __dep__ _b_._name_ (String)
+        __dep__ _a_._name_ (String)
         __has predicate__
-        __dep__ _c_._name_
-        __dep__ _b_._name_
+        __dep__ _c_._name_ (String)
+        __dep__ _b_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__
@@ -54,7 +54,7 @@ flowchart TD
     `"]
     13["`
         __VAR__
-        __name__: v2
+        __name__: v5
     `"]
     14["`
         __FILTER_EDGE__
@@ -77,7 +77,7 @@ flowchart TD
     `"]
     20["`
         __VAR__
-        __name__: v4
+        __name__: v10
     `"]
     21["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/loop-2
+++ b/test/v2/plan/success-reads/loop-2
@@ -33,14 +33,14 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _b_._name_
-        __dep__ _a_._name_
+        __dep__ _b_._name_ (String)
+        __dep__ _a_._name_ (String)
         __has predicate__
-        __dep__ _c_._name_
-        __dep__ _b_._name_
+        __dep__ _c_._name_ (String)
+        __dep__ _b_._name_ (String)
         __has predicate__
-        __dep__ _x_._name_
-        __dep__ _a_._name_
+        __dep__ _x_._name_ (String)
+        __dep__ _a_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__
@@ -57,7 +57,7 @@ flowchart TD
     `"]
     13["`
         __VAR__
-        __name__: v2
+        __name__: v5
     `"]
     14["`
         __FILTER_EDGE__
@@ -80,7 +80,7 @@ flowchart TD
     `"]
     20["`
         __VAR__
-        __name__: v4
+        __name__: v10
     `"]
     21["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/match-0
+++ b/test/v2/plan/success-reads/match-0
@@ -14,7 +14,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -27,7 +27,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__

--- a/test/v2/plan/success-reads/match-1
+++ b/test/v2/plan/success-reads/match-1
@@ -14,7 +14,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-reads/match-11
+++ b/test/v2/plan/success-reads/match-11
@@ -23,8 +23,8 @@ flowchart TD
     5["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _b_._name_
-        __dep__ _a_._name_
+        __dep__ _b_._name_ (String)
+        __dep__ _a_._name_ (String)
     `"]
     6["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-reads/match-2
+++ b/test/v2/plan/success-reads/match-2
@@ -14,7 +14,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_EDGES__

--- a/test/v2/plan/success-reads/match-3
+++ b/test/v2/plan/success-reads/match-3
@@ -14,7 +14,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_EDGES__
@@ -27,7 +27,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__

--- a/test/v2/plan/success-reads/match-4
+++ b/test/v2/plan/success-reads/match-4
@@ -15,7 +15,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -28,7 +28,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__

--- a/test/v2/plan/success-reads/match-5
+++ b/test/v2/plan/success-reads/match-5
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -29,7 +29,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__
@@ -77,7 +77,7 @@ flowchart TD
     `"]
     19["`
         __VAR__
-        __name__: v2
+        __name__: v6
     `"]
     20["`
         __FILTER_EDGE__
@@ -97,7 +97,7 @@ flowchart TD
     `"]
     25["`
         __VAR__
-        __name__: v3
+        __name__: v7
     `"]
     26["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/match-7
+++ b/test/v2/plan/success-reads/match-7
@@ -13,8 +13,8 @@ flowchart TD
     2["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _n_._duration_
-        __dep__ _m_._duration_
+        __dep__ _n_._duration_ (Integer)
+        __dep__ _m_._duration_ (Integer)
     `"]
     3["`
         __SCAN_NODES__

--- a/test/v2/plan/success-reads/match-limit-0
+++ b/test/v2/plan/success-reads/match-limit-0
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -29,7 +29,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__
@@ -77,7 +77,7 @@ flowchart TD
     `"]
     19["`
         __VAR__
-        __name__: v2
+        __name__: v6
     `"]
     20["`
         __FILTER_EDGE__
@@ -97,7 +97,7 @@ flowchart TD
     `"]
     25["`
         __VAR__
-        __name__: v3
+        __name__: v7
     `"]
     26["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/match-skip-0
+++ b/test/v2/plan/success-reads/match-skip-0
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -29,7 +29,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__
@@ -77,7 +77,7 @@ flowchart TD
     `"]
     19["`
         __VAR__
-        __name__: v2
+        __name__: v6
     `"]
     20["`
         __FILTER_EDGE__
@@ -97,7 +97,7 @@ flowchart TD
     `"]
     25["`
         __VAR__
-        __name__: v3
+        __name__: v7
     `"]
     26["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/match-skip-limit-0
+++ b/test/v2/plan/success-reads/match-skip-limit-0
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -29,7 +29,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._name_
+        __dep__ _e_._name_ (String)
     `"]
     6["`
         __GET_EDGE_TARGET__
@@ -77,7 +77,7 @@ flowchart TD
     `"]
     19["`
         __VAR__
-        __name__: v2
+        __name__: v6
     `"]
     20["`
         __FILTER_EDGE__
@@ -97,7 +97,7 @@ flowchart TD
     `"]
     25["`
         __VAR__
-        __name__: v3
+        __name__: v7
     `"]
     26["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/match-where-0
+++ b/test/v2/plan/success-reads/match-where-0
@@ -13,8 +13,8 @@ flowchart TD
     2["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _b_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _b_._name_ (String)
     `"]
     3["`
         __SCAN_NODES__

--- a/test/v2/plan/success-reads/match-where-1
+++ b/test/v2/plan/success-reads/match-where-1
@@ -33,8 +33,8 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _b_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _b_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__

--- a/test/v2/plan/success-reads/match-where-2
+++ b/test/v2/plan/success-reads/match-where-2
@@ -33,10 +33,10 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _b_._name_
-        __dep__ _b_._name_
-        __dep__ _c_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _c_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__

--- a/test/v2/plan/success-reads/match-where-3
+++ b/test/v2/plan/success-reads/match-where-3
@@ -33,12 +33,12 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _b_._name_
-        __dep__ _b_._name_
-        __dep__ _c_._name_
-        __dep__ _b_._name_
-        __dep__ _x_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _c_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _x_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__

--- a/test/v2/plan/success-reads/match-where-4
+++ b/test/v2/plan/success-reads/match-where-4
@@ -33,15 +33,15 @@ flowchart TD
     8["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _b_._duration_
-        __dep__ _a_._duration_
+        __dep__ _b_._duration_ (Integer)
+        __dep__ _a_._duration_ (Integer)
         __has predicate__
-        __dep__ _a_._name_
-        __dep__ _b_._name_
-        __dep__ _b_._name_
-        __dep__ _c_._name_
-        __dep__ _b_._name_
-        __dep__ _x_._name_
+        __dep__ _a_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _c_._name_ (String)
+        __dep__ _b_._name_ (String)
+        __dep__ _x_._name_ (String)
     `"]
     9["`
         __SCAN_NODES__
@@ -58,7 +58,7 @@ flowchart TD
     `"]
     13["`
         __VAR__
-        __name__: v2
+        __name__: v5
     `"]
     14["`
         __FILTER_EDGE__
@@ -81,7 +81,7 @@ flowchart TD
     `"]
     20["`
         __VAR__
-        __name__: v3
+        __name__: v6
     `"]
     21["`
         __FILTER_EDGE__

--- a/test/v2/plan/success-reads/return-prop-2
+++ b/test/v2/plan/success-reads/return-prop-2
@@ -13,7 +13,7 @@ flowchart TD
     2["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-reads/type-constraint-3
+++ b/test/v2/plan/success-reads/type-constraint-3
@@ -23,7 +23,7 @@ flowchart TD
     5["`
         __FILTER_NODE__
         __has predicate__
-        __dep__ _m_._isFrench_
+        __dep__ _m_._isFrench_ (Bool)
         __dep__ _n_:_Person_
     `"]
     6["`

--- a/test/v2/plan/success-reads/where-0
+++ b/test/v2/plan/success-reads/where-0
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _a_._name_
+        __dep__ _a_._name_ (String)
     `"]
     3["`
         __GET_EDGES__
@@ -29,7 +29,7 @@ flowchart TD
         __FILTER_EDGE__
         __edge_type__: KNOWS_WELL
         __has predicate__
-        __dep__ _e_._duration_
+        __dep__ _e_._duration_ (Integer)
     `"]
     6["`
         __GET_EDGE_TARGET__
@@ -42,7 +42,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _m_._name_
+        __dep__ _m_._name_ (String)
     `"]
     9["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-writes/delete-0
+++ b/test/v2/plan/success-writes/delete-0
@@ -15,7 +15,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-writes/delete-1
+++ b/test/v2/plan/success-writes/delete-1
@@ -15,7 +15,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__

--- a/test/v2/plan/success-writes/delete-2
+++ b/test/v2/plan/success-writes/delete-2
@@ -15,7 +15,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__

--- a/test/v2/plan/success-writes/match-create-2
+++ b/test/v2/plan/success-writes/match-create-2
@@ -17,7 +17,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __SCAN_NODES__
@@ -30,7 +30,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _m_._name_
+        __dep__ _m_._name_ (String)
     `"]
     6["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-writes/match-where-create-0
+++ b/test/v2/plan/success-writes/match-where-create-0
@@ -16,7 +16,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_PROPERTY__

--- a/test/v2/plan/success-writes/match-where-create-1
+++ b/test/v2/plan/success-writes/match-where-create-1
@@ -17,7 +17,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _n_._name_
+        __dep__ _n_._name_ (String)
     `"]
     3["`
         __GET_OUT_EDGES__
@@ -40,7 +40,7 @@ flowchart TD
         __FILTER_NODE__
         __label__: Person
         __has predicate__
-        __dep__ _m_._name_
+        __dep__ _m_._name_ (String)
     `"]
     9["`
         __GET_PROPERTY__

--- a/v2/AST/decl/DeclContext.cpp
+++ b/v2/AST/decl/DeclContext.cpp
@@ -10,7 +10,8 @@
 using namespace db::v2;
 
 DeclContext::DeclContext(DeclContext* parent)
-    : _parent(parent) {
+    : _parent(parent)
+{
 }
 
 DeclContext::~DeclContext() {

--- a/v2/analyzer/ExprAnalyzer.cpp
+++ b/v2/analyzer/ExprAnalyzer.cpp
@@ -13,6 +13,7 @@
 
 #include "expr/All.h"
 
+using namespace db;
 using namespace db::v2;
 
 ExprAnalyzer::ExprAnalyzer(CypherAST* ast, const GraphView& graphView)
@@ -278,7 +279,7 @@ void ExprAnalyzer::analyze(LiteralExpr* expr) {
     }
 }
 
-db::ValueType ExprAnalyzer::analyze(PropertyExpr* expr, bool allowCreate, ValueType defaultType) {
+ValueType ExprAnalyzer::analyze(PropertyExpr* expr, bool allowCreate, ValueType defaultType) {
     const QualifiedName* qualifiedName = expr->getFullName();
 
     if (qualifiedName->size() != 2) {
@@ -361,7 +362,7 @@ db::ValueType ExprAnalyzer::analyze(PropertyExpr* expr, bool allowCreate, ValueT
     expr->setType(type);
     expr->setDynamic();
 
-    // Create a variable declaration for the property expression 
+    // Create a variable declaration for the property expression
     // so that it can be retrieved later (for projection or in an expression / filter)
     expr->setExprVarDecl(_ctxt->createUnnamedVariable(_ast, expr->getType()));
 

--- a/v2/analyzer/ReadStmtAnalyzer.cpp
+++ b/v2/analyzer/ReadStmtAnalyzer.cpp
@@ -218,10 +218,8 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
             fullName->addName(propName);
 
             PropertyExpr* propExpr = PropertyExpr::create(_ast, fullName);
-            propExpr->setEntityVarDecl(decl);
-            propExpr->setPropertyName(propName->getName());
-
             BinaryExpr* predExpr = BinaryExpr::create(_ast, BinaryOperator::Equal, propExpr, expr);
+            _exprAnalyzer->analyzeRootExpr(predExpr);
 
             data->addExprConstraint(propName->getName(), propType->_valueType, predExpr);
         }
@@ -287,10 +285,8 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
             fullName->addName(propName);
 
             PropertyExpr* propExpr = PropertyExpr::create(_ast, fullName);
-            propExpr->setEntityVarDecl(decl);
-            propExpr->setPropertyName(propName->getName());
-
             BinaryExpr* predExpr = BinaryExpr::create(_ast, BinaryOperator::Equal, propExpr, expr);
+            _exprAnalyzer->analyzeRootExpr(predExpr);
 
             data->addExprConstraint(propName->getName(), propType->_valueType, predExpr);
         }

--- a/v2/plan/PlanGraphDebug.cpp
+++ b/v2/plan/PlanGraphDebug.cpp
@@ -42,7 +42,9 @@ void outputDependency(std::ostream& output, const ExprDependencies::VarDependenc
             output << ":_" << type->getName() << "_\n";
         }
     } else if (const auto* expr = dynamic_cast<const PropertyExpr*>(dep._expr)) {
-        output << "._" << expr->getPropName() << "_\n";
+        fmt::println(output, "._{}_ ({})",
+                     expr->getPropName(),
+                     EvaluatedTypeName::value(expr->getType()));
     }
 }
 


### PR DESCRIPTION
Also added the type information to PlanGraphDebug (so that it gets caught by the unit tests.
In the dumped graph, the unnamed variables v1, v2, etc also changed because there are now more unnamed variables (the property expressions were missing a var decl, now they have one which shifted all other var decl identifiers)