### PR TITLE
Fix critical rebase bugs

### DIFF
--- a/storage/versioning/ChangeConflictChecker.cpp
+++ b/storage/versioning/ChangeConflictChecker.cpp
@@ -127,8 +127,6 @@ void ChangeConflictChecker::checkNewEdgesIncidentToDeleted(const CommitData& lat
                     edgeID, record._nodeID);
                 throw VersionControlException(std::move(errorMsg));
             }
-
-            inEdgesIt.next();
         }
     }
 }

--- a/storage/versioning/DataPartRebaser.cpp
+++ b/storage/versioning/DataPartRebaser.cpp
@@ -44,28 +44,25 @@ bool DataPartRebaser::rebase(const MetadataRebaser& metadata,
     part._edgeIndexer->_firstNodeID = newFirstNodeID;
     part._edgeIndexer->_firstEdgeID = newFirstEdgeID;
 
-    // Nodes
-    if (metadata.labelsetsChanged()) {
+    { // @ref MetadataRebaser::rebase updates the Label(Set)Maps, so get new mapping
         for (auto& n : nodes->_nodes) {
             n._labelset = metadata.getLabelSetMapping(n._labelset.getID());
         }
 
-        LabelSetIndexer<NodeRange> newRanges;
-        for (const auto& [labelset, range] : nodes->_ranges) {
-            const auto newLabelSet = metadata.getLabelSetMapping(labelset.getID());
-            auto& r = newRanges[newLabelSet];
-            r = range;
-            r._first = _idRebaser->rebaseNodeID(r._first);
-        }
-        nodes->_ranges = std::move(newRanges);
-    } else {
-        for (auto& [labelset, range] : nodes->_ranges) {
-            range._first = _idRebaser->rebaseNodeID(range._first);
+        {
+            LabelSetIndexer<NodeRange> newRanges;
+            for (const auto& [labelset, range] : nodes->_ranges) {
+                const auto newLabelSet = metadata.getLabelSetMapping(labelset.getID());
+                auto& r = newRanges[newLabelSet];
+                r = range;
+                r._first = _idRebaser->rebaseNodeID(r._first);
+            }
+            nodes->_ranges = std::move(newRanges);
         }
     }
 
-    // Edges
-    if (metadata.edgeTypesChanged()) {
+
+    { // @ref MetadataRebaser::rebase updates EdgeTypeMap, so get new mapping
         for (auto& e : edges->_outEdges) {
             e._edgeTypeID = metadata.getEdgeTypeMapping(e._edgeTypeID);
         }
@@ -75,19 +72,16 @@ bool DataPartRebaser::rebase(const MetadataRebaser& metadata,
         }
     }
 
-    if (_nodeOffset != 0 && _edgeOffset != 0) {
+    { // Rebase all source, target, and edge IDs
         for (auto& e : edges->_outEdges) {
             e._nodeID = _idRebaser->rebaseNodeID(e._nodeID);
             e._otherID = _idRebaser->rebaseNodeID(e._otherID);
             e._edgeID = _idRebaser->rebaseEdgeID(e._edgeID);
         }
-    } else if (_nodeOffset != 0) {
-        for (auto& e : edges->_outEdges) {
+
+        for (auto& e : edges->_inEdges) {
             e._nodeID = _idRebaser->rebaseNodeID(e._nodeID);
             e._otherID = _idRebaser->rebaseNodeID(e._otherID);
-        }
-    } else if (_edgeOffset != 0) {
-        for (auto& e : edges->_outEdges) {
             e._edgeID = _idRebaser->rebaseEdgeID(e._edgeID);
         }
     }
@@ -101,7 +95,7 @@ bool DataPartRebaser::rebase(const MetadataRebaser& metadata,
         edgeIndexer->_patchNodeOffsets.swap(newPatchOffsets);
     }
 
-    if (metadata.labelsetsChanged()) {
+    { // Update spans for edge indexers, according to new LabelSetMap
         using EdgeSpan = std::span<const EdgeRecord>;
         using EdgeSpans = std::vector<EdgeSpan>;
 
@@ -123,60 +117,60 @@ bool DataPartRebaser::rebase(const MetadataRebaser& metadata,
     }
 
     // Node properties
-    {
-        if (metadata.propTypesChanged()) {
-            std::unordered_map<PropertyTypeID, std::unique_ptr<PropertyContainer>> newContainers;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> uint64s;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> int64s;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> doubles;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> strings;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> bools;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> embeddings;
+    { // @ref MetadataRebaser::rebase updates PropTypeMap, so get new mapping
+        std::unordered_map<PropertyTypeID, std::unique_ptr<PropertyContainer>> newContainers;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> uint64s;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> int64s;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> doubles;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> strings;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> bools;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> embeddings;
 
-            for (auto& [ptID, container] : nodeProperties->_map) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                newContainers[newPT._id] = std::unique_ptr<PropertyContainer> {container.release()};
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_uint64s) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                uint64s[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_int64s) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                int64s[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_doubles) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                doubles[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_strings) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                strings[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_bools) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                bools[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : nodeProperties->_embeddings) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                embeddings[newPT._id] = container;
-            }
-
-            nodeProperties->_map = std::move(newContainers);
-            nodeProperties->_uint64s = std::move(uint64s);
-            nodeProperties->_int64s = std::move(int64s);
-            nodeProperties->_doubles = std::move(doubles);
-            nodeProperties->_strings = std::move(strings);
-            nodeProperties->_bools = std::move(bools);
-            nodeProperties->_embeddings = std::move(embeddings);
-            static_assert((size_t)ValueType::_SIZE == 7 && "A value type was added");
+        for (auto& [ptID, container] : nodeProperties->_map) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            newContainers[newPT._id] =
+                std::unique_ptr<PropertyContainer> {container.release()};
         }
+
+        for (const auto& [ptID, container] : nodeProperties->_uint64s) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            uint64s[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : nodeProperties->_int64s) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            int64s[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : nodeProperties->_doubles) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            doubles[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : nodeProperties->_strings) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            strings[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : nodeProperties->_bools) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            bools[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : nodeProperties->_embeddings) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            embeddings[newPT._id] = container;
+        }
+
+        nodeProperties->_map = std::move(newContainers);
+        nodeProperties->_uint64s = std::move(uint64s);
+        nodeProperties->_int64s = std::move(int64s);
+        nodeProperties->_doubles = std::move(doubles);
+        nodeProperties->_strings = std::move(strings);
+        nodeProperties->_bools = std::move(bools);
+        nodeProperties->_embeddings = std::move(embeddings);
+        static_assert((size_t)ValueType::_SIZE == 7 && "A value type was added");
+
 
         if (metadata.labelsetsChanged() || metadata.propTypesChanged()) {
             PropertyIndexer newIndexers;
@@ -205,61 +199,60 @@ bool DataPartRebaser::rebase(const MetadataRebaser& metadata,
 
     // Edge properties
     {
-        if (metadata.propTypesChanged()) {
-            std::unordered_map<PropertyTypeID, std::unique_ptr<PropertyContainer>> newContainers;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> uint64s;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> int64s;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> doubles;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> strings;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> bools;
-            std::unordered_map<PropertyTypeID, PropertyContainer*> embeddings;
+        std::unordered_map<PropertyTypeID, std::unique_ptr<PropertyContainer>> newContainers;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> uint64s;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> int64s;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> doubles;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> strings;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> bools;
+        std::unordered_map<PropertyTypeID, PropertyContainer*> embeddings;
 
-            for (auto& [ptID, container] : edgeProperties->_map) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                newContainers[newPT._id] = std::unique_ptr<PropertyContainer> {container.release()};
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_uint64s) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                uint64s[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_int64s) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                int64s[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_doubles) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                doubles[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_strings) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                strings[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_bools) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                bools[newPT._id] = container;
-            }
-
-            for (const auto& [ptID, container] : edgeProperties->_embeddings) {
-                const auto newPT = metadata.getPropertyTypeMapping(ptID);
-                embeddings[newPT._id] = container;
-            }
-
-            edgeProperties->_map = std::move(newContainers);
-            edgeProperties->_uint64s = std::move(uint64s);
-            edgeProperties->_int64s = std::move(int64s);
-            edgeProperties->_doubles = std::move(doubles);
-            edgeProperties->_strings = std::move(strings);
-            edgeProperties->_bools = std::move(bools);
-            edgeProperties->_embeddings = std::move(embeddings);
-            static_assert((size_t)ValueType::_SIZE == 7 && "A value type was added");
+        for (auto& [ptID, container] : edgeProperties->_map) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            newContainers[newPT._id] =
+                std::unique_ptr<PropertyContainer> {container.release()};
         }
 
-        if (metadata.labelsetsChanged() || metadata.propTypesChanged()) {
+        for (const auto& [ptID, container] : edgeProperties->_uint64s) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            uint64s[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : edgeProperties->_int64s) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            int64s[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : edgeProperties->_doubles) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            doubles[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : edgeProperties->_strings) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            strings[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : edgeProperties->_bools) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            bools[newPT._id] = container;
+        }
+
+        for (const auto& [ptID, container] : edgeProperties->_embeddings) {
+            const auto newPT = metadata.getPropertyTypeMapping(ptID);
+            embeddings[newPT._id] = container;
+        }
+
+        edgeProperties->_map = std::move(newContainers);
+        edgeProperties->_uint64s = std::move(uint64s);
+        edgeProperties->_int64s = std::move(int64s);
+        edgeProperties->_doubles = std::move(doubles);
+        edgeProperties->_strings = std::move(strings);
+        edgeProperties->_bools = std::move(bools);
+        edgeProperties->_embeddings = std::move(embeddings);
+        static_assert((size_t)ValueType::_SIZE == 7 && "A value type was added");
+
+        { // Update property indexers based on our new LabelSetMapping
             PropertyIndexer newIndexers;
 
             for (const auto& [ptID, indexer] : edgeProperties->_indexers) {

--- a/test/query/queries/ChangeQueriesTest.cpp
+++ b/test/query/queries/ChangeQueriesTest.cpp
@@ -99,6 +99,12 @@ protected:
         return nullptr;
     }
 
+    constexpr static auto dump = [](const Dataframe* df) {
+        std::ostringstream out;
+        df->dump(out);
+        return out.str();
+    };
+
     // Helper to check the output of a db.propertyTypes()
     bool ensureProperties(std::initializer_list<std::string_view> props) {
         bool allPropsFound = true;
@@ -1112,8 +1118,52 @@ TEST_F(ChangeQueriesTest, historyWithDeletions) {
     ASSERT_TRUE(res);
 }
 
+TEST_F(ChangeQueriesTest, labelSetsSameCommitRebase) {
+    setWorkingGraph("default");
+    ChangeID changeA;
+    ChangeID changeB;
+    {
+        newChange(), changeA = _currentChange;
+        constexpr std::string_view CREATE_QUERY =
+            R"(CREATE (n1:Person{name:"Head"})-[:FOLLOWS]->(n2:Person{name:"Mid"})-[:FOLLOWS]->(n3:Person{name:"Tail"}))";
+        {
+            const auto res = query(CREATE_QUERY, emptyCallback);
+            ASSERT_TRUE(res) << res.getError();
+            ASSERT_TRUE(query("commit", emptyCallback));
+        }
+    }
+    {
+        newChange(), changeB = _currentChange;
+        constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Person{name:"Lone"}))";
+        const auto res = query(CREATE_QUERY, emptyCallback);
+        ASSERT_TRUE(res) << res.getError();
+    }
+
+    submitChange(changeB);
+    submitChange(changeA);
+
+    {
+        constexpr std::string_view CHAIN_QUERY = R"(MATCH (n1:Person)-[:FOLLOWS]->(n2:Person)-[:FOLLOWS]->(n3:Person) RETURN n1.name, n2.name, n3.name)";
+        const auto res2 = query(CHAIN_QUERY, [](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(3, df->size());
+            const auto* n1Names = findColumn(df, "n1.name")->as<ColumnOptVector<types::String::Primitive>>();
+            const auto* n2Names = findColumn(df, "n2.name")->as<ColumnOptVector<types::String::Primitive>>();
+            const auto* n3Names = findColumn(df, "n3.name")->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(n1Names && n2Names && n3Names);
+
+            ASSERT_FALSE(n1Names->empty() || n2Names->empty() || n3Names->empty());
+
+            EXPECT_EQ((std::vector<std::optional<std::string_view>>{ "Head" }), n1Names->getRaw()) << dump(df);
+            EXPECT_EQ((std::vector<std::optional<std::string_view>>{ "Mid" }), n2Names->getRaw()) << dump(df);
+            EXPECT_EQ((std::vector<std::optional<std::string_view>>{ "Tail" }), n3Names->getRaw()) << dump(df);
+        });
+        ASSERT_TRUE(res2) << res2.getError();
+    }
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
+        testing::GTEST_FLAG(repeat) = 100;
     });
 }


### PR DESCRIPTION
- {LabelSet, Label, PropertyType}Maps were std::moved unconditionally in MetadataRebaser::rebase, but ptrs were only updated conditionally on the contents of the maps changing
- In edges were not rebased
- In edges conflict checking was double iterated