### PR TITLE
Do string escaping for all endpoints and unescaping for string literal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ Key points:
 **Other rules:**
 - Never `using namespace` in headers
 - Never `using namespace std`
-- Use `const` extensively
+- Use `const` extensively — all local variables should be `const` unless they need mutation
+- When a conditional expression is long or compound, extract each part into a descriptively named `const bool` before the `if` statement
 - Use `bioassert` for assertions (from BioAssert.h)
 - Exceptions must derive from `TuringException`
 - No move semantics/RVO; pass by pointer or reference

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -19,6 +19,7 @@ set(common_sources
         StringUtils.cpp
         Profiler.cpp
         ThreadName.cpp
+        HybridString.cpp
 
         log/LogSetup.cpp
         log/LogUtils.cpp)

--- a/common/HybridString.cpp
+++ b/common/HybridString.cpp
@@ -1,0 +1,24 @@
+#include "HybridString.h"
+
+HybridString::HybridString(std::string_view view)
+    : _view(view)
+{
+}
+
+HybridString::~HybridString() {
+}
+
+void HybridString::setView(std::string_view view) {
+    _view = view;
+    _storage.clear();
+    _owned = false;
+}
+
+std::string& HybridString::mutate() {
+    if (!_owned) {
+        _storage.assign(_view);
+        _view = std::string_view();
+        _owned = true;
+    }
+    return _storage;
+}

--- a/common/HybridString.h
+++ b/common/HybridString.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stddef.h>
+
+#include <string>
+#include <string_view>
+
+class HybridString {
+public:
+    HybridString() = default;
+    HybridString(std::string_view view);
+    ~HybridString();
+
+    HybridString(const HybridString&) = delete;
+    HybridString(HybridString&&) = delete;
+    HybridString& operator=(const HybridString&) = delete;
+    HybridString& operator=(HybridString&&) = delete;
+
+    std::string_view getView() const { return _owned ? std::string_view(_storage) : _view; }
+    size_t size() const { return getView().size(); }
+    bool empty() const { return getView().empty(); }
+    const char* data() const { return getView().data(); }
+    bool isOwned() const { return _owned; }
+
+    void setView(std::string_view view);
+
+    std::string& mutate();
+
+private:
+    std::string_view _view;
+    std::string _storage;
+    bool _owned {false};
+};

--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -90,8 +90,8 @@ target_include_directories(turing_db_ast_s
 target_link_libraries(turing_db_ast_s
   PRIVATE turing_db_query_common_s
           turing_db_storage_s
-          turing_common_s
           turing_vector_s
           range-v3
-  PUBLIC turing_db_pipeline_s)
+  PUBLIC turing_db_pipeline_s
+         turing_common_s)
 

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -28,6 +28,29 @@ DoubleLiteral* DoubleLiteral::create(CypherAST* ast, double value) {
     return literal;
 }
 
+StringLiteral::StringLiteral(std::string_view raw) {
+    _value.reserve(raw.size());
+
+    for (size_t i = 0; i < raw.size(); i++) {
+        if (raw[i] == '\\' && i + 1 < raw.size()) {
+            char next = raw[i + 1];
+            switch (next) {
+                case '\\': _value.push_back('\\'); i++; break;
+                case '\'': _value.push_back('\''); i++; break;
+                case '"':  _value.push_back('"');  i++; break;
+                case 't':  _value.push_back('\t'); i++; break;
+                case 'n':  _value.push_back('\n'); i++; break;
+                case 'r':  _value.push_back('\r'); i++; break;
+                case 'b':  _value.push_back('\b'); i++; break;
+                case 'f':  _value.push_back('\f'); i++; break;
+                default:   _value.push_back(raw[i]); break;
+            }
+        } else {
+            _value.push_back(raw[i]);
+        }
+    }
+}
+
 StringLiteral* StringLiteral::create(CypherAST* ast, std::string_view value) {
     StringLiteral* literal = new StringLiteral(value);
     ast->addLiteral(literal);

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -138,7 +138,8 @@ DoubleLiteral* DoubleLiteral::create(CypherAST* ast, double value) {
     return literal;
 }
 
-StringLiteral::StringLiteral() {
+StringLiteral::StringLiteral()
+{
 }
 
 StringLiteral::~StringLiteral() {

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -84,22 +84,14 @@ void unescapeString(std::string_view raw, std::string& out) {
                         break;
                     }
 
-                    uint32_t cp = hexToCodepoint(raw.substr(i + 2, 4));
-                    const bool isHighSurrogate = cp >= 0xD800 && cp <= 0xDBFF;
+                    const uint32_t high = hexToCodepoint(raw.substr(i + 2, 4));
+                    const bool isHighSurrogate = high >= 0xD800 && high <= 0xDBFF;
                     const bool hasLowSurrogate = isHighSurrogate && hasSurrogatePairAt(raw, i + 6);
+                    const uint32_t low = hasLowSurrogate ? hexToCodepoint(raw.substr(i + 8, 4)) : 0;
+                    const bool validLow = hasLowSurrogate && low >= 0xDC00 && low <= 0xDFFF;
 
-                    if (hasLowSurrogate) {
-                        const uint32_t low = hexToCodepoint(raw.substr(i + 8, 4));
-                        const bool validLow = low >= 0xDC00 && low <= 0xDFFF;
-                        if (validLow) {
-                            cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
-                            i += 11;
-                        } else {
-                            i += 5;
-                        }
-                    } else {
-                        i += 5;
-                    }
+                    const uint32_t cp = validLow ? 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00) : high;
+                    i += validLow ? 11 : 5;
 
                     encodeUTF8(cp, out);
                     break;

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -4,6 +4,34 @@
 
 using namespace db;
 
+namespace {
+
+void unescapeString(std::string_view raw, std::string& out) {
+    out.clear();
+    out.reserve(raw.size());
+
+    for (size_t i = 0; i < raw.size(); i++) {
+        if (raw[i] == '\\' && i + 1 < raw.size()) {
+            char next = raw[i + 1];
+            switch (next) {
+                case '\\': out.push_back('\\'); i++; break;
+                case '\'': out.push_back('\''); i++; break;
+                case '"':  out.push_back('"');  i++; break;
+                case 't':  out.push_back('\t'); i++; break;
+                case 'n':  out.push_back('\n'); i++; break;
+                case 'r':  out.push_back('\r'); i++; break;
+                case 'b':  out.push_back('\b'); i++; break;
+                case 'f':  out.push_back('\f'); i++; break;
+                default:   out.push_back(raw[i]); break;
+            }
+        } else {
+            out.push_back(raw[i]);
+        }
+    }
+}
+
+} // anonymous namespace
+
 NullLiteral* NullLiteral::create(CypherAST* ast) {
     NullLiteral* literal = new NullLiteral();
     ast->addLiteral(literal);
@@ -28,31 +56,15 @@ DoubleLiteral* DoubleLiteral::create(CypherAST* ast, double value) {
     return literal;
 }
 
-StringLiteral::StringLiteral(std::string_view raw) {
-    _value.reserve(raw.size());
+StringLiteral::StringLiteral() {
+}
 
-    for (size_t i = 0; i < raw.size(); i++) {
-        if (raw[i] == '\\' && i + 1 < raw.size()) {
-            char next = raw[i + 1];
-            switch (next) {
-                case '\\': _value.push_back('\\'); i++; break;
-                case '\'': _value.push_back('\''); i++; break;
-                case '"':  _value.push_back('"');  i++; break;
-                case 't':  _value.push_back('\t'); i++; break;
-                case 'n':  _value.push_back('\n'); i++; break;
-                case 'r':  _value.push_back('\r'); i++; break;
-                case 'b':  _value.push_back('\b'); i++; break;
-                case 'f':  _value.push_back('\f'); i++; break;
-                default:   _value.push_back(raw[i]); break;
-            }
-        } else {
-            _value.push_back(raw[i]);
-        }
-    }
+StringLiteral::~StringLiteral() {
 }
 
 StringLiteral* StringLiteral::create(CypherAST* ast, std::string_view value) {
-    StringLiteral* literal = new StringLiteral(value);
+    StringLiteral* literal = new StringLiteral();
+    unescapeString(value, literal->_value);
     ast->addLiteral(literal);
     return literal;
 }

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -6,13 +6,67 @@ using namespace db;
 
 namespace {
 
+bool isHexDigit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+uint32_t hexToCodepoint(std::string_view hex) {
+    uint32_t cp = 0;
+    for (const char c : hex) {
+        cp <<= 4;
+        if (c >= '0' && c <= '9') cp |= (c - '0');
+        else if (c >= 'a' && c <= 'f') cp |= (c - 'a' + 10);
+        else cp |= (c - 'A' + 10);
+    }
+    return cp;
+}
+
+void encodeUTF8(uint32_t cp, std::string& out) {
+    if (cp <= 0x7F) {
+        out.push_back(static_cast<char>(cp));
+    } else if (cp <= 0x7FF) {
+        out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp <= 0xFFFF) {
+        out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp <= 0x10FFFF) {
+        out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+}
+
+bool hasHexDigitsAt(std::string_view raw, size_t pos, size_t count) {
+    if (pos + count > raw.size()) {
+        return false;
+    }
+    for (size_t j = 0; j < count; j++) {
+        if (!isHexDigit(raw[pos + j])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool hasSurrogatePairAt(std::string_view raw, size_t pos) {
+    const bool enoughRoom = pos + 5 < raw.size();
+    if (!enoughRoom) {
+        return false;
+    }
+    const bool hasEscapePrefix = raw[pos] == '\\' && raw[pos + 1] == 'u';
+    return hasEscapePrefix && hasHexDigitsAt(raw, pos + 2, 4);
+}
+
 void unescapeString(std::string_view raw, std::string& out) {
     out.clear();
     out.reserve(raw.size());
 
     for (size_t i = 0; i < raw.size(); i++) {
         if (raw[i] == '\\' && i + 1 < raw.size()) {
-            char next = raw[i + 1];
+            const char next = raw[i + 1];
             switch (next) {
                 case '\\': out.push_back('\\'); i++; break;
                 case '\'': out.push_back('\''); i++; break;
@@ -22,7 +76,35 @@ void unescapeString(std::string_view raw, std::string& out) {
                 case 'r':  out.push_back('\r'); i++; break;
                 case 'b':  out.push_back('\b'); i++; break;
                 case 'f':  out.push_back('\f'); i++; break;
-                default:   out.push_back(raw[i]); break;
+                case 'u': {
+                    const bool validEscape = hasHexDigitsAt(raw, i + 2, 4);
+                    if (!validEscape) {
+                        out.push_back(next);
+                        i++;
+                        break;
+                    }
+
+                    uint32_t cp = hexToCodepoint(raw.substr(i + 2, 4));
+                    const bool isHighSurrogate = cp >= 0xD800 && cp <= 0xDBFF;
+                    const bool hasLowSurrogate = isHighSurrogate && hasSurrogatePairAt(raw, i + 6);
+
+                    if (hasLowSurrogate) {
+                        const uint32_t low = hexToCodepoint(raw.substr(i + 8, 4));
+                        const bool validLow = low >= 0xDC00 && low <= 0xDFFF;
+                        if (validLow) {
+                            cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+                            i += 11;
+                        } else {
+                            i += 5;
+                        }
+                    } else {
+                        i += 5;
+                    }
+
+                    encodeUTF8(cp, out);
+                    break;
+                }
+                default: out.push_back(next); i++; break;
             }
         } else {
             out.push_back(raw[i]);

--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -60,26 +60,34 @@ bool hasSurrogatePairAt(std::string_view raw, size_t pos) {
     return hasEscapePrefix && hasHexDigitsAt(raw, pos + 2, 4);
 }
 
-void unescapeString(std::string_view raw, std::string& out) {
-    out.clear();
-    out.reserve(raw.size());
+void unescapeString(std::string_view raw, HybridString& out) {
+    const size_t firstEscape = raw.find('\\');
+    if (firstEscape == std::string_view::npos) {
+        out.setView(raw);
+        return;
+    }
 
-    for (size_t i = 0; i < raw.size(); i++) {
+    std::string& buf = out.mutate();
+    buf.clear();
+    buf.reserve(raw.size());
+    buf.append(raw.substr(0, firstEscape));
+
+    for (size_t i = firstEscape; i < raw.size(); i++) {
         if (raw[i] == '\\' && i + 1 < raw.size()) {
             const char next = raw[i + 1];
             switch (next) {
-                case '\\': out.push_back('\\'); i++; break;
-                case '\'': out.push_back('\''); i++; break;
-                case '"':  out.push_back('"');  i++; break;
-                case 't':  out.push_back('\t'); i++; break;
-                case 'n':  out.push_back('\n'); i++; break;
-                case 'r':  out.push_back('\r'); i++; break;
-                case 'b':  out.push_back('\b'); i++; break;
-                case 'f':  out.push_back('\f'); i++; break;
+                case '\\': buf.push_back('\\'); i++; break;
+                case '\'': buf.push_back('\''); i++; break;
+                case '"':  buf.push_back('"');  i++; break;
+                case 't':  buf.push_back('\t'); i++; break;
+                case 'n':  buf.push_back('\n'); i++; break;
+                case 'r':  buf.push_back('\r'); i++; break;
+                case 'b':  buf.push_back('\b'); i++; break;
+                case 'f':  buf.push_back('\f'); i++; break;
                 case 'u': {
                     const bool validEscape = hasHexDigitsAt(raw, i + 2, 4);
                     if (!validEscape) {
-                        out.push_back(next);
+                        buf.push_back(next);
                         i++;
                         break;
                     }
@@ -93,13 +101,13 @@ void unescapeString(std::string_view raw, std::string& out) {
                     const uint32_t cp = validLow ? 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00) : high;
                     i += validLow ? 11 : 5;
 
-                    encodeUTF8(cp, out);
+                    encodeUTF8(cp, buf);
                     break;
                 }
-                default: out.push_back(next); i++; break;
+                default: buf.push_back(next); i++; break;
             }
         } else {
-            out.push_back(raw[i]);
+            buf.push_back(raw[i]);
         }
     }
 }

--- a/query/AST/Literal.h
+++ b/query/AST/Literal.h
@@ -7,6 +7,8 @@
 #include <span>
 #include <vector>
 
+#include "HybridString.h"
+
 #include "decl/EvaluatedType.h"
 
 namespace db {
@@ -124,10 +126,10 @@ public:
 
     constexpr EvaluatedType getType() const override { return EvaluatedType::String; }
 
-    std::string_view getValue() const { return _value; }
+    std::string_view getValue() const { return _value.getView(); }
 
 private:
-    std::string _value;
+    HybridString _value;
 
     StringLiteral();
 

--- a/query/AST/Literal.h
+++ b/query/AST/Literal.h
@@ -129,9 +129,9 @@ public:
 private:
     std::string _value;
 
-    StringLiteral(std::string_view value);
+    StringLiteral();
 
-    ~StringLiteral() override = default;
+    ~StringLiteral() override;
 };
 
 class CharLiteral : public Literal {

--- a/query/AST/Literal.h
+++ b/query/AST/Literal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <string>
 #include <string_view>
 #include <stdint.h>
 #include <span>
@@ -126,12 +127,9 @@ public:
     std::string_view getValue() const { return _value; }
 
 private:
-    std::string_view _value;
+    std::string _value;
 
-    StringLiteral(std::string_view value)
-        : _value(value)
-    {
-    }
+    StringLiteral(std::string_view value);
 
     ~StringLiteral() override = default;
 };

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -44,6 +44,7 @@ add_subdirectory(start-stop)
 add_subdirectory(load_jsonl_reactome)
 add_subdirectory(history_on_change)
 add_subdirectory(reload_submit_edge)
+add_subdirectory(json_escape_properties)
 
 # write run_regress target
 # The script finds the wheel at runtime to avoid needing to re-run cmake after wheel build

--- a/regress/json_escape_properties/CMakeLists.txt
+++ b/regress/json_escape_properties/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+regress_test(json_escape_properties run.sh main.py)

--- a/regress/json_escape_properties/main.py
+++ b/regress/json_escape_properties/main.py
@@ -1,0 +1,141 @@
+"""
+Regression test for GitHub issue #592:
+JSON API responses contain invalid escape sequences in string property values.
+
+TuringDB returns \\' (backslash-apostrophe) in JSON strings, which is not a valid
+JSON escape sequence. It also returns unescaped double quotes inside string values.
+
+This causes JSON.parse() to fail in JavaScript clients (e.g. the visualizer).
+
+Valid JSON escapes are: \\" \\\\ \\/ \\b \\f \\n \\r \\t \\uXXXX
+"""
+
+import json
+import subprocess
+import sys
+import httpx
+from turingdb import TuringDB
+
+HOST = "http://localhost:6666"
+GRAPH = "json_escape_test"
+
+
+def main():
+    print("=== json_escape_properties regression test ===")
+    print()
+
+    client = TuringDB(host=HOST)
+
+    # 1. Create a graph with nodes whose properties contain special characters
+    print("1. Creating test graph with problematic string properties...")
+    client.query(f"CREATE GRAPH {GRAPH}")
+    client.set_graph(GRAPH)
+
+    change = client.new_change()
+    client.checkout(change=change)
+
+    # Single quote (triggers \' in current output)
+    client.query("CREATE (:Company {name: \"Lloyd's of London\"})")
+
+    # Double quote inside value (triggers unescaped " in current output)
+    client.query("CREATE (:Equipment {description: '40ft container (9\\'6\")', code: 'HC96'})")
+
+    # Backslash itself
+    client.query("CREATE (:Path {value: 'C:\\\\Users\\\\test'})")
+
+    client.query("COMMIT")
+    client.query("CHANGE SUBMIT")
+    client.checkout()
+    print("   Created 3 nodes with special characters in properties")
+    print()
+
+    # 2. Fetch nodes via /get_nodes and validate the JSON is parseable
+    print("2. Fetching nodes via /get_nodes HTTP endpoint...")
+    node_ids = client.query(f"MATCH (n) RETURN n")["n"].tolist()
+    print(f"   Node IDs: {node_ids}")
+
+    response = httpx.post(
+        f"{HOST}/get_nodes?graph={GRAPH}",
+        json={"nodeIDs": node_ids},
+        timeout=10,
+    )
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+    raw_text = response.text
+    print(f"   Response length: {len(raw_text)} bytes")
+    print()
+
+    # 3. Validate that the response is valid JSON (Python)
+    print("3. Validating JSON is parseable by Python json.loads()...")
+    try:
+        parsed = json.loads(raw_text)
+        print("   OK: Python json.loads() succeeded")
+    except json.JSONDecodeError as e:
+        print(f"   FAILED: Invalid JSON at position {e.pos}")
+        print(f"   Error: {e.msg}")
+        start = max(0, e.pos - 40)
+        end = min(len(raw_text), e.pos + 40)
+        print(f"   Context: ...{repr(raw_text[start:end])}...")
+        print()
+        print("TEST FAILED: /get_nodes returned invalid JSON (Python)")
+        return 1
+    print()
+
+    # 4. Validate that the response is valid JSON (JavaScript / Node.js)
+    #    This is the actual client that fails — the visualizer uses JSON.parse()
+    print("4. Validating JSON is parseable by JavaScript JSON.parse()...")
+    js_result = subprocess.run(
+        ["node", "-e", "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))"],
+        input=raw_text.encode(),
+        capture_output=True,
+        timeout=5,
+    )
+    if js_result.returncode != 0:
+        stderr = js_result.stderr.decode().strip()
+        print(f"   FAILED: JavaScript JSON.parse() threw:")
+        print(f"   {stderr}")
+        print()
+        print("TEST FAILED: /get_nodes returned JSON that JavaScript cannot parse")
+        return 1
+    print("   OK: JavaScript JSON.parse() succeeded")
+    print()
+
+    # 5. Validate the actual property values are correct
+    print("5. Validating property values...")
+    nodes = parsed["data"]
+
+    found_apostrophe = False
+    found_quote = False
+    found_backslash = False
+
+    for node_id, node in nodes.items():
+        props = node.get("properties", {})
+        for key, value in props.items():
+            if isinstance(value, str):
+                if "Lloyd" in value:
+                    assert value == "Lloyd's of London", f"Expected \"Lloyd's of London\", got {repr(value)}"
+                    found_apostrophe = True
+                    print(f"   Node {node_id}.{key} = {repr(value)}  (apostrophe)")
+
+                if "container" in value:
+                    assert '9\'6"' in value, f"Expected value containing 9'6\", got {repr(value)}"
+                    found_quote = True
+                    print(f"   Node {node_id}.{key} = {repr(value)}  (double quote)")
+
+                if "Users" in value:
+                    assert "\\" in value, f"Expected backslash in path, got {repr(value)}"
+                    found_backslash = True
+                    print(f"   Node {node_id}.{key} = {repr(value)}  (backslash)")
+
+    assert found_apostrophe, "Did not find node with apostrophe property"
+    assert found_quote, "Did not find node with double-quote property"
+    assert found_backslash, "Did not find node with backslash property"
+
+    print()
+    print("TEST PASSED: All JSON responses are valid and property values are correct")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/regress/json_escape_properties/run.sh
+++ b/regress/json_escape_properties/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Regression test: json_escape_properties (GitHub issue #592)
+#
+# Verifies that /get_nodes returns valid JSON when node properties contain
+# special characters: single quotes, double quotes, backslashes.
+#
+# Expected: This test FAILS until the JSON serializer properly escapes strings.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+
+# Kill any existing turingdb processes (SIGKILL for reliability)
+pkill -9 turingdb 2>/dev/null || true
+sleep 0.5
+# Wait for port 6666 to be free (nc -z returns 0 if open, 1 if closed)
+for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null || break; sleep 0.1; done
+
+rm -rf $SCRIPT_DIR/.turing
+turingdb -demon -turing-dir $SCRIPT_DIR/.turing
+
+# Wait for daemon to be ready
+for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null && break; sleep 0.1; done
+
+rm -f pyproject.toml
+uv init
+uv add $PYTURINGDB
+uv add httpx
+
+uv run main.py
+testres=$?
+
+turingdb stop -turing-dir $SCRIPT_DIR/.turing
+
+exit $testres

--- a/server/HTTPResponseWriter.h
+++ b/server/HTTPResponseWriter.h
@@ -6,6 +6,7 @@
 #include "metadata/PropertyTypeMap.h"
 #include "views/NodeView.h"
 #include "QueryStatus.h"
+#include "ControlCharacters.h"
 
 #include "BioAssert.h"
 
@@ -269,9 +270,8 @@ public:
     }
 
     void writeValue(std::string_view v) {
-        write('"');
-        write(v);
-        write('"');
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(v, _sanitized);
+        write(_sanitized);
     }
 
     void writeValue(std::integral auto v) {
@@ -368,6 +368,7 @@ public:
 
 private:
     net::NetWriter* _writer {nullptr};
+    std::string _sanitized;
 };
 
 }

--- a/server/PayloadWriter.h
+++ b/server/PayloadWriter.h
@@ -10,6 +10,7 @@
 #include "views/EdgeView.h"
 #include "metadata/PropertyType.h"
 #include "NetWriter.h"
+#include "ControlCharacters.h"
 
 namespace db {
 
@@ -96,13 +97,12 @@ public:
 
     void key(std::string_view k) {
         if (_comma) {
-            _writer->write(",\"");
+            _writer->write(',');
             _comma = false;
-        } else {
-            _writer->write('"');
         }
-        write(k);
-        _writer->write("\":");
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(k, _sanitized);
+        _writer->write(_sanitized);
+        _writer->write(':');
     }
 
     void key(JsonKey auto k) {
@@ -145,12 +145,10 @@ public:
 
     void value(std::string_view v) {
         if (_comma) {
-            _writer->write(",\"");
-        } else {
-            _writer->write('"');
+            _writer->write(',');
         }
-        write(v);
-        write('"');
+        ControlCharactersEscaper::escapeAndSurroundByQuotes(v, _sanitized);
+        _writer->write(_sanitized);
         _comma = true;
     }
 
@@ -224,6 +222,7 @@ private:
     const GraphMetadata* _metadata {nullptr};
     std::vector<char> _closingTokens;
     bool _comma {false};
+    std::string _sanitized;
 
     void write(std::signed_integral auto v) {
         _writer->write(v);

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_turing_test(test_common_perfstat PerfStatTest.cpp)
 add_turing_test(test_common_smallvector SmallVectorTest.cpp)
+add_turing_test(test_common_hybridstring HybridStringTest.cpp)

--- a/test/common/HybridStringTest.cpp
+++ b/test/common/HybridStringTest.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+
+#include "HybridString.h"
+
+TEST(HybridStringTest, DefaultIsEmptyView) {
+    HybridString s;
+    ASSERT_FALSE(s.isOwned());
+    ASSERT_TRUE(s.empty());
+    ASSERT_EQ(s.size(), 0);
+}
+
+TEST(HybridStringTest, ViewDoesNotAllocate) {
+    const char* src = "hello world";
+    HybridString s{std::string_view(src)};
+
+    ASSERT_FALSE(s.isOwned());
+    ASSERT_EQ(s.size(), 11);
+    ASSERT_EQ(s.getView(), "hello world");
+    ASSERT_EQ(s.data(), src);
+}
+
+TEST(HybridStringTest, MutateCopiesOnFirstCall) {
+    const char* src = "abcdef";
+    HybridString s{std::string_view(src)};
+
+    std::string& storage = s.mutate();
+    ASSERT_TRUE(s.isOwned());
+    ASSERT_EQ(storage, "abcdef");
+    ASSERT_NE(s.data(), src);
+
+    storage.push_back('X');
+    ASSERT_EQ(s.getView(), "abcdefX");
+}
+
+TEST(HybridStringTest, MutateIsIdempotent) {
+    HybridString s{std::string_view("seed")};
+    std::string& first = s.mutate();
+    first.append("++");
+
+    std::string& second = s.mutate();
+    ASSERT_EQ(&first, &second);
+    ASSERT_EQ(s.getView(), "seed++");
+}
+
+TEST(HybridStringTest, SetViewResetsOwnership) {
+    HybridString s;
+    s.mutate().assign("owned");
+    ASSERT_TRUE(s.isOwned());
+
+    const char* src = "viewed";
+    s.setView(std::string_view(src));
+    ASSERT_FALSE(s.isOwned());
+    ASSERT_EQ(s.getView(), "viewed");
+    ASSERT_EQ(s.data(), src);
+}


### PR DESCRIPTION
* The /get_nodes endpoint returns invalid JSON when string properties contain single quotes (\') or unescaped double quotes. Creates a minimal regress test to reproduce.
* Escaping strings in all REST endpoints
* Unescape strings that may be escaped during query parsing when creating StringLiteral

Fixes #592 