### PR TITLE
Fix narrowing conversion in getCommitIndex

### DIFF
--- a/storage/versioning/VersionController.cpp
+++ b/storage/versioning/VersionController.cpp
@@ -1,5 +1,7 @@
 #include "VersionController.h"
 
+#include <optional>
+
 #include <range/v3/view/enumerate.hpp>
 
 #include "JobSystem.h"
@@ -139,11 +141,11 @@ void VersionController::addCommit(std::unique_ptr<Commit> commit) {
     _head.store(ptr);
 }
 
-ssize_t VersionController::getCommitIndex(CommitHash hash) const {
+std::optional<size_t> VersionController::getCommitIndex(CommitHash hash) const {
     auto it = _offsets.find(hash);
 
     if (it == _offsets.end()) {
-        return -1;
+        return std::nullopt;
     }
 
     return it->second;
@@ -154,8 +156,10 @@ Commit::CommitSpan VersionController::getCommitsSinceCommitHash(CommitHash from)
     // Should not be trying to check conflicts if we are not rebasing
     bioassert(from != CommitHash::head(), "should not be checking conflicts if not rebasing");
 
-    const ssize_t startIndex = getCommitIndex(from);
-    bioassert(startIndex != -1, "Could not find Commit with hash {:x}", from.get());
+    const std::optional<size_t> startIndexOpt = getCommitIndex(from);
+    bioassert(startIndexOpt, "Could not find Commit with hash {:x}", from.get());
+
+    const size_t startIndex = *startIndexOpt;
     bioassert(static_cast<size_t>(startIndex) + 1 <= _commits.size(), "invalid startIndex");
 
     // +1 to skip the commit we branched from

--- a/storage/versioning/VersionController.h
+++ b/storage/versioning/VersionController.h
@@ -14,7 +14,6 @@
 #include "versioning/Commit.h"
 #include "versioning/CommitHash.h"
 #include "DataPart.h"
-#include "versioning/WriteSet.h"
 
 namespace db {
 
@@ -49,7 +48,8 @@ public:
     [[nodiscard]] CommitHash getHeadHash() const;
     [[nodiscard]] const Graph* getGraph() const { return _graph; }
 
-    ssize_t getCommitIndex(CommitHash hash) const;
+    /// Gets the offset for a given commit hash, or nullopt if not found
+    std::optional<size_t> getCommitIndex(CommitHash hash) const;
 
     WeakArc<CommitData> createCommitData(CommitHash hash) {
         Profile profile("VersionController::createCommitData");


### PR DESCRIPTION
Context:
- Previous implementation used narrowing conversion from `size_t` to `ssize_t`, which is implementation-defined and unsafe since it is possible for a `size_t` to be greater than that which is representable by a `ssize_t`

Changes:
- Replace `-1`; `size_t` semantics with `std::optional<size_t>`