### PR TITLE
Fix flushRightStream column offset and reset _hasWritten

### DIFF
--- a/query/pipeline/processors/HashJoinProcessor.cpp
+++ b/query/pipeline/processors/HashJoinProcessor.cpp
@@ -95,6 +95,7 @@ void HashJoinProcessor::prepare(ExecutionContext* ctxt) {
     markAsPrepared();
 }
 void HashJoinProcessor::reset() {
+    _hasWritten = false;
     markAsReset();
 }
 
@@ -469,15 +470,16 @@ void HashJoinProcessor::flushRightStream(size_t& rowsRemaining,
 
     const size_t rowsToCopy = std::min(rows.size() - rowOffsetIdx, rowsRemaining);
 
+    size_t columnOffset = _leftRowLen;
     for (size_t j = 0; j < rightDf->size(); ++j) {
         //Skip Columns present in the left input and the join key
-        if (leftDf->getColumn(cols[j]->getTag()) != nullptr || 
+        if (leftDf->getColumn(cols[j]->getTag()) != nullptr ||
             cols[j]->getTag() == _rightJoinKey) {
             continue;
         }
 
         auto* inputColumn = cols[j]->getColumn();
-        auto* outputColumn = outCols[_leftRowLen + j]->getColumn();
+        auto* outputColumn = outCols[columnOffset]->getColumn();
         dispatchColumnVector(outputColumn, [&](auto* col) {
             auto* typedOutCol = static_cast<decltype(col)>(outputColumn);
             const auto* typedInCol = static_cast<decltype(col)>(inputColumn);
@@ -487,6 +489,7 @@ void HashJoinProcessor::flushRightStream(size_t& rowsRemaining,
                              totalRowsInserted,
                              rowsToCopy);
         });
+        ++columnOffset;
     }
 
     // Copy the join column to the last output column


### PR DESCRIPTION
`flushRightStream` used `_leftRowLen + j` as the output column index, but j iterates over all right columns including skipped ones (columns shared with the left dataframe). 

This is inconsistent with processRightStream which correctly uses a separate columnOffset variable that only increments for non-skipped columns.

On main today the bug is latent: 
The only overlap between left and right dataframes is the join key column itself (COMMON_SUCCESSOR joins share the entity ID tag), and that column is already excluded by the join-key skip condition, so j and a correct columnOffset never diverge. 
However, value hash joins (PREDICATE type) use different tags for left and right join keys, making it possible for other columns to overlap between the two sides. This would cause flushRightStream to write into wrong output column positions.

Also reset _hasWritten in reset() so the empty-input write guard at the end of execute() works correctly if the processor is reused across pipeline cycles.