### PR TITLE
Fix segfault when calling db.history() in return clause

### DIFF
--- a/query/AST/FunctionInvocation.cpp
+++ b/query/AST/FunctionInvocation.cpp
@@ -1,11 +1,18 @@
 #include "FunctionInvocation.h"
 
 #include "CypherAST.h"
+#include "expr/ExprChain.h"
 
 using namespace db;
 
 FunctionInvocation* FunctionInvocation::create(CypherAST* ast, QualifiedName* name) {
     FunctionInvocation* invocation = new FunctionInvocation(name);
     ast->addFunctionInvocation(invocation);
+
+    // Create empty arguments ExprChain in case the function has no arguments
+    // It may be replaced later by doing setArguments, it's ok since it's all registered in CypherAST
+    ExprChain* emptyArgs = ExprChain::create(ast);
+    invocation->setArguments(emptyArgs);
+
     return invocation;
 }

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -488,7 +488,8 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr) {
         throwError(fmt::format("Function '{}' does not exist", name), expr);
     }
 
-    const auto& requestedArgs = invoc->getArguments()->getExprs();
+    const ExprChain* argsChain = invoc->getArguments();
+    const auto& requestedArgs = argsChain->getExprs();
 
     bool isDynamic = false;
     bool isAggregate = false;


### PR DESCRIPTION
Fix segfault reported by @cyrusknopf in #257  when db.history() is used as a function invocation in the return clause:

```cypher
MATCH (n), (m) RETURN db.history()
``` 

The crash was happening in ExprAnalyzer.cpp:
```c++
void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr) {
...
    const ExprChain* argsChain = invoc->getArguments();
    const auto& requestedArgs = argsChain->getExprs();

    bool isDynamic = false;
    bool isAggregate = false;

    for (Expr* arg : requestedArgs) {
        analyzeExpr(arg);

        isDynamic |= arg->isDynamic();
        isAggregate |= arg->isAggregate();
    }
``` 
And the grammar in CypherParser.y for function invocations is:
```c++
functionInvocation
    : invocationName OPAREN CPAREN { $$ = FunctionInvocation::create(ast, $1); LOC($$, @$); }
    | invocationName OPAREN DISTINCT CPAREN { scanner.notImplemented(@$, "Function invocations with DISTINCT"); }
    | invocationName OPAREN exprChain CPAREN { $$ = FunctionInvocation::create(ast, $1); $$->setArguments($3); LOC($$, @$); }
    | invocationName OPAREN DISTINCT exprChain CPAREN { scanner.notImplemented(@$, "Function invocations with DISTINCT"); }
    ;
``` 

So when there are no arguments between OPAREN and CPAREN FunctionInvocation::setArguments() is never called, thus ExprChain* used to represent the chain of arguments was nullptr. This was causing the segfault when dereferencing the invoc->getArguments() pointer in ExprAnalyzer and trying to iterate over requestedArgs.

The fix is to create systematically an empty ExprChain in FunctionInvocation::create, that can be replaced if there are actually arguments to be set.