### PR TITLE
Fix deadlock between SIGTERM sent to server thread and worker threads

### DIFF
--- a/net/http_server/HTTPServer.cpp
+++ b/net/http_server/HTTPServer.cpp
@@ -23,6 +23,15 @@ HTTPServer::~HTTPServer() {
 }
 
 FlowStatus HTTPServer::initialize() {
+    // Install no-op handler for SIGUSR1. Used by terminate() to interrupt
+    // worker threads blocked in eventWait() without triggering the SIGTERM
+    // handler (which would deadlock by calling stop() from a worker thread).
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = [](int) {};
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, nullptr);
+
     _serverSocket = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
     if (_serverSocket == -1) {
@@ -133,9 +142,13 @@ void HTTPServer::terminate() {
     spdlog::info("Terminating server");
     _running.store(false);
 
-    // Terminate all threads
+    // Wake up worker threads so they check _running and exit.
+    // Uses SIGUSR1 (no-op handler) instead of SIGTERM to avoid
+    // triggering the SIGTERM signal handler which calls stop()
+    // and deadlocks (worker joins server thread, server thread
+    // joins worker).
     for (auto& thread : _threads) {
-        pthread_kill(thread.native_handle(), SIGTERM);
+        pthread_kill(thread.native_handle(), SIGUSR1);
     }
 }
 
@@ -155,9 +168,15 @@ void HTTPServer::runThread(size_t threadID, ServerContext& ctxt) {
 
     for (;;) {
         const int nfds = utils::eventWait(instance, events.data(), eventCount, -1);
+
+        if (!ctxt._running.load()) {
+            return;
+        }
+
         if (nfds <= 0) {
             utils::logError("EpollWait");
             ctxt._status.store(FlowStatus::WAIT_ERROR);
+            continue;
         }
 
         for (int i = 0; i < nfds; i++) {

--- a/server/TuringServer.cpp
+++ b/server/TuringServer.cpp
@@ -86,13 +86,17 @@ void TuringServer::start() {
 }
 
 void TuringServer::wait() {
-    _serverThread.join();
+    if (_serverThread.joinable()) {
+        _serverThread.join();
+    }
     _server->terminate();
 }
 
 void TuringServer::stop() {
     _server->terminate();
-    _serverThread.join();
+    if (_serverThread.joinable()) {
+        _serverThread.join();
+    }
 }
 
 void TuringServer::setupSignals() {
@@ -105,5 +109,15 @@ void TuringServer::setupSignals() {
     sigemptyset(&sa.sa_mask);
     const int sigIntRes = sigaction(SIGINT, &sa, nullptr);
     const int sigTermRes = sigaction(SIGTERM, &sa, nullptr);
-    bioassert(sigIntRes >= 0 && sigTermRes >= 0, "Failed to setup signal handlers in TuringServer");
+    bioassert(sigIntRes >= 0 && sigTermRes >= 0,
+              "Failed to setup signal handlers in TuringServer");
+
+    // Unblock SIGTERM/SIGINT on the main thread so the sigaction handler
+    // fires for external signals (e.g. kill, Ctrl+C). Worker threads keep
+    // these signals blocked so they are delivered via signalfd/kqueue instead.
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+    pthread_sigmask(SIG_UNBLOCK, &mask, nullptr);
 }


### PR DESCRIPTION
Fix turingdb that was hanging in a deadlock when were sending SIGTERM with ctrl+c and stuck in "Terminating server"