### PR TITLE
Fixed escape sequences in HTTP response

### DIFF
--- a/common/ControlCharacters.h
+++ b/common/ControlCharacters.h
@@ -1,54 +1,95 @@
 #pragma once
 
+#include <string.h>
 #include <string>
+#include <array>
 
 class ControlCharactersEscaper {
 public:
-    static void escape(std::string_view src, std::string& result) {
-        result.clear();
-        for (const char c : src) {
-            switch (c) {
-                case '\a': {
-                    result += "\\a";
-                    break;
+    static void escapeAndSurroundByQuotes(std::string_view src, std::string& res) {
+        res.resize(src.size() + 1);
+        res[0] = '"';
+        escapeImpl(src, res, 1);
+        res.push_back('"');
+    }
+
+    static void escape(std::string_view src, std::string& res) {
+        res.resize(src.size());
+        escapeImpl(src, res);
+    }
+
+    static void escapeImpl(std::string_view src, std::string& res, size_t start = 0) {
+        size_t i = start;
+
+        for (const unsigned char c : src) {
+            if (c >= _controlMap.size()) {
+                if (c == '"') {
+                    // Escape double quotes
+                    res.resize(res.size() + 2);
+                    res[i++] = '\\';
+                    res[i++] = '"';
+
+                } else if (c == '\\') {
+                    // Escape backslashes
+                    res.resize(res.size() + 2);
+                    res[i++] = '\\';
+                    res[i++] = '\\';
+
+                } else {
+                    // Normal character
+                    res[i++] = static_cast<char>(c);
                 }
-                case '\x08': {
-                    result += "\\b";
-                    break;
-                }
-                case '\t': {
-                    result += "\\t";
-                    break;
-                }
-                case '\n': {
-                    result += "\\n";
-                    break;
-                }
-                case '\v': {
-                    result += "\\v";
-                    break;
-                }
-                case '\f': {
-                    result += "\\f";
-                    break;
-                }
-                case '\r': {
-                    result += "\\r";
-                    break;
-                }
-                case '\"': {
-                    result += "\\\"";
-                    break;
-                }
-                case '\\': {
-                    result += "\\\\";
-                    break;
-                }
-                default: {
-                    result += c;
-                    break;
-                }
+            } else {
+                // Retrieve the escape sequence for the control character
+                // and append it to the result string
+                const std::string_view esc = _controlMap[c];
+
+                res.resize(res.size() + esc.size());
+                memcpy(res.data() + i, esc.data(), esc.size());
+                i += esc.size();
             }
         }
+
+        res.resize(i);
     }
+
+    static constexpr std::string_view escapedControlCharacter(char c) {
+        return _controlMap[static_cast<unsigned char>(c)];
+    }
+
+private:
+    static constexpr std::array<std::string_view, 32> _controlMap = {
+        "\\u0000",
+        "\\u0001",
+        "\\u0002",
+        "\\u0003",
+        "\\u0004",
+        "\\u0005",
+        "\\u0006",
+        "\\u0007",
+        "\\b",
+        "\\t",
+        "\\n",
+        "\\u000B",
+        "\\f",
+        "\\r",
+        "\\u000E",
+        "\\u000F",
+        "\\u0010",
+        "\\u0011",
+        "\\u0012",
+        "\\u0013",
+        "\\u0014",
+        "\\u0015",
+        "\\u0016",
+        "\\u0017",
+        "\\u0018",
+        "\\u0019",
+        "\\u001A",
+        "\\u001B",
+        "\\u001C",
+        "\\u001D",
+        "\\u001E",
+        "\\u001F",
+    };
 };

--- a/net/http_server/NetWriter.h
+++ b/net/http_server/NetWriter.h
@@ -200,17 +200,19 @@ public:
             return;
         }
 
-        if (content.size() > _chunk._remaining) {
-            flush();
-
-            if (content.size() > _maxChunkSize) {
-                _status = Status::ValueTooLarge;
-                return;
+        while (!content.empty()) {
+            if (_chunk._remaining == 0) {
+                flush();
             }
-        }
 
-        memcpy(_chunk._content.data() + _chunk._position, content.data(), content.size());
-        _chunk.increment(content.size());
+            const size_t copySize = std::min(content.size(), _chunk._remaining);
+            memcpy(_chunk._content.data() + _chunk._position, content.data(), copySize);
+            _chunk.increment(copySize);
+
+            // If string was too large to fit in chunk, send the remaining parts
+            // in subsequent chunks
+            content.remove_prefix(copySize);
+        }
     }
 
     void write(char c) {

--- a/python/turingdb/turingdb.py
+++ b/python/turingdb/turingdb.py
@@ -112,13 +112,14 @@ class TuringDB:
             raise TuringDBException("Cannot create a new change while working on one")
 
         if self._params.get("commit") is not None:
-            raise TuringDBException("Cannot create a new change while working on a commit")
+            raise TuringDBException(
+                "Cannot create a new change while working on a commit"
+            )
 
         res = self.query("CHANGE NEW")
         change_id = int(res.loc[0, "changeID"])
         self.set_change(change_id)
         return change_id
-
 
     def set_graph(self, graph_name: str):
         self._params["graph"] = graph_name
@@ -174,7 +175,20 @@ class TuringDB:
             )
         response.raise_for_status()
 
-        json = orjson.loads(response.text)
+        try:
+            json = orjson.loads(response.text)
+        except orjson.JSONDecodeError as e:
+            # Grab a window around the error position
+            start = max(0, e.pos - 40)
+            end = min(len(e.doc), e.pos + 40)
+            snippet = e.doc[start:end]
+            pointer = " " * (e.pos - start) + "^"
+            raise TuringDBException(
+                f"Invalid response from the server: {e}.\n"
+                f"Context (line {e.lineno}, col {e.colno}):\n"
+                f"  {snippet}\n"
+                f"  {pointer}"
+            )
 
         if isinstance(json, dict):
             err = json.get("error")
@@ -212,10 +226,14 @@ class TuringDB:
         df = pd.DataFrame()
 
         for chunk in json["data"]:
-            df_chunk = pd.DataFrame({
-                cname: pd.Series(col, dtype=dtype_map.get(ctype, "object"))
-                for (cname, ctype), col in zip(zip(column_names, column_types), chunk)
-            })
+            df_chunk = pd.DataFrame(
+                {
+                    cname: pd.Series(col, dtype=dtype_map.get(ctype, "object"))
+                    for (cname, ctype), col in zip(
+                        zip(column_names, column_types), chunk
+                    )
+                }
+            )
             df = pd.concat([df, df_chunk], ignore_index=True)
 
         self._t1 = time.time()

--- a/query/outputs/JsonEncoder.h
+++ b/query/outputs/JsonEncoder.h
@@ -8,6 +8,7 @@
 #include "dataframe/Dataframe.h"
 #include "OutputWriter.h"
 #include "OutputValues.h"
+#include "ControlCharacters.h"
 
 namespace db {
 
@@ -61,7 +62,7 @@ public:
 private:
     WriterT& _writer;
     const size_t _logicalRowCount {0};
-    std::string _escaped;
+    std::string _sanitized;
 
     template <Optional T>
     void encodeValue(const T& value) {
@@ -97,7 +98,8 @@ private:
     }
 
     void encodeValue(ValueType value) {
-        _writer.write(fmt::format("\"{}\"", ValueTypeName::value(value)));
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(ValueTypeName::value(value), _sanitized);
+        _writer.write(_sanitized);
     }
 
     void encodeValue(PropertyNull) {
@@ -106,31 +108,8 @@ private:
 
     template <std::convertible_to<std::string_view> T>
     void encodeValue(const T& value) {
-        sanitizeJsonString(value);
-        _writer.write(_escaped);
-    }
-
-    void sanitizeJsonString(std::string_view input) {
-        constexpr std::string_view escapedQuotes = "\\\"";
-        constexpr std::string_view escapedBackslash = "\\\\";
-        constexpr std::string_view escapedNewline = "\\n";
-
-        _escaped.clear();
-        _escaped.push_back('\"');
-
-        for (const char c : input) {
-            if (c == '"') {
-                _escaped += escapedQuotes;
-            } else if (c == '\\') {
-                _escaped += escapedBackslash;
-            } else if (c == '\n') {
-                _escaped += escapedNewline;
-            } else {
-                _escaped += c;
-            }
-        }
-
-        _escaped.push_back('\"');
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(value, _sanitized);
+        _writer.write(_sanitized);
     }
 };
 
@@ -194,8 +173,8 @@ public:
         key("column_types");
         arr();
 
-        std::string columnName;
-        ColumnTypeGenerator generator(columnName);
+        std::string columnType;
+        ColumnTypeGenerator generator(columnType);
 
         using Types = OutputtedTypes;
         using ColTypeGen = ColumnSingleDispatcher<Types::Allowed, ColumnTypeGenerator, Types::Excluded>;
@@ -205,7 +184,7 @@ public:
 
             ColTypeGen::dispatch(col, generator);
 
-            value(columnName);
+            value(columnType);
         }
 
         end(); // column_types
@@ -270,10 +249,11 @@ public:
     }
 
     void key(std::string_view k) {
+        ControlCharactersEscaper::escape(k, _sanitized);
         if (_comma) {
-            _writer.write(fmt::format(",\"{}\":", k));
+            _writer.write(fmt::format(",\"{}\":", _sanitized));
         } else {
-            _writer.write(fmt::format("\"{}\":", k));
+            _writer.write(fmt::format("\"{}\":", _sanitized));
         }
 
         _comma = false;
@@ -284,18 +264,14 @@ public:
             end();
         }
 
+        // Escape error message
         const std::string_view errstr = QueryStatusDescription::value(status);
-        std::string sanitizedDetails;
-        sanitizeJsonString(details.empty()
-                               ? "No error message available."
-                               : details,
-                           sanitizedDetails);
 
         key("error");
         value(errstr);
 
         key("error_details");
-        value(sanitizedDetails);
+        value(details.empty() ? "No error message available." : details);
     }
 
     void encodeTime(float milliseconds) {
@@ -308,35 +284,22 @@ public:
     }
 
     void value(std::string_view v) {
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(v, _sanitized);
         if (_comma) {
-            _writer.write(fmt::format(",\"{}\"", v));
+            _writer.write(',');
+            _writer.write(_sanitized);
         } else {
-            _writer.write(fmt::format("\"{}\"", v));
+            _writer.write(_sanitized);
         }
 
         _comma = true;
-    }
-
-    static void sanitizeJsonString(std::string_view input, std::string& res) {
-        res.reserve(input.size() * 1.2);
-
-        for (const char c : input) {
-            if (c == '"') {
-                res += "\\\"";
-            } else if (c == '\\') {
-                res += "\\\\";
-            } else if (c == '\n') {
-                res += "\\n";
-            } else {
-                res += c;
-            }
-        }
     }
 
 private:
     WriterT& _writer;
     std::string _closingTokens;
     bool _comma {false};
+    std::string _sanitized;
 };
 
 }


### PR DESCRIPTION
## Summary
- Handle all control characters properly in JSONEncoder = '\' and '"'
- Send large strings in multiple chunks in NetWriter
- Better error messages if orjson fails in the SDK

## Fixes all bugs in reactome:
- Send all the text properties (huge strings + many risky characters)
```
>>> t.query('MATCH (n) WHERE n.text IS NOT NULL RETURN n, n.text')
             n                                             n.text
0      2442661  The methyl ester produced by the action of PCM...
1      2442662  WNT5A induces internalization of FZD4 in a man...
2      2442663  WNT5A-dependent FZD4 uptake into clathrin-coat...
3      2442664  In capillaries of the lungs Erythrocytes take ...
4      2442665  The Cpt1a gene is transcribed to yield mRNA (M...
...        ...                                                ...
21327  2463988  N-sulphoglucosamine sulphohydrolase (SGSH) hyd...
21328  2463989  Extracellular signal-regulated kinase 5 (ERK5)...
21329  2463990  Neuroligins (NLGNs) bind to the third PDZ doma...
21330  2463991  CXXC5 expression is estrogen-responsive and de...
21331  2463992  The latent precursor form of heparanase (proHP...

[21332 rows x 2 columns]
```

- Send all displayNames
```
>>> t.query('MATCH (n) RETURN n.displayName')
                                      n.displayName
0                                         Drug ADME
1                                         Drug ADME
2                                         Drug ADME
3                                         Drug ADME
4                                         Drug ADME
...                                             ...
2978197  UniProt:Q02241 <-> UniProt:Q9H8V3 (IntAct)
2978198  UniProt:Q02241 <-> UniProt:Q9WVM1 (IntAct)
2978199  UniProt:Q02241 <-> UniProt:Q9Z179 (IntAct)
2978200  UniProt:Q02241 <-> UniProt:Q9JLQ0 (IntAct)
2978201  UniProt:Q02241 <-> UniProt:P62258 (IntAct)

[2978202 rows x 1 columns]
```

