### PR TITLE
Fix bug with non-templated ColumnKinds

### DIFF
--- a/storage/columns/ColumnKind.h
+++ b/storage/columns/ColumnKind.h
@@ -35,7 +35,8 @@ public:
             // It is either ColumnMask or ListColumnConst
             constexpr Code container = ContainerKind::code<T>();
             static_assert(container != ContainerKind::Invalid);
-            return container;
+            constexpr auto code = container << InternalKind::BitCount;
+            return code;
         } else {
             // Column is a template class, such as ColumnVector<U>
             constexpr Code internal = InternalKind::code<U>();


### PR DESCRIPTION
Context:
- `ColumnKind` was inconsistent for `ColumnMask`, the following code:
```
std::bitset<32> cmsc = ColumnMask::staticKind();
std::bitset<32> cmcc = ContainerKind::code<ColumnMask>();
std::bitset<32> cmec = ColumnKind::extractContainerKind(ColumnMask::staticKind());
std::cout << "static, container, extracted: \n";
std::cout << cmsc << '\n';
std::cout << cmcc << '\n';
std::cout << cmec << '\n';
```
outputs:
```
static, container, extracted:
00000000000000000000000000000100
00000000000000000000000000000100
00000000000000000000000000000000
```
i.e. the `extractContainerKind` function is not consistent  with how `ColumnKind::code<ColumnMask>()` is computed.
i.e. `static_assert(ContainerKind::code<ColumnMask>() == ColumnKind::extractContainerKind(ColumnMask::staticKind()));` fails

Changes:
- Apply the internal type bitshift even for non-templated types, to be consistent with `extractContainerKind`

Verified with:
- `static_assert(ContainerKind::code<ColumnMask>() == ColumnKind::extractContainerKind(ColumnMask::staticKind()));` now passing