### PR TITLE
Fix empty() in CommitJournal and CommitWriteBuffer

### DIFF
--- a/storage/versioning/CommitJournal.cpp
+++ b/storage/versioning/CommitJournal.cpp
@@ -15,7 +15,7 @@ void CommitJournal::clear() {
 }
 
 bool CommitJournal::empty() const {
-    return _nodeWriteSet.empty() && _nodeWriteSet.empty();
+    return _nodeWriteSet.empty() && _edgeWriteSet.empty();
 }
 
 void CommitJournal::addWrittenNode(NodeID node) {

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -90,7 +90,7 @@ public:
      const DeletedEdges& deletedEdges() const { return _deletedEdges; }
 
      bool empty() const {
-         return _pendingNodes.empty() && _pendingEdges.empty() && _deletedEdges.empty()
+         return _pendingNodes.empty() && _pendingEdges.empty() && _deletedNodes.empty()
              && _deletedEdges.empty();
      }
 


### PR DESCRIPTION
Discovered during automated crash vector discovery with Claude Code.
Possible typo patterns.

In CommitJournal::empty()
```c++
return _nodeWriteSet.empty() && _nodeWriteSet.empty();
``` 

In CommitWriteBuffer::empty()
```c++
return _pendingNodes.empty() && _pendingEdges.empty() && _deletedEdges.empty()
``` 