### PR TITLE
Build wheel for Intel Haswell by default on x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if(NOT APPLE)
        AND "$ENV{TURING_NATIVE_BUILD}" STREQUAL "1")
         set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -march=native")
     else()
-        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -march=x86-64-v3")
+        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -march=haswell")
     endif()
 endif()
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -79,13 +79,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 # Linux x86_64 architecture targeting for portable PyPI wheels.
-# Default: -march=x86-64-v3 (Haswell-level: AVX2, FMA, BMI1/2)
+# Default: -march=haswell (AVX2, FMA, BMI1/2)
 # Set TURING_NATIVE_BUILD=1 to use -march=native for local development.
 if [[ "$(uname)" == "Linux" ]]; then
     if [[ "${TURING_NATIVE_BUILD:-}" == "1" ]]; then
         ARCH_FLAG="-march=native"
     else
-        ARCH_FLAG="-march=x86-64-v3"
+        ARCH_FLAG="-march=haswell"
     fi
     LINUX_ARCH_ARGS=(
         "-DCMAKE_C_FLAGS=${ARCH_FLAG}"


### PR DESCRIPTION
Build wheel and dependencies targetting Intel Haswell architecture by default.

Use environment variable TURING_NATIVE_BUILD=1 to use -march=native