### PR TITLE
Remove old cast now that we use optional

### DIFF
--- a/storage/versioning/VersionController.cpp
+++ b/storage/versioning/VersionController.cpp
@@ -193,7 +193,6 @@ Commit::CommitSpan VersionController::getCommitsSinceCommitHash(CommitHash from)
     bioassert(startIndexOpt, "Could not find Commit with hash {:x}", from.get());
 
     const size_t startIndex = *startIndexOpt;
-    bioassert(static_cast<size_t>(startIndex) + 1 <= _commits.size(), "invalid startIndex");
 
     // +1 to skip the commit we branched from
     const auto* spanStart = _commits.data() + startIndex + 1;


### PR DESCRIPTION
Previously casted from `ssize_t` to `size_t`, now use `std::optional`. Cast was not removed in move to `std::optional`.