### PR TITLE
Add local copy of CommitWriteBuffer with rollback in WriteProcessor

### DIFF
--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -1,6 +1,7 @@
 #include "WriteProcessor.h"
 
 #include <algorithm>
+#include <exception>
 #include <optional>
 #include <string_view>
 #include <utility>
@@ -48,9 +49,9 @@ bool isColumnConst(const Column* col) {
 }
 
 template <TypedInternalID IDT>
-void validateDeletions(const GraphReader reader, const ColumnVector<IDT>* col) {
+WriteResult validateDeletions(const GraphReader reader, const ColumnVector<IDT>* col) {
     if (!col) {
-        throw FatalException("Attempted to delete null column.");
+        return WriteError {"Attempted to delete null column."};
     }
 
     constexpr bool isNode = std::is_same_v<IDT, NodeID>;
@@ -64,15 +65,17 @@ void validateDeletions(const GraphReader reader, const ColumnVector<IDT>* col) {
             existsAndNotDeleted = reader.graphHasEdge(id);
         }
 
-        if (!existsAndNotDeleted) [[unlikely]] {
-            throw PipelineException(fmt::format("Graph does not contain {} with ID: {}.",
-                                                isNode ? "node" : "edge", id.getValue()));
+        if (!existsAndNotDeleted) {
+            return WriteError {fmt::format("Graph does not contain {} with ID: {}.",
+                                           isNode ? "node" : "edge", id.getValue())};
         }
     }
+
+    return {};
 }
 
-template void validateDeletions<NodeID>(const GraphReader reader, const ColumnVector<NodeID>* col);
-template void validateDeletions<EdgeID>(const GraphReader reader, const ColumnVector<EdgeID>* col);
+template WriteResult validateDeletions<NodeID>(const GraphReader reader, const ColumnVector<NodeID>* col);
+template WriteResult validateDeletions<EdgeID>(const GraphReader reader, const ColumnVector<EdgeID>* col);
 
 class ColumnVectorToUntypedProperties {
 public:
@@ -169,7 +172,7 @@ private:
     PropertyTypeID _propID;
 };
 
-void getUntypedProperties(const Column* valueColumn,
+WriteResult getUntypedProperties(const Column* valueColumn,
                           CommitWriteBuffer::UntypedProperties& props,
                           PropertyTypeID pid) {
     using Types = WriteProcessorPropertyTypes;
@@ -179,7 +182,16 @@ void getUntypedProperties(const Column* valueColumn,
                                Types::ExcludedVector>;
     // Determines type of property values and fills @ref propBuffer with variants
     ColumnVectorToUntypedProperties toVec(props, pid);
-    Dispatcher::dispatch(valueColumn, toVec);
+
+    try {
+        Dispatcher::dispatch(valueColumn, toVec);
+    } catch (const std::exception& e) {
+        return WriteError {e.what()};
+    } catch (...) {
+        return WriteError {"Unknown error."};
+    }
+
+    return {};
 }
 
 class ColumnConstToUntypedProperty {
@@ -277,6 +289,7 @@ void WriteProcessor::prepare(ExecutionContext* ctxt) {
 
     _metadataBuilder = &commitBuilder->metadata();
     _writeBuffer = &commitBuilder->writeBuffer();
+    _localCopy = std::make_unique<CommitWriteBuffer>(*_writeBuffer);
 
     bioassert(_metadataBuilder, "Failed to get MetadataBuilder in WriteProcessor");
     bioassert(_writeBuffer, "Failed to get CommitWriteBuffer in WriteProcessor");
@@ -286,26 +299,31 @@ void WriteProcessor::reset() {
     markAsReset();
 }
 
-void WriteProcessor::performDeletions() {
+WriteResult WriteProcessor::performDeletions() {
     const GraphReader reader = _ctxt->getGraphView().read();
     const Dataframe* inDf = _input->getDataframe();
 
     for (const ColumnTag deletedTag : _deletedNodes) {
         if (!inDf->hasColumn(deletedTag)) {
-            throw FatalException(fmt::format(
+            return WriteError {fmt::format(
                 "Attempted to delete nodes in Column {}, but found no such column "
                 "in the input Dataframe.",
-                deletedTag.getValue()));
+                deletedTag.getValue())};
         }
 
         const auto* nodeColumn = inDf->getColumn(deletedTag)->as<ColumnNodeIDs>();
         if (!nodeColumn) { // @ref as<> performs dynamic_cast
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " deleted nodes, but is not a NodeID"
-                                             " column.", deletedTag.getValue()));
+            return WriteError {fmt::format("Column {} was marked as a column of"
+                                           " deleted nodes, but is not a NodeID"
+                                           " column.",
+                                           deletedTag.getValue())};
         }
 
-        validateDeletions(reader, nodeColumn);
+        WriteResult res = validateDeletions(reader, nodeColumn);
+        if (!res) {
+            return res;
+        }
+
         _writeBuffer->addDeletedNodes(nodeColumn->getRaw());
         // TODO: Guard around if the query is DETACH or NODETACH
         _writeBuffer->addHangingEdges(_ctxt->getGraphView());
@@ -313,22 +331,29 @@ void WriteProcessor::performDeletions() {
 
     for (const ColumnTag deletedTag : _deletedEdges) {
         if (!inDf->hasColumn(deletedTag)) {
-            throw FatalException(fmt::format(
+            return WriteError {fmt::format(
                 "Attempted to delete edges in Column {}, but found no such column "
                 "in the input Dataframe.",
-                deletedTag.getValue()));
+                deletedTag.getValue())};
         }
 
         const auto* edgeColumn = inDf->getColumn(deletedTag)->as<ColumnEdgeIDs>();
         if (!edgeColumn) {
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " deleted edges, but is not an EdgeID"
-                                             " column.", deletedTag.getValue()));
+            return WriteError {fmt::format("Column {} was marked as a column of"
+                                           " deleted edges, but is not an EdgeID"
+                                           " column.",
+                                           deletedTag.getValue())};
         }
 
-        validateDeletions(reader, edgeColumn);
+        WriteResult res = validateDeletions(reader, edgeColumn);
+        if (!res) {
+            return res;
+        }
+
         _writeBuffer->addDeletedEdges(edgeColumn->getRaw());
     }
+
+    return {};
 }
 
 LabelSet WriteProcessor::getLabelSet(std::span<const std::string_view> labels) {
@@ -340,7 +365,7 @@ LabelSet WriteProcessor::getLabelSet(std::span<const std::string_view> labels) {
     return labelset;
 }
 
-void WriteProcessor::createNodes(size_t numIters) {
+WriteResult WriteProcessor::createNodes(size_t numIters) {
     NodeID nextNodeID = _writeBuffer->numPendingNodes();
     const Dataframe* outDf = _output.getDataframe();
 
@@ -357,7 +382,7 @@ void WriteProcessor::createNodes(size_t numIters) {
         const std::span labels = node._labels;
 
         if (labels.empty()) {
-            throw PipelineException("Nodes require at least 1 label.");
+            return WriteError {"Nodes require at least 1 label."};
         }
         lblset = getLabelSet(labels);
 
@@ -412,10 +437,12 @@ void WriteProcessor::createNodes(size_t numIters) {
 
         nextNodeID += numIters;
     }
+
+    return {};
 }
 
 // @warn assumes all pending nodes have already been created
-void WriteProcessor::createEdges(size_t numIters) {
+WriteResult WriteProcessor::createEdges(size_t numIters) {
     EdgeID nextEdgeID = _writeBuffer->numPendingEdges();
     const Dataframe* inDf = _input ? _input->getDataframe() : nullptr;
     const Dataframe* outDf = _output.getDataframe();
@@ -440,16 +467,16 @@ void WriteProcessor::createEdges(size_t numIters) {
         // always retrieve the column from the output dataframe, regardless of whether
         // the source node was the result of a CREATE or a MATCH
         if (!outDf->hasColumn(srcTag)) {
-            throw FatalException(fmt::format("Attempted to create edge {} with "
-                                             "source node with no such column: {}",
-                                             edge._name, edge._srcTag.getValue()));
+            return WriteError {fmt::format("Attempted to create edge {} with "
+                                           "source node with no such column: {}",
+                                           edge._name, edge._srcTag.getValue())};
         }
         srcCol = outDf->getColumn(srcTag)->as<ColumnNodeIDs>();
         if (!srcCol) { // @ref as<> performs dynamic_cast
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " pending source nodes, but is not a NodeID"
-                                             " column.",
-                                             srcTag.getValue()));
+            return WriteError {fmt::format("Column {} was marked as a column of"
+                                           " pending source nodes, but is not a NodeID"
+                                           " column.",
+                                           srcTag.getValue())};
         }
 
         ColumnNodeIDs* tgtCol = nullptr;
@@ -457,16 +484,16 @@ void WriteProcessor::createEdges(size_t numIters) {
         const bool tgtIsPending = !inDf || inDf->getColumn(tgtTag) == nullptr;
 
         if (!outDf->hasColumn(tgtTag)) {
-            throw FatalException(fmt::format("Attempted to create edge {} with "
-                                             "target node with no such column: {}",
-                                             edge._name, edge._tgtTag.getValue()));
+            return WriteError {fmt::format("Attempted to create edge {} with "
+                                           "target node with no such column: {}",
+                                           edge._name, edge._tgtTag.getValue())};
         }
         tgtCol = outDf->getColumn(tgtTag)->as<ColumnNodeIDs>();
         if (!tgtCol) { // @ref as<> performs dynamic_cast
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " pending target nodes, but is not a NodeID"
-                                             " column.",
-                                             tgtTag.getValue()));
+            return WriteError {fmt::format("Column {} was marked as a column of"
+                                           " pending target nodes, but is not a NodeID"
+                                           " column.",
+                                           tgtTag.getValue())};
         }
 
         bioassert(tgtCol->size() == srcCol->size(), "src and target column should have same dimension");
@@ -542,6 +569,8 @@ void WriteProcessor::createEdges(size_t numIters) {
 
         nextEdgeID += numIters;
     }
+
+    return {};
 }
 
 void WriteProcessor::postProcessTempIDs() {
@@ -569,7 +598,7 @@ void WriteProcessor::postProcessTempIDs() {
     }
 }
 
-void WriteProcessor::updateNodes() {
+WriteResult WriteProcessor::updateNodes() {
     const Dataframe* inDf = tryGetInput().getDataframe();
 
     // Temporary buffers, reused over iterations, to add write buffer updates
@@ -598,7 +627,11 @@ void WriteProcessor::updateNodes() {
                 _writeBuffer->addNodeUpdate(n, propBuffer);
             }
         } else { // Column(Opt)Vector -> unique property for each node
-            getUntypedProperties(valueColumn, propsBuffer, pid);
+            WriteResult res = getUntypedProperties(valueColumn, propsBuffer, pid);
+            if (!res) {
+                return res;
+            }
+
             bioassert(source->size() == propsBuffer.size(),
                       "Mismatch in dimensions of nodes to update and property values.");
 
@@ -607,9 +640,11 @@ void WriteProcessor::updateNodes() {
             }
         }
     }
+
+    return {};
 }
 
-void WriteProcessor::updateEdges() {
+WriteResult WriteProcessor::updateEdges() {
     const Dataframe* inDf = tryGetInput().getDataframe();
 
     // Temporary buffers, reused over iterations, to add write buffer updates
@@ -638,7 +673,11 @@ void WriteProcessor::updateEdges() {
                 _writeBuffer->addEdgeUpdate(e, propBuffer);
             }
         } else { // Column(Opt)Vector -> unique property for each edge
-            getUntypedProperties(valueColumn, propsBuffer, pid);
+            WriteResult res = getUntypedProperties(valueColumn, propsBuffer, pid);
+            if (!res) {
+                return res;
+            }
+
             bioassert(source->size() == propsBuffer.size(),
                       "Mismatch in dimensions of edges to updates and property values.");
 
@@ -647,25 +686,52 @@ void WriteProcessor::updateEdges() {
             }
         }
     }
+
+    return {};
 }
 
-void WriteProcessor::performCreations() {
+WriteResult WriteProcessor::performCreations() {
     // We apply the CREATE command for each row in the input, or just a single row if we
     // have no inputs
     const size_t numIters = _input ? _input->getDataframe()->getLogicalRowCount() : 1;
     if (numIters == 0) {
-        return;
+        return {};
     }
 
-    createNodes(numIters);
-    createEdges(numIters);
+    {
+        WriteResult res = createNodes(numIters);
+        if (!res) {
+            return res;
+        }
+    }
+    {
+        WriteResult res = createEdges(numIters);
+        if (!res) {
+            return res;
+        }
+    }
 
     postProcessTempIDs();
+
+    return {};
 }
 
-void WriteProcessor::performUpdates() {
-    updateNodes();
-    updateEdges();
+WriteResult WriteProcessor::performUpdates() {
+    {
+        WriteResult res = updateNodes();
+        if (!res) {
+            return res;
+        }
+    }
+
+    {
+        WriteResult res = updateEdges();
+        if (!res) {
+            return res;
+        }
+    }
+
+    return {};
 }
 
 void WriteProcessor::setup() {
@@ -722,18 +788,30 @@ void WriteProcessor::execute() {
         if (!_input) {
             throw PipelineException("Cannot delete pending entity: DELETE queries require a MATCH input.");
         }
-        performDeletions();
+        WriteResult res = performDeletions();
+        if (!res) {
+            *_writeBuffer = *_localCopy;
+            throw PipelineException(std::move(res.error()));
+        }
     }
 
     // Evaluate instructions so that property columns are populated with their
     // evaluated value
     _exprProgram->evaluateInstructions();
     if (!_pendingNodes.empty() || !_pendingEdges.empty()) {
-        performCreations();
+        WriteResult res = performCreations();
+        if (!res) {
+            *_writeBuffer = *_localCopy;
+            throw PipelineException(std::move(res.error()));
+        }
     }
 
     if (!_updatedNodes.empty() || !_updatedEdges.empty()) {
-        performUpdates();
+        WriteResult res = performUpdates();
+        if (!res) {
+            *_writeBuffer = *_localCopy;
+            throw PipelineException(std::move(res.error()));
+        }
     }
 
     if (_input) {

--- a/query/pipeline/processors/WriteProcessor.h
+++ b/query/pipeline/processors/WriteProcessor.h
@@ -1,17 +1,19 @@
 #pragma once
 
 #include <math.h>
+#include <memory>
 #include <optional>
 #include <string_view>
 
 #include "Processor.h"
 #include "WriteProcessorTypes.h"
 
+#include "dataframe/ColumnTag.h"
 #include "interfaces/PipelineBlockInputInterface.h"
 #include "interfaces/PipelineBlockOutputInterface.h"
-#include "dataframe/ColumnTag.h"
 #include "interfaces/PipelineInputInterface.h"
 #include "metadata/LabelSet.h"
+#include "versioning/CommitWriteBuffer.h"
 
 #include "FatalException.h"
 
@@ -19,7 +21,6 @@ namespace db {
 
 class Dataframe;
 class MetadataBuilder;
-class CommitWriteBuffer;
 
 }
 
@@ -77,6 +78,8 @@ private:
     MetadataBuilder* _metadataBuilder {nullptr};
     CommitWriteBuffer* _writeBuffer {nullptr};
 
+    std::unique_ptr<CommitWriteBuffer> _localCopy;
+
     DeletedNodes _deletedNodes;
     DeletedEdges _deletedEdges;
 
@@ -103,7 +106,7 @@ private:
      * _writeBuffer.
      * @warn Currently always deletes any edges which are incident to a deleted node.
      */
-    void performDeletions();
+    WriteResult performDeletions();
 
     /**
      * @brief Adds pending nodes and edges to @ref _writeBuffer, one copy for each input
@@ -111,23 +114,23 @@ private:
      * (where "estimation" is an estimation of what each node/edge ID will be once
      * committed).
      */
-    void performCreations();
+    WriteResult performCreations();
 
     /**
      * @brief Adds node and edge updates to @ref _writeBuffer.
      */
-    void performUpdates();
+    WriteResult performUpdates();
 
-    void updateNodes();
+    WriteResult updateNodes();
 
-    void updateEdges();
+    WriteResult updateEdges();
 
     /**
      * @brief Adds @param numIters copies of each element of @ref _pendingNodes to @ref
      * _writeBuffer. Fills @ref _output dataframe with the index in @ref
      * _writeBuffer::_pendingNodes for which each node can be found.
      */
-    void createNodes(size_t numIters);
+    WriteResult createNodes(size_t numIters);
 
     /**
      * @brief Adds @param numIters copies of each element of @ref _pendingEdges to
@@ -135,7 +138,7 @@ private:
      * _writeBuffer::_pendingEdges for which each node can be found.
      * @warn Requires @ref createNodes to have been called prior
      */
-    void createEdges(size_t numIters);
+    WriteResult createEdges(size_t numIters);
 
     /**
      * @brief Transforms each column in @ref _output dataframe which has a tag belonging

--- a/query/pipeline/processors/WriteProcessorTypes.h
+++ b/query/pipeline/processors/WriteProcessorTypes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <expected>
 #include <stddef.h>
 #include <string_view>
 
@@ -8,6 +9,9 @@
 #include "metadata/PropertyType.h"
 
 namespace db {
+
+using WriteResult = std::expected<void, std::string>;
+using WriteError = std::unexpected<std::string>;
 
 class Column;
 

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -7,15 +7,15 @@
 
 #include "Graph.h"
 #include "ID.h"
+
 #include "columns/ColumnVector.h"
 #include "iterators/GetInEdgesIterator.h"
 #include "iterators/GetOutEdgesIterator.h"
 #include "metadata/PropertyType.h"
 #include "reader/GraphReader.h"
-#include "versioning/MetadataRebaser.h"
 #include "versioning/EntityIDRebaser.h"
+#include "versioning/MetadataRebaser.h"
 #include "writers/DataPartBuilder.h"
-#include "Tombstones.h"
 
 using namespace db;
 namespace rg = ranges;
@@ -53,7 +53,7 @@ struct PrimitiveToTag<types::Embedding::OwningPrimitive> {
 }
 
 CommitWriteBuffer::CommitWriteBuffer(CommitJournal& journal, GraphView view)
-    : _journal(journal),
+    : _journal(&journal),
     _view(view)
 {
 }
@@ -148,7 +148,7 @@ void CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
             value);
     }
 
-    _journal.addWrittenNode(nodeID);
+    _journal->addWrittenNode(nodeID);
 }
 
 void CommitWriteBuffer::buildPendingNodes(DataPartBuilder& builder) {
@@ -209,7 +209,7 @@ void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
             value);
     }
 
-    _journal.addWrittenEdge(newEdgeID);
+    _journal->addWrittenEdge(newEdgeID);
 }
 
 void CommitWriteBuffer::buildPendingEdges(DataPartBuilder& builder) {
@@ -239,7 +239,7 @@ void CommitWriteBuffer::applyNodeUpdates(DataPartBuilder& builder) {
             },
             value);
 
-        _journal.addWrittenNode(nodeID);
+        _journal->addWrittenNode(nodeID);
     }
 }
 
@@ -259,7 +259,7 @@ void CommitWriteBuffer::applyExistingEdgeUpdate(DataPartBuilder& builder,
         },
         val);
 
-    _journal.addWrittenEdge(record._edgeID);
+    _journal->addWrittenEdge(record._edgeID);
 }
 
 void CommitWriteBuffer::applyPendingEdgeUpdate(DataPartBuilder& builder,
@@ -348,8 +348,8 @@ void CommitWriteBuffer::applyDeletions(Tombstones& tombstones) {
     tombstones.addNodeTombstones(_deletedNodes);
     tombstones.addEdgeTombstones(_deletedEdges);
     // Delete nodes/edges should be in the "write set" of this commit
-    _journal.addWrittenNodes(_deletedNodes);
-    _journal.addWrittenEdges(_deletedEdges);
+    _journal->addWrittenNodes(_deletedNodes);
+    _journal->addWrittenEdges(_deletedEdges);
 }
 
 void CommitWriteBufferRebaser::rebase() {

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -177,7 +177,7 @@ private:
 
     bool _flushed {false};
 
-    CommitJournal& _journal;
+    CommitJournal* _journal {nullptr};
 
     // NOTE: This view is NOT updated by CommitWriteBuffer::rebase
     GraphView _view;


### PR DESCRIPTION
_This is more a proof of concept of a fix that needs to be added._

It may be possible that `WriteProcessor::execute` modifies the `CommitWriteBuffer` of the current change, and errors in the same cycle. This violates the atomicity of a single query. This PR adds a naïve fix of keeping a copy of the `CommitWriteBuffer` on `prepare`, and rolling back to the local copy before throwing any exceptions to be caught by the `QueryInterpreter`.

Implemented in this PR by using `Result` types in the `WriteProcessor` instead of exceptions. This means we have minimal `try ... catch` blocks, and that errors can be propagated up to a single point, where the rollback occurs if it needs to, and then finally an exception can be thrown to be caught by `QueryInterpreter`.