### PR TITLE
Use date-based dev version for nightly releases to avoid PyPI conflicts

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -14,6 +14,10 @@ on:
       python_version_list:
         required: true
         type: string
+      dev_version_suffix:
+        required: false
+        type: string
+        default: ''
 
   workflow_dispatch:
 
@@ -56,10 +60,32 @@ jobs:
     - name: Setup Python
       run: uv python install ${{ matrix.python_version }}
 
+    - name: Compute version override
+      id: version
+      if: inputs.dev_version_suffix != ''
+      run: |
+        DESC=$(git describe --tags --long --match 'v*' --first-parent)
+        TAG_VERSION=$(echo "$DESC" | sed 's/^v\(.*\)-[0-9]*-g[0-9a-f]*$/\1/')
+        DISTANCE=$(echo "$DESC" | sed 's/^v.*-\([0-9]*\)-g[0-9a-f]*$/\1/')
+        if [ "$DISTANCE" != "0" ]; then
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$TAG_VERSION"
+          PATCH=${PATCH:-0}
+          PATCH=$((PATCH + 1))
+          VERSION="${MAJOR}.${MINOR}.${PATCH}.dev${{ inputs.dev_version_suffix }}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed version override: $VERSION"
+        fi
+
     - name: Build wheel
-      run: ./build.sh
+      run: |
+        if [ -n "$VERSION_OVERRIDE" ]; then
+          export SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION_OVERRIDE"
+          echo "Using version: $SETUPTOOLS_SCM_PRETEND_VERSION"
+        fi
+        ./build.sh
       env:
         PYTHON_VERSION: ${{ matrix.python_version }}
+        VERSION_OVERRIDE: ${{ steps.version.outputs.version }}
 
     - name: Prepare SimpleDB
       run: |

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -15,8 +15,13 @@ jobs:
     outputs:
       os_list: '["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15", "macos-26"]'
       python_version_list: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      dev_version_suffix: ${{ steps.suffix.outputs.value }}
     steps:
       - run: echo "Defining matrix"
+      - name: Compute dev version suffix for nightly builds
+        id: suffix
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        run: echo "value=$(date -u +%Y%m%d%H%M)" >> "$GITHUB_OUTPUT"
 
   build-release:
     needs: setup
@@ -24,6 +29,7 @@ jobs:
     with:
       os_list: ${{ needs.setup.outputs.os_list }}
       python_version_list: ${{ needs.setup.outputs.python_version_list }}
+      dev_version_suffix: ${{ needs.setup.outputs.dev_version_suffix }}
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
Scheduled and manual CI releases now use YYYYMMDDHHMM as the dev version suffix (via SETUPTOOLS_SCM_PRETEND_VERSION) instead of the git commit distance. This ensures each run produces a unique version even without new commits, preventing "file already exists" errors from PyPI. Tag-based releases and regular push/PR builds are unaffected.