### PR TITLE
Fix regress by using pip python SDK in regress

### DIFF
--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -27,8 +27,6 @@ add_subdirectory(submit_empty_change)
 add_subdirectory(call_metadata)
 add_subdirectory(complex_rebases)
 add_subdirectory(serialization)
-add_subdirectory(count_simpledb)
-add_subdirectory(multi_type_properties)
 #add_subdirectory(snapshot_isolation) Disabled until ID injection in v2
 
 # Python SDK version to be used by uv


### PR DESCRIPTION
We were using the git repository of the SDK directly for regress tests. 
Instead we want to use the pip package directly from pypi