### PR TITLE
Restore NameOf code to use other macros

### DIFF
--- a/common/NameOf.h
+++ b/common/NameOf.h
@@ -7,14 +7,16 @@ namespace db {
 template <typename T>
 struct NameOf {
     static std::string_view get() {
-#ifdef __clang__
+#if defined(__clang__)
         const std::string_view sv = __PRETTY_FUNCTION__;
         const size_t start = sv.find('[') + 5;
         const size_t end = sv.rfind(']');
-#elifdef __GNUC__
+
+#elif defined(__GNUC__)
         const std::string_view sv = __PRETTY_FUNCTION__;
         const size_t start = sv.find("T = ") + 4;
         const size_t end = sv.rfind(']');
+
 #endif
         return sv.substr(start, end - start);
     }


### PR DESCRIPTION
Using `#ifdef` caused build issues on the full matrix build.