### PR TITLE
Test: Verify Code Style Review trigger

### DIFF
--- a/storage/test_style_check.cpp
+++ b/storage/test_style_check.cpp
@@ -1,0 +1,23 @@
+// Test file with intentional style violations
+// This file is used to verify that the Code Style Review workflow triggers
+
+#include <iostream>
+
+using namespace std;  // VIOLATION: Never use 'using namespace std'
+
+class TestClass {
+  public:  // VIOLATION: public should be aligned with class
+    int x;
+
+    void doSomething()
+    {
+        // VIOLATION: Opening brace should be on same line
+        cout << "Hello" << endl;
+    }
+};
+
+int main() {
+    TestClass t;
+    t.doSomething();
+    return 0;
+}


### PR DESCRIPTION
## Summary
Testing if the Code Style Review workflow triggers when only `.cpp` files are changed (without workflow file modifications).

This is a test to verify that PR 346's Code Style Review not triggering is due to the workflow file being modified in the same PR.

## Test Plan
- Observe if Code Style Review workflow triggers for this PR
- If it does: confirms the theory that workflow file modifications block the trigger
- If it doesn't: need further investigation

This PR will be closed after observation.