### PR TITLE
Add manual CI to run on macos 14

### DIFF
--- a/.github/workflows/ci_macos14_manual.yml
+++ b/.github/workflows/ci_macos14_manual.yml
@@ -1,0 +1,13 @@
+name: CI Macos14
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci_build.yml
+    with:
+      os_list: '["macos-14"]'
+      python_version_list: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+


### PR DESCRIPTION
Add CI workflow to run build on macos 14 manually