### PR TITLE
Add checks for null columns in EdgeTypesProcedure, LabelsProcedure, PropertyTypesProcedure

### DIFF
--- a/query/pipeline/procedures/EdgeTypesProcedure.cpp
+++ b/query/pipeline/procedures/EdgeTypesProcedure.cpp
@@ -51,10 +51,15 @@ void EdgeTypesProcedure::execute(ProcedureState* proc) {
 
     switch (proc->getStep()) {
         case ProcedureState::Step::PREPARE: {
-            data._it = std::make_unique<ScanEdgeTypesChunkWriter>(
-                view.metadata().edgeTypes());
-            data._it->setIDs(idsCol);
-            data._it->setNames(namesCol);
+            data._it = std::make_unique<ScanEdgeTypesChunkWriter>(view.metadata().edgeTypes());
+
+            if (idsCol) {
+                data._it->setIDs(idsCol);
+            }
+
+            if (namesCol) {
+                data._it->setNames(namesCol);
+            }
         }
         break;
 
@@ -64,6 +69,11 @@ void EdgeTypesProcedure::execute(ProcedureState* proc) {
         break;
 
         case ProcedureState::Step::EXECUTE: {
+            if (!idsCol && !namesCol) {
+                proc->finish();
+                break;
+            }
+
             data._it->fill(proc->getContext()->getChunkSize());
 
             if (!data._it->isValid()) {

--- a/query/pipeline/procedures/LabelsProcedure.cpp
+++ b/query/pipeline/procedures/LabelsProcedure.cpp
@@ -51,18 +51,29 @@ void LabelsProcedure::execute(ProcedureState* proc) {
 
     switch (proc->getStep()) {
         case ProcedureState::Step::PREPARE: {
-            data._it = std::make_unique<ScanLabelsChunkWriter>(
-                view.metadata().labels());
-            data._it->setIDs(idsCol);
-            data._it->setNames(namesCol);
+            data._it = std::make_unique<ScanLabelsChunkWriter>(view.metadata().labels());
+
+            if (idsCol) {
+                data._it->setIDs(idsCol);
+            }
+
+            if (namesCol) {
+                data._it->setNames(namesCol);
+            }
         }
         break;
 
-        case ProcedureState::Step::RESET:
+        case ProcedureState::Step::RESET: {
             data._it->reset();
+        }
         break;
 
         case ProcedureState::Step::EXECUTE: {
+            if (!idsCol && !namesCol) {
+                proc->finish();
+                break;
+            }
+
             data._it->fill(proc->getContext()->getChunkSize());
 
             if (!data._it->isValid()) {

--- a/query/pipeline/procedures/PropertyTypesProcedure.cpp
+++ b/query/pipeline/procedures/PropertyTypesProcedure.cpp
@@ -54,11 +54,19 @@ void PropertyTypesProcedure::execute(ProcedureState* proc) {
 
     switch (proc->getStep()) {
         case ProcedureState::Step::PREPARE: {
-            data._it = std::make_unique<ScanPropertyTypesChunkWriter>(
-                view.metadata().propTypes());
-            data._it->setPropertyTypes(idsCol);
-            data._it->setNames(namesCol);
-            data._it->setValueTypes(valueTypesCol);
+            data._it = std::make_unique<ScanPropertyTypesChunkWriter>(view.metadata().propTypes());
+
+            if (idsCol) {
+                data._it->setPropertyTypes(idsCol);
+            }
+
+            if (namesCol) {
+                data._it->setNames(namesCol);
+            }
+
+            if (valueTypesCol) {
+                data._it->setValueTypes(valueTypesCol);
+            }
         }
         break;
 
@@ -68,6 +76,11 @@ void PropertyTypesProcedure::execute(ProcedureState* proc) {
         break;
 
         case ProcedureState::Step::EXECUTE: {
+            if (!idsCol && !namesCol && !valueTypesCol) {
+                proc->finish();
+                break;
+            }
+
             data._it->fill(proc->getContext()->getChunkSize());
 
             if (!data._it->isValid()) {


### PR DESCRIPTION
Add checks for columns being potentially nullptr in procedures.
Fixes #551 