### PR TITLE
fix: resolve dangling reference warning in TombstoneSerialisationTest

### DIFF
--- a/test/serialisation/TombstoneSerialisationTest.cpp
+++ b/test/serialisation/TombstoneSerialisationTest.cpp
@@ -136,7 +136,7 @@ TEST_F(TombstoneSerialisationTest, deleteNodesThenLoad) {
         _env->getSystemManager().getGraph(_workingGraphName)->getPath());
     ASSERT_TRUE(res);
 
-    const Tombstones& tombstones =
+    const auto tombstones =
         _loadedGraph->openTransaction().viewGraph().commits().back().tombstones();
 
     const Tombstones::NodeTombstones& nodeTombstones = tombstones.nodeTombstones();


### PR DESCRIPTION
# Description

## Summary

Fixed compiler warning (-Werror=dangling-reference) in TombstoneSerialisationTest.cpp by storing the temporary return value in a local variable instead of a const reference.

## Problem

The compiler detected a potentially dangling reference when storing the result of a chain of method calls in a const reference. The temporary object returned by tombstones() is destroyed at the end of the full expression, leaving a dangling reference.

## Solution
Store the result in a local variable using auto instead of a const reference:

### Before:

```cpp
const Tombstones& tombstones =
    _loadedGraph->openTransaction().viewGraph().commits().back().tombstones();
```

### After:

```cpp
const auto tombstones =
    _loadedGraph->openTransaction().viewGraph().commits().back().tombstones();
```

### Changes

Line 139: deleteNodesThenLoad_Test::TestBody()

### Testing

 Code compiles without warnings with -Werror=dangling-reference
 Existing tests pass

### Checklist

 Follows project coding standards
 No functional changes, only fixes compiler warning
 Maintains the same semantics with local copy instead of reference