### PR TITLE
Fix const checker false positive on namespace declarations

### DIFF
--- a/scripts/codereview/src/codereview/checks/missing_const.py
+++ b/scripts/codereview/src/codereview/checks/missing_const.py
@@ -236,7 +236,8 @@ class MissingConstCheck(BaseCheck):
         # Matches: Type name = value; or Type name(value); or Type name{value};
         var_decl = re.compile(
             r"^\s*"
-            r"(?!return|if|else|for|while|switch|case|break|continue|goto|throw|void|virtual|static|inline)"
+            r"(?!return|if|else|for|while|switch|case|break|continue|goto|throw|void|virtual|static|inline|"
+            r"namespace|class|struct|enum|union)"
             r"(?:const\s+)?"
             r"(\w+(?:::\w+)?(?:<[^>]+>)?)"  # type
             r"(?:\s*[*&])?\s+"  # optional pointer/ref

--- a/scripts/codereview/tests/test_missing_const.py
+++ b/scripts/codereview/tests/test_missing_const.py
@@ -948,6 +948,39 @@ void test() {
         warnings = get_warnings_on_lines(code)
         # Static locals often get modified across calls
 
+    def test_namespace_declaration(self):
+        """Namespace declarations should not be mistaken for variables."""
+        code = """
+namespace db {
+template class ShortestPathProcessor<types::UInt64>;
+template class ShortestPathProcessor<types::Double>;
+}
+"""
+        warnings = get_warnings_on_lines(code)
+        assert 1 not in warnings, "Namespace name should not be flagged as variable"
+
+    def test_class_declaration(self):
+        """Class declarations should not be mistaken for variables."""
+        code = """
+class MyClass {
+public:
+    int value;
+};
+"""
+        warnings = get_warnings_on_lines(code)
+        assert 1 not in warnings, "Class name should not be flagged as variable"
+
+    def test_struct_declaration(self):
+        """Struct declarations should not be mistaken for variables."""
+        code = """
+struct MyStruct {
+    int x;
+    int y;
+};
+"""
+        warnings = get_warnings_on_lines(code)
+        assert 1 not in warnings, "Struct name should not be flagged as variable"
+
 
 # =============================================================================
 # Iterator and range patterns


### PR DESCRIPTION
The var_decl regex was matching "namespace db {" as a variable declaration, treating "namespace" as the type and "db" as the variable. Add namespace, class, struct, enum, and union to the negative lookahead to prevent these C++ keywords from being matched as type names.

It was reporting db as a variable missing const in:
```c++
namespace db {
template class ShortestPathProcessor<types::UInt64>;
template class ShortestPathProcessor<types::Double>;
}
``` 