### PR TITLE
Use max of all column sizes in getLogicalRowCount()

### DIFF
--- a/storage/dataframe/Dataframe.cpp
+++ b/storage/dataframe/Dataframe.cpp
@@ -22,32 +22,12 @@ void Dataframe::addColumn(NamedColumn* column) {
 }
 
 size_t Dataframe::getLogicalRowCount() const {
-    if (_cols.size() == 0) {
-        return 0;
-    }
-
-    // Nullopt until we find a non-ColumnConst to take size of
-    std::optional<size_t> foundSize(std::nullopt);
-
-    constexpr ContainerKind::Code colConstKind =
-        ColumnKind::extractContainerKind(ColumnConst<int>::staticKind());
-
+    size_t maxSize = 0;
     for (const NamedColumn* ncol : _cols) {
         const Column* col = ncol->getColumn();
-        // Ignore ColumnConsts
-        if (col->getContainerKind() == colConstKind) {
-            continue;
-        }
-        foundSize = col->size();
+        maxSize = std::max(maxSize, col->size());
     }
-
-    // We have at least 1 column, but all were ColumnConst => optional not set
-    // => logical size = 1
-    if (!foundSize.has_value()) {
-        return 1;
-    }
-
-    return foundSize.value();
+    return maxSize;
 }
 
 bool Dataframe::isRectangular() const {


### PR DESCRIPTION
Use the max of the column sizes as the value returned by Dataframe::getLogicalRowCount(). ColumnConst returns a size of 1.

Currently the loop is just returning the size of the LAST column, so taking the max makes more sense. Also returns the correct number of rows for dataframes with just ColumnConst or ColumnVector + ColumnConst.