### PR TITLE
Fix Full Matrix CI: Use std::iota instead of std::ranges::iota 

### DIFF
--- a/query/pipeline/processors/OrderByProcessor.cpp
+++ b/query/pipeline/processors/OrderByProcessor.cpp
@@ -575,7 +575,7 @@ void OrderByProcessor::merge() {
     // Reset @ref _indices, we now need to determine the correct order of all rows from
     // each sorted run in memory
     _indices->resize(memRowCount);
-    std::ranges::iota(*_indices, 0);
+    std::iota(_indices->begin(), _indices->end(), (size_t)0);
 
     SortedRun mergedRun = _sortedRuns.front();
 


### PR DESCRIPTION
std::ranges::iota is not present on gcc 11/12 used on Ubuntu 22.04.

Full Matrix build CI was failing https://github.com/turing-db/turingdb/actions/runs/22503755762