### PR TITLE
Add a flake.nix for development environments and builds

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -105,7 +105,6 @@ OPENSSL_SRC_DIR=$BUILD_DIR/openssl-${OPENSSL_VERSION}
 if [[ ! -d "$OPENSSL_SRC_DIR" ]]; then
     echo "Extracting OpenSSL ${OPENSSL_VERSION}..."
     cd $BUILD_DIR
-    echo "looking for $SOURCE_DIR/external/$OPENSSL_TARBALL"
     tar xf "$SOURCE_DIR/external/$OPENSSL_TARBALL"
 fi
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -105,6 +105,7 @@ OPENSSL_SRC_DIR=$BUILD_DIR/openssl-${OPENSSL_VERSION}
 if [[ ! -d "$OPENSSL_SRC_DIR" ]]; then
     echo "Extracting OpenSSL ${OPENSSL_VERSION}..."
     cd $BUILD_DIR
+    echo "looking for $SOURCE_DIR/external/$OPENSSL_TARBALL"
     tar xf "$SOURCE_DIR/external/$OPENSSL_TARBALL"
 fi
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768649915,
-        "narHash": "sha256-jc21hKogFnxU7KXSVTRmxC7u5D4RHwm9BAvDf5/Z1Uo=",
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3f3c7f9977dc123c23ee21e8085ed63daf8c37",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-25.05-darwin",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768649915,
+        "narHash": "sha256-jc21hKogFnxU7KXSVTRmxC7u5D4RHwm9BAvDf5/Z1Uo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3e3f3c7f9977dc123c23ee21e8085ed63daf8c37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "TuringDB - the fastest in-memory graph database";
 
   inputs = {
-    nixpkgs.url =  "github:nixos/nixpkgs/nixpkgs-25.05-darwin";
+    nixpkgs.url =  "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -17,7 +17,7 @@
           darwin = pkgs.stdenv.isDarwin;
 
           # We use LLVM on macOS; gcc on Linux
-          compiler = if darwin then pkgs.llvmPackages_20 else pkgs.gcc15;
+          compiler = if darwin then pkgs.llvmPackages_21 else pkgs.gcc15;
           turingstdenv = compiler.stdenv;
           
           # If using LLVM, we need to specify OpenMP explictly
@@ -26,7 +26,7 @@
             compiler.libcxx
 
             # macOS-specific debugging utilities
-            lldb_20
+            lldb_21
           ] else [];
 
           # If on Linux, add gcc15 as an input explicitly
@@ -48,6 +48,7 @@
             cmake
             git-lfs
             gnum4
+            python3
 
             # clangd, clang-format, etc.
             clang-tools

--- a/flake.nix
+++ b/flake.nix
@@ -16,14 +16,16 @@
 
           darwin = pkgs.stdenv.isDarwin;
 
+          # We use LLVM on macOS; gcc on Linux
           compiler = if darwin then pkgs.llvmPackages20 else pkgs.gcc15;
-
           turingstdenv = compiler.stdenv;
           
+          # If using LLVM, we need to specify OpenMP explictly
           darwinInputs = if darwin then [
             compiler.openmp
           ] else [];
 
+          # If on Linux, add gcc15 as an input explicitly
           linuxInputs = if !darwin then [
             compiler
           ] else [];

--- a/flake.nix
+++ b/flake.nix
@@ -21,13 +21,24 @@
           turingstdenv = compiler.stdenv;
           
           # If using LLVM, we need to specify OpenMP explictly
-          darwinInputs = if darwin then [
+          darwinInputs = with pkgs; if darwin then [
             compiler.openmp
+            compiler.libcxx
+
+            # macOS-specific debugging utilities
+            lldb_20
           ] else [];
 
           # If on Linux, add gcc15 as an input explicitly
-          linuxInputs = if !darwin then [
+          linuxInputs = with pkgs; if !darwin then [
             compiler
+
+            # Linux-specific debugging utilities
+            gdb
+            valgrind
+
+            # Linux-specific performance analysis tools
+            linuxPackages_latest.perf
           ] else [];
 
           sharedNativeBuildInputs = with pkgs; [];
@@ -40,21 +51,56 @@
 
             # clangd, clang-format, etc.
             clang-tools
-
-            # Debugging utilities
-            gdb
-            valgrind
-
-            # Performance analysis tools
-            linuxPackages_latest.perf
           ] ++ darwinInputs ++ linuxInputs;
 
+          macos_setup = ''
+            # Detect the macOS SDK path
+            MACOS_SDK_PATH=$(xcrun --show-sdk-path 2>/dev/null)
+          
+            # Set LLVM_PREFIX to the Nix store path
+            LLVM_PREFIX="${compiler.clang}"
+            LIBCXX_PATH="${compiler.libcxx}/lib/c++"
+          
+            # Common macOS toolchain args for building all dependencies with LLVM
+            MACOS_COMPILER_ARGS=(
+                "-DCMAKE_C_COMPILER=$LLVM_PREFIX/bin/clang"
+                "-DCMAKE_CXX_COMPILER=$LLVM_PREFIX/bin/clang++"
+                "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+                "-DCMAKE_OSX_SYSROOT=$MACOS_SDK_PATH"
+                "-DCMAKE_EXE_LINKER_FLAGS=-L$LIBCXX_PATH -Wl,-rpath,$LIBCXX_PATH"
+                "-DCMAKE_SHARED_LINKER_FLAGS=-L$LIBCXX_PATH -Wl,-rpath,$LIBCXX_PATH"
+            )
+          
+            # Build a properly quoted CMAKE_ARGS string
+            QUOTED_ARGS=()
+            for arg in "''${MACOS_COMPILER_ARGS[@]}"; do
+                QUOTED_ARGS+=("'$arg'")
+            done
+          
+            # Write environment variables to $MACOS_SETENV
+            DEPENDENCIES_DIR=external/dependencies
+            MACOS_SETENV=$DEPENDENCIES_DIR/macos_setenv.sh
+            echo "export LLVM_PREFIX=$LLVM_PREFIX" > "$MACOS_SETENV"
+            echo "export CMAKE_ARGS=\"''${QUOTED_ARGS[*]}\"" >> "$MACOS_SETENV"
+          
+            echo "LLVM_PREFIX: $LLVM_PREFIX"
+            echo "LIBCXX_PATH: $LIBCXX_PATH"
+            echo "macOS SDK: $MACOS_SDK_PATH"
+            echo ""
+            echo "Environment written to: $MACOS_SETENV"
+            echo "Source it with: source $MACOS_SETENV"
+            echo ""
+            echo "libc++ static libraries available at:"
+            ls -lh ${compiler.libcxx}/lib/*.a 2>/dev/null || echo "  (none found)"
+          '';
         in
         {
           # Development shell: facilitates manual building and development of TuringDB
           devShells.default = pkgs.mkShell.override { stdenv = turingstdenv; } {
             nativeBuildInputs = sharedNativeBuildInputs;
             buildInputs = sharedBuildInputs;
+
+            shellHook = if darwin then macos_setup else "echo 'linux'";
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           darwin = pkgs.stdenv.isDarwin;
 
           # We use LLVM on macOS; gcc on Linux
-          compiler = if darwin then pkgs.llvmPackages20 else pkgs.gcc15;
+          compiler = if darwin then pkgs.llvmPackages_20 else pkgs.gcc15;
           turingstdenv = compiler.stdenv;
           
           # If using LLVM, we need to specify OpenMP explictly

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "TuringDB - the fastest in-memory graph database";
+
+  inputs = {
+    nixpkgs.url =  "github:nixos/nixpkgs/nixpkgs-25.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ] (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          darwin = pkgs.stdenv.isDarwin;
+
+          compiler = if darwin then pkgs.llvmPackages20 else pkgs.gcc15;
+
+          turingstdenv = compiler.stdenv;
+          
+          darwinInputs = if darwin then [
+            compiler.openmp
+          ] else [];
+
+          linuxInputs = if !darwin then [
+            compiler
+          ] else [];
+
+          sharedNativeBuildInputs = with pkgs; [];
+
+          sharedBuildInputs = with pkgs; [
+            cmake
+            git-lfs
+            gnum4
+          ] ++ darwinInputs ++ linuxInputs;
+
+        in
+        {
+          packages.default = turingstdenv.mkDerivation {
+            pname = "turingdb";
+            version = "1.20";
+
+            src = ./.;
+
+            nativeBuildInputs = sharedNativeBuildInputs;
+            buildInputs = sharedBuildInputs;
+
+            cmakeFlags = [
+              "-DNIX_BUILD=ON" # CMake flag for top-level turingdb CMakeLists
+              "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_CXX_FLAGS=-fopenmp"
+            ] ++ pkgs.lib.optionals darwin [
+              "-DOpenMP_CXX_FLAGS=-fopenmp"
+              "-DOpenMP_CXX_LIB_NAMES=omp"
+              "-DOpenMP_omp_LIBRARY=${pkgs.llvmPackages_20.openmp}/lib/libomp.dylib"
+            ];
+
+            preConfigure = ''
+              if [ ! -d "common/.git" ]; then
+                echo "Warning: Submodules might not be properly initialized"
+              fi
+            '';
+
+            meta = {
+              description = "High performance in-memory column-oriented graph database engine";
+              longDescription = ''
+                TuringDB is a high-performance in-memory column-oriented graph database engine
+                designed for analytical and read-intensive workloads. Built from scratch in C++,
+                it delivers millisecond query latency on graphs with millions of nodes and edges.
+
+                Key features:
+                - 0.1-50ms query latency for analytical queries on 10M+ node graphs
+                - Zero-lock concurrency model
+                - Git-like versioning system for graphs
+                - OpenCypher query language support
+                - Python SDK with comprehensive API
+              '';
+              homepage = "https://turingdb.ai";
+              changelog = "https://github.com/turing-db/turingdb/releases";
+              # license = pkgs.licenses.bsl11;
+              platforms = [ "x86_64-linux" "aarch64-darwin" ];
+              mainProgram = "turingdb";
+              maintainers = with pkgs.lib.maintainers; [ cyrusknopf ];
+            };
+          };
+
+          # Dev shell
+          devShells.default = pkgs.mkShell.override { stdenv = turingstdenv; } {
+            nativeBuildInputs = sharedNativeBuildInputs;
+            buildInputs = sharedBuildInputs;
+
+            # shellHook = "bash ./pull.sh";
+          };
+        }
+      );
+}

--- a/test-suite/flake.lock
+++ b/test-suite/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768649915,
+        "narHash": "sha256-jc21hKogFnxU7KXSVTRmxC7u5D4RHwm9BAvDf5/Z1Uo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3e3f3c7f9977dc123c23ee21e8085ed63daf8c37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/test-suite/flake.nix
+++ b/test-suite/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "TuringDB - the fastest in-memory graph database";
+  description = "TuringDB query test-suite";
 
   inputs = {
     nixpkgs.url =  "github:nixos/nixpkgs/nixpkgs-25.05-darwin";

--- a/test-suite/flake.nix
+++ b/test-suite/flake.nix
@@ -17,41 +17,18 @@
           darwin = pkgs.stdenv.isDarwin;
 
           # We use LLVM on macOS; gcc on Linux
-          compiler = if darwin then pkgs.llvmPackages_20 else pkgs.gcc15;
+          compiler = if darwin then pkgs.llvmPackages20 else pkgs.gcc15;
           turingstdenv = compiler.stdenv;
           
-          # If using LLVM, we need to specify OpenMP explictly
-          darwinInputs = if darwin then [
-            compiler.openmp
-          ] else [];
-
-          # If on Linux, add gcc15 as an input explicitly
-          linuxInputs = if !darwin then [
-            compiler
-          ] else [];
-
           sharedNativeBuildInputs = with pkgs; [];
 
           sharedBuildInputs = with pkgs; [
-            # Build tools
-            cmake
-            git-lfs
-            gnum4
-
-            # clangd, clang-format, etc.
-            clang-tools
-
-            # Debugging utilities
-            gdb
-            valgrind
-
-            # Performance analysis tools
-            linuxPackages_latest.perf
-          ] ++ darwinInputs ++ linuxInputs;
+            # Bun is required to run the test-suite web UI
+            bun
+          ];
 
         in
         {
-          # Development shell: facilitates manual building and development of TuringDB
           devShells.default = pkgs.mkShell.override { stdenv = turingstdenv; } {
             nativeBuildInputs = sharedNativeBuildInputs;
             buildInputs = sharedBuildInputs;


### PR DESCRIPTION
Adds two Nix flakes, one for entering a dev environment for C++ development on TuringDB, and one flake containing the dependencies for `test-suite`, namely `bun`.

Both flakes currently add a devShell, but do not add build (derivation) instructions.