### PR TITLE
Implement constructors & destructors of exceptions in cpp files instead of pure headers

### DIFF
--- a/query/pipeline/CMakeLists.txt
+++ b/query/pipeline/CMakeLists.txt
@@ -6,6 +6,7 @@ set(pipeline_sources
     PipelinePort.cpp
     PipelineBuilder.cpp
     PipelineExecutor.cpp
+    PipelineException.cpp
     interfaces/PipelineInterface.cpp)
 
 set(processors_sources

--- a/query/pipeline/PipelineException.cpp
+++ b/query/pipeline/PipelineException.cpp
@@ -1,0 +1,11 @@
+#include "PipelineException.h"
+
+using namespace db;
+
+PipelineException::PipelineException(std::string&& msg)
+    : TuringException(std::move(msg))
+{
+}
+
+PipelineException::~PipelineException() noexcept {
+}

--- a/query/pipeline/PipelineException.h
+++ b/query/pipeline/PipelineException.h
@@ -13,12 +13,8 @@ public:
     PipelineException& operator=(const PipelineException&) = default;
     PipelineException& operator=(PipelineException&&) = default;
 
-    explicit PipelineException(std::string&& msg)
-        : TuringException(std::move(msg))
-    {
-    }
-
-    ~PipelineException() noexcept override = default;
+    explicit PipelineException(std::string&& msg);
+    ~PipelineException() noexcept override;
 };
 
 }

--- a/query/plan/CMakeLists.txt
+++ b/query/plan/CMakeLists.txt
@@ -10,6 +10,7 @@ set(plan_sources
     PipelineGenerator.cpp
     ExprProgramGenerator.cpp
     PredicateProgramGenerator.cpp
+    PlannerException.cpp
 )
 
 add_library(turing_db_plan_s STATIC ${plan_sources})

--- a/query/plan/PlannerException.cpp
+++ b/query/plan/PlannerException.cpp
@@ -1,0 +1,11 @@
+#include "PlannerException.h"
+
+using namespace db;
+
+PlannerException::PlannerException(std::string&& msg)
+    : CompilerException(std::move(msg))
+{
+}
+
+PlannerException::~PlannerException() noexcept {
+}

--- a/query/plan/PlannerException.h
+++ b/query/plan/PlannerException.h
@@ -8,10 +8,8 @@ namespace db {
 
 class PlannerException : public CompilerException {
 public:
-    explicit PlannerException(std::string&& msg)
-        : CompilerException(std::move(msg))
-    {
-    }
+    explicit PlannerException(std::string&& msg);
+    ~PlannerException() noexcept override;
 };
 
 }

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(VECTOR_SOURCES
         RandomGenerator.cpp
+        VectorException.cpp
         StorageManager.cpp
         LSHShardRouter.cpp
         VectorResult.cpp
@@ -13,6 +14,7 @@ set(VECTOR_SOURCES
         VecLibAccessor.cpp
         VecLib.cpp
         import/ImportResult.cpp
+        import/ImportException.cpp
         import/JsonImporter.cpp)
 
 add_library(turing_vector_s STATIC ${VECTOR_SOURCES})

--- a/vector/VectorException.cpp
+++ b/vector/VectorException.cpp
@@ -1,0 +1,11 @@
+#include "VectorException.h"
+
+using namespace vec;
+
+VectorException::VectorException(const std::string& message)
+    : std::runtime_error(message)
+{
+}
+
+VectorException::~VectorException() noexcept {
+}

--- a/vector/VectorException.h
+++ b/vector/VectorException.h
@@ -6,10 +6,8 @@ namespace vec {
 
 class VectorException : public std::runtime_error {
 public:
-    explicit VectorException(const std::string& message)
-        : std::runtime_error(message)
-    {
-    }
+    explicit VectorException(const std::string& message);
+    ~VectorException() noexcept override;
 };
 
 }

--- a/vector/import/ImportException.cpp
+++ b/vector/import/ImportException.cpp
@@ -1,0 +1,11 @@
+#include "ImportException.h"
+
+using namespace vec;
+
+ImportException::ImportException(ImportErrorCode code, const std::string& message)
+    : _e(code, message)
+{
+}
+
+ImportException::~ImportException() noexcept {
+}

--- a/vector/import/ImportException.h
+++ b/vector/import/ImportException.h
@@ -8,10 +8,8 @@ namespace vec {
 
 class ImportException : public TuringException {
 public:
-    ImportException(ImportErrorCode code, const std::string& message = "")
-        : _e(code, message)
-    {
-    }
+    ImportException(ImportErrorCode code, const std::string& message = "");
+    ~ImportException() noexcept override;
 
     const ImportError& err() const {
         return _e;


### PR DESCRIPTION
Some exceptions deriving from TuringException were classes in pure header. Thus the constructors and destructors were considered as weak symbols, which may be treated differently by gcc and llvm and source of many weird and mysterious pains.