### PR TITLE
Add the `DROP INDEX` query

### DIFF
--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -78,6 +78,7 @@ set(ast_sources
     YieldItems.cpp
     CreateNodePropertyIndexQuery.cpp
     CreateEdgePropertyIndexQuery.cpp
+    DropIndexQuery.cpp
 
     ExprUtils.cpp
   )

--- a/query/AST/CypherAST.h
+++ b/query/AST/CypherAST.h
@@ -94,6 +94,7 @@ class ShowExtensionsQuery;
 class VectorSearchStmt;
 class CreateNodePropertyIndexQuery;
 class CreateEdgePropertyIndexQuery;
+class DropIndexQuery;
 
 class CypherAST {
 public:
@@ -173,6 +174,7 @@ public:
     friend YCypherParser;
     friend CreateNodePropertyIndexQuery;
     friend CreateEdgePropertyIndexQuery;
+    friend DropIndexQuery;
 
     using QueryCommands = std::vector<QueryCommand*>;
 

--- a/query/AST/CypherASTDumper.cpp
+++ b/query/AST/CypherASTDumper.cpp
@@ -166,6 +166,10 @@ void CypherASTDumper::dump(std::ostream& out) {
             case QueryCommand::Kind::CREATE_EDGE_PROPERTY_INDEX_QUERY:
                 out << "    script ||--o{ CREATE_EDGE_PROPERTY_INDEX : \"\"\n";
             break;
+
+            case QueryCommand::Kind::DROP_INDEX_QUERY:
+                out << "    script ||--o{ DROP_INDEX : \"\"\n";
+            break;
         }
     }
 }

--- a/query/AST/DropIndexQuery.cpp
+++ b/query/AST/DropIndexQuery.cpp
@@ -10,6 +10,9 @@ DropIndexQuery::DropIndexQuery(DeclContext* declCtxt, std::string_view indexName
 {
 }
 
+DropIndexQuery::~DropIndexQuery() {
+}
+
 DropIndexQuery* DropIndexQuery::create(CypherAST *ast, std::string_view indexName) {
     constexpr DeclContext* parent = nullptr;
     DeclContext* declCtxt = DeclContext::create(ast, parent);

--- a/query/AST/DropIndexQuery.cpp
+++ b/query/AST/DropIndexQuery.cpp
@@ -1,0 +1,23 @@
+#include "DropIndexQuery.h"
+#include "QueryCommand.h"
+#include "decl/DeclContext.h"
+
+using namespace db;
+
+
+DropIndexQuery::DropIndexQuery(DeclContext* declCtxt, std::string_view indexName)
+    : QueryCommand(declCtxt),
+    _indexName(indexName)
+{
+}
+
+DropIndexQuery* DropIndexQuery::create(CypherAST *ast, std::string_view indexName) {
+    constexpr DeclContext* parent = nullptr;
+    DeclContext* declCtxt = DeclContext::create(ast, parent);
+
+    DropIndexQuery* query = new DropIndexQuery(declCtxt, indexName);
+
+    ast->addQuery(query);
+
+    return query;
+}

--- a/query/AST/DropIndexQuery.cpp
+++ b/query/AST/DropIndexQuery.cpp
@@ -4,7 +4,6 @@
 
 using namespace db;
 
-
 DropIndexQuery::DropIndexQuery(DeclContext* declCtxt, std::string_view indexName)
     : QueryCommand(declCtxt),
     _indexName(indexName)

--- a/query/AST/DropIndexQuery.h
+++ b/query/AST/DropIndexQuery.h
@@ -17,6 +17,8 @@ public:
 
 private:
     DropIndexQuery(DeclContext* declCtxt, std::string_view indexName);
+    ~DropIndexQuery() final;
+
     std::string_view _indexName;
 };
 

--- a/query/AST/DropIndexQuery.h
+++ b/query/AST/DropIndexQuery.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string_view>
+
+#include "CypherAST.h"
+#include "QueryCommand.h"
+
+namespace db {
+
+class DropIndexQuery final : public QueryCommand {
+public:
+    static DropIndexQuery* create(CypherAST* ast, std::string_view indexName);
+
+    std::string_view indexName() const { return _indexName; }
+
+    Kind getKind() const final { return QueryCommand::Kind::DROP_INDEX_QUERY; }
+
+private:
+    DropIndexQuery(DeclContext* declCtxt, std::string_view indexName);
+    std::string_view _indexName;
+};
+
+}

--- a/query/AST/QueryCommand.h
+++ b/query/AST/QueryCommand.h
@@ -30,6 +30,7 @@ public:
         SHOW_EXTENSIONS_QUERY,
         CREATE_NODE_PROPERTY_INDEX_QUERY,
         CREATE_EDGE_PROPERTY_INDEX_QUERY,
+        DROP_INDEX_QUERY,
     };
 
     virtual Kind getKind() const = 0;

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -130,6 +130,10 @@ void CypherAnalyzer::analyze() {
                 analyze(static_cast<const CreateEdgePropertyIndexQuery*>(query));
             break;
 
+            case QueryCommand::Kind::DROP_INDEX_QUERY:
+                throwError("Not implemented (analyzer).");
+            break;
+
             // Nothing to analyze
             case QueryCommand::Kind::CHANGE_QUERY:
             case QueryCommand::Kind::COMMIT_QUERY:

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -133,10 +133,6 @@ void CypherAnalyzer::analyze() {
                 analyze(static_cast<const CreateEdgePropertyIndexQuery*>(query));
             break;
 
-            case QueryCommand::Kind::DROP_INDEX_QUERY:
-                analyze(static_cast<const DropIndexQuery*>(query));
-            break;
-
             // Nothing to analyze
             case QueryCommand::Kind::CHANGE_QUERY:
             case QueryCommand::Kind::COMMIT_QUERY:
@@ -146,6 +142,7 @@ void CypherAnalyzer::analyze() {
             case QueryCommand::Kind::SHOW_VECTOR_INDEXES_QUERY:
             case QueryCommand::Kind::LOAD_COMMIT_QUERY:
             case QueryCommand::Kind::SHOW_EXTENSIONS_QUERY:
+            case QueryCommand::Kind::DROP_INDEX_QUERY:
             break;
 
         }
@@ -571,22 +568,6 @@ void CypherAnalyzer::analyze(const CreateEdgePropertyIndexQuery* query) {
     const GraphReader reader = _graphView.read();
     if (!reader.isEdgeProperty(propType._id)) {
         throwError("Property is not an edge property.", propertyExpr);
-    }
-}
-
-void CypherAnalyzer::analyze(const DropIndexQuery* query) {
-    const std::string_view toDrop = query->indexName();
-
-    const std::span indexes = _graphView.indexes();
-
-    const auto matches = [&](const WeakArc<Index>& index) -> bool {
-        return index->name() == toDrop;
-    };
-
-    const bool toDropExists = !std::ranges::none_of(indexes, matches);
-
-    if (!toDropExists) {
-        throwError("Index not found", query);
     }
 }
 

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -1,5 +1,6 @@
 #include "CypherAnalyzer.h"
 
+#include <algorithm>
 #include <spdlog/fmt/bundled/core.h>
 #include <string_view>
 
@@ -34,6 +35,7 @@
 #include "decl/EvaluatedType.h"
 #include "expr/Expr.h"
 #include "expr/PropertyExpr.h"
+#include "indexes/Index.h"
 #include "metadata/PropertyType.h"
 #include "reader/GraphReader.h"
 #include "stmt/ShortestPathStmt.h"
@@ -48,6 +50,7 @@
 #include "stmt/Limit.h"
 #include "CreateNodePropertyIndexQuery.h"
 #include "CreateEdgePropertyIndexQuery.h"
+#include "DropIndexQuery.h"
 
 #include "FunctionDecls.h"
 
@@ -131,7 +134,7 @@ void CypherAnalyzer::analyze() {
             break;
 
             case QueryCommand::Kind::DROP_INDEX_QUERY:
-                throwError("Not implemented (analyzer).");
+                analyze(static_cast<const DropIndexQuery*>(query));
             break;
 
             // Nothing to analyze
@@ -568,6 +571,22 @@ void CypherAnalyzer::analyze(const CreateEdgePropertyIndexQuery* query) {
     const GraphReader reader = _graphView.read();
     if (!reader.isEdgeProperty(propType._id)) {
         throwError("Property is not an edge property.", propertyExpr);
+    }
+}
+
+void CypherAnalyzer::analyze(const DropIndexQuery* query) {
+    const std::string_view toDrop = query->indexName();
+
+    const std::span indexes = _graphView.indexes();
+
+    const auto matches = [&](const WeakArc<Index>& index) -> bool {
+        return index->name() == toDrop;
+    };
+
+    const bool toDropExists = !std::ranges::none_of(indexes, matches);
+
+    if (!toDropExists) {
+        throwError("Index not found", query);
     }
 }
 

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -1,6 +1,5 @@
 #include "CypherAnalyzer.h"
 
-#include <algorithm>
 #include <spdlog/fmt/bundled/core.h>
 #include <string_view>
 
@@ -35,7 +34,6 @@
 #include "decl/EvaluatedType.h"
 #include "expr/Expr.h"
 #include "expr/PropertyExpr.h"
-#include "indexes/Index.h"
 #include "metadata/PropertyType.h"
 #include "reader/GraphReader.h"
 #include "stmt/ShortestPathStmt.h"
@@ -50,7 +48,6 @@
 #include "stmt/Limit.h"
 #include "CreateNodePropertyIndexQuery.h"
 #include "CreateEdgePropertyIndexQuery.h"
-#include "DropIndexQuery.h"
 
 #include "FunctionDecls.h"
 

--- a/query/analyzer/CypherAnalyzer.h
+++ b/query/analyzer/CypherAnalyzer.h
@@ -58,7 +58,6 @@ public:
     void analyze(const InstallExtensionQuery* query);
     void analyze(const CreateNodePropertyIndexQuery* query);
     void analyze(const CreateEdgePropertyIndexQuery* query);
-    void analyze(const DropIndexQuery* query);
 
     // Sub-statements
     void analyze(OrderBy* orderBySt);

--- a/query/analyzer/CypherAnalyzer.h
+++ b/query/analyzer/CypherAnalyzer.h
@@ -28,6 +28,7 @@ class Limit;
 class ReturnStmt;
 class CreateNodePropertyIndexQuery;
 class CreateEdgePropertyIndexQuery;
+class DropIndexQuery;
 
 class CypherAnalyzer {
 public:
@@ -57,6 +58,7 @@ public:
     void analyze(const InstallExtensionQuery* query);
     void analyze(const CreateNodePropertyIndexQuery* query);
     void analyze(const CreateEdgePropertyIndexQuery* query);
+    void analyze(const DropIndexQuery* query);
 
     // Sub-statements
     void analyze(OrderBy* orderBySt);

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -76,6 +76,7 @@
     #include "VecLibMetadata.h"
     #include "CreateNodePropertyIndexQuery.h"
     #include "CreateEdgePropertyIndexQuery.h"
+    #include "DropIndexQuery.h"
 
     namespace db {
         class YCypherScanner;
@@ -358,6 +359,7 @@
 %type<bool> opt_distinct
 %type<db::CreateNodePropertyIndexQuery*> createNodePropertyIndexQuery
 %type<db::CreateEdgePropertyIndexQuery*> createEdgePropertyIndexQuery
+%type<db::DropIndexQuery*> dropIndexQuery
 
 %expect 0
 
@@ -404,6 +406,7 @@ singleQuery
     | createVectorIndexQuery { $$ = $1; }
     | createNodePropertyIndexQuery { $$ = $1; }
     | createEdgePropertyIndexQuery { $$ = $1; }
+    | dropIndexQuery { $$ = $1; }
     | loadVectorQuery { $$ = $1; }
     | deleteVectorIndexQuery { $$ = $1; }
     | showVectorIndexesQuery { $$ = $1; }
@@ -461,6 +464,9 @@ createEdgePropertyIndexQuery
         LOC($$, @$);
       }
     ;
+
+dropIndexQuery
+    : DROP INDEX ID { $$ = DropIndexQuery::create(ast, $3); LOC($$, @$); }
 
 distanceMetric
     : EUCLID { $$ = vec::DistanceMetric::EUCLIDEAN_DIST; }

--- a/query/pipeline/CMakeLists.txt
+++ b/query/pipeline/CMakeLists.txt
@@ -71,6 +71,7 @@ set(processors_sources
     processors/CreatePropertyIndexProcessor.cpp
     processors/IndexLookupProcessor.cpp
     processors/ApplyMask.cpp
+    processors/DropIndexProcessor.cpp
 )
 
 set(procedures_sources

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -10,6 +10,7 @@
 #include "processors/CartesianProductProcessor.h"
 #include "processors/ChangeProcessor.h"
 #include "processors/CommitProcessor.h"
+#include "processors/DropIndexProcessor.h"
 #include "processors/IndexLookupProcessor.h"
 #include "processors/LoadCommitProcessor.h"
 #include "processors/CallProcedureProcessor.h"
@@ -1392,6 +1393,17 @@ PipelineValuesOutputInterface& PipelineBuilder::addIndexLookup(const Index* inde
     }
 
     _pendingOutput.updateInterface(&output);
+    _lastProc = proc;
+    return output;
+}
+
+
+PipelineBlockOutputInterface& PipelineBuilder::addDropIndex(std::string_view indexName) {
+    auto* proc = DropIndexProcessor::create(_pipeline, indexName);
+
+    PipelineBlockOutputInterface& output = proc->output();
+
+    _pendingOutput.setInterface(&output);
     _lastProc = proc;
     return output;
 }

--- a/query/pipeline/PipelineBuilder.h
+++ b/query/pipeline/PipelineBuilder.h
@@ -232,6 +232,8 @@ public:
                                                          std::string_view propName,
                                                          bool isNodeIndex);
 
+    PipelineBlockOutputInterface& addDropIndex(std::string_view indexName);
+
     template <typename Q, typename R>
     PipelineValuesOutputInterface& addIndexLookup(const Index* index);
 

--- a/query/pipeline/processors/DropIndexProcessor.cpp
+++ b/query/pipeline/processors/DropIndexProcessor.cpp
@@ -1,0 +1,93 @@
+#include "DropIndexProcessor.h"
+
+#include <string_view>
+
+#include <spdlog/fmt/bundled/format.h>
+
+#include "ExecutionContext.h"
+#include "PipelineException.h"
+#include "PipelineExecutor.h"
+#include "indexes/Index.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/CommitWriteBuffer.h"
+#include "versioning/Transaction.h"
+
+#include "PipelinePort.h"
+
+#include "FatalException.h"
+
+using namespace db;
+
+DropIndexProcessor::DropIndexProcessor(std::string_view indexName)
+    :_indexName(indexName)
+{
+}
+
+std::string DropIndexProcessor::describe() const {
+    return fmt::format("DropIndexProcessor @={}", fmt::ptr(this));
+}
+
+DropIndexProcessor* DropIndexProcessor::create(PipelineV2* pipeline,
+                                               std::string_view indexName) {
+    DropIndexProcessor* proc = new DropIndexProcessor(indexName);
+
+    {
+        PipelineOutputPort* out = PipelineOutputPort::create(pipeline, proc);
+
+        proc->_output.setPort(out);
+        proc->addOutput(out);
+    }
+
+    proc->postCreate(pipeline);
+
+    return proc;
+}
+
+void DropIndexProcessor::prepare(ExecutionContext* ctxt) {
+    _ctxt = ctxt;
+
+    Transaction* rawTx = ctxt->getTransaction();
+    if (!rawTx) {
+        throw FatalException(
+            "Attempted to create property index without transaction.");
+    }
+
+    if (!rawTx->writingPendingCommit()) {
+        throw PipelineException(
+            "DROP INDEX: Cannot perform writes outside of a write transaction");
+    }
+
+    auto& tx = rawTx->get<PendingCommitWriteTx>();
+    _commitBuilder = tx.commitBuilder();
+
+    bioassert(_commitBuilder, "Could not get commit builder to drop index.");
+
+    markAsPrepared();
+}
+
+void DropIndexProcessor::reset() {
+    markAsReset();
+}
+
+void DropIndexProcessor::execute() {
+    const GraphView view = _ctxt->getGraphView();
+    const std::span indexes = view.indexes();
+
+    const auto name = [&](const WeakArc<Index>& index) -> std::string_view {
+        return index->name();
+    };
+
+    const auto foundIt = std::ranges::find(indexes, _indexName, name);
+
+    if (foundIt == end(indexes)) {
+        std::string err = fmt::format("Index {} does not exist.", _indexName);
+        throw PipelineException(std::move(err));
+    }
+
+    const WeakArc<Index>& droppedIndex = *foundIt;
+
+    CommitWriteBuffer& wb = _commitBuilder->writeBuffer();
+    wb.addDroppedIndex(droppedIndex);
+
+    finish();
+}

--- a/query/pipeline/processors/DropIndexProcessor.cpp
+++ b/query/pipeline/processors/DropIndexProcessor.cpp
@@ -48,8 +48,7 @@ void DropIndexProcessor::prepare(ExecutionContext* ctxt) {
 
     Transaction* rawTx = ctxt->getTransaction();
     if (!rawTx) {
-        throw FatalException(
-            "Attempted to create property index without transaction.");
+        throw FatalException("Attempted to drop index without transaction.");
     }
 
     if (!rawTx->writingPendingCommit()) {

--- a/query/pipeline/processors/DropIndexProcessor.h
+++ b/query/pipeline/processors/DropIndexProcessor.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string_view>
+
+#include "Processor.h"
+
+#include "interfaces/PipelineBlockOutputInterface.h"
+
+namespace db {
+
+class PipelineV2;
+class ExecutionContext;
+class CommitBuilder;
+
+class DropIndexProcessor final : public Processor {
+public:
+    static DropIndexProcessor* create(PipelineV2* pipeline, std::string_view indexName);
+
+    std::string describe() const final;
+
+    void prepare(ExecutionContext* ctxt) final;
+    void reset() final;
+    void execute() final;
+
+    PipelineBlockOutputInterface& output() { return _output; }
+
+private:
+    ExecutionContext* _ctxt {nullptr};
+    CommitBuilder* _commitBuilder {nullptr};
+
+    PipelineBlockOutputInterface _output;
+
+    std::string_view _indexName;
+
+    explicit DropIndexProcessor(std::string_view indexName);
+    ~DropIndexProcessor() final = default;
+};
+
+}

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -503,6 +503,10 @@ PipelineOutputInterface* PipelineGenerator::translateNode(PlanGraphNode* node) {
             return translateIndexLookupNode(static_cast<IndexLookupNode*>(node));
         break;
 
+        case PlanGraphOpcode::DROP_INDEX:
+            return translateDropIndexNode(static_cast<DropIndexNode*>(node));
+        break;
+
         case PlanGraphOpcode::FUNC_EVAL:
         case PlanGraphOpcode::GET_ENTITY_TYPE:
         case PlanGraphOpcode::PROJECT_RESULTS:
@@ -1891,5 +1895,11 @@ PipelineOutputInterface* PipelineGenerator::translateIndexLookupNode(IndexLookup
     }
 
 
+    return _builder.getPendingOutputInterface();
+}
+
+PipelineOutputInterface* PipelineGenerator::translateDropIndexNode(DropIndexNode* node) {
+    const std::string_view indexName = node->indexName();
+    _builder.addDropIndex(indexName);
     return _builder.getPendingOutputInterface();
 }

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -91,6 +91,7 @@
 #include "nodes/ConstWriteSourceNode.h"
 #include "nodes/CreatePropertyIndexNode.h"
 #include "nodes/IndexLookupNode.h"
+#include "nodes/DropIndexNode.h"
 
 #include "TranslateJoinHelpers.h"
 

--- a/query/plan/PipelineGenerator.h
+++ b/query/plan/PipelineGenerator.h
@@ -65,6 +65,7 @@ class ConstScanNode;
 class ConstWriteSourceNode;
 class CreatePropertyIndexNode;
 class IndexLookupNode;
+class DropIndexNode;
 
 class PipelineGenerator {
 public:
@@ -169,6 +170,7 @@ private:
     PipelineOutputInterface* translateConstWriteSourceNode(ConstWriteSourceNode* node);
     PipelineOutputInterface* translateCreatePropertyIndexNode(CreatePropertyIndexNode* node);
     PipelineOutputInterface* translateIndexLookupNode(IndexLookupNode* node);
+    PipelineOutputInterface* translateDropIndexNode(DropIndexNode* node);
 
     std::vector<std::string> _csvHeaders;
 };

--- a/query/plan/PlanGraphGenerator.cpp
+++ b/query/plan/PlanGraphGenerator.cpp
@@ -187,6 +187,9 @@ void PlanGraphGenerator::generate(const QueryCommand* query) {
             generateCreateEdgePropertyIndexQuery(static_cast<const CreateEdgePropertyIndexQuery*>(query));
         break;
 
+        case QueryCommand::Kind::DROP_INDEX_QUERY:
+            throwError("Not implemented (generator).");
+        break;
     }
 
     _tree.removeIsolatedNodes();

--- a/query/plan/PlanGraphGenerator.cpp
+++ b/query/plan/PlanGraphGenerator.cpp
@@ -63,7 +63,6 @@
 #include "nodes/ShowExtensionsNode.h"
 #include "nodes/CreatePropertyIndexNode.h"
 #include "nodes/DropIndexNode.h"
-#include "nodes/PlanGraphNode.h"
 
 #include "QueryCommand.h"
 #include "SinglePartQuery.h"

--- a/query/plan/PlanGraphGenerator.cpp
+++ b/query/plan/PlanGraphGenerator.cpp
@@ -62,6 +62,8 @@
 #include "nodes/InstallExtensionNode.h"
 #include "nodes/ShowExtensionsNode.h"
 #include "nodes/CreatePropertyIndexNode.h"
+#include "nodes/DropIndexNode.h"
+#include "nodes/PlanGraphNode.h"
 
 #include "QueryCommand.h"
 #include "SinglePartQuery.h"
@@ -84,6 +86,7 @@
 #include "ShowExtensionsQuery.h"
 #include "CreateNodePropertyIndexQuery.h"
 #include "CreateEdgePropertyIndexQuery.h"
+#include "DropIndexQuery.h"
 
 #include "decl/VarDecl.h"
 #include "decl/PatternData.h"
@@ -188,7 +191,7 @@ void PlanGraphGenerator::generate(const QueryCommand* query) {
         break;
 
         case QueryCommand::Kind::DROP_INDEX_QUERY:
-            throwError("Not implemented (generator).");
+            generateDropIndexQuery(static_cast<const DropIndexQuery*>(query));
         break;
     }
 
@@ -425,6 +428,14 @@ void PlanGraphGenerator::generateCreateEdgePropertyIndexQuery(const CreateEdgePr
     const PropertyExpr* propExpr = query->propertyExpr();
 
     auto* node = _tree.create<CreatePropertyIndexNode>(indexName, IndexEntityKind::Edge, propExpr);
+
+    _tree.newOut<ProduceResultsNode>(node);
+}
+
+void PlanGraphGenerator::generateDropIndexQuery(const DropIndexQuery* query) {
+    const std::string_view indexName = query->indexName();
+
+    auto* node = _tree.create<DropIndexNode>(indexName);
 
     _tree.newOut<ProduceResultsNode>(node);
 }

--- a/query/plan/PlanGraphGenerator.h
+++ b/query/plan/PlanGraphGenerator.h
@@ -37,6 +37,7 @@ class ShowExtensionsQuery;
 class QueryCommand;
 class CreateNodePropertyIndexQuery;
 class CreateEdgePropertyIndexQuery;
+class DropIndexQuery;
 
 class PlanGraphGenerator {
 public:
@@ -79,6 +80,7 @@ private:
     void generateShowExtensionsQuery(const ShowExtensionsQuery* query);
     void generateCreateNodePropertyIndexQuery(const CreateNodePropertyIndexQuery* query);
     void generateCreateEdgePropertyIndexQuery(const CreateEdgePropertyIndexQuery* query);
+    void generateDropIndexQuery(const DropIndexQuery* query);
 
     [[noreturn]] void throwError(std::string_view msg, const void* obj = 0) const;
 };

--- a/query/plan/nodes/CreatePropertyIndexNode.h
+++ b/query/plan/nodes/CreatePropertyIndexNode.h
@@ -13,9 +13,9 @@ enum class IndexEntityKind {
 
 class CreatePropertyIndexNode : public PlanGraphNode {
 public:
-    explicit CreatePropertyIndexNode(std::string_view indexName,
-                                     IndexEntityKind entityKind,
-                                     const PropertyExpr* propExpr)
+    CreatePropertyIndexNode(std::string_view indexName,
+                            IndexEntityKind entityKind,
+                            const PropertyExpr* propExpr)
         : PlanGraphNode(PlanGraphOpcode::CREATE_PROPERTY_INDEX),
         _indexName(indexName),
         _entityKind(entityKind),

--- a/query/plan/nodes/DropIndexNode.h
+++ b/query/plan/nodes/DropIndexNode.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string_view>
+
+#include "PlanGraphNode.h"
+
+namespace db {
+    
+class DropIndexNode final : public PlanGraphNode {
+public:
+    explicit DropIndexNode(std::string_view indexName)
+        : PlanGraphNode(PlanGraphOpcode::DROP_INDEX),
+        _indexName(indexName)
+    {
+    }
+
+    std::string_view indexName() const { return _indexName; }
+
+private:
+    std::string_view _indexName;
+};
+
+}

--- a/query/plan/nodes/PlanGraphNode.h
+++ b/query/plan/nodes/PlanGraphNode.h
@@ -58,6 +58,7 @@ enum class PlanGraphOpcode {
     CONST_WRITE_SOURCE,
     CREATE_PROPERTY_INDEX,
     INDEX_LOOKUP,
+    DROP_INDEX,
 
     _SIZE
 };
@@ -113,7 +114,8 @@ using PlanGraphOpcodeDescription = EnumToString<PlanGraphOpcode>::Create<
     EnumStringPair<PlanGraphOpcode::CONST_SCAN, "CONST_SCAN">,
     EnumStringPair<PlanGraphOpcode::CONST_WRITE_SOURCE, "CONST_WRITE_SOURCE">,
     EnumStringPair<PlanGraphOpcode::CREATE_PROPERTY_INDEX, "CREATE_PROPERTY_INDEX">,
-    EnumStringPair<PlanGraphOpcode::INDEX_LOOKUP, "INDEX_LOOKUP">
+    EnumStringPair<PlanGraphOpcode::INDEX_LOOKUP, "INDEX_LOOKUP">,
+    EnumStringPair<PlanGraphOpcode::DROP_INDEX, "DROP_INDEX">
 >;
 
 class PlanGraphNode {

--- a/storage/versioning/ChangeRebaser.cpp
+++ b/storage/versioning/ChangeRebaser.cpp
@@ -104,11 +104,14 @@ void ChangeRebaser::rebaseCommitBuilder(CommitBuilder& commitBuilder,
 
     // Rebase the history, including any committed dataparts
     historyRebaser.rebase(_metadataRebaser, _entityIDRebaser, _dataPartRebaser, *_currentHeadHistory);
-    historyRebaser.addValidIndexes(*_currentHeadHistory, commitsSinceBranch);
+
+    CommitWriteBuffer& wb = commitBuilder.writeBuffer();
+    const CommitWriteBuffer::DroppedIndexes& dropped = wb.droppedIndexes();
+    historyRebaser.addValidIndexes(*_currentHeadHistory, commitsSinceBranch, dropped);
 
     // If we have not yet flushed, we must rebase the write buffer prior to it being flushed
-    if (!commitBuilder.writeBuffer().isFlushed()) {
-        CommitWriteBufferRebaser wbRb(&_entityIDRebaser, commitBuilder.writeBuffer());
+    if (!wb.isFlushed()) {
+        CommitWriteBufferRebaser wbRb(&_entityIDRebaser, wb);
         wbRb.rebase();
         wbRb.rebaseIndexes(commitsSinceBranch);
     }

--- a/storage/versioning/CommitBuilder.cpp
+++ b/storage/versioning/CommitBuilder.cpp
@@ -149,9 +149,10 @@ void CommitBuilder::flushWriteBuffer([[maybe_unused]] JobSystem& jobsystem) {
 
     bioassert(_commit->history().journal().empty(), "Journal must be empty on flush.");
 
+    // At this point, any conflict checking should have already been done in @ref
+    // Change::rebase, so all writes are valid.
+
     if (wb.containsDeletes()) {
-        // At this point, conflict checking should have already been done in @ref
-        // Change::rebase, so all deletes are valid
         wb.applyDeletions(tombstones);
     }
 

--- a/storage/versioning/CommitBuilder.cpp
+++ b/storage/versioning/CommitBuilder.cpp
@@ -191,17 +191,24 @@ void CommitBuilder::flushWriteBuffer([[maybe_unused]] JobSystem& jobsystem) {
         const auto& nodePropUpdates = ourJournal->nodePropertyWriteSet();
         const auto& edgePropUpdates = ourJournal->edgePropertyWriteSet();
 
+        const CommitWriteBuffer::DroppedIndexes& droppedIndexes = wb.droppedIndexes();
+
         const auto invalidated = [&](const WeakArc<Index>& index) -> bool {
             const bool isNode = index->isNodeIndex();
             const PropertyTypeID indexedProp = index->property();
             const WriteSet<PropertyTypeID>& propUpdates =
                 isNode ? nodePropUpdates : edgePropUpdates;
             const bool propertyInvalidated = propUpdates.contains(indexedProp);
-            return propertyInvalidated;
+
+            const auto findIt = std::ranges::find(droppedIndexes, index);
+            const auto dropped = findIt != end(droppedIndexes);
+
+            return propertyInvalidated | dropped;
         };
 
         // By default we carry over the previous commit's indexes. Remove any that have
-        // become invalidated due to the writes (SETs, CREATEs) of this commit
+        // become invalidated due to the writes (SETs, CREATEs) of this commit, or dropped
+        // by a DROP INDEX command
         std::erase_if(ourIndexes, invalidated);
     }
 

--- a/storage/versioning/CommitHistoryRebaser.cpp
+++ b/storage/versioning/CommitHistoryRebaser.cpp
@@ -9,6 +9,7 @@
 #include "DataPartRebaser.h"
 
 #include "ID.h"
+#include "versioning/CommitWriteBuffer.h"
 #include "versioning/EntityIDRebaser.h"
 #include "versioning/MetadataRebaser.h"
 
@@ -74,7 +75,8 @@ void CommitHistoryRebaser::rebase(const MetadataRebaser& metadataRebaser,
 }
 
 void CommitHistoryRebaser::addValidIndexes(const CommitHistory& prevHistory,
-                                           Commit::CommitSpan commitsSinceBranch) {
+                                           Commit::CommitSpan commitsSinceBranch,
+                                           const CommitWriteBuffer::DroppedIndexes& droppedIndexes) {
     std::vector<WeakArc<Index>>& incomingIndexes = _history._validIndexes;
 
     // Combine the indexes on the change under rebase with the indexes on main
@@ -83,9 +85,18 @@ void CommitHistoryRebaser::addValidIndexes(const CommitHistory& prevHistory,
         const auto findIt = std::ranges::find(incomingIndexes, newHeadIndex);
         const bool alreadyTracked = findIt != end(incomingIndexes);
 
-        if (!alreadyTracked) {
-            incomingIndexes.push_back(newHeadIndex);
+        if (alreadyTracked) {
+            continue;
         }
+
+        const auto droppedIt = std::ranges::find(droppedIndexes, newHeadIndex);
+        const bool dropped = droppedIt == std::end(droppedIndexes);
+
+        if (dropped) {
+            continue;
+        }
+
+        incomingIndexes.push_back(newHeadIndex);
     }
 
     // Find all the properties that are now invalid due to property updates

--- a/storage/versioning/CommitHistoryRebaser.h
+++ b/storage/versioning/CommitHistoryRebaser.h
@@ -3,6 +3,7 @@
 #include <stddef.h>
 
 #include "Commit.h"
+#include "CommitWriteBuffer.h"
 
 namespace db {
 
@@ -26,7 +27,8 @@ public:
     void removeCreatedDataParts();
 
     void addValidIndexes(const CommitHistory& prevHistory,
-                         Commit::CommitSpan commitsSinceBranch);
+                         Commit::CommitSpan commitsSinceBranch,
+                         const CommitWriteBuffer::DroppedIndexes& droppedIndexes);
 
 private:
     CommitHistory& _history;

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -385,6 +385,10 @@ void CommitWriteBuffer::addPendingIndex(const WeakArc<Index>& index) {
     _pendingIndexes.push_back(index);
 }
 
+void CommitWriteBuffer::addDroppedIndex(const WeakArc<Index>& index) {
+    _droppedIndexes.push_back(index);
+}
+
 void CommitWriteBufferRebaser::rebase() {
     bioassert(_idRebaser, "Invalid _idRebaser");
     // We only need to rebase things which refer to a concrete NodeID or EdgeID.

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -173,6 +173,7 @@ public:
     void addHangingEdges(const GraphView& view);
 
     void addPendingIndex(const WeakArc<Index>& index);
+    void addDroppedIndex(const WeakArc<Index>& index);
 
     void setFlushed() { _flushed = true; }
     void setUnflushed() { _flushed = false; }

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -183,6 +183,7 @@ public:
     PendingEdge& getPendingEdge(size_t idx) { return _pendingEdges.at(idx); }
 
     const PendingIndexes& pendingIndexes() const { return _pendingIndexes; }
+    const DroppedIndexes& droppedIndexes() const { return _droppedIndexes; }
 
 private:
     friend DataPartBuilder;

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -56,6 +56,7 @@ public:
      using UpdatedNodes = std::vector<NodeUpdate>;
      using UpdatedEdges = std::vector<EdgeUpdate>;
      using PendingIndexes = std::vector<WeakArc<Index>>;
+     using DroppedIndexes = std::vector<WeakArc<Index>>;
 
      explicit CommitWriteBuffer(CommitJournal& journal, GraphView view);
 
@@ -210,6 +211,7 @@ private:
     UpdatedEdges _updatedEdges;
 
     PendingIndexes _pendingIndexes;
+    DroppedIndexes _droppedIndexes;
 
     PendingNodes& pendingNodes() { return _pendingNodes; }
     PendingEdges& pendingEdges() { return _pendingEdges; }

--- a/test/query/queries/IndexQueriesTest.cpp
+++ b/test/query/queries/IndexQueriesTest.cpp
@@ -590,10 +590,98 @@ TEST_F(IndexQueriesTest, ageIndexTypedTwoHopTraversal) {
     EXPECT_NE(results.end(), std::find(results.begin(), results.end(), cookingID));
 }
 
-// MATCH (n) WHERE n.age = 32 RETURN n.name
-// The age index identifies Remy and Adam; the query then reads and returns
-// the name property from those same nodes.
-// Expected: exactly the two names "Remy" and "Adam" (order not guaranteed).
+TEST_F(IndexQueriesTest, dropIndexRemovedAfterCommit) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX dropme FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_EQ(1, countIndexes());
+
+    ASSERT_TRUE(query("DROP INDEX dropme", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("dropme"));
+}
+
+TEST_F(IndexQueriesTest, dropIndexRemovedAfterSubmit) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX dropme FOR (n) ON n.age", emptyCallback));
+    submitCurrentChange();
+    ASSERT_EQ(1, countIndexes());
+
+    newChange();
+    ASSERT_TRUE(query("DROP INDEX dropme", emptyCallback));
+    submitCurrentChange();
+
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("dropme"));
+}
+
+TEST_F(IndexQueriesTest, dropIndexOnlyRemovesNamedIndex) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX keepme FOR (n) ON n.name", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_TRUE(query("CREATE INDEX dropme FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    submitCurrentChange();
+    ASSERT_EQ(2, countIndexes());
+
+    newChange();
+    ASSERT_TRUE(query("DROP INDEX dropme", emptyCallback));
+    submitCurrentChange();
+
+    EXPECT_EQ(1, countIndexes());
+    EXPECT_TRUE(hasIndex("keepme"));
+    EXPECT_FALSE(hasIndex("dropme"));
+}
+
+TEST_F(IndexQueriesTest, droppedIndexNotVisibleBeforeCommit) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX dropme FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_EQ(1, countIndexes());
+
+    // DROP without committing — index should still be visible
+    ASSERT_TRUE(query("DROP INDEX dropme", emptyCallback));
+    EXPECT_EQ(1, countIndexes());
+    EXPECT_TRUE(hasIndex("dropme"));
+
+    ASSERT_TRUE(query("commit", emptyCallback));
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("dropme"));
+}
+
+TEST_F(IndexQueriesTest, recreateIndexAfterDrop) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX myindex FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_TRUE(query("DROP INDEX myindex", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    submitCurrentChange();
+
+    ASSERT_EQ(0, countIndexes());
+
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX myindex FOR (n) ON n.age", emptyCallback));
+    submitCurrentChange();
+
+    EXPECT_EQ(1, countIndexes());
+    EXPECT_TRUE(hasIndex("myindex"));
+}
+
+TEST_F(IndexQueriesTest, dropEdgeIndex) {
+    newChange();
+    ASSERT_TRUE(query("CREATE INDEX durationidx FOR [e] ON e.duration", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_EQ(1, countIndexes());
+
+    ASSERT_TRUE(query("DROP INDEX durationidx", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("durationidx"));
+}
+
 TEST_F(IndexQueriesTest, ageIndexReturnPropertyOnIndexedNode) {
     newChange();
     ASSERT_TRUE(query("CREATE INDEX ageindex FOR (n) ON n.age", emptyCallback));

--- a/test/query/queries/IndexQueriesTest.cpp
+++ b/test/query/queries/IndexQueriesTest.cpp
@@ -682,6 +682,74 @@ TEST_F(IndexQueriesTest, dropEdgeIndex) {
     EXPECT_FALSE(hasIndex("durationidx"));
 }
 
+// A drop in change1 survives rebase when change2 (submitted first) is unrelated.
+TEST_F(IndexQueriesTest, dropIndexSurvivesUnrelatedRebase) {
+    ChangeID change1, change2;
+
+    newChange(), change1 = _currentChange;
+    ASSERT_TRUE(query("CREATE INDEX dropme FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_TRUE(query("DROP INDEX dropme", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("dropme"));
+
+    newChange(), change2 = _currentChange;
+    // Unrelated write — creates a node with a property not covered by the index.
+    ASSERT_TRUE(query("CREATE (n:TestNode { val: 1 })", emptyCallback));
+
+    // Submit change2 first so change1 must rebase against it.
+    submitChange(change2);
+    submitChange(change1);
+
+    EXPECT_EQ(0, countIndexes());
+    EXPECT_FALSE(hasIndex("dropme"));
+}
+
+TEST_F(IndexQueriesTest, createRebasedOnTopOfDrop) {
+    ChangeID change1, change2;
+
+    newChange(), change1 = _currentChange;
+    ASSERT_TRUE(query("CREATE INDEX myindex FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    newChange(), change2 = _currentChange;
+    ASSERT_TRUE(query("CREATE INDEX myindex FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_TRUE(query("DROP INDEX myindex", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    submitChange(change2);
+    submitChange(change1);
+
+    EXPECT_EQ(1, countIndexes());
+    EXPECT_TRUE(hasIndex("myindex"));
+}
+
+// change1 drops an index; change2 (submitted first) creates an unrelated index.
+// After rebase both the drop and the unrelated index should be reflected.
+TEST_F(IndexQueriesTest, dropAndUnrelatedIndexMergedAfterRebase) {
+    ChangeID change1, change2;
+
+    newChange(), change1 = _currentChange;
+    ASSERT_TRUE(query("CREATE INDEX ageidx FOR (n) ON n.age", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+    ASSERT_TRUE(query("DROP INDEX ageidx", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    newChange(), change2 = _currentChange;
+    ASSERT_TRUE(query("CREATE INDEX nameidx FOR (n) ON n.name", emptyCallback));
+    ASSERT_TRUE(query("commit", emptyCallback));
+
+    // Submit change2 first — head gains nameidx.
+    // change1 rebases: its drop of ageidx should survive; nameidx from the head should be kept.
+    submitChange(change2);
+    submitChange(change1);
+
+    EXPECT_FALSE(hasIndex("ageidx"));
+    EXPECT_TRUE(hasIndex("nameidx"));
+}
+
 TEST_F(IndexQueriesTest, ageIndexReturnPropertyOnIndexedNode) {
     newChange();
     ASSERT_TRUE(query("CREATE INDEX ageindex FOR (n) ON n.age", emptyCallback));


### PR DESCRIPTION
Allows for dropping indexes from subsequent commits; specifying the index to drop by its name.

Usage:
~~~
DROP INDEX <index name>
~~~

Indexes to drop are added to the `CommitWriteBuffer`. When a `CommitWriteBuffer` is flushed, the vector of valid indexes is filtered to remove those which are to be dropped.