### PR TITLE
Fix endpoints crash when invalid NodeIDs are requested

### DIFF
--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(read_script)
 add_subdirectory(neo4j_import)
 add_subdirectory(wine_ontology)
 add_subdirectory(bulk_create_crash)
+add_subdirectory(get_nodes_invalid_id)
 
 # Python SDK version to be used by uv
 set(PYTURINGDB "turingdb")

--- a/regress/get_nodes_invalid_id/CMakeLists.txt
+++ b/regress/get_nodes_invalid_id/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+regress_test(get_nodes_invalid_id run.sh main.py)

--- a/regress/get_nodes_invalid_id/main.py
+++ b/regress/get_nodes_invalid_id/main.py
@@ -1,0 +1,93 @@
+"""
+Regression test for /get_nodes crash with invalid node ID.
+
+This test demonstrates that requesting a non-existent node ID via the /get_nodes
+endpoint causes the server to crash with a segmentation fault.
+
+The crash occurs because:
+1. GraphReader::getNodeView() returns an invalid NodeView for non-existent nodes
+2. The invalid NodeView has a null _labelset pointer (default-constructed LabelSetHandle)
+3. PayloadWriter::write(const NodeView&) calls labelset().decompose()
+4. decompose() calls hasLabel() which dereferences the null _labelset pointer
+
+Expected: Once fixed, the server should return an error or skip invalid nodes.
+"""
+
+import sys
+import time
+import requests
+from turingdb import TuringDB
+
+HOST = "http://localhost:6666"
+
+def main():
+    print("=== get_nodes_invalid_id regression test ===")
+    print()
+
+    # Setup: Create a graph with one node
+    client = TuringDB(host=HOST)
+
+    print("1. Creating test graph with one node...")
+    client.query("CREATE GRAPH testgraph")
+    client.set_graph("testgraph")
+    change = client.query("CHANGE NEW")["changeID"][0]
+    client.checkout(change=str(change))
+    client.query("CREATE (:Person {name: 'Alice'})")
+    client.query("COMMIT")
+    client.query("CHANGE SUBMIT")
+    print("   Graph created with node ID 0")
+    print()
+
+    # Test: Request a non-existent node ID via /get_nodes
+    print("2. Requesting non-existent node ID 999999 via /get_nodes...")
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-TuringDB-Graph": "testgraph",
+    }
+    payload = {
+        "nodeIDs": [999999]
+    }
+
+    try:
+        response = requests.post(f"{HOST}/get_nodes", json=payload, headers=headers, timeout=5)
+        print(f"   Response status: {response.status_code}")
+        print(f"   Response body: {response.text[:200]}")
+        print()
+    except requests.exceptions.ChunkedEncodingError as e:
+        print(f"   ERROR: Response ended prematurely - server crashed mid-response")
+        print(f"   Exception: {e}")
+        print()
+        print("TEST FAILED: Server crashed when requesting invalid node ID")
+        return 1
+    except requests.exceptions.ConnectionError as e:
+        print(f"   ERROR: Connection failed - server likely crashed")
+        print(f"   Exception: {e}")
+        print()
+        print("TEST FAILED: Server crashed when requesting invalid node ID")
+        return 1
+    except requests.exceptions.Timeout:
+        print("   ERROR: Request timed out - server may have crashed or hung")
+        print()
+        print("TEST FAILED: Server unresponsive when requesting invalid node ID")
+        return 1
+
+    # Verify server is still alive
+    print("3. Verifying server is still responding...")
+    try:
+        check_response = requests.get(f"{HOST}/status", timeout=5)
+        print(f"   Server status: {check_response.status_code}")
+    except Exception as e:
+        print(f"   ERROR: Server not responding after /get_nodes request")
+        print(f"   Exception: {e}")
+        print()
+        print("TEST FAILED: Server died after /get_nodes request")
+        return 1
+
+    print()
+    print("TEST PASSED: Server handled invalid node ID without crashing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/regress/get_nodes_invalid_id/run.sh
+++ b/regress/get_nodes_invalid_id/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Regression test: get_nodes_invalid_id
+#
+# This test demonstrates a crash (segfault) when requesting a non-existent node ID
+# via the /get_nodes endpoint.
+#
+#
+# Expected behavior: This test should FAIL (server crash) until the bug is fixed.
+# Once fixed, the test should pass with a proper error response or empty result.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+
+# Kill any existing turingdb processes (SIGKILL for reliability)
+killall -9 turingdb 2>/dev/null || true
+# Brief sleep to ensure process dies and port is released
+sleep 0.5
+# Wait for port 6666 to be free (nc -z returns 0 if open, 1 if closed)
+for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null || break; sleep 0.1; done
+
+rm -rf $SCRIPT_DIR/.turing
+turingdb -demon -turing-dir $SCRIPT_DIR/.turing
+# Wait for turingdb to be ready
+for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null && break; sleep 0.1; done
+
+rm -f pyproject.toml
+uv init
+# PYTURINGDB is set by the regression test runner, fallback to "turingdb" if not set
+uv add ${PYTURINGDB:-turingdb}
+uv add requests
+
+uv run main.py
+testres=$?
+
+killall -9 turingdb 2>/dev/null || true
+
+exit $testres

--- a/server/DBServerProcessor.cpp
+++ b/server/DBServerProcessor.cpp
@@ -1030,13 +1030,25 @@ void DBServerProcessor::get_nodes() {
         return;
     }
 
+    // Validate all node IDs before writing response
+    std::vector<NodeView> nodes;
+    nodes.reserve(nodeIDs->size());
+    for (const auto nodeID : *nodeIDs) {
+        NodeView node = reader.getNodeView(nodeID);
+        if (!node.isValid()) {
+            payload.key("error");
+            payload.value("Invalid node ID: " + std::to_string(nodeID.getValue()));
+            return;
+        }
+        nodes.push_back(std::move(node));
+    }
+
     payload.key("data");
     payload.obj();
 
-    for (const auto nodeID : *nodeIDs) {
-        const NodeView node = reader.getNodeView(nodeID);
-        payload.key(nodeID);
-        payload.value(node);
+    for (size_t i = 0; i < nodeIDs->size(); ++i) {
+        payload.key((*nodeIDs)[i]);
+        payload.value(nodes[i]);
     }
 }
 
@@ -1130,6 +1142,16 @@ void DBServerProcessor::get_node_edges() {
         payload.key("error");
         payload.value(EndpointStatusDescription::value(EndpointStatus::COULD_NOT_PARSE_BODY));
         return;
+    }
+
+    // Validate all node IDs before writing response
+    for (const NodeID nodeID : *nodeIDs) {
+        const NodeView node = reader.getNodeView(nodeID);
+        if (!node.isValid()) {
+            payload.key("error");
+            payload.value("Invalid node ID: " + std::to_string(nodeID.getValue()));
+            return;
+        }
     }
 
     std::unordered_map<EdgeTypeID, size_t> outCounts;
@@ -1437,13 +1459,25 @@ void DBServerProcessor::get_edges() {
         return;
     }
 
+    // Validate all edge IDs before writing response
+    std::vector<EdgeView> edges;
+    edges.reserve(edgeIDs->size());
+    for (const auto edgeID : *edgeIDs) {
+        EdgeView edge = reader.getEdgeView(edgeID);
+        if (!edge.isValid()) {
+            payload.key("error");
+            payload.value("Invalid edge ID: " + std::to_string(edgeID.getValue()));
+            return;
+        }
+        edges.push_back(std::move(edge));
+    }
+
     payload.key("data");
     payload.obj();
 
-    for (const auto edgeID : *edgeIDs) {
-        const EdgeView edge = reader.getEdgeView(edgeID);
-        payload.key(edgeID);
-        payload.value(edge);
+    for (size_t i = 0; i < edgeIDs->size(); ++i) {
+        payload.key((*edgeIDs)[i]);
+        payload.value(edges[i]);
     }
 }
 


### PR DESCRIPTION
Fix for #317 reported by @LucLabarriere

Some server endpoints such as /get_nodes, /get_edges and /get_node_edges were using NodeView or EdgeView on requested NodeIDs/EdgeIDs without checking if the view is valid before using it.

I added the check of views first and return an error if one of the IDs is invalid without starting to write the response before the check, so that introduces a bit of memorization of the views before using them.