### PR TITLE
Now using monospace font in the json renderer in the test suite

### DIFF
--- a/test-suite/frontend/src/App.tsx
+++ b/test-suite/frontend/src/App.tsx
@@ -1747,7 +1747,7 @@ export default function App() {
                   try {
                     const parsed = JSON.parse(raw);
                     return (
-                      <div className="mt-3 max-h-[36rem] overflow-auto rounded-xl bg-paper p-3 text-xs">
+                      <div className="mt-3 max-h-[36rem] overflow-auto rounded-xl bg-paper p-3 text-xs font-mono">
                         <JsonView data={parsed} style={darkStyles} />
                       </div>
                     );


### PR DESCRIPTION
<img width="510" height="189" alt="image" src="https://github.com/user-attachments/assets/972ac5cf-1397-4691-9e5d-15e4e175a3e8" />
