### PR TITLE
Correctly encode ColumnConst in JsonEncoder

### DIFF
--- a/query/outputs/JsonEncoder.h
+++ b/query/outputs/JsonEncoder.h
@@ -58,6 +58,10 @@ public:
         }
     }
 
+private:
+    WriterT& _writer;
+    const size_t _logicalRowCount {0};
+
     template <Optional T>
     void encodeValue(const T& value) {
         if (!value.has_value()) {
@@ -99,10 +103,6 @@ public:
     void encodeValue(const T& value) {
         _writer.write(fmt::format("\"{}\"", value));
     }
-
-private:
-    WriterT& _writer;
-    const size_t _logicalRowCount {0};
 };
 
 template <Writer WriterT>


### PR DESCRIPTION
Context:
- With the new `JsonEncoder`, `ColumnConst<T>` only outputted a single value

Changes:
- Use `Dataframe::getLogicalRowCount` to determine how many values of `ColumnVector<T>` and `ColumnConst<T>` to output

Note: Cannot verify behaviour of returning `ColumnConst<T>` in this PR because it is not possible to return a `ColumnConst<T>` of logical-length greater than 1 until #407 is merged, however there are passing tests in #407 with the same changes in this PR applied