### PR TITLE
Fix EdgeOutputInterface::connectTo ignoring projected stream

### DIFF
--- a/query/pipeline/interfaces/PipelineInterface.cpp
+++ b/query/pipeline/interfaces/PipelineInterface.cpp
@@ -101,9 +101,7 @@ void PipelineEdgeOutputInterface::connectTo(PipelineNodeInputInterface& input) {
 }
 
 void PipelineEdgeOutputInterface::connectTo(PipelineBlockInputInterface& input) {
-    input.setStream(EntityOutputStream::createEdgeStream(_edgeIDs->getTag(),
-                                                         _otherNodes->getTag(),
-                                                         _edgeTypes->getTag()));
+    input.setStream(_stream);
     _port->connectTo(input.getPort());
 }
 


### PR DESCRIPTION
- `PipelineEdgeOutputInterface::connectTo(PipelineBlockInputInterface&)` was recreating a fresh `EdgeStream` from member columns instead of using `_stream`, which may have been modified by `projectEdgeTarget()`
- This caused the projected `NodeStream` to be lost when materializing after an edge target projection without an intermediate materialize step (e.g. when an empty filter node is removed by the optimizer)
- Now uses `_stream` directly, consistent with how `PipelineBlockOutputInterface::connectTo` already works