### PR TITLE
Enable dynamic properties in `CREATE` queries

### DIFF
--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <utility>
 
@@ -413,7 +412,6 @@ void WriteProcessor::createNodes(size_t numIters) {
             for (const PerNodeProperties& props : properties) {
                 const size_t numProps = props.size();
 
-                // TODO: test with empty MATCH into CREATE
                 const bool isDynamic = numProps == numIters;
                 const bool isStatic = !isDynamic && numProps == 1;
 

--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -364,20 +364,26 @@ void WriteProcessor::createNodes(size_t numIters) {
         // Get all properties: this can throw, so we do this BEFORE adding PendingNodes to
         // CommitWriteBuffer, as otherwise after throwing this could leave it in invalid
         // state.
-        std::vector<CommitWriteBuffer::UntypedProperty> constProps;
-        constProps.reserve(node._properties.size());
+        std::vector<CommitWriteBuffer::UntypedProperty> properties;
+        properties.reserve(node._properties.size());
 
-        // Temporary buffer, reused across iterations, to add properties to the WriteBuffer
+        // Temporary buffers, reused across iterations, to add properties to the WriteBuffer
         CommitWriteBuffer::UntypedProperty propBuffer;
+        CommitWriteBuffer::UntypedProperties propsBuffer;
 
         for (const auto& [name, type, valueCol] : node._properties) {
             const PropertyTypeID propID =
                 _metadataBuilder->getOrCreatePropertyType(name, type)._id;
 
-            // Extract the constant value from the value column
-            getConstantUntypedProperty(valueCol, propBuffer, propID);
-
-            constProps.emplace_back(propBuffer);
+            if (isColumnConst(valueCol)) {
+                getConstantUntypedProperty(valueCol, propBuffer, propID);
+                properties.emplace_back(propBuffer);
+            } else {
+                getUntypedProperties(valueCol, propsBuffer, propID);
+                for (const CommitWriteBuffer::UntypedProperty& x : propsBuffer) {
+                    properties.emplace_back(x);
+                }
+            }
         }
 
         {
@@ -389,10 +395,8 @@ void WriteProcessor::createNodes(size_t numIters) {
                 newNode.labelsetHandle = hdl;
             }
 
-            // Add each property; NOTE: for now all ColumnConst, so all same value.
             // Extract the value first, then add that value to each node to create.
-            // TODO: More cache friendly access patterns
-            for (const CommitWriteBuffer::UntypedProperty& prop : constProps) {
+            for (const CommitWriteBuffer::UntypedProperty& prop : properties) {
                 for (size_t i = 0; i < numIters; i++) {
                     auto& pendingNode = _writeBuffer->getPendingNode(numPendingNodesPrior + i);
                     pendingNode.properties.emplace_back(prop);

--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 #include <range/v3/view/zip.hpp>
 
@@ -364,8 +366,8 @@ void WriteProcessor::createNodes(size_t numIters) {
         // Get all properties: this can throw, so we do this BEFORE adding PendingNodes to
         // CommitWriteBuffer, as otherwise after throwing this could leave it in invalid
         // state.
-        std::vector<CommitWriteBuffer::UntypedProperty> properties;
-        properties.reserve(node._properties.size());
+        using PerNodeProperties = std::vector<CommitWriteBuffer::UntypedProperty>;
+        std::vector<PerNodeProperties> properties;
 
         // Temporary buffers, reused across iterations, to add properties to the WriteBuffer
         CommitWriteBuffer::UntypedProperty propBuffer;
@@ -377,11 +379,12 @@ void WriteProcessor::createNodes(size_t numIters) {
 
             if (isColumnConst(valueCol)) {
                 getConstantUntypedProperty(valueCol, propBuffer, propID);
-                properties.emplace_back(propBuffer);
+                properties.emplace_back(PerNodeProperties {propBuffer});
             } else {
                 getUntypedProperties(valueCol, propsBuffer, propID);
+                PerNodeProperties& newProps = properties.emplace_back();
                 for (const CommitWriteBuffer::UntypedProperty& x : propsBuffer) {
-                    properties.emplace_back(x);
+                    newProps.emplace_back(x);
                 }
             }
         }
@@ -396,10 +399,29 @@ void WriteProcessor::createNodes(size_t numIters) {
             }
 
             // Extract the value first, then add that value to each node to create.
-            for (const CommitWriteBuffer::UntypedProperty& prop : properties) {
-                for (size_t i = 0; i < numIters; i++) {
-                    auto& pendingNode = _writeBuffer->getPendingNode(numPendingNodesPrior + i);
-                    pendingNode.properties.emplace_back(prop);
+            for (const PerNodeProperties& props : properties) {
+                const size_t numProps = props.size();
+
+                const bool isDynamic = numProps == numIters;
+                const bool isStatic = !isDynamic && numProps == 1;
+
+                if (isStatic) {
+                    const auto& propValue = props.front();
+
+                    for (size_t i = 0; i < numIters; i++) {
+                        const size_t pendingNodeIdx = numPendingNodesPrior + i;
+                        auto& pendingNode = _writeBuffer->getPendingNode(pendingNodeIdx);
+
+                        pendingNode.properties.emplace_back(propValue);
+                    }
+                } else if (isDynamic) {
+                    for (size_t i = 0; i < numIters; i++) {
+                        const size_t pendingNodeIdx = numPendingNodesPrior + i;
+                        auto& pendingNode = _writeBuffer->getPendingNode(pendingNodeIdx);
+                        const auto& propValue = props.at(i);
+
+                        pendingNode.properties.emplace_back(propValue);
+                    }
                 }
             }
         }

--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <string_view>
 #include <utility>
-#include <variant>
 
 #include <range/v3/view/zip.hpp>
 
@@ -366,6 +365,16 @@ void WriteProcessor::createNodes(size_t numIters) {
         // Get all properties: this can throw, so we do this BEFORE adding PendingNodes to
         // CommitWriteBuffer, as otherwise after throwing this could leave it in invalid
         // state.
+
+        // A single @ref WriteProcessorTypes::PendingNode refers to a column of nodes to
+        // be created. This means that a single PendingNode can materialise into some
+        // number, k, nodes in the db. For a property type T, each of these k nodes may
+        // have the same value for that property, or dynamic differing values.
+        // e.g. `MATCH (m) CREATE (n:X{name: m.name, age: 100})` - name is dynamic but age
+        // is static.
+        // Thus we need to store single static valued or an arbitrary number of dynamic
+        // values, per PendingNode. PerNodeProperties is a singleton vector in the case of
+        // a static property, and otherwise is of dynamic length.
         using PerNodeProperties = std::vector<CommitWriteBuffer::UntypedProperty>;
         std::vector<PerNodeProperties> properties;
 
@@ -377,10 +386,10 @@ void WriteProcessor::createNodes(size_t numIters) {
             const PropertyTypeID propID =
                 _metadataBuilder->getOrCreatePropertyType(name, type)._id;
 
-            if (isColumnConst(valueCol)) {
+            if (isColumnConst(valueCol)) { // static: single value for all nodes to create
                 getConstantUntypedProperty(valueCol, propBuffer, propID);
                 properties.emplace_back(PerNodeProperties {propBuffer});
-            } else {
+            } else { // dynamic: differing value for each node to create
                 getUntypedProperties(valueCol, propsBuffer, propID);
                 PerNodeProperties& newProps = properties.emplace_back();
                 for (const CommitWriteBuffer::UntypedProperty& x : propsBuffer) {
@@ -402,6 +411,7 @@ void WriteProcessor::createNodes(size_t numIters) {
             for (const PerNodeProperties& props : properties) {
                 const size_t numProps = props.size();
 
+                // TODO: test with empty MATCH into CREATE
                 const bool isDynamic = numProps == numIters;
                 const bool isStatic = !isDynamic && numProps == 1;
 
@@ -422,6 +432,8 @@ void WriteProcessor::createNodes(size_t numIters) {
 
                         pendingNode.properties.emplace_back(propValue);
                     }
+                } else {
+                    throw FatalException("Incorrectly fetched node properties.");
                 }
             }
         }
@@ -465,35 +477,21 @@ void WriteProcessor::createEdges(size_t numIters) {
         // However, all input columns are also propagated to the output, so we can
         // always retrieve the column from the output dataframe, regardless of whether
         // the source node was the result of a CREATE or a MATCH
-        if (!outDf->hasColumn(srcTag)) {
-            throw FatalException(fmt::format("Attempted to create edge {} with "
-                                             "source node with no such column: {}",
-                                             edge._name, edge._srcTag.getValue()));
-        }
+        const bool outputHasSrc = outDf->hasColumn(srcTag);
+        bioassert(outputHasSrc, "Output missing source {}", srcTag.getValue());
+
         srcCol = outDf->getColumn(srcTag)->as<ColumnNodeIDs>();
-        if (!srcCol) { // @ref as<> performs dynamic_cast
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " pending source nodes, but is not a NodeID"
-                                             " column.",
-                                             srcTag.getValue()));
-        }
+        bioassert(srcCol, "Invalid source column, {}.", srcTag.getValue());
 
         ColumnNodeIDs* tgtCol = nullptr;
         const ColumnTag tgtTag = edge._tgtTag;
         const bool tgtIsPending = !inDf || inDf->getColumn(tgtTag) == nullptr;
 
-        if (!outDf->hasColumn(tgtTag)) {
-            throw FatalException(fmt::format("Attempted to create edge {} with "
-                                             "target node with no such column: {}",
-                                             edge._name, edge._tgtTag.getValue()));
-        }
+        const bool outputHasTgt = outDf->hasColumn(tgtTag);
+        bioassert(outputHasTgt, "Output missing target {}", tgtTag.getValue());
+
         tgtCol = outDf->getColumn(tgtTag)->as<ColumnNodeIDs>();
-        if (!tgtCol) { // @ref as<> performs dynamic_cast
-            throw FatalException(fmt::format("Column {} was marked as a column of"
-                                             " pending target nodes, but is not a NodeID"
-                                             " column.",
-                                             tgtTag.getValue()));
-        }
+        bioassert(tgtCol, "Invalid target column {}.", tgtTag.getValue());
 
         bioassert(tgtCol->size() == srcCol->size(), "src and target column should have same dimension");
         bioassert(tgtCol->size() == numIters, "invalid size of target column");
@@ -501,20 +499,27 @@ void WriteProcessor::createEdges(size_t numIters) {
         // Get all properties: this can throw, so we do this BEFORE adding PendingEdges to
         // CommitWriteBuffer, as otherwise after throwing this could leave it in invalid
         // state.
-        std::vector<CommitWriteBuffer::UntypedProperty> constProps;
-        constProps.reserve(edge._properties.size());
+        using PerEdgeProperties = std::vector<CommitWriteBuffer::UntypedProperty>;
+        std::vector<PerEdgeProperties> properties;
 
-        // Temporary buffer, reused across iterations, to add properties to the WriteBuffer
+        // Temporary buffers, reused across iterations, to add properties to the WriteBuffer
         CommitWriteBuffer::UntypedProperty propBuffer;
+        CommitWriteBuffer::UntypedProperties propsBuffer;
 
         for (const auto& [name, type, valueCol] : edge._properties) {
             const PropertyTypeID propID =
                 _metadataBuilder->getOrCreatePropertyType(name, type)._id;
 
-            // Extract the constant value from the value column
-            getConstantUntypedProperty(valueCol, propBuffer, propID);
-
-            constProps.emplace_back(std::move(propBuffer));
+            if (isColumnConst(valueCol)) { // static: single value for all edges to create
+                getConstantUntypedProperty(valueCol, propBuffer, propID);
+                properties.emplace_back(PerEdgeProperties {propBuffer});
+            } else { // dynamic: differing value for each edge to create
+                getUntypedProperties(valueCol, propsBuffer, propID);
+                PerEdgeProperties& newProps = properties.emplace_back();
+                for (const CommitWriteBuffer::UntypedProperty& x : propsBuffer) {
+                    newProps.emplace_back(x);
+                }
+            }
         }
 
         const size_t numPendingEdgesPrior = _writeBuffer->numPendingEdges();
@@ -546,13 +551,31 @@ void WriteProcessor::createEdges(size_t numIters) {
             pendingEdge.edgeType = typeID;
         }
 
-        // Add each property; NOTE: for now all ColumnConst, so all same value.
-        // Extract the value first, then add that value to each node to create.
-        // TODO: More cache friendly access patterns
-        for (const CommitWriteBuffer::UntypedProperty& prop : constProps) {
-            for (size_t i = 0; i < numIters; i++) {
-                auto& pendingEdge = _writeBuffer->getPendingEdge(numPendingEdgesPrior + i);
-                pendingEdge.properties.emplace_back(prop);
+        for (const PerEdgeProperties& props : properties) {
+            const size_t numProps = props.size();
+
+            const bool isDynamic = numProps == numIters;
+            const bool isStatic = !isDynamic && numProps == 1;
+
+            if (isStatic) {
+                const auto& propValue = props.front();
+
+                for (size_t i = 0; i < numIters; i++) {
+                    const size_t pendingEdgeIdx = numPendingEdgesPrior + i;
+                    auto& pendingEdge = _writeBuffer->getPendingEdge(pendingEdgeIdx);
+
+                    pendingEdge.properties.emplace_back(propValue);
+                }
+            } else if (isDynamic) {
+                for (size_t i = 0; i < numIters; i++) {
+                    const size_t pendingEdgeIdx = numPendingEdgesPrior + i;
+                    auto& pendingEdge = _writeBuffer->getPendingEdge(pendingEdgeIdx);
+                    const auto& propValue = props.at(i);
+
+                    pendingEdge.properties.emplace_back(propValue);
+                }
+            } else {
+                throw FatalException("Incorrectly fetched edge properties.");
             }
         }
 

--- a/query/pipeline/processors/WriteProcessor.cpp
+++ b/query/pipeline/processors/WriteProcessor.cpp
@@ -386,7 +386,9 @@ void WriteProcessor::createNodes(size_t numIters) {
             const PropertyTypeID propID =
                 _metadataBuilder->getOrCreatePropertyType(name, type)._id;
 
-            if (isColumnConst(valueCol)) { // static: single value for all nodes to create
+            const bool isStatic = isColumnConst(valueCol);
+
+            if (isStatic) { // static: single value for all nodes to create
                 getConstantUntypedProperty(valueCol, propBuffer, propID);
                 properties.emplace_back(PerNodeProperties {propBuffer});
             } else { // dynamic: differing value for each node to create
@@ -510,7 +512,9 @@ void WriteProcessor::createEdges(size_t numIters) {
             const PropertyTypeID propID =
                 _metadataBuilder->getOrCreatePropertyType(name, type)._id;
 
-            if (isColumnConst(valueCol)) { // static: single value for all edges to create
+            const bool isStatic = isColumnConst(valueCol);
+
+            if (isStatic) { // static: single value for all edges to create
                 getConstantUntypedProperty(valueCol, propBuffer, propID);
                 properties.emplace_back(PerEdgeProperties {propBuffer});
             } else { // dynamic: differing value for each edge to create

--- a/query/plan/WriteStmtGenerator.cpp
+++ b/query/plan/WriteStmtGenerator.cpp
@@ -36,6 +36,8 @@
 #include "stmt/CreateStmt.h"
 #include "stmt/DeleteStmt.h"
 
+#include "BioAssert.h"
+
 using namespace db;
 
 WriteStmtGenerator::WriteStmtGenerator(const CypherAST* ast,
@@ -202,7 +204,7 @@ void WriteStmtGenerator::generateCreatePatternElement(const PatternElement* elem
 
     if (!_writeNode->hasPendingNode(originDecl) && varNode == nullptr) {
         // Node is not created yet and is not an input
-        checkDependencies(*_variables, data);
+        supplyPropertyDependencies(*_variables, data);
         _writeNode->addNode(originDecl, data);
 
         _variables->setProducer(originDecl, _writeNode);
@@ -219,7 +221,7 @@ void WriteStmtGenerator::generateCreatePatternElement(const PatternElement* elem
 
         if (!_writeNode->hasPendingNode(rhs) && rhsVarNode == nullptr) {
             // Node is not created yet and is not an input
-            checkDependencies(*_variables, rhsData);
+            supplyPropertyDependencies(*_variables, rhsData);
             _writeNode->addNode(rhs, rhsData);
             _variables->setProducer(rhs, _writeNode);
         }
@@ -228,7 +230,7 @@ void WriteStmtGenerator::generateCreatePatternElement(const PatternElement* elem
         const VarDecl* edgeDecl = edge->getDecl();
         {
             const EdgePatternData* edgeData = edge->getData();
-            checkDependencies(*_variables, edgeData);
+            supplyPropertyDependencies(*_variables, edgeData);
             _variables->setProducer(edgeDecl, _writeNode);
         }
 
@@ -260,15 +262,20 @@ void WriteStmtGenerator::prepareWriteNode() {
     }
 }
 
-void WriteStmtGenerator::checkDependencies(PlanGraphVariables& variables, const PatternData* data) {
+void WriteStmtGenerator::supplyPropertyDependencies(PlanGraphVariables& variables,
+                                                    const PatternData* data) {
     ExprDependencies deps;
-    for (auto&& d : data->exprConstraints()) {
+    for (const EntityPropertyConstraint& d : data->exprConstraints()) {
         deps.genExprDependencies(variables, d._expr);
 
         for (const ExprDependencies::VarDependency& dep : deps.getVarDeps()) {
             Expr* e = dep._expr;
+            bioassert(e, "Null dependency.");
+
             if (e->getKind() == Expr::Kind::PROPERTY) {
                 fetchOrGenerateProperty(static_cast<PropertyExpr*>(e));
+            } else {
+                throwError("Unknown dependency.", e);
             }
         }
     }

--- a/query/plan/WriteStmtGenerator.cpp
+++ b/query/plan/WriteStmtGenerator.cpp
@@ -38,19 +38,6 @@
 
 using namespace db;
 
-namespace {
-
-template <typename T>
-    requires (std::is_same_v<const NodePatternData*, T>) || (std::is_same_v<const EdgePatternData*, T>)
-void checkDependencies(PlanGraphVariables& variables, T data) {
-    ExprDependencies deps;
-    for (auto&& d : data->exprConstraints()) {
-        deps.genExprDependencies(variables, d._expr);
-    }
-}
-
-}
-
 WriteStmtGenerator::WriteStmtGenerator(const CypherAST* ast,
                                        PlanGraph* tree,
                                        PlanGraphVariables* variables,
@@ -270,6 +257,20 @@ void WriteStmtGenerator::prepareWriteNode() {
     } else {
         // Previous node is not a write node, create a new one
         _writeNode = _tree->newOut<WriteNode>(_prevNode);
+    }
+}
+
+void WriteStmtGenerator::checkDependencies(PlanGraphVariables& variables, const PatternData* data) {
+    ExprDependencies deps;
+    for (auto&& d : data->exprConstraints()) {
+        deps.genExprDependencies(variables, d._expr);
+
+        for (const ExprDependencies::VarDependency& dep : deps.getVarDeps()) {
+            Expr* e = dep._expr;
+            if (e->getKind() == Expr::Kind::PROPERTY) {
+                fetchOrGenerateProperty(static_cast<PropertyExpr*>(e));
+            }
+        }
     }
 }
 

--- a/query/plan/WriteStmtGenerator.cpp
+++ b/query/plan/WriteStmtGenerator.cpp
@@ -47,10 +47,6 @@ void checkDependencies(PlanGraphVariables& variables, T data) {
     for (auto&& d : data->exprConstraints()) {
         deps.genExprDependencies(variables, d._expr);
     }
-    if (!deps.empty()) {
-        throw PlannerException("CREATE statements with entity dependencies "
-                               "are not yet supported.");
-    }
 }
 
 }

--- a/query/plan/WriteStmtGenerator.h
+++ b/query/plan/WriteStmtGenerator.h
@@ -21,6 +21,7 @@ class NodePattern;
 class EdgePattern;
 class GetPropertyCache;
 class PropertyExpr;
+class PatternData;
 
 class WriteStmtGenerator {
 public:
@@ -59,6 +60,7 @@ private:
 
     void prepareWriteNode();
 
+    void checkDependencies(PlanGraphVariables& variables, const PatternData* data);
     void fetchOrGenerateProperty(PropertyExpr* prop);
 
     [[noreturn]] void throwError(std::string_view msg, const void* obj = 0) const;

--- a/query/plan/WriteStmtGenerator.h
+++ b/query/plan/WriteStmtGenerator.h
@@ -60,10 +60,11 @@ private:
 
     void prepareWriteNode();
 
-    void checkDependencies(PlanGraphVariables& variables, const PatternData* data);
+    void supplyPropertyDependencies(PlanGraphVariables& variables,
+                                    const PatternData* data);
     void fetchOrGenerateProperty(PropertyExpr* prop);
 
-    [[noreturn]] void throwError(std::string_view msg, const void* obj = 0) const;
+    [[noreturn]] void throwError(std::string_view msg, const void* obj = nullptr) const;
 
     static constexpr bool DELETE_PENDING_SUPPORTED {false};
 };

--- a/storage/DataPart.cpp
+++ b/storage/DataPart.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <range/v3/action/sort.hpp>
+#include <range/v3/action/stable_sort.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 
@@ -76,7 +77,7 @@ CommitResult<void> DataPart::load(const GraphView& view, JobSystem& jobSystem, D
     }
 
     // Sorting based on the labelset
-    rg::sort(rv::zip(coreNodeLabelSets, tmpNodeIDs),
+    rg::stable_sort(rv::zip(coreNodeLabelSets, tmpNodeIDs),
              [](const auto& data1, const auto& data2) {
                  const LabelSetHandle& lset1 = std::get<0>(data1);
                  const LabelSetHandle& lset2 = std::get<0>(data2);

--- a/storage/DataPart.cpp
+++ b/storage/DataPart.cpp
@@ -5,7 +5,6 @@
 #include <string>
 
 #include <range/v3/action/sort.hpp>
-#include <range/v3/action/stable_sort.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 
@@ -77,7 +76,7 @@ CommitResult<void> DataPart::load(const GraphView& view, JobSystem& jobSystem, D
     }
 
     // Sorting based on the labelset
-    rg::stable_sort(rv::zip(coreNodeLabelSets, tmpNodeIDs),
+    rg::sort(rv::zip(coreNodeLabelSets, tmpNodeIDs),
              [](const auto& data1, const auto& data2) {
                  const LabelSetHandle& lset1 = std::get<0>(data1);
                  const LabelSetHandle& lset2 = std::get<0>(data2);

--- a/storage/properties/PropertyContainer.h
+++ b/storage/properties/PropertyContainer.h
@@ -269,9 +269,10 @@ public:
     ~TypedPropertyContainer() override = default;
 
     void add(EntityID entityID, std::span<const float> v) {
-        _entityIndexMap[entityID] = _ids.size();
+        const size_t index = _values.size();
         _values.alloc(v);
         _ids.emplace_back(entityID);
+        _entityIndexMap[entityID] = index;
     }
 
     bool has(EntityID entityID) const override {

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -1200,13 +1200,11 @@ TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
     using Rows = LineContainer<types::String::Primitive>;
     Rows expected;
     {
-        size_t i = 0;
         for (const NodeID n : read().scanNodes()) {
             const types::String::Primitive* name =
                 read().tryGetNodeProperty<types::String>(NAME_PROP_ID, n);
             ASSERT_TRUE(name);
             expected.add({*name});
-            ++i;
         }
     }
 
@@ -1265,7 +1263,7 @@ TEST_F(WriteQueriesTest, createInterleavedLabelSetsBatch) {
     Rows actual;
     auto res = query(R"(MATCH (n) RETURN n, n.name)", [&](const Dataframe* df) {
         ASSERT_TRUE(df);
-        auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+        auto* ns = df->cols().front()->as<ColumnNodeIDs>();
         auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
         ASSERT_TRUE(ns && names);
         const size_t rowCount = df->getLogicalRowCount();
@@ -1338,7 +1336,7 @@ TEST_F(WriteQueriesTest, matchCreateTwoLabelSetsInterleaved) {
         Rows actual;
         auto res = query(R"(MATCH (n:BetaType) RETURN n, n.name)", [&](const Dataframe* df) {
             ASSERT_TRUE(df);
-            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
             auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
             ASSERT_TRUE(ns && names);
             const size_t rowCount = df->getLogicalRowCount();
@@ -1370,7 +1368,6 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
 
     {
         constexpr std::string_view preQuery = R"(MATCH (n:Person) RETURN n, n.name)";
-        size_t pendingIdx = 0;
         auto res = query(preQuery, [&](const Dataframe* df) {
             auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
             ASSERT_TRUE(names);
@@ -1380,7 +1377,6 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
                 redExpected.add({*names->at(r)});
                 greenExpected.add({*names->at(r)});
                 blueExpected.add({*names->at(r)});
-                ++pendingIdx;
             }
         });
         ASSERT_TRUE(res);
@@ -1541,10 +1537,10 @@ TEST_F(WriteQueriesTest, createEdgeCrossProductDynamicTwoProps) {
         auto res = query(preQuery, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(df->size(), 4);
-            auto* ns     = df->cols().front()->as<ColumnNodeIDs>();
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
             auto* name1s = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
             auto* name2s = findColumn(df, "m.name")->as<ColumnOptVector<types::String::Primitive>>();
-            auto* ms     = df->cols().back()->as<ColumnNodeIDs>();
+            auto* ms = df->cols().back()->as<ColumnNodeIDs>();
             ASSERT_TRUE(ns && name1s && name2s && ms);
             const size_t rowCount = df->getLogicalRowCount();
             ASSERT_NE(rowCount, 0) << "Pre-query matched no rows; check SimpleGraph predicates";

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <algorithm>
 #include <range/v3/view/enumerate.hpp>
+#include <string_view>
 
 #include "EdgeRecord.h"
 #include "TuringDB.h"
@@ -11,6 +12,7 @@
 #include "SimpleGraph.h"
 #include "SystemManager.h"
 #include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
 #include "metadata/PropertyType.h"
 #include "versioning/Change.h"
 #include "versioning/Transaction.h"
@@ -1646,8 +1648,7 @@ TEST_F(WriteQueriesTest, dynamicPropExpression) {
 
     {
         newChange();
-        const auto res = query(CREATE_QUERY, _emptyCallback);
-        ASSERT_TRUE(res) << res.getError();
+        ASSERT_TRUE(query(CREATE_QUERY, _emptyCallback));
         submitCurrentChange();
     }
 
@@ -1665,6 +1666,65 @@ TEST_F(WriteQueriesTest, dynamicPropExpression) {
                 const types::String::Primitive name = *names->operator[](i);
                 const types::Int64::Primitive age = *ages->operator[](i);
                 actual.add({name, age});
+            }
+        });
+    }
+
+    ASSERT_TRUE(expected.equals(actual)) << [expected, actual] {
+        std::ostringstream out;
+        out << "expected:\n";
+        expected.print(out);
+        out << "actual:\n";
+        actual.print(out);
+        return out.str();
+    }();
+}
+
+TEST_F(WriteQueriesTest, doubleDynamicExpression) {
+    std::string_view CREATE_QUERY =
+        R"(MATCH (n)-->(m) WHERE n.age IS NOT NULL AND m.age IS NOT NULL CREATE (n)-[e:NEW{age_prod: n.age * m.age}]->(m))";
+
+    using Rows = LineContainer<types::Int64::Primitive>;
+
+    Rows expected;
+    {
+        std::string_view q = "MATCH (n)-->(m) WHERE n.age IS NOT NULL AND m.age IS NOT "
+                             "NULL RETURN n.age, m.age";
+
+        auto res = query(q, [&expected](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* nages = findColumn(df, "n.age")->as<ColumnOptVector<types::Int64::Primitive>>();
+            auto* mages = findColumn(df, "m.age")->as<ColumnOptVector<types::Int64::Primitive>>();
+            ASSERT_TRUE(nages && mages);
+
+            const size_t rows = df->getLogicalRowCount();
+            for (size_t i = 0; i < rows; i++) {
+                const auto nage = *nages->at(i);
+                const auto mage = *mages->at(i);
+                expected.add({nage * mage});
+            }
+        });
+        ASSERT_TRUE(res) << res.getError();
+    }
+
+    {
+        newChange();
+        ASSERT_TRUE(query(CREATE_QUERY, _emptyCallback));
+        submitCurrentChange();
+    }
+
+    Rows actual;
+    {
+        std::string_view MATCH_QUERY = R"(MATCH ()-[e:NEW]->() RETURN e.age_prod)";
+        auto res = query(MATCH_QUERY, [&actual](const Dataframe* df){
+            ASSERT_TRUE(df);
+            auto* eprods = findColumn(df, "e.age_prod")->as<ColumnOptVector<types::Int64::Primitive>>();
+            ASSERT_TRUE(eprods);
+
+            const size_t rows = df->getLogicalRowCount();
+            for (size_t i = 0; i < rows; i++) {
+                const auto prod = *eprods->at(i);
+                actual.add({prod});
             }
         });
     }

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -962,6 +962,62 @@ TEST_F(WriteQueriesTest, scanNodesCreateNodeConstProp) {
     }
 }
 
+TEST_F(WriteQueriesTest, scanNodesCreateNodeDynamicProp) {
+    constexpr std::string_view CREATE_QUERY = R"(MATCH (n) CREATE (m:Person{name:n.name}))";
+    constexpr std::string_view MATCH_QUERY = "MATCH (n) RETURN n, n.name";
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    PropertyTypeID NAME_PROP_ID(0); // 'name' is the first property type registered
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+
+    Rows expected;
+    {
+        for (const NodeID n : read().scanNodes()) {
+            const types::String::Primitive* name =
+                read().tryGetNodeProperty<types::String>(NAME_PROP_ID, n);
+            ASSERT_TRUE(name);
+            // Original node keeps its name
+            expected.add({n, *name});
+            // New Person node created from matching n gets n.name
+            expected.add({n + numNodesPrior, *name});
+        }
+    }
+
+    {
+        newChange();
+        auto res = query(CREATE_QUERY, [](const Dataframe* df) -> void {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 0);
+        });
+        ASSERT_TRUE(res);
+        submitCurrentChange();
+    }
+
+    {
+        Rows actual;
+        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 2);
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns);
+            ASSERT_TRUE(names);
+            ASSERT_EQ(ns->size(), numNodesPrior * 2);
+            ASSERT_EQ(names->size(), numNodesPrior * 2);
+
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t rowPtr = 0; rowPtr < rowCount; rowPtr++) {
+                ASSERT_TRUE(names->at(rowPtr));
+                actual.add({ns->at(rowPtr), *names->at(rowPtr)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual));
+    }
+}
+
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {
     setWorkingGraph("default");
     // NOTE: Returning properties of just-created nodes is not yet supported

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -1018,6 +1018,232 @@ TEST_F(WriteQueriesTest, scanNodesCreateNodeDynamicProp) {
     }
 }
 
+TEST_F(WriteQueriesTest, createNodesFromPersonSubsetDynamicName) {
+    constexpr std::string_view CREATE_QUERY = R"(MATCH (n:Person) CREATE (m:Copy{name:n.name}))";
+    constexpr std::string_view MATCH_QUERY = R"(MATCH (n:Copy) RETURN n, n.name)";
+
+    PropertyTypeID NAME_PROP_ID(0);
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+
+    Rows expected;
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n:Person) RETURN n, n.name)";
+        size_t pendingIdx = 0;
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                expected.add({NodeID(numNodesPrior + pendingIdx), *names->at(r)});
+                ++pendingIdx;
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    {
+        newChange();
+        auto res = query(CREATE_QUERY, [](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 0);
+        });
+        ASSERT_TRUE(res);
+        submitCurrentChange();
+    }
+
+    {
+        Rows actual;
+        auto res = query(MATCH_QUERY, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 2);
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({ns->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual)) << "Dynamic name property was not preserved "
+                                                "across DataPart::load for same-label-set nodes.";
+    }
+}
+
+TEST_F(WriteQueriesTest, createNodesDynamicNameAndDob) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n:Person) WHERE n.dob IS NOT NULL CREATE (m:PersonCopy{name:n.name, dob:n.dob}))";
+
+    PropertyTypeID NAME_PROP_ID(0);
+    PropertyTypeID DOB_PROP_ID(1); // 'dob' is the second property added in SimpleGraph
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    using Rows = LineContainer<NodeID, types::String::Primitive, types::String::Primitive>;
+
+    Rows expected;
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n:Person) WHERE n.dob IS NOT NULL RETURN n, n.name, n.dob)";
+        size_t pendingIdx = 0;
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 3);
+            auto* names = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* dobs  = findColumn(df, "n.dob")->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(names && dobs);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                if (!names->at(r) || !dobs->at(r)) { ++pendingIdx; continue; }
+                expected.add({NodeID(numNodesPrior + pendingIdx),
+                              *names->at(r),
+                              *dobs->at(r)});
+                ++pendingIdx;
+            }
+        });
+        ASSERT_TRUE(res) << res.getError();
+    }
+
+    {
+        newChange();
+        auto res = query(CREATE_QUERY, [](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 0);
+        });
+        ASSERT_TRUE(res);
+        submitCurrentChange();
+    }
+
+    {
+        Rows actual;
+        constexpr std::string_view matchQuery =
+            R"(MATCH (n:PersonCopy) RETURN n, n.name, n.dob)";
+        auto res = query(matchQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* ns   = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* dobs  = findColumn(df, "n.dob")->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names && dobs);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r)) << "New node " << ns->at(r).getValue()
+                                          << " is missing name";
+                ASSERT_TRUE(dobs->at(r))  << "New node " << ns->at(r).getValue()
+                                          << " is missing dob";
+                actual.add({ns->at(r), *names->at(r), *dobs->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual)) << "One or more dynamic properties were "
+                                                "permuted across same-label-set nodes.";
+    }
+}
+
+TEST_F(WriteQueriesTest, setDynamicNameOnNewNodes) {
+    setWorkingGraph("default");
+
+    newChange();
+
+    for (const auto& name : {"Alpha", "Beta", "Gamma", "Delta"}) {
+        const std::string q = fmt::format(R"(CREATE (n:Source{{name:"{}"}}))", name);
+        ASSERT_TRUE(query(q, [](const Dataframe*) {}));
+    }
+
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+
+    constexpr std::string_view copyQuery =
+        R"(MATCH (n:Source) CREATE (m:Copy{name:n.name}))";
+    ASSERT_TRUE(query(copyQuery, [](const Dataframe*) {}));
+
+    submitCurrentChange();
+
+    // Every :Copy node must have a name that belongs to a :Source node, and
+    // each name must appear exactly once.
+    using Rows = LineContainer<types::String::Primitive>;
+    const Rows expected = [] {
+        Rows r;
+        for (const auto& n : {"Alpha", "Beta", "Gamma", "Delta"}) {
+            r.add({n});
+        }
+        return r;
+    }();
+
+    Rows actual;
+    {
+        constexpr std::string_view matchQuery = R"(MATCH (n:Copy) RETURN n.name)";
+        auto res = query(matchQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* names = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(names);
+            ASSERT_EQ(names->size(), 4);
+            for (auto& name : *names) {
+                ASSERT_TRUE(name);
+                actual.add({*name});
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+    ASSERT_TRUE(expected.equals(actual));
+}
+
+TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n) CREATE (m:Snapshot{name:n.name}))";
+
+    PropertyTypeID NAME_PROP_ID(0);
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    Rows expected;
+    {
+        size_t i = 0;
+        for (const NodeID n : read().scanNodes()) {
+            const types::String::Primitive* name =
+                read().tryGetNodeProperty<types::String>(NAME_PROP_ID, n);
+            ASSERT_TRUE(name);
+            expected.add({NodeID(numNodesPrior + i), *name});
+            ++i;
+        }
+    }
+
+    newChange();
+    {
+        auto res = query(CREATE_QUERY, [](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 0);
+        });
+        ASSERT_TRUE(res);
+    }
+
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    {
+        Rows actual;
+        constexpr std::string_view matchQuery = R"(MATCH (n:Snapshot) RETURN n, n.name)";
+        auto res = query(matchQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r)) << "Node " << ns->at(r).getValue()
+                                          << " lost its name across DataPart boundary";
+                actual.add({ns->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual)) << "Names were permuted when DataPart was "
+                                                "reloaded after explicit commit.";
+    }
+}
+
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {
     setWorkingGraph("default");
     // NOTE: Returning properties of just-created nodes is not yet supported

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -1529,6 +1529,104 @@ TEST_F(WriteQueriesTest, createEdgesFromNodesDynamicName) {
     }
 }
 
+TEST_F(WriteQueriesTest, createEdgeCrossProductDynamicTwoProps) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n), (m) WHERE n.age = 32 AND m.hasPhD AND NOT m.isFrench)"
+        R"( CREATE (n)-[e:NEW{name1:n.name, name2:m.name}]->(m))";
+
+    using Rows = LineContainer<NodeID, types::String::Primitive, types::String::Primitive, NodeID>;
+    Rows expected;
+
+    {
+        // Mirror the same MATCH/WHERE to build the expected (src, name1, name2, dst) set
+        // without hardcoding node IDs.
+        constexpr std::string_view preQuery =
+            R"(MATCH (n), (m) WHERE n.age = 32 AND m.hasPhD AND NOT m.isFrench)"
+            R"( RETURN n, n.name, m.name, m)";
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 4);
+            auto* ns     = df->cols().front()->as<ColumnNodeIDs>();
+            auto* name1s = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* name2s = findColumn(df, "m.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ms     = df->cols().back()->as<ColumnNodeIDs>();
+            ASSERT_TRUE(ns && name1s && name2s && ms);
+            const size_t rowCount = df->getLogicalRowCount();
+            ASSERT_NE(rowCount, 0) << "Pre-query matched no rows; check SimpleGraph predicates";
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(name1s->at(r));
+                ASSERT_TRUE(name2s->at(r));
+                expected.add({ns->at(r), *name1s->at(r), *name2s->at(r), ms->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    {
+        Rows actual;
+        constexpr std::string_view matchQuery =
+            R"(MATCH (n)-[e:NEW]->(m) RETURN n, e.name1, e.name2, m)";
+        auto res = query(matchQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 4);
+            auto* ns     = df->cols().front()->as<ColumnNodeIDs>();
+            auto* name1s = findColumn(df, "e.name1")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* name2s = findColumn(df, "e.name2")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ms     = df->cols().back()->as<ColumnNodeIDs>();
+            ASSERT_TRUE(ns && name1s && name2s && ms);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(name1s->at(r));
+                ASSERT_TRUE(name2s->at(r));
+                actual.add({ns->at(r), *name1s->at(r), *name2s->at(r), ms->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual));
+    }
+}
+
+TEST_F(WriteQueriesTest, createNodeEmptyMatch) {
+    // MATCH returns zero rows; CREATE must not produce any nodes.
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n) WHERE n.age = 9999 CREATE (m:Ghost{name:n.name}))";
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe* df) {
+        ASSERT_TRUE(df);
+        ASSERT_EQ(df->getLogicalRowCount(), 0);
+    }));
+    submitCurrentChange();
+
+    ASSERT_EQ(read().getTotalNodesAllocated(), numNodesPrior);
+}
+
+TEST_F(WriteQueriesTest, createEdgeEmptyMatch) {
+    // MATCH returns zero rows; CREATE must not produce any edges or nodes.
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n)-[e]->() WHERE n.age = 9999 CREATE (n)-[f:COPY{name:e.name}]->(n))";
+
+    const size_t totalEdgesPrior = read().getTotalEdgesAllocated();
+    const size_t totalNodesPrior = read().getTotalNodesAllocated();
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe* df) {
+        ASSERT_TRUE(df);
+        ASSERT_EQ(df->getLogicalRowCount(), 0);
+    }));
+    submitCurrentChange();
+
+    ASSERT_EQ(read().getTotalEdgesAllocated(), totalEdgesPrior);
+    ASSERT_EQ(read().getTotalNodesAllocated(), totalNodesPrior);
+}
+
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {
     setWorkingGraph("default");
     // NOTE: Returning properties of just-created nodes is not yet supported

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -1244,6 +1244,188 @@ TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
     }
 }
 
+TEST_F(WriteQueriesTest, createInterleavedLabelSetsBatch) {
+    setWorkingGraph("default");
+
+    constexpr std::string_view CREATE_QUERY =
+        R"(CREATE (:TypeAlpha{name:"A0"}), (:TypeBeta{name:"B0"}), (:TypeAlpha{name:"A1"}), (:TypeBeta{name:"B1"}), (:TypeAlpha{name:"A2"}), (:TypeBeta{name:"B2"}))";
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    Rows expected;
+    // Ensures sorted by labelset; even when not provided in labelset order
+    expected.add({NodeID(0), "A0"});
+    expected.add({NodeID(1), "A1"});
+    expected.add({NodeID(2), "A2"});
+    expected.add({NodeID(3), "B0"});
+    expected.add({NodeID(4), "B1"});
+    expected.add({NodeID(5), "B2"});
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    Rows actual;
+    auto res = query(R"(MATCH (n) RETURN n, n.name)", [&](const Dataframe* df) {
+        ASSERT_TRUE(df);
+        auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+        auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+        ASSERT_TRUE(ns && names);
+        const size_t rowCount = df->getLogicalRowCount();
+        for (size_t r = 0; r < rowCount; r++) {
+            ASSERT_TRUE(names->at(r)) << "Node " << ns->at(r).getValue() << " has null name";
+            actual.add({ns->at(r), *names->at(r)});
+        }
+    });
+    ASSERT_TRUE(res) << res.getError();
+    ASSERT_TRUE(expected.equals(actual));
+}
+
+TEST_F(WriteQueriesTest, matchCreateTwoLabelSetsInterleaved) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n:Person) CREATE (a:AlphaType{name:n.name}), (b:BetaType{name:n.name}))";
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    Rows alphaExpected;
+    Rows betaExpected;
+
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n:Person) RETURN n, n.name)";
+        size_t pendingIdx = 0;
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                alphaExpected.add({NodeID(numNodesPrior + pendingIdx), *names->at(r)});
+                betaExpected.add({NodeID(numNodesPrior + pendingIdx + names->size()), *names->at(r)});
+                ++pendingIdx;
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    {
+        Rows actual;
+        auto res = query(R"(MATCH (n:AlphaType) RETURN n, n.name)", [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({ns->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(alphaExpected.equals(actual)) << [alphaExpected, actual] {
+            std::ostringstream out;
+            out << "expected:\n";
+            alphaExpected.print(out);
+            out << "actual:\n";
+            actual.print(out);
+            return out.str();
+        }();
+    }
+
+    {
+        Rows actual;
+        auto res = query(R"(MATCH (n:BetaType) RETURN n, n.name)", [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({ns->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(betaExpected.equals(actual)) << [betaExpected, actual] {
+            std::ostringstream out;
+            out << "expected:\n";
+            betaExpected.print(out);
+            out << "actual:\n";
+            actual.print(out);
+            return out.str();
+        }();
+    }
+}
+
+TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n:Person) CREATE (r:RedType{name:n.name}), (g:GreenType{name:n.name}), (b:BlueType{name:n.name}))";
+
+    const size_t numNodesPrior = read().getTotalNodesAllocated();
+
+    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    Rows redExpected;
+    Rows greenExpected;
+    Rows blueExpected;
+
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n:Person) RETURN n, n.name)";
+        size_t pendingIdx = 0;
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                redExpected.add(  {NodeID(numNodesPrior + pendingIdx), *names->at(r)});
+                greenExpected.add({NodeID(numNodesPrior + pendingIdx + names->size()), *names->at(r)});
+                blueExpected.add( {NodeID(numNodesPrior + pendingIdx + (2 * names->size())), *names->at(r)});
+                ++pendingIdx;
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    auto verify = [this](std::string_view matchQuery, const Rows& expected, const char* label) {
+        Rows actual;
+        auto res = query(matchQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(ns && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({ns->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        EXPECT_TRUE(expected.equals(actual)) << [expected, actual, &label] {
+            std::ostringstream out;
+            out << label << '\n';
+            out << "expected:\n";
+            expected.print(out);
+            out << "actual:\n";
+            actual.print(out);
+            return out.str();
+        }();
+    };
+
+    verify(R"(MATCH (n:RedType) RETURN n, n.name)",   redExpected,   "RedType");
+    verify(R"(MATCH (n:GreenType) RETURN n, n.name)", greenExpected, "GreenType");
+    verify(R"(MATCH (n:BlueType) RETURN n, n.name)",  blueExpected,  "BlueType");
+}
+
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {
     setWorkingGraph("default");
     // NOTE: Returning properties of just-created nodes is not yet supported
@@ -1793,7 +1975,7 @@ TEST_F(WriteQueriesTest, multipleEdgeSetsSameProperty) {
 
             ASSERT_TRUE(std::ranges::all_of(*duration,
                 [](std::optional<types::Int64::Primitive> dur) { return *dur == 100; })
-            ) << [df]{ std::ostringstream out; df->dump(out); return out.str(); }();;
+            ) << [df]{ std::ostringstream out; df->dump(out); return out.str(); }();
         });
         ASSERT_TRUE(res);
     }

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -970,7 +970,7 @@ TEST_F(WriteQueriesTest, scanNodesCreateNodeDynamicProp) {
 
     PropertyTypeID NAME_PROP_ID(0); // 'name' is the first property type registered
 
-    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    using Rows = LineContainer<types::String::Primitive>;
 
     Rows expected;
     {
@@ -979,9 +979,9 @@ TEST_F(WriteQueriesTest, scanNodesCreateNodeDynamicProp) {
                 read().tryGetNodeProperty<types::String>(NAME_PROP_ID, n);
             ASSERT_TRUE(name);
             // Original node keeps its name
-            expected.add({n, *name});
+            expected.add({*name});
             // New Person node created from matching n gets n.name
-            expected.add({n + numNodesPrior, *name});
+            expected.add({*name});
         }
     }
 
@@ -1010,7 +1010,7 @@ TEST_F(WriteQueriesTest, scanNodesCreateNodeDynamicProp) {
             const size_t rowCount = df->getLogicalRowCount();
             for (size_t rowPtr = 0; rowPtr < rowCount; rowPtr++) {
                 ASSERT_TRUE(names->at(rowPtr));
-                actual.add({ns->at(rowPtr), *names->at(rowPtr)});
+                actual.add({*names->at(rowPtr)});
             }
         });
         ASSERT_TRUE(res);
@@ -1196,9 +1196,8 @@ TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
         R"(MATCH (n) CREATE (m:Snapshot{name:n.name}))";
 
     PropertyTypeID NAME_PROP_ID(0);
-    const size_t numNodesPrior = read().getTotalNodesAllocated();
 
-    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    using Rows = LineContainer<types::String::Primitive>;
     Rows expected;
     {
         size_t i = 0;
@@ -1206,7 +1205,7 @@ TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
             const types::String::Primitive* name =
                 read().tryGetNodeProperty<types::String>(NAME_PROP_ID, n);
             ASSERT_TRUE(name);
-            expected.add({NodeID(numNodesPrior + i), *name});
+            expected.add({*name});
             ++i;
         }
     }
@@ -1233,14 +1232,12 @@ TEST_F(WriteQueriesTest, dynamicNamePreservedAcrossCommit) {
             ASSERT_TRUE(ns && names);
             const size_t rowCount = df->getLogicalRowCount();
             for (size_t r = 0; r < rowCount; r++) {
-                ASSERT_TRUE(names->at(r)) << "Node " << ns->at(r).getValue()
-                                          << " lost its name across DataPart boundary";
-                actual.add({ns->at(r), *names->at(r)});
+                ASSERT_TRUE(names->at(r));
+                actual.add({*names->at(r)});
             }
         });
         ASSERT_TRUE(res);
-        ASSERT_TRUE(expected.equals(actual)) << "Names were permuted when DataPart was "
-                                                "reloaded after explicit commit.";
+        ASSERT_TRUE(expected.equals(actual));
     }
 }
 
@@ -1366,9 +1363,7 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
     constexpr std::string_view CREATE_QUERY =
         R"(MATCH (n:Person) CREATE (r:RedType{name:n.name}), (g:GreenType{name:n.name}), (b:BlueType{name:n.name}))";
 
-    const size_t numNodesPrior = read().getTotalNodesAllocated();
-
-    using Rows = LineContainer<NodeID, types::String::Primitive>;
+    using Rows = LineContainer<types::String::Primitive>;
     Rows redExpected;
     Rows greenExpected;
     Rows blueExpected;
@@ -1382,9 +1377,9 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
             const size_t rowCount = df->getLogicalRowCount();
             for (size_t r = 0; r < rowCount; r++) {
                 ASSERT_TRUE(names->at(r));
-                redExpected.add(  {NodeID(numNodesPrior + pendingIdx), *names->at(r)});
-                greenExpected.add({NodeID(numNodesPrior + pendingIdx + names->size()), *names->at(r)});
-                blueExpected.add( {NodeID(numNodesPrior + pendingIdx + (2 * names->size())), *names->at(r)});
+                redExpected.add({*names->at(r)});
+                greenExpected.add({*names->at(r)});
+                blueExpected.add({*names->at(r)});
                 ++pendingIdx;
             }
         });
@@ -1400,13 +1395,13 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
         Rows actual;
         auto res = query(matchQuery, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
-            auto* ns    = df->cols().front()->as<ColumnNodeIDs>();
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
             auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
             ASSERT_TRUE(ns && names);
             const size_t rowCount = df->getLogicalRowCount();
             for (size_t r = 0; r < rowCount; r++) {
                 ASSERT_TRUE(names->at(r));
-                actual.add({ns->at(r), *names->at(r)});
+                actual.add({*names->at(r)});
             }
         });
         ASSERT_TRUE(res);

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -1426,6 +1426,109 @@ TEST_F(WriteQueriesTest, matchCreateThreeLabelSetsInterleaved) {
     verify(R"(MATCH (n:BlueType) RETURN n, n.name)",  blueExpected,  "BlueType");
 }
 
+TEST_F(WriteQueriesTest, scanEdgesCreateEdgeDynamicName) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n)-[e]->(m) CREATE (n)-[f:COPYEDGE{name:e.name}]->(m))";
+    constexpr std::string_view MATCH_QUERY =
+        R"(MATCH (n)-[f:COPYEDGE]->(m) RETURN n, f.name, m)";
+
+    using Rows = LineContainer<NodeID, types::String::Primitive, NodeID>;
+    Rows expected;
+
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n)-[e]->(m) RETURN n, e.name, m)";
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 3);
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().at(1)->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ms = df->cols().back()->as<ColumnNodeIDs>();
+            ASSERT_TRUE(ns && names && ms);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                expected.add({ns->at(r), *names->at(r), ms->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    {
+        Rows actual;
+        auto res = query(MATCH_QUERY, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 3);
+            auto* ns = df->cols().front()->as<ColumnNodeIDs>();
+            auto* names = df->cols().at(1)->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ms = df->cols().back()->as<ColumnNodeIDs>();
+            ASSERT_TRUE(ns && names && ms);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({ns->at(r), *names->at(r), ms->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual));
+    }
+}
+
+TEST_F(WriteQueriesTest, createEdgesFromNodesDynamicName) {
+    constexpr std::string_view CREATE_QUERY =
+        R"(MATCH (n:Person) CREATE (n)-[e:SELFEDGE{name:n.name}]->(n))";
+    constexpr std::string_view MATCH_QUERY =
+        R"(MATCH ()-[e:SELFEDGE]->() RETURN e, e.name)";
+
+    const size_t totalEdgesPrior = read().getTotalEdgesAllocated();
+
+    using Rows = LineContainer<EdgeID, types::String::Primitive>;
+    Rows expected;
+
+    {
+        constexpr std::string_view preQuery = R"(MATCH (n:Person) RETURN n, n.name)";
+        size_t pendingIdx = 0;
+        auto res = query(preQuery, [&](const Dataframe* df) {
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                expected.add({EdgeID(totalEdgesPrior + pendingIdx), *names->at(r)});
+                ++pendingIdx;
+            }
+        });
+        ASSERT_TRUE(res);
+    }
+
+    newChange();
+    ASSERT_TRUE(query(CREATE_QUERY, [](const Dataframe*) {}));
+    ASSERT_TRUE(query("commit", [](const Dataframe*) {}));
+    submitCurrentChange();
+
+    {
+        Rows actual;
+        auto res = query(MATCH_QUERY, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            ASSERT_EQ(df->size(), 2);
+            auto* es    = df->cols().front()->as<ColumnEdgeIDs>();
+            auto* names = df->cols().back()->as<ColumnOptVector<types::String::Primitive>>();
+            ASSERT_TRUE(es && names);
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t r = 0; r < rowCount; r++) {
+                ASSERT_TRUE(names->at(r));
+                actual.add({es->at(r), *names->at(r)});
+            }
+        });
+        ASSERT_TRUE(res);
+        ASSERT_TRUE(expected.equals(actual));
+    }
+}
+
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {
     setWorkingGraph("default");
     // NOTE: Returning properties of just-created nodes is not yet supported

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -86,6 +86,8 @@ protected:
         df->dump(out);
         return out.str();
     };
+
+    static constexpr auto _emptyCallback = [](const Dataframe*) -> void {};
 };
 
 TEST_F(WriteQueriesTest, scanNodesCreateNode) {
@@ -1144,7 +1146,7 @@ TEST_F(WriteQueriesTest, createNodesDynamicNameAndDob) {
     }
 }
 
-TEST_F(WriteQueriesTest, setDynamicNameOnNewNodes) {
+TEST_F(WriteQueriesTest, dynamicNameOnNewNodes) {
     setWorkingGraph("default");
 
     newChange();
@@ -1616,6 +1618,65 @@ TEST_F(WriteQueriesTest, createEdgeEmptyMatch) {
 
     ASSERT_EQ(read().getTotalEdgesAllocated(), totalEdgesPrior);
     ASSERT_EQ(read().getTotalNodesAllocated(), totalNodesPrior);
+}
+
+TEST_F(WriteQueriesTest, dynamicPropExpression) {
+    std::string_view CREATE_QUERY = R"(MATCH (n) WHERE n.age IS NOT NULL CREATE (m:Clone{name: n.name, age: n.age + 10}) )";
+
+    using Rows = LineContainer<types::String::Primitive, types::Int64::Primitive>;
+
+    Rows expected;
+    {
+        std::string_view q = R"(MATCH (n) WHERE n.age IS NOT NULL RETURN n.name, n.age)";
+
+        auto res = query(q, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* names = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ages = findColumn(df, "n.age")->as<ColumnOptVector<types::Int64::Primitive>>();
+            ASSERT_TRUE(names && ages);
+
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t i = 0; i < rowCount; i++) {
+                const types::String::Primitive name = *names->operator[](i);
+                const types::Int64::Primitive age = *ages->operator[](i);
+                expected.add({name, age + 10});
+            }
+        });
+    }
+
+    {
+        newChange();
+        const auto res = query(CREATE_QUERY, _emptyCallback);
+        ASSERT_TRUE(res) << res.getError();
+        submitCurrentChange();
+    }
+
+    Rows actual;
+    {
+        std::string_view MATCH_QUERY = R"(MATCH (n:Clone) RETURN n.name, n.age)";
+        auto res = query(MATCH_QUERY, [&](const Dataframe* df) {
+            ASSERT_TRUE(df);
+            auto* names = findColumn(df, "n.name")->as<ColumnOptVector<types::String::Primitive>>();
+            auto* ages = findColumn(df, "n.age")->as<ColumnOptVector<types::Int64::Primitive>>();
+            ASSERT_TRUE(names && ages);
+
+            const size_t rowCount = df->getLogicalRowCount();
+            for (size_t i = 0; i < rowCount; i++) {
+                const types::String::Primitive name = *names->operator[](i);
+                const types::Int64::Primitive age = *ages->operator[](i);
+                actual.add({name, age});
+            }
+        });
+    }
+
+    ASSERT_TRUE(expected.equals(actual)) << [expected, actual] {
+        std::ostringstream out;
+        out << "expected:\n";
+        expected.print(out);
+        out << "actual:\n";
+        actual.print(out);
+        return out.str();
+    }();
 }
 
 TEST_F(WriteQueriesTest, createSingleNodeConstProps) {


### PR DESCRIPTION
Implements #574 

Allows for queries such as

~~~
MATCH (n:Person) CREATE (m:Clone{name:n.name})
                                 ^^^^^^^^^^^
                             reference to property dynamic in n
~~~

and

~~~
MATCH (n:Person) CREATE (m:Clone{name: n.name, age: n.age + 100})
~~~