### PR TITLE
Column dispatch + operation evaluation rework

### DIFF
--- a/query/pipeline/CMakeLists.txt
+++ b/query/pipeline/CMakeLists.txt
@@ -50,6 +50,8 @@ set(processors_sources
     processors/FilterProcessor.cpp
     processors/LambdaSourceProcessor.cpp
     processors/ExprProgram.cpp
+    processors/EvalBinaryExpr.cpp
+    processors/EvalUnaryExpr.cpp
 )
 
 set(procedures_sources

--- a/query/pipeline/processors/EvalBinaryExpr.cpp
+++ b/query/pipeline/processors/EvalBinaryExpr.cpp
@@ -1,0 +1,215 @@
+#include "EvalBinaryExpr.h"
+
+#include "columns/ColumnOperationExecutor.h"
+
+#include "Panic.h"
+
+using namespace db;
+
+namespace {
+
+template <ColumnOperator Op>
+struct EqualEval {
+    Column* _res {nullptr};
+
+    template <typename T, typename U>
+    void operator()(const T* lhs, const U* rhs) {
+        bioassert(_res && lhs && rhs, "Invalid inputs to Equal");
+
+        if constexpr (Op == OP_EQUAL) {
+            // using ResultType = ColumnCombinations<Equal, T, U>::ResultType;
+            // execOperation<Equal>(static_cast<ResultType*>(_res), lhs, rhs);
+            fmt::println("EQUAL {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_NOT_EQUAL) {
+            // using ResultType = ColumnCombinations<NotEqual, T, U>::ResultType;
+            // execOperation<NotEqual>(static_cast<ResultType*>(_res), lhs, rhs);
+            fmt::println("NOT EQUAL {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for Equal");
+        }
+    }
+};
+
+template <ColumnOperator Op>
+struct CompareEval {
+    Column* _res {nullptr};
+
+    void operator()(const auto* lhs, const auto* rhs) {
+        bioassert(_res && lhs && rhs, "Invalid inputs to Compare");
+
+        if constexpr (Op == OP_GREATER_THAN) {
+            fmt::println("GREATER_THAN_OR_EQUAL {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_LESS_THAN) {
+            fmt::println("LESS_THAN_OR_EQUAL {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for Compare");
+        }
+    }
+};
+
+template <ColumnOperator Op>
+struct CompareEqualEval {
+    Column* _res {nullptr};
+
+    void operator()(const auto* lhs, const auto* rhs) {
+        bioassert(_res && lhs && rhs, "Invalid inputs to CompareEqual");
+
+        if constexpr (Op == OP_GREATER_THAN_OR_EQUAL) {
+            fmt::println("GREATER_THAN {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_LESS_THAN_OR_EQUAL) {
+            fmt::println("LESS_THAN_OR_EQUAL {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for CompareEqual");
+        }
+    }
+};
+
+template <ColumnOperator Op>
+struct BooleanEval {
+    Column* _res {nullptr};
+
+    void operator()(const auto* lhs, const auto* rhs) {
+        bioassert(_res && lhs && rhs, "Invalid inputs to Boolean");
+
+        if constexpr (Op == OP_AND) {
+            fmt::println("AND {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_OR) {
+            fmt::println("OR {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_NOT) {
+            fmt::println("NOT {}", typeid(*lhs).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for Boolean");
+        }
+    }
+};
+
+template <ColumnOperator Op>
+struct ArithmeticEval {
+    Column* _res {nullptr};
+
+    void operator()(const auto* lhs, const auto* rhs) {
+        bioassert(_res && lhs && rhs, "Invalid inputs to Arithmetic");
+
+        if constexpr (Op == OP_MINUS) {
+            fmt::println("MINUS {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else if constexpr (Op == OP_PLUS) {
+            fmt::println("PLUS {}, {}", typeid(*lhs).name(), typeid(*rhs).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for Arithmetic");
+        }
+    }
+};
+
+}
+
+template <ColumnOperator Op>
+void EvalBinaryExpr::opEqual(Column* res, const Column* lhs, const Column* rhs) {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<int64_t, int64_t>::Pairs,
+        OptionalKindPairs<int64_t, uint64_t>::Pairs,
+        OptionalKindPairs<uint64_t, uint64_t>::Pairs,
+        OptionalKindPairs<CustomBool, CustomBool>::Pairs,
+        OptionalKindPairs<std::string_view, std::string_view>::Pairs,
+        OptionalKindPairs<EntityID, EntityID>::Pairs,
+        OptionalKindPairs<EntityID, NodeID>::Pairs,
+        OptionalKindPairs<EntityID, EdgeID>::Pairs,
+        OptionalKindPairs<NodeID, NodeID>::Pairs,
+        OptionalKindPairs<EdgeID, EdgeID>::Pairs,
+
+        std::tuple<KindPair<PropertyNull, std::optional<EntityID>>,
+                   KindPair<PropertyNull, std::optional<NodeID>>,
+                   KindPair<PropertyNull, std::optional<EdgeID>>,
+                   KindPair<PropertyNull, std::optional<int64_t>>,
+                   KindPair<PropertyNull, std::optional<uint64_t>>,
+                   KindPair<PropertyNull, std::optional<double>>,
+                   KindPair<PropertyNull, std::optional<std::string_view>>,
+                   KindPair<PropertyNull, std::optional<CustomBool>>,
+                   KindPair<PropertyNull, std::optional<ValueType>>>>;
+
+    using AllowedMixed = AllowedMixedList<
+        MixedKind<ColumnMask, PropertyNull>,
+        MixedKind<ColumnMask, CustomBool>,
+        MixedKind<ColumnMask, std::optional<CustomBool>>>;
+
+    using Excluded = ExcludedContainers<ContainerKind::code<ColumnSet>(),
+                                        ContainerKind::code<ColumnMask>()>;
+
+    EqualEval<Op> fn {res};
+    ColumnDoubleDispatcher<Allowed, AllowedMixed, ::EqualEval<Op>, Excluded>::dispatch(lhs, rhs, fn);
+}
+
+template <ColumnOperator Op>
+void EvalBinaryExpr::opCompare(Column* res, const Column* lhs, const Column* rhs) {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<int64_t, int64_t>::Pairs,
+        OptionalKindPairs<int64_t, uint64_t>::Pairs,
+        OptionalKindPairs<int64_t, double>::Pairs,
+        OptionalKindPairs<uint64_t, uint64_t>::Pairs,
+        OptionalKindPairs<uint64_t, double>::Pairs,
+        OptionalKindPairs<double, double>::Pairs>;
+
+    using AllowedMixed = AllowedMixedList<>;
+
+    CompareEval<Op> fn {res};
+    ColumnDoubleDispatcher<Allowed, AllowedMixed, ::CompareEval<Op>>::dispatch(lhs, rhs, fn);
+}
+
+template <ColumnOperator Op>
+void EvalBinaryExpr::opCompareEqual(Column* res, const Column* lhs, const Column* rhs) {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<int64_t, int64_t>::Pairs,
+        OptionalKindPairs<int64_t, uint64_t>::Pairs,
+        OptionalKindPairs<uint64_t, uint64_t>::Pairs>;
+
+    using AllowedMixed = AllowedMixedList<>;
+
+    CompareEqualEval<Op> fn {res};
+    ColumnDoubleDispatcher<Allowed, AllowedMixed, ::CompareEqualEval<Op>>::dispatch(lhs, rhs, fn);
+}
+
+template <ColumnOperator Op>
+void EvalBinaryExpr::opBoolean(Column* res, const Column* lhs, const Column* rhs) {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<CustomBool, CustomBool>::Pairs,
+        std::tuple<KindPair<PropertyNull, CustomBool>,
+                   KindPair<PropertyNull, std::optional<CustomBool>>>>;
+
+    using AllowedMixed = AllowedMixedList<
+        MixedKind<ColumnMask, PropertyNull>,
+        MixedKind<ColumnMask, CustomBool>,
+        MixedKind<ColumnMask, std::optional<CustomBool>>>;
+
+    BooleanEval<Op> fn {res};
+    ColumnDoubleDispatcher<Allowed, AllowedMixed, ::BooleanEval<Op>>::dispatch(lhs, rhs, fn);
+}
+
+template <ColumnOperator Op>
+void EvalBinaryExpr::opArithmetic(Column* res, const Column* lhs, const Column* rhs) {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<int64_t, int64_t>::Pairs,
+        OptionalKindPairs<int64_t, uint64_t>::Pairs,
+        OptionalKindPairs<int64_t, double>::Pairs,
+        OptionalKindPairs<uint64_t, uint64_t>::Pairs,
+        OptionalKindPairs<uint64_t, double>::Pairs,
+        OptionalKindPairs<double, double>::Pairs>;
+
+    using AllowedMixed = AllowedMixedList<>;
+
+    ArithmeticEval<Op> fn {res};
+    ColumnDoubleDispatcher<Allowed, AllowedMixed, ::ArithmeticEval<Op>>::dispatch(lhs, rhs, fn);
+}
+
+template void EvalBinaryExpr::opEqual<OP_EQUAL>(Column* res, const Column* lhs, const Column* rhs);
+template void EvalBinaryExpr::opEqual<OP_NOT_EQUAL>(Column* res, const Column* lhs, const Column* rhs);
+
+template void EvalBinaryExpr::opCompare<OP_GREATER_THAN>(Column* res, const Column* lhs, const Column* rhs);
+template void EvalBinaryExpr::opCompare<OP_LESS_THAN>(Column* res, const Column* lhs, const Column* rhs);
+
+template void EvalBinaryExpr::opCompareEqual<OP_GREATER_THAN_OR_EQUAL>(Column* res, const Column* lhs, const Column* rhs);
+template void EvalBinaryExpr::opCompareEqual<OP_LESS_THAN_OR_EQUAL>(Column* res, const Column* lhs, const Column* rhs);
+
+template void EvalBinaryExpr::opBoolean<OP_AND>(Column* res, const Column* lhs, const Column* rhs);
+template void EvalBinaryExpr::opBoolean<OP_OR>(Column* res, const Column* lhs, const Column* rhs);
+
+template void EvalBinaryExpr::opArithmetic<OP_MINUS>(Column* res, const Column* lhs, const Column* rhs);
+template void EvalBinaryExpr::opArithmetic<OP_PLUS>(Column* res, const Column* lhs, const Column* rhs);

--- a/query/pipeline/processors/EvalBinaryExpr.h
+++ b/query/pipeline/processors/EvalBinaryExpr.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "columns/ColumnOperator.h"
+
+namespace db {
+
+class Column;
+
+class EvalBinaryExpr {
+public:
+    template <ColumnOperator Op>
+    static void opEqual(Column* res, const Column* lhs, const Column* rhs);
+
+    template <ColumnOperator Op>
+    static void opCompare(Column* res, const Column* lhs, const Column* rhs);
+
+    template <ColumnOperator Op>
+    static void opCompareEqual(Column* res, const Column* lhs, const Column* rhs);
+
+    template <ColumnOperator Op>
+    static void opBoolean(Column* res, const Column* lhs, const Column* rhs);
+
+    template <ColumnOperator Op>
+    static void opArithmetic(Column* res, const Column* lhs, const Column* rhs);
+};
+
+}

--- a/query/pipeline/processors/EvalUnaryExpr.cpp
+++ b/query/pipeline/processors/EvalUnaryExpr.cpp
@@ -1,0 +1,43 @@
+#include "EvalUnaryExpr.h"
+
+#include "columns/ColumnOperationExecutor.h"
+
+#include "Panic.h"
+
+using namespace db;
+
+namespace {
+
+template <ColumnOperator Op>
+struct BooleanEval {
+    Column* _res {nullptr};
+
+    void operator()(const auto* operand) {
+        bioassert(_res && operand, "Invalid inputs to Boolean");
+
+        if constexpr (Op == OP_NOT) {
+            fmt::println("NOT {}", typeid(*operand).name());
+        } else {
+            COMPILE_ERROR("Invalid operator for Boolean");
+        }
+    }
+};
+
+}
+
+template <ColumnOperator Op>
+void EvalUnaryExpr::opBoolean(Column* res, const Column* operand) {
+    using Allowed = GenerateKindList<
+        // Optional types
+        OptionalKinds<CustomBool>::Types,
+
+        // Non-optional types
+        std::tuple<PropertyNull>>;
+
+    using Excluded = ExcludedContainers<ContainerKind::code<ColumnSet>()>;
+
+    BooleanEval<Op> fn {res};
+    ColumnSingleDispatcher<Allowed, ::BooleanEval<Op>, Excluded>::dispatch(operand, fn);
+}
+
+template void EvalUnaryExpr::opBoolean<OP_NOT>(Column* res, const Column* operand);

--- a/query/pipeline/processors/EvalUnaryExpr.h
+++ b/query/pipeline/processors/EvalUnaryExpr.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "columns/ColumnOperator.h"
+
+namespace db {
+
+class Column;
+
+class EvalUnaryExpr {
+public:
+    template <ColumnOperator Op>
+    static void opBoolean(Column* res, const Column* operand);
+};
+
+}

--- a/query/pipeline/processors/ExprProgram.cpp
+++ b/query/pipeline/processors/ExprProgram.cpp
@@ -1,186 +1,16 @@
 #include "ExprProgram.h"
 
 #include <stdint.h>
-#include <string_view>
 
 #include "columns/ColumnOperator.h"
-#include "columns/ColumnOperators.h"
-#include "columns/OperationKind.h"
-#include "columns/ColumnKind.h"
-#include "columns/ColumnOptVector.h"
-#include "columns/ColumnVector.h"
-#include "metadata/LabelSet.h"
-#include "metadata/PropertyType.h"
+#include "EvalBinaryExpr.h"
+#include "EvalUnaryExpr.h"
 
 #include "PipelineV2.h"
 
-#include "PipelineException.h"
 #include "FatalException.h"
 
 using namespace db;
-
-namespace {
-
-template <ColumnOperator Op, typename Lhs, typename Rhs>
-constexpr OperationKind::Code OpCase = OperationKind::code(Op, Lhs::staticKind(), Rhs::staticKind());
-
-template <ColumnOperator Op, typename Lhs>
-constexpr OperationKind::Code UnaryOpCase = OperationKind::code(Op, Lhs::staticKind());
-
-}
-
-// Mask operators
-#define AND_MASK_CASE(Lhs, Rhs)                                      \
-    case OpCase<OP_AND, Lhs, Rhs>: {                                 \
-        ColumnOperators::andOp(static_cast<ColumnMask*>(instr._res), \
-                               static_cast<const Lhs*>(instr._lhs),  \
-                               static_cast<const Rhs*>(instr._rhs)); \
-        break;                                                       \
-    }
-
-#define OR_MASK_CASE(Lhs, Rhs)                                      \
-    case OpCase<OP_OR, Lhs, Rhs>: {                                 \
-        ColumnOperators::orOp(static_cast<ColumnMask*>(instr._res), \
-                              static_cast<const Lhs*>(instr._lhs),  \
-                              static_cast<const Rhs*>(instr._rhs)); \
-        break;                                                      \
-    }
-
-#define NOT_MASK_CASE(Lhs)                                           \
-    case UnaryOpCase<OP_NOT, Lhs>: {                                 \
-        ColumnOperators::notOp(static_cast<ColumnMask*>(instr._res), \
-                               static_cast<const Lhs*>(instr._lhs)); \
-        break;                                                       \
-    }
-
-// Property-based operators - these use a ColumnOpt as their result
-#define EQUAL_CASE(Lhs, Rhs)                                            \
-    case OpCase<OP_EQUAL, Lhs, Rhs>: {                                  \
-        ColumnOperators::equal(static_cast<ColumnOptMask*>(instr._res), \
-                               static_cast<const Lhs*>(instr._lhs),     \
-                               static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                          \
-    }
-
-#define NOT_EQUAL_CASE(Lhs, Rhs)                                           \
-    case OpCase<OP_NOT_EQUAL, Lhs, Rhs>: {                                 \
-        ColumnOperators::notEqual(static_cast<ColumnOptMask*>(instr._res), \
-                                  static_cast<const Lhs*>(instr._lhs),     \
-                                  static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                             \
-    }
-
-#define GREATER_THAN_CASE(Lhs, Rhs)                                           \
-    case OpCase<OP_GREATER_THAN, Lhs, Rhs>: {                                 \
-        ColumnOperators::greaterThan(static_cast<ColumnOptMask*>(instr._res), \
-                                     static_cast<const Lhs*>(instr._lhs),     \
-                                     static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                                \
-    }
-
-#define LESS_THAN_CASE(Lhs, Rhs)                                           \
-    case OpCase<OP_LESS_THAN, Lhs, Rhs>: {                                 \
-        ColumnOperators::lessThan(static_cast<ColumnOptMask*>(instr._res), \
-                                  static_cast<const Lhs*>(instr._lhs),     \
-                                  static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                             \
-    }
-
-#define GREATER_THAN_OR_EQUAL_CASE(Lhs, Rhs)                                         \
-    case OpCase<OP_GREATER_THAN_OR_EQUAL, Lhs, Rhs>: {                               \
-        ColumnOperators::greaterThanOrEqual(static_cast<ColumnOptMask*>(instr._res), \
-                                            static_cast<const Lhs*>(instr._lhs),     \
-                                            static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                                       \
-    }
-
-#define LESS_THAN_OR_EQUAL_CASE(Lhs, Rhs)                                         \
-    case OpCase<OP_LESS_THAN_OR_EQUAL, Lhs, Rhs>: {                               \
-        ColumnOperators::lessThanOrEqual(static_cast<ColumnOptMask*>(instr._res), \
-                                         static_cast<const Lhs*>(instr._lhs),     \
-                                         static_cast<const Rhs*>(instr._rhs));    \
-        break;                                                                    \
-    }
-
-#define AND_CASE(Lhs, Rhs)                                                     \
-    case OpCase<OP_AND, Lhs, Rhs>: {                                           \
-        ColumnOperators::andOp(                                                \
-            static_cast<ColumnOptVector<types::Bool::Primitive>*>(instr._res), \
-            static_cast<const Lhs*>(instr._lhs),                               \
-            static_cast<const Rhs*>(instr._rhs));                              \
-        break;                                                                 \
-    }
-
-#define OR_CASE(Lhs, Rhs)                                                      \
-    case OpCase<OP_OR, Lhs, Rhs>: {                                            \
-        ColumnOperators::orOp(                                                 \
-            static_cast<ColumnOptVector<types::Bool::Primitive>*>(instr._res), \
-            static_cast<const Lhs*>(instr._lhs),                               \
-            static_cast<const Rhs*>(instr._rhs));                              \
-        break;                                                                 \
-    }
-
-#define NOT_CASE(Lhs)                                                          \
-    case UnaryOpCase<OP_NOT, Lhs>: {                                           \
-        ColumnOperators::notOp(                                                \
-            static_cast<ColumnOptVector<types::Bool::Primitive>*>(instr._res), \
-            static_cast<const Lhs*>(instr._lhs));                              \
-        break;                                                                 \
-    }
-
-#define PROJECT_CASE(Lhs, Rhs)                    \
-    case OpCase<OP_PROJECT, Lhs, Rhs>: {          \
-        ColumnOperators::projectOp(               \
-            static_cast<ColumnMask*>(instr._res), \
-            static_cast<const Lhs*>(instr._lhs),  \
-            static_cast<const Rhs*>(instr._rhs)); \
-        break;                                    \
-    }
-
-#define IN_CASE(Lhs, Rhs)                         \
-    case OpCase<OP_IN, Lhs, Rhs>: {               \
-        ColumnOperators::inOp(                    \
-            static_cast<ColumnMask*>(instr._res), \
-            static_cast<const Lhs*>(instr._lhs),  \
-            static_cast<const Rhs*>(instr._rhs)); \
-        break;                                    \
-    }
-
-#define INSTANTIATE_PROPERTY_OPERATOR(CASE_NAME) \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnOptVector<types::Int64::Primitive>)    \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnConst<types::Int64::Primitive>)        \
-    CASE_NAME(ColumnConst<types::Int64::Primitive>, ColumnOptVector<types::Int64::Primitive>)        \
-                                                                                                     \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnOptVector<types::UInt64::Primitive>)  \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnConst<types::UInt64::Primitive>)      \
-    CASE_NAME(ColumnConst<types::UInt64::Primitive>, ColumnOptVector<types::UInt64::Primitive>)      \
-                                                                                                     \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnOptVector<types::Double::Primitive>)  \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnConst<types::Double::Primitive>)      \
-    CASE_NAME(ColumnConst<types::Double::Primitive>, ColumnOptVector<types::Double::Primitive>)      \
-                                                                                                     \
-    CASE_NAME(ColumnOptVector<types::String::Primitive>, ColumnOptVector<types::String::Primitive>)  \
-    CASE_NAME(ColumnOptVector<types::String::Primitive>, ColumnConst<types::String::Primitive>)      \
-    CASE_NAME(ColumnConst<types::String::Primitive>, ColumnOptVector<types::String::Primitive>)      \
-                                                                                                     \
-    CASE_NAME(ColumnOptVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)      \
-    CASE_NAME(ColumnOptVector<types::Bool::Primitive>, ColumnConst<types::Bool::Primitive>)          \
-    CASE_NAME(ColumnConst<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)          \
-                                                                                                     \
-    /* Numeric types are totally ordered: allow comparisions between types.*/                        \
-    /* NOTE: Some are blocked by planner */                                                          \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnOptVector<types::UInt64::Primitive>)   \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnOptVector<types::Double::Primitive>)   \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnConst<types::UInt64::Primitive>)       \
-    CASE_NAME(ColumnOptVector<types::Int64::Primitive>, ColumnConst<types::Double::Primitive>)       \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnOptVector<types::Int64::Primitive>)   \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnOptVector<types::Double::Primitive>)  \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnConst<types::Int64::Primitive>)       \
-    CASE_NAME(ColumnOptVector<types::UInt64::Primitive>, ColumnConst<types::Double::Primitive>)      \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnOptVector<types::Int64::Primitive>)   \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnOptVector<types::UInt64::Primitive>)  \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnConst<types::Int64::Primitive>)       \
-    CASE_NAME(ColumnOptVector<types::Double::Primitive>, ColumnConst<types::UInt64::Primitive>)      \
 
 ExprProgram* ExprProgram::create(PipelineV2* pipeline) {
     ExprProgram* prog = new ExprProgram();
@@ -216,142 +46,127 @@ void ExprProgram::evalBinaryInstr(const Instruction& instr) {
     const ColumnOperator op = instr._op;
     const Column* lhs = instr._lhs;
     const Column* rhs = instr._rhs;
+    Column* res = instr._res;
 
     if (!lhs) {
         throw FatalException("Binary instruction had null left input.");
     }
+
     if (!rhs) {
         throw FatalException("Binary instruction had null right input.");
     }
 
-    switch (OperationKind::code(op, lhs->getKind(), rhs->getKind())) {
-        EQUAL_CASE(ColumnVector<size_t>, ColumnVector<size_t>)
-        EQUAL_CASE(ColumnVector<size_t>, ColumnConst<size_t>)
-        EQUAL_CASE(ColumnConst<size_t>, ColumnVector<size_t>)
-        EQUAL_CASE(ColumnConst<size_t>, ColumnConst<size_t>)
-        EQUAL_CASE(ColumnVector<EntityID>, ColumnVector<EntityID>)
-        EQUAL_CASE(ColumnVector<EntityID>, ColumnConst<EntityID>)
-        EQUAL_CASE(ColumnConst<EntityID>, ColumnVector<EntityID>)
-        EQUAL_CASE(ColumnConst<EntityID>, ColumnConst<EntityID>)
-        EQUAL_CASE(ColumnVector<NodeID>, ColumnVector<NodeID>)
-        EQUAL_CASE(ColumnVector<NodeID>, ColumnConst<NodeID>)
-        EQUAL_CASE(ColumnConst<NodeID>, ColumnVector<NodeID>)
-        EQUAL_CASE(ColumnConst<NodeID>, ColumnConst<NodeID>)
-        EQUAL_CASE(ColumnVector<EdgeID>, ColumnVector<EdgeID>)
-        EQUAL_CASE(ColumnVector<EdgeID>, ColumnConst<EdgeID>)
-        EQUAL_CASE(ColumnConst<EdgeID>, ColumnVector<EdgeID>)
-        EQUAL_CASE(ColumnConst<EdgeID>, ColumnConst<EdgeID>)
+    switch (op) {
+        case OP_EQUAL: {
+            EvalBinaryExpr::opEqual<OP_EQUAL>(res, lhs, rhs);
+        } break;
+        case OP_NOT_EQUAL: {
+            EvalBinaryExpr::opEqual<OP_NOT_EQUAL>(res, lhs, rhs);
+        } break;
+        case OP_GREATER_THAN: {
+            EvalBinaryExpr::opCompare<OP_GREATER_THAN>(res, lhs, rhs);
+        } break;
+        case OP_LESS_THAN: {
+            EvalBinaryExpr::opCompare<OP_LESS_THAN>(res, lhs, rhs);
+        } break;
+        case OP_GREATER_THAN_OR_EQUAL: {
+            EvalBinaryExpr::opCompareEqual<OP_GREATER_THAN_OR_EQUAL>(res, lhs, rhs);
+        } break;
+        case OP_LESS_THAN_OR_EQUAL: {
+            EvalBinaryExpr::opCompareEqual<OP_LESS_THAN_OR_EQUAL>(res, lhs, rhs);
+        } break;
 
-        EQUAL_CASE(ColumnVector<LabelSetID>, ColumnVector<LabelSetID>)
-        EQUAL_CASE(ColumnVector<LabelSetID>, ColumnConst<LabelSetID>)
-        EQUAL_CASE(ColumnConst<LabelSetID>, ColumnVector<LabelSetID>)
-        EQUAL_CASE(ColumnConst<LabelSetID>, ColumnConst<LabelSetID>)
-        EQUAL_CASE(ColumnVector<EdgeTypeID>, ColumnVector<EdgeTypeID>)
-        EQUAL_CASE(ColumnVector<EdgeTypeID>, ColumnConst<EdgeTypeID>)
-        EQUAL_CASE(ColumnConst<EdgeTypeID>, ColumnVector<EdgeTypeID>)
-        EQUAL_CASE(ColumnConst<EdgeTypeID>, ColumnConst<EdgeTypeID>)
-        EQUAL_CASE(ColumnVector<LabelSet>, ColumnVector<LabelSet>)
-        EQUAL_CASE(ColumnVector<LabelSet>, ColumnConst<LabelSet>)
-        EQUAL_CASE(ColumnConst<LabelSet>, ColumnVector<LabelSet>)
-        EQUAL_CASE(ColumnConst<LabelSet>, ColumnConst<LabelSet>)
+        case OP_AND: {
+            EvalBinaryExpr::opBoolean<OP_AND>(res, lhs, rhs);
+        } break;
+        case OP_OR: {
+            EvalBinaryExpr::opBoolean<OP_OR>(res, lhs, rhs);
+        } break;
+        case OP_NOT: {
+            throw FatalException("NOT binary operator is not supported.");
+        } break;
 
-        EQUAL_CASE(ColumnVector<std::string>, ColumnVector<std::string>)
-        EQUAL_CASE(ColumnVector<std::string>, ColumnConst<std::string>)
-        EQUAL_CASE(ColumnConst<std::string>, ColumnVector<std::string>)
-        EQUAL_CASE(ColumnConst<std::string>, ColumnConst<std::string>)
-        EQUAL_CASE(ColumnVector<std::string_view>, ColumnVector<std::string_view>)
-        EQUAL_CASE(ColumnVector<std::string_view>, ColumnConst<std::string_view>)
-        EQUAL_CASE(ColumnConst<std::string_view>, ColumnVector<std::string_view>)
-        EQUAL_CASE(ColumnConst<std::string_view>, ColumnConst<std::string_view>)
-        EQUAL_CASE(ColumnVector<std::string_view>, ColumnVector<std::string>)
-        EQUAL_CASE(ColumnVector<std::string_view>, ColumnConst<std::string>)
-        EQUAL_CASE(ColumnConst<std::string_view>, ColumnVector<std::string>)
-        EQUAL_CASE(ColumnConst<std::string_view>, ColumnConst<std::string>)
-        EQUAL_CASE(ColumnVector<std::string>, ColumnVector<std::string_view>)
-        EQUAL_CASE(ColumnVector<std::string>, ColumnConst<std::string_view>)
-        EQUAL_CASE(ColumnConst<std::string>, ColumnVector<std::string_view>)
-        EQUAL_CASE(ColumnConst<std::string>, ColumnConst<std::string_view>)
-        EQUAL_CASE(ColumnVector<CustomBool>, ColumnConst<CustomBool>)
-        EQUAL_CASE(ColumnConst<CustomBool>, ColumnVector<CustomBool>)
-        EQUAL_CASE(ColumnVector<double>, ColumnConst<double>)
-        EQUAL_CASE(ColumnConst<double>, ColumnVector<double>)
-        EQUAL_CASE(ColumnVector<int64_t>, ColumnConst<int64_t>)
-        EQUAL_CASE(ColumnConst<int64_t>, ColumnVector<int64_t>)
+        case OP_MINUS: {
+            EvalBinaryExpr::opArithmetic<OP_MINUS>(res, lhs, rhs);
+        } break;
+        case OP_PLUS: {
+            EvalBinaryExpr::opArithmetic<OP_PLUS>(res, lhs, rhs);
+        } break;
 
-        // Property opts
-        INSTANTIATE_PROPERTY_OPERATOR(EQUAL_CASE)
-        INSTANTIATE_PROPERTY_OPERATOR(NOT_EQUAL_CASE)
-        INSTANTIATE_PROPERTY_OPERATOR(GREATER_THAN_CASE)
-        INSTANTIATE_PROPERTY_OPERATOR(LESS_THAN_CASE)
-        INSTANTIATE_PROPERTY_OPERATOR(GREATER_THAN_OR_EQUAL_CASE)
-        INSTANTIATE_PROPERTY_OPERATOR(LESS_THAN_OR_EQUAL_CASE)
+        case OP_PROJECT: {
+            throw FatalException("Project operator is not supported.");
+        } break;
+        case OP_IN: {
+            throw FatalException("In operator is not supported.");
+        } break;
 
-        // Special cases for IS NOT NULL and IS NULL
-        EQUAL_CASE(ColumnOptVector<types::Int64::Primitive>, ColumnConst<PropertyNull>)
-        EQUAL_CASE(ColumnOptVector<types::UInt64::Primitive>, ColumnConst<PropertyNull>)
-        EQUAL_CASE(ColumnOptVector<types::Double::Primitive>, ColumnConst<PropertyNull>)
-        EQUAL_CASE(ColumnOptVector<types::String::Primitive>, ColumnConst<PropertyNull>)
-        EQUAL_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnConst<PropertyNull>)
+        case OP_NOOP: {
+            throw FatalException("NOOP operator is not supported.");
+        } break;
 
-        NOT_EQUAL_CASE(ColumnOptVector<types::Int64::Primitive>, ColumnConst<PropertyNull>)
-        NOT_EQUAL_CASE(ColumnOptVector<types::UInt64::Primitive>, ColumnConst<PropertyNull>)
-        NOT_EQUAL_CASE(ColumnOptVector<types::Double::Primitive>, ColumnConst<PropertyNull>)
-        NOT_EQUAL_CASE(ColumnOptVector<types::String::Primitive>, ColumnConst<PropertyNull>)
-        NOT_EQUAL_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnConst<PropertyNull>)
-
-        // Boolean property ops
-        AND_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)
-        AND_CASE(ColumnVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)
-        AND_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnVector<types::Bool::Primitive>)
-        AND_CASE(ColumnVector<types::Bool::Primitive>, ColumnVector<types::Bool::Primitive>)
-
-        OR_CASE(ColumnVector<types::Bool::Primitive>, ColumnVector<types::Bool::Primitive>)
-        OR_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnVector<types::Bool::Primitive>)
-        OR_CASE(ColumnVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)
-        OR_CASE(ColumnOptVector<types::Bool::Primitive>, ColumnOptVector<types::Bool::Primitive>)
-
-        // Project ops
-        PROJECT_CASE(ColumnVector<size_t>, ColumnMask)
-        PROJECT_CASE(ColumnMask, ColumnVector<size_t>)
-
-        // Mask ops
-        AND_MASK_CASE(ColumnMask, ColumnMask)
-        OR_MASK_CASE(ColumnMask, ColumnMask)
-
-        // Set ops
-        IN_CASE(ColumnVector<size_t>, ColumnSet<size_t>)
-        IN_CASE(ColumnVector<EntityID>, ColumnSet<EntityID>)
-        IN_CASE(ColumnVector<NodeID>, ColumnSet<NodeID>)
-        IN_CASE(ColumnVector<EdgeID>, ColumnSet<EdgeID>)
-        IN_CASE(ColumnVector<LabelSetID>, ColumnSet<LabelSetID>)
-        IN_CASE(ColumnVector<LabelSet>, ColumnSet<LabelSet>)
-        IN_CASE(ColumnVector<std::string>, ColumnSet<std::string>)
-        IN_CASE(ColumnVector<double>, ColumnSet<double>)
-        IN_CASE(ColumnVector<int64_t>, ColumnSet<int64_t>)
-
-        default: {
-            const std::string_view opName = ColumnOperatorDescription::value(op);
-            throw PipelineException(
-                fmt::format("Operator {} not implemented (kinds: {} and {})", opName,
-                            lhs->getKind(), rhs->getKind()));
-        }
+        case _SIZE: {
+            throw FatalException(
+                "Attempted to evaluate invalid ColumnOperator.");
+        } break;
     }
 }
 
 void ExprProgram::evalUnaryInstr(const Instruction& instr) {
     const ColumnOperator op = instr._op;
     const Column* input = instr._lhs;
+    Column* res = instr._res;
 
-    switch (OperationKind::code(op, input->getKind())) {
-        // XXX: What else can NOT be applied to?
-        NOT_CASE(ColumnVector<types::Bool::Primitive>);    // Also handles CustomBool
-        NOT_CASE(ColumnOptVector<types::Bool::Primitive>); // Also handles CustomBool
+    switch (op) {
+        case OP_EQUAL: {
+            throw FatalException("Equal operator is not supported.");
+        } break;
+        case OP_NOT_EQUAL: {
+            throw FatalException("NotEqual operator is not supported.");
+        } break;
+        case OP_GREATER_THAN: {
+            throw FatalException("GreaterThan operator is not supported.");
+        } break;
+        case OP_LESS_THAN: {
+            throw FatalException("LessThan operator is not supported.");
+        } break;
+        case OP_GREATER_THAN_OR_EQUAL: {
+            throw FatalException("GreaterThanOrEqual operator is not supported.");
+        } break;
+        case OP_LESS_THAN_OR_EQUAL: {
+            throw FatalException("LessThanOrEqual operator is not supported.");
+        } break;
 
-        default: {
-            const std::string_view opName = ColumnOperatorDescription::value(op);
-            throw PipelineException(
-                fmt::format("Unary operator {} not implemented for input kind: {} ",
-                            opName, (uint8_t)input->getKind()));
-        }
+        case OP_AND: {
+            throw FatalException("And operator is not supported.");
+        } break;
+        case OP_OR: {
+            throw FatalException("Or operator is not supported.");
+        } break;
+        case OP_NOT: {
+            EvalUnaryExpr::opBoolean<OP_NOT>(res, input);
+        } break;
+
+        case OP_MINUS: {
+            throw FatalException("Minus operator is not supported.");
+        } break;
+        case OP_PLUS: {
+            throw FatalException("Plus operator is not supported.");
+        } break;
+
+        case OP_PROJECT: {
+            throw FatalException("Project operator is not supported.");
+        } break;
+        case OP_IN: {
+            throw FatalException("In operator is not supported.");
+        } break;
+
+        case OP_NOOP: {
+            throw FatalException("NOOP operator is not supported.");
+        } break;
+
+        case _SIZE: {
+            throw FatalException(
+                "Attempted to evaluate invalid ColumnOperator.");
+        } break;
     }
 }

--- a/storage/columns/Column.h
+++ b/storage/columns/Column.h
@@ -4,6 +4,13 @@
 
 namespace db {
 
+template <class>
+struct ColumnSupportFor : std::false_type {};
+
+template <template <typename> class Container, typename T>
+inline constexpr bool ColumnSupportsInternal =
+    ColumnSupportFor<Container<T>>::value;
+
 class Column {
 public:
     Column() = delete;
@@ -21,6 +28,9 @@ public:
     virtual void dump(std::ostream& out) const = 0;
 
     ColumnKind::Code getKind() const { return _kind; }
+
+    virtual ContainerKind::Code getContainerKind() const = 0;
+    virtual InternalKind::Code getInternalKind() const = 0;
 
     template <typename T>
     T* cast() { return static_cast<T*>(this); }

--- a/storage/columns/ColumnConst.h
+++ b/storage/columns/ColumnConst.h
@@ -66,10 +66,16 @@ public:
 
     static consteval auto staticKind() { return _staticKind; }
 
+    ContainerKind::Code getContainerKind() const override { return ContainerKind::code<ColumnConst<T>>(); }
+    InternalKind::Code getInternalKind() const override { return InternalKind::code<T>(); }
+
 private:
     T _value;
 
     static constexpr auto _staticKind = ColumnKind::code<ColumnConst<T>>();
 };
+
+template <class T>
+struct ColumnSupportFor<ColumnConst<T>> : std::true_type {};
 
 }

--- a/storage/columns/ColumnMask.h
+++ b/storage/columns/ColumnMask.h
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "Column.h"
-#include "columns/ColumnOptVector.h"
+#include "ColumnOptVector.h"
 
 #include "DebugDump.h"
 #include "BioAssert.h"
@@ -162,6 +162,9 @@ public:
     }
 
     static consteval auto staticKind() { return _staticKind; }
+
+    ContainerKind::Code getContainerKind() const override { return ContainerKind::code<ColumnMask>(); }
+    InternalKind::Code getInternalKind() const override { return 0; }
 
 private:
     std::vector<Bool_t> _data;

--- a/storage/columns/ColumnOperationExecutor.h
+++ b/storage/columns/ColumnOperationExecutor.h
@@ -1,0 +1,392 @@
+#pragma once
+
+#include "ColumnVector.h"
+#include "ColumnConst.h"
+#include "ColumnSet.h"
+#include "ColumnMask.h"
+#include "PairColumnKind.h"
+
+#include "FatalException.h"
+
+namespace db {
+
+#define CASE_DOUBLE_DISPATCH(LHS, RHS)                                                   \
+    case PairColumnKind::code(ContainerKind::code<LHS>(), ContainerKind::code<RHS>()): { \
+        if constexpr (!ExcludedContainers::template contains<LHS>()                      \
+                      && !ExcludedContainers::template contains<RHS>()) {                \
+            dispatchInternal<LHS, RHS>(lhs, rhs, fn);                                    \
+        } else {                                                                         \
+            throw FatalException("Unsupported operation");                               \
+        }                                                                                \
+    } break;
+
+#define CASE_SINGLE_DISPATCH(Operand)                                      \
+    case ContainerKind::code<Operand>(): {                                 \
+        if constexpr (!ExcludedContainers::template contains<Operand>()) { \
+            dispatchInternal<Operand>(operand, fn);                        \
+        } else {                                                           \
+            throw FatalException("Unsupported operation");                 \
+        }                                                                  \
+    } break;
+
+template <typename... Tuples>
+struct TupleFlatten {
+    using Type = decltype(std::tuple_cat(std::declval<Tuples>()...));
+};
+
+template <typename Tuple>
+struct KindPairListFromTuple;
+
+template <typename... Pairs>
+struct KindPairList {
+    static constexpr std::size_t size = sizeof...(Pairs);
+};
+
+template <typename T>
+struct IsKindPairList : std::false_type {};
+
+template <typename... Pairs>
+struct IsKindPairList<KindPairList<Pairs...>> : std::true_type {};
+
+template <typename T>
+concept KindPairListExact = IsKindPairList<T>::value;
+
+template <typename L, typename R>
+struct KindPair {
+    using Lhs = L;
+    using Rhs = R;
+};
+
+template <typename... Pairs>
+struct KindPairListFromTuple<std::tuple<Pairs...>> {
+    using Type = KindPairList<Pairs...>;
+};
+
+template <typename L, typename R>
+struct OptionalKindPairs {
+    using Pairs = std::tuple<
+        KindPair<L, R>,
+        KindPair<std::optional<L>, R>,
+        KindPair<L, std::optional<R>>,
+        KindPair<std::optional<L>, std::optional<R>>>;
+};
+
+template <typename T>
+struct OptionalKinds {
+    using Types = std::tuple<
+        T,
+        std::optional<T>>;
+};
+
+template <typename... Tuples>
+using GenerateKindList =
+    TupleFlatten<typename TupleFlatten<Tuples...>::Type>::Type;
+
+template <typename... Tuples>
+using GenerateKindPairList =
+    KindPairListFromTuple<typename TupleFlatten<Tuples...>::Type>::Type;
+
+template <typename NonTemplated, typename K>
+struct MixedKind {
+    using NonTemplatedType = NonTemplated;
+    using Kind = K;
+};
+
+template <typename... Mixed>
+struct AllowedMixedList {
+    static constexpr std::size_t size = sizeof...(Mixed);
+};
+
+template <ContainerKind::Code... Excluded>
+struct ExcludedContainers {
+    // Contains
+    template <typename T>
+    static consteval bool contains() {
+        static constexpr auto code = ContainerKind::code<T>();
+        return ((code == Excluded) || ...);
+    }
+
+    template <template <typename> class T>
+    static consteval bool contains() {
+        static constexpr auto code = ContainerKind::code<T>();
+        return ((code == Excluded) || ...);
+    }
+};
+
+template <typename Tuple>
+struct IsTuple : std::false_type {};
+
+template <typename... Ts>
+struct IsTuple<std::tuple<Ts...>> : std::true_type {};
+
+template <typename T>
+concept TupleExact = IsTuple<T>::value;
+
+template <TupleExact AllowedInternalTypes,
+          class Functor,
+          class ExcludedContainers = ExcludedContainers<>>
+class ColumnSingleDispatcher {
+
+    using Fn = void (*)(const Column*, Functor&);
+
+    static void unsupported(const Column*, Functor&) {
+        throw FatalException("Unsupported operation");
+    }
+
+public:
+    static void dispatch(const Column* operand, Functor& fn) {
+        const ContainerKind::Code containerKind = ColumnKind::extractContainerKind(operand->getKind());
+
+        using Dummy = size_t;
+
+        switch (containerKind) {
+            CASE_SINGLE_DISPATCH(ColumnVector<Dummy>)
+            CASE_SINGLE_DISPATCH(ColumnConst<Dummy>)
+            CASE_SINGLE_DISPATCH(ColumnSet<Dummy>)
+            CASE_SINGLE_DISPATCH(ColumnMask)
+
+            default: {
+                throw FatalException("Unknown container kind");
+            }
+        }
+    }
+
+private:
+    template <class OperandRaw>
+    static void dispatchInternal(const Column* operand, Functor& fn) {
+        using Container = OuterTypeHelper<OperandRaw>::type;
+
+        if constexpr (std::is_same_v<Container, std::false_type>) {
+            fn(static_cast<const OperandRaw*>(operand));
+        } else {
+            const auto i = ColumnKind::extractInternalKind(operand->getKind());
+
+            static constexpr auto table = makeTable<Container::template type>(AllowedInternalTypes {});
+            table[i](operand, fn);
+        }
+    }
+
+    static constexpr std::size_t N = InternalKind::Types::count();
+
+    template <template <typename> class Container, typename T>
+    static void invoke(const Column* operand, Functor& fn) {
+        fn(static_cast<const Container<T>*>(operand));
+    }
+
+    template <template <typename> class Container, typename T>
+    static consteval void installFuncs(std::array<Fn, N + 1>& t) {
+        constexpr auto i = InternalKind::code<T>();
+
+        if constexpr (ColumnSupportsInternal<Container, T>) {
+            t[i] = &invoke<Container, T>;
+        }
+    }
+
+    template <template <typename> class Container, typename... Types>
+    static consteval auto makeTable(std::tuple<Types...>) {
+        std::array<Fn, N + 1> t {};
+
+        for (std::size_t i = 0; i <= N; ++i) {
+            t[i] = &unsupported;
+        }
+
+        (installFuncs<Container, Types>(t), ...);
+        return t;
+    }
+};
+
+template <KindPairListExact AllowedPairs, class AllowedMixed, class Functor, class ExcludedContainers = ExcludedContainers<>>
+class ColumnDoubleDispatcher {
+    using Fn = void (*)(const Column*, const Column*, Functor&);
+
+    static void unsupported(const Column*, const Column*, Functor&) {
+        throw FatalException("Unsupported operation");
+    }
+
+public:
+    static void dispatch(const Column* lhs, const Column* rhs, Functor& fn) {
+        const ContainerKind::Code lkind = ColumnKind::extractContainerKind(lhs->getKind());
+        const ContainerKind::Code rkind = ColumnKind::extractContainerKind(rhs->getKind());
+        const PairColumnKind::Code pairKind = PairColumnKind::code(lkind, rkind);
+
+        using Dummy = size_t;
+
+        switch (pairKind) {
+            // Vector vs X
+            CASE_DOUBLE_DISPATCH(ColumnVector<Dummy>, ColumnVector<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnVector<Dummy>, ColumnConst<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnVector<Dummy>, ColumnSet<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnVector<Dummy>, ColumnMask)
+
+            // Const vs X
+            CASE_DOUBLE_DISPATCH(ColumnConst<Dummy>, ColumnVector<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnConst<Dummy>, ColumnConst<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnConst<Dummy>, ColumnSet<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnConst<Dummy>, ColumnMask)
+
+            // Set vs X
+            CASE_DOUBLE_DISPATCH(ColumnSet<Dummy>, ColumnVector<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnSet<Dummy>, ColumnConst<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnSet<Dummy>, ColumnSet<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnSet<Dummy>, ColumnMask)
+
+            // Mask vs X
+            CASE_DOUBLE_DISPATCH(ColumnMask, ColumnVector<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnMask, ColumnConst<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnMask, ColumnSet<Dummy>)
+            CASE_DOUBLE_DISPATCH(ColumnMask, ColumnMask)
+
+            default: {
+                throw FatalException("Unknown pair column kind");
+            }
+        }
+    }
+
+private:
+    template <class LhsRaw, class RhsRaw>
+    static void dispatchInternal(const Column* lhs, const Column* rhs, Functor& fn) {
+        using LhsContainer = OuterTypeHelper<LhsRaw>::type;
+        using RhsContainer = OuterTypeHelper<RhsRaw>::type;
+
+        if constexpr (std::is_same_v<LhsContainer, std::false_type>
+                      && std::is_same_v<RhsContainer, std::false_type>) {
+            fn(static_cast<const LhsRaw*>(lhs), static_cast<const RhsRaw*>(rhs));
+        } else if constexpr (std::is_same_v<LhsContainer, std::false_type>) {
+            dispatchInternalR<LhsRaw, RhsContainer::template type>(lhs, rhs, fn);
+        } else if constexpr (std::is_same_v<RhsContainer, std::false_type>) {
+            dispatchInternalL<LhsContainer::template type, RhsRaw>(lhs, rhs, fn);
+        } else {
+            dispatchInternalLR<LhsContainer::template type, RhsContainer::template type>(lhs, rhs, fn);
+        }
+    }
+
+    template <class LhsContainer, template <typename> class RhsContainer>
+    static void dispatchInternalR(const Column* lhs, const Column* rhs, Functor& fn) {
+        const auto ri = ColumnKind::extractInternalKind(rhs->getKind());
+        static constexpr auto table = makeTableR<RhsContainer>();
+        table[ri](lhs, rhs, fn);
+    }
+
+    template <template <typename> class LhsContainer, class RhsContainer>
+    static void dispatchInternalL(const Column* lhs, const Column* rhs, Functor& fn) {
+        const auto li = ColumnKind::extractInternalKind(lhs->getKind());
+        static constexpr auto table = makeTableL<LhsContainer>();
+        table[li](lhs, rhs, fn);
+    }
+
+    template <template <typename> class LhsContainer, template <typename> class RhsContainer>
+    static void dispatchInternalLR(const Column* lhs, const Column* rhs, Functor& fn) {
+        const auto li = ColumnKind::extractInternalKind(lhs->getKind());
+        const auto ri = ColumnKind::extractInternalKind(rhs->getKind());
+
+        static constexpr auto table = makeTableLR<LhsContainer, RhsContainer>(AllowedPairs {});
+        table[li][ri](lhs, rhs, fn);
+    }
+
+    template <template <typename> class LhsContainer, typename RhsRaw, typename LK>
+    static void invokeL(const Column* lhs, const Column* rhs, Functor& fn) {
+        auto* l = static_cast<const LhsContainer<LK>*>(lhs);
+        auto* r = static_cast<const RhsRaw*>(rhs);
+        fn(l, r);
+    }
+
+    template <typename LhsRaw, template <typename> class RhsContainer, typename RK>
+    static void invokeR(const Column* lhs, const Column* rhs, Functor& fn) {
+        auto* l = static_cast<const LhsRaw*>(lhs);
+        auto* r = static_cast<const RhsContainer<RK>*>(rhs);
+        fn(l, r);
+    }
+
+    static constexpr std::size_t N = InternalKind::Types::count();
+
+    template <template <typename> class LhsContainer, template <typename> class RhsContainer, typename LK, typename RK>
+    static void invokeLR(const Column* lhs, const Column* rhs, Functor& fn) {
+        auto* l = static_cast<const LhsContainer<LK>*>(lhs);
+        auto* r = static_cast<const RhsContainer<RK>*>(rhs);
+        fn(l, r);
+    }
+
+    template <template <typename> class LhsContainer, typename Mixed>
+    static consteval void installMixedL(std::array<Fn, N + 1>& t) {
+        using K = typename Mixed::Kind;
+        constexpr auto ki = InternalKind::code<K>();
+
+        if constexpr (ColumnSupportsInternal<LhsContainer, K>) {
+            t[ki] = &invokeL<LhsContainer, typename Mixed::NonTemplatedType, K>;
+        }
+    }
+
+    template <template <typename> class RhsContainer, typename Mixed>
+    static consteval void installMixedR(std::array<Fn, N + 1>& t) {
+        using K = typename Mixed::Kind;
+        constexpr auto ki = InternalKind::code<K>();
+
+        if constexpr (ColumnSupportsInternal<RhsContainer, K>) {
+            t[ki] = &invokeR<typename Mixed::NonTemplatedType, RhsContainer, K>;
+        }
+    }
+
+    template <template <typename> class LhsContainer, template <typename> class RhsContainer, typename LK, typename RK>
+    static consteval void installLRPair(std::array<std::array<Fn, N + 1>, N + 1>& t) {
+        constexpr auto li = InternalKind::code<LK>();
+        constexpr auto ri = InternalKind::code<RK>();
+
+        if constexpr (ColumnSupportsInternal<LhsContainer, LK> && ColumnSupportsInternal<RhsContainer, RK>) {
+            t[li][ri] = &invokeLR<LhsContainer, RhsContainer, LK, RK>;
+        }
+
+        if constexpr (ColumnSupportsInternal<LhsContainer, RK> && ColumnSupportsInternal<RhsContainer, LK>) {
+            t[ri][li] = &invokeLR<LhsContainer, RhsContainer, RK, LK>;
+        }
+    }
+
+    template <template <typename> class LhsContainer>
+    static consteval auto makeTableL() {
+        return makeTableLImpl<LhsContainer>(AllowedMixed {});
+    }
+
+    template <template <typename> class LhsContainer, typename... Mixed>
+    static consteval auto makeTableLImpl(AllowedMixedList<Mixed...>) {
+        std::array<Fn, N + 1> t {};
+
+        for (std::size_t i = 0; i <= N; ++i) {
+            t[i] = &unsupported;
+        }
+
+        (installMixedL<LhsContainer, Mixed>(t), ...);
+        return t;
+    }
+
+    template <template <typename> class RhsContainer>
+    static consteval auto makeTableR() {
+        return makeTableRImpl<RhsContainer>(AllowedMixed {});
+    }
+
+    template <template <typename> class RhsContainer, typename... Mixed>
+    static consteval auto makeTableRImpl(AllowedMixedList<Mixed...>) {
+        std::array<Fn, N + 1> t {};
+
+        for (std::size_t i = 0; i <= N; ++i) {
+            t[i] = &unsupported;
+        }
+
+        (installMixedR<RhsContainer, Mixed>(t), ...);
+        return t;
+    }
+
+    template <template <typename> class LhsContainer, template <typename> class RhsContainer, typename... Pairs>
+    static consteval auto makeTableLR(KindPairList<Pairs...>) {
+        std::array<std::array<Fn, N + 1>, N + 1> t {};
+
+        for (std::size_t i = 0; i <= N; ++i) {
+            for (std::size_t j = 0; j <= N; ++j) {
+                t[i][j] = &unsupported;
+            }
+        }
+
+        (installLRPair<LhsContainer, RhsContainer, typename Pairs::Lhs, typename Pairs::Rhs>(t), ...);
+        return t;
+    }
+};
+
+}

--- a/storage/columns/ColumnSet.h
+++ b/storage/columns/ColumnSet.h
@@ -3,6 +3,7 @@
 #include <unordered_set>
 
 #include "Column.h"
+
 #include "DebugDump.h"
 #include "BioAssert.h"
 
@@ -27,25 +28,25 @@ public:
 
     ColumnSet(std::initializer_list<T> v)
         : Column(_staticKind),
-          _data(v)
+        _data(v)
     {
     }
 
     explicit ColumnSet(const std::unordered_set<T>& set)
         : Column(_staticKind),
-          _data(set)
+        _data(set)
     {
     }
 
     explicit ColumnSet(std::unordered_set<T>&& set) noexcept
         : Column(_staticKind),
-          _data(std::move(set))
+        _data(std::move(set))
     {
     }
 
     explicit ColumnSet(size_t size)
         : Column(_staticKind),
-          _data(size)
+        _data(size)
     {
     }
 
@@ -112,9 +113,21 @@ public:
 
     static consteval auto staticKind() { return _staticKind; }
 
+    ContainerKind::Code getContainerKind() const override { return ContainerKind::code<ColumnSet<T>>(); }
+    InternalKind::Code getInternalKind() const override { return InternalKind::code<T>(); }
+
 private:
     std::unordered_set<T> _data;
 
     static constexpr auto _staticKind = ColumnKind::code<ColumnSet<T>>();
 };
+
+template <typename T>
+concept SetElement = requires(const T& t) {
+    { std::hash<T> {}(t) } -> std::convertible_to<std::size_t>;
+};
+
+template <SetElement T>
+struct ColumnSupportFor<ColumnSet<T>> : std::true_type {};
+
 }

--- a/storage/columns/ColumnVector.h
+++ b/storage/columns/ColumnVector.h
@@ -3,8 +3,8 @@
 #include <vector>
 
 #include "Column.h"
-#include "DebugDump.h"
 
+#include "DebugDump.h"
 #include "BioAssert.h"
 
 namespace db {
@@ -141,10 +141,15 @@ public:
 
     static consteval auto staticKind() { return _staticKind; }
 
+    ContainerKind::Code getContainerKind() const override { return ContainerKind::code<ColumnVector<T>>(); }
+    InternalKind::Code getInternalKind() const override { return InternalKind::code<T>(); }
+
 private:
     std::vector<T> _data;
 
     static constexpr auto _staticKind = ColumnKind::code<ColumnVector<T>>();
 };
 
+template <class T>
+struct ColumnSupportFor<ColumnVector<T>> : std::true_type {};
 }

--- a/storage/columns/ContainerKind.h
+++ b/storage/columns/ContainerKind.h
@@ -24,14 +24,13 @@ class ColumnMask;
 // Implementation
 
 class ContainerKind {
-private:
+public:
     using Types = KindTypes<
         TemplateKind<ColumnVector>,
         TemplateKind<ColumnConst>,
         TemplateKind<ColumnSet>,
         ColumnMask>;
 
-public:
     using Code = uint8_t;
 
     /// @brief Returns the code for the given container type
@@ -41,15 +40,26 @@ public:
 
         if constexpr (std::is_same_v<Outer, std::false_type>) {
             // T is not a template class
-            static_assert(Types::contains<T>(), "Container type was not registered as a valid container type");
+            static_assert(Types::contains<T>(),
+                          "Container type was not registered as a valid container type");
             constexpr auto code = (Code)Types::indexOf<T>();
             return code;
         } else {
             // T is a template class
-            static_assert(Types::contains<Outer>(), "Container type was not registered as a valid container type");
+            static_assert(Types::contains<Outer>(),
+                          "Container type was not registered as a valid container type");
             constexpr auto code = (Code)Types::indexOf<Outer>();
             return code;
         }
+    }
+
+    /// @brief Returns the code for the given container type
+    template <template <typename> typename T>
+    static consteval Code code() {
+        static_assert(Types::contains<TemplateKind<T>>(),
+                      "Container type was not registered as a valid container type");
+        constexpr auto code = (Code)Types::indexOf<TemplateKind<T>>();
+        return code;
     }
 
     /// @brief Value indicating an invalid container type code

--- a/storage/columns/InternalKind.h
+++ b/storage/columns/InternalKind.h
@@ -34,7 +34,7 @@ class Column;
 // Implementation
 
 class InternalKind {
-private:
+public:
     using Types = KindTypes<
         signed char,
         unsigned char,
@@ -86,14 +86,14 @@ private:
         const Change*,
         Column*>;
 
-public:
     using Code = uint8_t;
 
     /// @brief Returns the code for the given type
     template <typename T>
     static consteval Code code() {
         constexpr auto code = (Code)Types::indexOf<T>();
-        static_assert(code != Invalid, "Internal type was not registered as a valid internal type");
+        static_assert(code != Invalid,
+                      "Internal type was not registered as a valid internal type");
         return code;
     }
 

--- a/storage/columns/KindTypes.h
+++ b/storage/columns/KindTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tuple>
+#include <array>
 
 namespace db {
 
@@ -87,10 +88,16 @@ public:
         return IndexOfHelper<T, Tuple>::value + 1;
     }
 
+    // TypeAt
+    template <std::size_t I>
+    using TypeAt = std::tuple_element_t<I, Tuple>;
+
+    // ALlUnique
     static consteval bool allUnique() {
         return AllUniqueHelper<Ts...>::value();
     }
 
+    // Count
     static consteval std::size_t count() {
         return std::tuple_size_v<Tuple>;
     }


### PR DESCRIPTION
- Single dispatch
- Double dispatch

Both using: switch on the container types first (vector, const, set, mask), then jump table based on the internal kind (int, double, etc).

+ @cyrusknopf Cleaner implementation of Column operators