### PR TITLE
Removed automatic append of (Type) during imports

### DIFF
--- a/import/json/Neo4j/EdgeParser.h
+++ b/import/json/Neo4j/EdgeParser.h
@@ -41,11 +41,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Bool)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Bool) {
+                _currentPropName += " (Bool)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
             }
 
             _buf->addEdgeProperty<types::Bool>(*_currentEdge, propType._id, val);
@@ -61,11 +65,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Int64)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Int64) {
+                _currentPropName += " (Int64)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             }
 
             _buf->addEdgeProperty<types::Int64>(*_currentEdge, propType._id, val);
@@ -81,14 +89,18 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (UInt64)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::UInt64);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
             }
 
-            _buf->addEdgeProperty<types::UInt64>(*_currentEdge, propType._id, val);
+            if (propType._valueType != ValueType::Int64) {
+                _currentPropName += " (Int64)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
+            }
+
+            _buf->addEdgeProperty<types::Int64>(*_currentEdge, propType._id, val);
             return true;
         }
 
@@ -121,11 +133,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Double)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Double) {
+                _currentPropName += " (Double)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
             }
 
             _buf->addEdgeProperty<types::Double>(*_currentEdge, propType._id, val);
@@ -141,11 +157,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (String)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::String) {
+                _currentPropName += " (String)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
             }
 
             std::string escaped;
@@ -234,4 +254,5 @@ private:
     std::regex _regEscapes {"\"|\\\\"};
     std::regex _regNewline {"\n"};
 };
+
 }

--- a/import/json/Neo4j/EdgePropertyParser.h
+++ b/import/json/Neo4j/EdgePropertyParser.h
@@ -63,23 +63,22 @@ public:
 
         if (_nesting == 7) {
             if (val == "Integer" || val == "Long") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Int64)", ValueType::Int64);
-                _metadata->getOrCreatePropertyType(_currentPropName + " (UInt64)", ValueType::UInt64);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
                 return true;
             }
 
             if (val == "Double") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Double)", ValueType::Double);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
                 return true;
             }
 
             if (val == "Boolean") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Bool)", ValueType::Bool);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
                 return true;
             }
 
             if (val == "String" || val == "Date") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (String)", ValueType::String);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
                 return true;
             }
 

--- a/import/json/Neo4j/NodeParser.h
+++ b/import/json/Neo4j/NodeParser.h
@@ -35,11 +35,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Bool)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Bool) {
+                _currentPropName += " (Bool)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
             }
 
             _buf->addNodeProperty<types::Bool>(_currentNodeID, propType._id, val);
@@ -55,11 +59,14 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Int64)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Int64) {
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             }
 
             _buf->addNodeProperty<types::Int64>(_currentNodeID, propType._id, val);
@@ -75,14 +82,18 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (UInt64)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::UInt64);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
             }
 
-            _buf->addNodeProperty<types::UInt64>(_currentNodeID, propType._id, val);
+            if (propType._valueType != ValueType::Int64) {
+                _currentPropName += " (Int64)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
+            }
+
+            _buf->addNodeProperty<types::Int64>(_currentNodeID, propType._id, val);
             return true;
         }
 
@@ -101,11 +112,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (Double)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::Double) {
+                _currentPropName += " (Double)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
             }
 
             _buf->addNodeProperty<types::Double>(_currentNodeID, propType._id, val);
@@ -127,11 +142,15 @@ public:
         }
 
         if (_nesting == 7) {
-            _currentPropName += " (String)";
-            const PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
+            PropertyType propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
             if (!propType.isValid()) {
                 spdlog::info("Property type {} not supported", _currentPropName);
                 return true;
+            }
+
+            if (propType._valueType != ValueType::String) {
+                _currentPropName += " (String)";
+                propType = _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
             }
 
             std::string escaped;

--- a/import/json/Neo4j/NodePropertyParser.h
+++ b/import/json/Neo4j/NodePropertyParser.h
@@ -63,23 +63,22 @@ public:
 
         if (_nesting == 7) {
             if (val == "Integer" || val == "Long") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Int64)", ValueType::Int64);
-                _metadata->getOrCreatePropertyType(_currentPropName + " (UInt64)", ValueType::UInt64);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Int64);
                 return true;
             }
 
             if (val == "Double") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Double)", ValueType::Double);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Double);
                 return true;
             }
 
             if (val == "Boolean") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (Bool)", ValueType::Bool);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::Bool);
                 return true;
             }
 
             if (val == "String" || val == "Date") {
-                _metadata->getOrCreatePropertyType(_currentPropName + " (String)", ValueType::String);
+                _metadata->getOrCreatePropertyType(_currentPropName, ValueType::String);
                 return true;
             }
 


### PR DESCRIPTION
Now only adding `(Type)` at the end of the property name, if a conflicting property already exists. For example, in Reactome, only the `checksum` property is a variant, so only this property type will have a variant with `(Type)` in the name.

Full result of `CALL db.propertyTypes()` after doing neo4j import of reactome. There may be an issue though which is that for this to work, I had to parse all integers as int64 instead of having both uint and int supported. This effectively sets the limit of maximum integer value to ~4 billion

```
+----+----------------------------------+-----------+
| id | propertyType                     | valueType |
+----+----------------------------------+-----------+
| 0  | dbId                             | Int64     |
+----+----------------------------------+-----------+
| 1  | schemaClass                      | String    |
+----+----------------------------------+-----------+
| 2  | displayName                      | String    |
+----+----------------------------------+-----------+
| 3  | label                            | String    |
+----+----------------------------------+-----------+
| 4  | coordinate                       | Int64     |
+----+----------------------------------+-----------+
| 5  | stId                             | String    |
+----+----------------------------------+-----------+
| 6  | oldStId                          | String    |
+----+----------------------------------+-----------+
| 7  | isInDisease                      | Bool      |
+----+----------------------------------+-----------+
| 8  | releaseDate                      | String    |
+----+----------------------------------+-----------+
| 9  | systematicName                   | String    |
+----+----------------------------------+-----------+
| 10 | isChimeric                       | Bool      |
+----+----------------------------------+-----------+
| 11 | stIdVersion                      | String    |
+----+----------------------------------+-----------+
| 12 | speciesName                      | String    |
+----+----------------------------------+-----------+
| 13 | isInferred                       | Bool      |
+----+----------------------------------+-----------+
| 14 | category                         | String    |
+----+----------------------------------+-----------+
| 15 | releaseStatus                    | String    |
+----+----------------------------------+-----------+
| 16 | secondCoordinate                 | Int64     |
+----+----------------------------------+-----------+
| 17 | endPositionInReferenceSequence   | Int64     |
+----+----------------------------------+-----------+
| 18 | startPositionInReferenceSequence | Int64     |
+----+----------------------------------+-----------+
| 19 | pubMedIdentifier                 | Int64     |
+----+----------------------------------+-----------+
| 20 | title                            | String    |
+----+----------------------------------+-----------+
| 21 | year                             | Int64     |
+----+----------------------------------+-----------+
| 22 | journal                          | String    |
+----+----------------------------------+-----------+
| 23 | volume                           | Int64     |
+----+----------------------------------+-----------+
| 24 | pages                            | String    |
+----+----------------------------------+-----------+
| 25 | identifier                       | String    |
+----+----------------------------------+-----------+
| 26 | databaseName                     | String    |
+----+----------------------------------+-----------+
| 27 | url                              | String    |
+----+----------------------------------+-----------+
| 28 | definition                       | String    |
+----+----------------------------------+-----------+
| 29 | alteredAminoAcidFragment         | String    |
+----+----------------------------------+-----------+
| 30 | formula                          | String    |
+----+----------------------------------+-----------+
| 31 | trivial                          | Bool      |
+----+----------------------------------+-----------+
| 32 | taxId                            | String    |
+----+----------------------------------+-----------+
| 33 | abbreviation                     | String    |
+----+----------------------------------+-----------+
| 34 | score                            | Double    |
+----+----------------------------------+-----------+
| 35 | diagramHeight                    | Int64     |
+----+----------------------------------+-----------+
| 36 | hasEHLD                          | Bool      |
+----+----------------------------------+-----------+
| 37 | hasDiagram                       | Bool      |
+----+----------------------------------+-----------+
| 38 | lastUpdatedDate                  | String    |
+----+----------------------------------+-----------+
| 39 | doi                              | String    |
+----+----------------------------------+-----------+
| 40 | diagramWidth                     | Int64     |
+----+----------------------------------+-----------+
| 41 | sequenceLength                   | Int64     |
+----+----------------------------------+-----------+
| 42 | checksum                         | String    |
+----+----------------------------------+-----------+
| 43 | isSequenceChanged                | Bool      |
+----+----------------------------------+-----------+
| 44 | approved                         | Bool      |
+----+----------------------------------+-----------+
| 45 | inn                              | String    |
+----+----------------------------------+-----------+
| 46 | type                             | String    |
+----+----------------------------------+-----------+
| 47 | startCoordinate                  | Int64     |
+----+----------------------------------+-----------+
| 48 | endCoordinate                    | Int64     |
+----+----------------------------------+-----------+
| 49 | referenceType                    | String    |
+----+----------------------------------+-----------+
| 50 | accession                        | String    |
+----+----------------------------------+-----------+
| 51 | name                             | String    |
+----+----------------------------------+-----------+
| 52 | curatorComment                   | String    |
+----+----------------------------------+-----------+
| 53 | uniformResourceLocator           | String    |
+----+----------------------------------+-----------+
| 54 | chapterTitle                     | String    |
+----+----------------------------------+-----------+
| 55 | ISBN                             | String    |
+----+----------------------------------+-----------+
| 56 | releaseNumber                    | Int64     |
+----+----------------------------------+-----------+
| 57 | neo4j                            | String    |
+----+----------------------------------+-----------+
| 58 | orcidId                          | String    |
+----+----------------------------------+-----------+
| 59 | firstname                        | String    |
+----+----------------------------------+-----------+
| 60 | initial                          | String    |
+----+----------------------------------+-----------+
| 61 | surname                          | String    |
+----+----------------------------------+-----------+
| 62 | project                          | String    |
+----+----------------------------------+-----------+
| 63 | minUnitCount                     | Int64     |
+----+----------------------------------+-----------+
| 64 | maxUnitCount                     | Int64     |
+----+----------------------------------+-----------+
| 65 | stoichiometryKnown               | Bool      |
+----+----------------------------------+-----------+
| 66 | resourceIdentifier               | String    |
+----+----------------------------------+-----------+
| 67 | accessUrl                        | String    |
+----+----------------------------------+-----------+
| 68 | note                             | String    |
+----+----------------------------------+-----------+
| 69 | dateTime                         | String    |
+----+----------------------------------+-----------+
| 70 | address                          | String    |
+----+----------------------------------+-----------+
| 71 | variantIdentifier                | String    |
+----+----------------------------------+-----------+
| 72 | isOrdered                        | Bool      |
+----+----------------------------------+-----------+
| 73 | deletedStId                      | String    |
+----+----------------------------------+-----------+
| 74 | clazz                            | String    |
+----+----------------------------------+-----------+
| 75 | deletedInstanceDbId              | Int64     |
+----+----------------------------------+-----------+
| 76 | text                             | String    |
+----+----------------------------------+-----------+
| 77 | ecNumber                         | String    |
+----+----------------------------------+-----------+
| 78 | order                            | Int64     |
+----+----------------------------------+-----------+
| 79 | stoichiometry                    | Int64     |
+----+----------------------------------+-----------+
| 80 | checksum (Int64)                 | Int64     |
+----+----------------------------------+-----------+
```