### PR TITLE
Now sanitizing strings before outputing to json

### DIFF
--- a/query/outputs/JsonEncoder.h
+++ b/query/outputs/JsonEncoder.h
@@ -61,6 +61,7 @@ public:
 private:
     WriterT& _writer;
     const size_t _logicalRowCount {0};
+    std::string _escaped;
 
     template <Optional T>
     void encodeValue(const T& value) {
@@ -105,7 +106,31 @@ private:
 
     template <std::convertible_to<std::string_view> T>
     void encodeValue(const T& value) {
-        _writer.write(fmt::format("\"{}\"", value));
+        sanitizeJsonString(value);
+        _writer.write(_escaped);
+    }
+
+    void sanitizeJsonString(std::string_view input) {
+        constexpr std::string_view escapedQuotes = "\\\"";
+        constexpr std::string_view escapedBackslash = "\\\\";
+        constexpr std::string_view escapedNewline = "\\n";
+
+        _escaped.clear();
+        _escaped.push_back('\"');
+
+        for (const char c : input) {
+            if (c == '"') {
+                _escaped += escapedQuotes;
+            } else if (c == '\\') {
+                _escaped += escapedBackslash;
+            } else if (c == '\n') {
+                _escaped += escapedNewline;
+            } else {
+                _escaped += c;
+            }
+        }
+
+        _escaped.push_back('\"');
     }
 };
 


### PR DESCRIPTION
This fixes issue #447. Should wait for #445

- Before the fix:
```
>>> from turingdb import TuringDB; t = TuringDB(); t.try_reach(); t.set_graph('reactome');
>>> t.query('MATCH (n { displayName: \'"Activator" RAF:YWHAB dimer binds RAS:GTP\' }) RETURN n, n.displayName')
Traceback (most recent call last):
  File "<python-input-6>", line 1, in <module>
    t.query('MATCH (n { displayName: \'"Activator" RAF:YWHAB dimer binds RAS:GTP\' }) RETURN n, n.displayName')
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/turingdb/main/python/turingdb/turingdb.py", line 82, in query
    json = self._send_request("query", data=query, params=self._params)
  File "/home/ubuntu/work/turingdb/main/python/turingdb/turingdb.py", line 177, in _send_request
    json = orjson.loads(response.text)
orjson.JSONDecodeError: unexpected character: line 1 column 153 (char 152)
```

- After the fix:
```
>>> from turingdb import TuringDB; t = TuringDB(); t.try_reach(); t.set_graph('reactome');
>>> t.query('MATCH (n { displayName: \'"Activator" RAF:YWHAB dimer binds RAS:GTP\' }) RETURN n, n.displayName')
       n                              n.displayName
0  31489  "Activator" RAF:YWHAB dimer binds RAS:GTP
1  46748  "Activator" RAF:YWHAB dimer binds RAS:GTP
2  46750  "Activator" RAF:YWHAB dimer binds RAS:GTP
3  46752  "Activator" RAF:YWHAB dimer binds RAS:GTP
4  46753  "Activator" RAF:YWHAB dimer binds RAS:GTP
5  46810  "Activator" RAF:YWHAB dimer binds RAS:GTP
6  46812  "Activator" RAF:YWHAB dimer binds RAS:GTP
7  46814  "Activator" RAF:YWHAB dimer binds RAS:GTP
8  46816  "Activator" RAF:YWHAB dimer binds RAS:GTP
```