### PR TITLE
TURING-951 Enable comparison of different numeric types

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -101,6 +101,15 @@ void ExprAnalyzer::analyzeBinaryExpr(BinaryExpr* expr) {
         case BinaryOperator::Equal: {
             type = EvaluatedType::Bool;
 
+            if (pair == TypePairBitset(EvaluatedType::Double, EvaluatedType::Double)) {
+                const std::string error = fmt::format(
+                    "Equality of types '{}' and '{}' is not encouraged due to "
+                    "potential rounding innacuracy. Please constrain with '<' "
+                    "and '>' instead.",
+                    EvaluatedTypeName::value(a), EvaluatedTypeName::value(b));
+                throwError(error, expr);
+            }
+
             if (pair == TypePairBitset(EvaluatedType::Integer, EvaluatedType::Integer)
                 || pair == TypePairBitset(EvaluatedType::String, EvaluatedType::String)
                 || pair == TypePairBitset(EvaluatedType::String, EvaluatedType::Char)

--- a/query/pipeline/processors/ExprProgram.cpp
+++ b/query/pipeline/processors/ExprProgram.cpp
@@ -200,7 +200,8 @@ constexpr ColumnKind::ColumnKindCode UnaryOpCase = getOpCase(Op, Lhs::staticKind
     CASE_NAME(ColumnOptVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)      \
     CASE_NAME(ColumnOptVector<types::Bool::Primitive>, ColumnConst<types::Bool::Primitive>)          \
                                                                                                      \
-    /* Numeric types are totally ordered: allow comparisions between types */                        \
+    /* Numeric types are totally ordered: allow comparisions between types.*/                        \
+    /* NOTE: Some are blocked by planner */                                                         \
     CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnOptVector<types::UInt64::Primitive>)   \
     CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnOptVector<types::Double::Primitive>)   \
     CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnConst<types::UInt64::Primitive>)       \


### PR DESCRIPTION
- Add code to instantiate operators for comparing, e.g. Double and Int64, in Filters
- Add a helpful error message for queries trying to compare equalities of Doubles