### PR TITLE
Fixed non-deterministic bug in AgingRingCache

### DIFF
--- a/io/cache/AgingRingCache.h
+++ b/io/cache/AgingRingCache.h
@@ -142,10 +142,13 @@ public:
                     return it2->second._state != AgingRingCacheState::LOADING;
                 });
 
-                // The state of the entry has changed, check if the loading succeeded
-                if (!_map.contains(key)) {
-                    return AgingRingCacheError::result(AgingRingCacheErrorCode::COULD_NOT_LOAD);
-                }
+                // At this point, there are three possibilities:
+                // 1. The loading succeeded, we can retry and we should get a cache hit
+                // 2. The loading failed, we can retry to have a cache miss
+                //    this will trigger a new attempt to load again.
+                //    If it fails again, it will return COULD_NOT_LOAD
+                // 3. The loading succeeded, but got evicted immediately.
+                //    We can retry to have a cache miss which will trigger a new load attempt.
 
                 continue; // -> Retry
             }

--- a/test/io/AgingRingCacheTest.cpp
+++ b/test/io/AgingRingCacheTest.cpp
@@ -410,7 +410,8 @@ TEST_F(AgingRingCacheTest, MT_ConcurrentAcquireWithEviction) {
 
     std::vector<std::thread> threads;
     threads.reserve(kThreads);
-    std::atomic<int> errorCount {0};
+    std::mutex errorCountsMutex;
+    std::unordered_map<AgingRingCacheErrorCode, size_t> errorCounts;
 
     for (int t = 0; t < kThreads; t++) {
         threads.emplace_back([&, t] {
@@ -418,7 +419,8 @@ TEST_F(AgingRingCacheTest, MT_ConcurrentAcquireWithEviction) {
                 const int key = (t * kIters + i) % 15; // limited key space forces eviction
                 auto res = cache.acquire(key);
                 if (!res && res.error().getType() != AgingRingCacheErrorCode::NOTHING_TO_EVICT) {
-                    errorCount++;
+                    const std::unique_lock lock(errorCountsMutex);
+                    errorCounts[res.error().getType()]++;
                 }
                 std::this_thread::sleep_for(std::chrono::microseconds(100));
             }
@@ -429,7 +431,10 @@ TEST_F(AgingRingCacheTest, MT_ConcurrentAcquireWithEviction) {
         th.join();
     }
 
-    EXPECT_EQ(errorCount.load(), 0);
+    for (const auto& [code, count] : errorCounts) {
+        EXPECT_EQ(count, 0) << "error: " << AgingRingCacheErrorTypeDescription::value(code);
+    }
+
     cache.shutdown();
 }
 


### PR DESCRIPTION
In this case of the `acquire()` method:

```c++
/* Case 2: Found an entry, but it's currently being loaded by another thread
 *         Wait until it's done and retry */
if (entry._state == AgingRingCacheState::LOADING) {
    _stateCv.wait(lock, [&] {
        const auto it2 = _map.find(key);
        if (it2 == _map.end()) {
            // This can happen in case an error occured during the loading
            return true;
        }

        return it2->second._state != AgingRingCacheState::LOADING;
    });

    // The state of the entry has changed, check if the loading succeeded
    if (!_map.contains(key)) {
        return AgingRingCacheError::result(AgingRingCacheErrorCode::COULD_NOT_LOAD);
    }

    continue; // -> Retry
}
```

The final check before the retry:

```c++
if (!_map.contains(key)) {
    return AgingRingCacheError::result(AgingRingCacheErrorCode::COULD_NOT_LOAD);
}
```

Was incorrect because it is possible for a payload to be evicted right after it got loaded, which should just trigger a retry (will hit a cache miss and retry to load). After the retry, if the load fails, it will return COULD_NOT_LOAD automatically in the cache miss branch, so no need to handle it here.

Bug was confirmed by adding a `std::this_thread::sleep_for` right before the check `_map.contains(key)` which allowed to reproduce the unit test failure.