### PR TITLE
Fix dangling reference warnings in range-based for loops

### DIFF
--- a/test/query/queries/FilterPredicatesTest.cpp
+++ b/test/query/queries/FilterPredicatesTest.cpp
@@ -2160,7 +2160,8 @@ TEST_F(FilterPredicatesTest, multiHopWithFilter) {
             ColumnNodeIDs bNodes;
             bNodes.push_back(e1._otherID);
 
-            for (const EdgeRecord& e2 : read().getOutEdges(&bNodes)) {
+            auto outEdges = read().getOutEdges(&bNodes);
+            for (const EdgeRecord& e2 : outEdges) {
                 const auto* cName = read().tryGetNodeProperty<types::String>(nameID, e2._otherID);
                 if (cName) {
                     expected.add({*aName, *cName});

--- a/test/query/queries/QueriesTest.cpp
+++ b/test/query/queries/QueriesTest.cpp
@@ -2101,7 +2101,8 @@ TEST_F(QueriesTest, pitchDeckPersonInterest) {
                 people.push_back(n);
             }
         }
-        for (EdgeRecord e : read().getOutEdges(&people)) {
+        auto outEdges = read().getOutEdges(&people);
+        for (EdgeRecord e : outEdges) {
             NodeView v = read().getNodeView(e._otherID);
             if (v.labelset().hasLabel(interestLabel)) {
                 expected.add({e._nodeID, e._otherID});
@@ -2561,7 +2562,8 @@ TEST_F(QueriesTest, indirectLabelFilter) {
             ColumnNodeIDs iNodes;
             iNodes.push_back(interestI);
 
-            for (const EdgeRecord& e2 : read().getInEdges(&iNodes)) {
+            auto inEdges = read().getInEdges(&iNodes);
+            for (const EdgeRecord& e2 : inEdges) {
                 NodeView srcView2 = read().getNodeView(e2._nodeID);
                 if (!srcView2.labelset().hasLabel(personLabelID)) {
                     continue;


### PR DESCRIPTION
## Summary
- Fix dangling reference warnings detected by GCC 14.2's `-Werror=dangling-reference`
- Store results of `read().getOutEdges()` and `read().getInEdges()` in local variables before iterating
- Prevents undefined behavior from temporary objects being destroyed during iteration

## Changes
- `test/query/queries/QueriesTest.cpp`: Fixed 2 instances (lines 2104, 2565)
- `test/query/queries/FilterPredicatesTest.cpp`: Fixed 1 instance (line 2163)