### PR TITLE
fix: resolve dangling reference warnings in MultiHopPatternTest

### DIFF
--- a/test/query/queries/MultiHopPatternTest.cpp
+++ b/test/query/queries/MultiHopPatternTest.cpp
@@ -670,7 +670,8 @@ TEST_F(MultiHopPatternTest, forwardChain_personKnowsPersonInterest) {
             ColumnNodeIDs bNodes;
             bNodes.push_back(personB);
 
-            for (const EdgeRecord& e2 : read().getOutEdges(&bNodes)) {
+            auto edges = read().getOutEdges(&bNodes);
+	    for (const EdgeRecord& e2 : edges) {
                 if (read().getEdgeTypeID(e2._edgeID) != INTERESTED_IN_TYPEID) continue;
                 if (!read().getNodeView(e2._otherID).labelset().hasLabel(interestLabelID)) continue;
 
@@ -742,7 +743,8 @@ TEST_F(MultiHopPatternTest, forwardChain_withFilters) {
             ColumnNodeIDs bNodes;
             bNodes.push_back(personB);
 
-            for (const EdgeRecord& e2 : read().getOutEdges(&bNodes)) {
+	    auto edges = read().getOutEdges(&bNodes);
+            for (const EdgeRecord& e2 : edges) {
                 if (read().getEdgeTypeID(e2._edgeID) != INTERESTED_IN_TYPEID) continue;
                 if (!read().getNodeView(e2._otherID).labelset().hasLabel(interestLabelID)) continue;
 
@@ -806,7 +808,8 @@ TEST_F(MultiHopPatternTest, forwardChain_deadEnd) {
             iNodes.push_back(interestI);
 
             // Look for any outgoing edges from Interest node
-            for (const EdgeRecord& e2 : read().getOutEdges(&iNodes)) {
+	    auto edges = read().getOutEdges(&iNodes);
+            for (const EdgeRecord& e2 : edges) {
                 const NodeID nodeX = e2._otherID;
 
                 const auto* nameP =


### PR DESCRIPTION
# Description

## Summary

Fixed compiler warnings (-Werror=dangling-reference) in MultiHopPatternTest.cpp by storing temporary return values in local variables before iteration.

## Problem

The compiler detected potentially dangling references when using range-based for loops directly on temporary objects returned by read().getOutEdges(). The temporary object is destroyed at the end of the full expression, leaving dangling references during iteration.

##  Solution
Store the result of getOutEdges() in a local variable before iterating:

### Before:

```cpp
for (const EdgeRecord& e2 : read().getOutEdges(&bNodes)) {
    // ...
}
```

### After:

```cpp
auto edges = read().getOutEdges(&bNodes);
for (const EdgeRecord& e2 : edges) {
    // ...
}
```

## Changes

Line 673: forwardChain_personKnowsPersonInterest_Test
Line 745: forwardChain_withFilters_Test
Line 809: forwardChain_deadEnd_Test

## Testing

 Code compiles without warnings with -Werror=dangling-reference
 Existing tests pass

## Checklist

 Follows project coding standards
 No functional changes, only fixes compiler warnings
 All affected test cases modified consistently