### PR TITLE
Added type(e) as alias for edgeType(e)

### DIFF
--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -15,6 +15,10 @@ void FunctionDecls::initDefault() {
     edgeType->setArguments({EvaluatedType::EdgePattern});
     edgeType->setReturnTypes({{EvaluatedType::String}});
 
+    FunctionSignature* type = createFunction("type");
+    type->setArguments({EvaluatedType::EdgePattern});
+    type->setReturnTypes({{EvaluatedType::String}});
+
     FunctionSignature* labels = createFunction("labels");
     labels->setArguments({EvaluatedType::NodePattern});
     labels->setReturnTypes({{EvaluatedType::String}});

--- a/query/plan/ExprProgramGenerator.cpp
+++ b/query/plan/ExprProgramGenerator.cpp
@@ -425,7 +425,7 @@ Column* ExprProgramGenerator::generateFuncInvocationExpr(const FunctionInvocatio
         return resCol;
     }
 
-    if (funcName == "edgeType") {
+    if (funcName == "edgeType" || funcName == "type") {
         if (args->size() != 1) {
             throw PlannerException(
                 fmt::format("{}() expects 1 argument, got {}", funcName, args->size()));


### PR DESCRIPTION
Added an alias to the edgeType(e) function to match better neo4j's syntax so that LLMs generate better queries

```
turing:reactome> MATCH (n)-[e]->(m) RETURN type(e) LIMIT 5

+----------+
| type(e)  |
+----------+
| hasEvent |
+----------+
| hasEvent |
+----------+
| species  |
+----------+
| hasEvent |
+----------+
| hasEvent |
+----------+

```