### PR TITLE
Add plan errors for returning properties from `PathExplorer`

### DIFF
--- a/query/pipeline/processors/GetPropertiesWithNullProcessor.cpp
+++ b/query/pipeline/processors/GetPropertiesWithNullProcessor.cpp
@@ -2,10 +2,11 @@
 
 #include <spdlog/fmt/fmt.h>
 
-#include "PipelineException.h"
 #include "columns/ColumnIDs.h"
 #include "dataframe/Dataframe.h"
 #include "dataframe/NamedColumn.h"
+
+#include "PipelineException.h"
 
 namespace db {
 
@@ -56,6 +57,7 @@ void GetPropertiesWithNullProcessor<Entity, T>::prepare(ExecutionContext* ctxt) 
         const Column* idsCol = _input.getDataframe()->getColumn(_entityTag)->getColumn();
         ids = dynamic_cast<const ColumnEdgeIDs*>(idsCol);
     }
+    bioassert(ids, "Could not get input IDs column.");
 
     _propWriter = std::make_unique<ChunkWriter>(ctxt->getGraphView(), _propType._id, ids);
 

--- a/query/plan/ExprDependencies.cpp
+++ b/query/plan/ExprDependencies.cpp
@@ -1,10 +1,13 @@
 #include "ExprDependencies.h"
 
 #include "FunctionInvocation.h"
+#include "PlanGraph.h"
 #include "PlannerException.h"
 #include "PlanGraphTopology.h"
+#include "decl/VarDecl.h"
 #include "expr/ExprChain.h"
 #include "expr/SymbolExpr.h"
+#include "nodes/PlanGraphNode.h"
 #include "nodes/VarNode.h"
 
 #include "expr/BinaryExpr.h"
@@ -67,13 +70,42 @@ void ExprDependencies::genExprDependencies(PlanGraphVariables& variables, Expr* 
                 break;
             }
 
+            {
+                // Check if a variable is produced by a processor such as @ref
+                // PathExplorerProcessor which does not produce a single entity column
+                const VarDecl* var = prop->getEntityVarDecl();
+                const PlanGraphNode* producer = variables.getProducer(var);
+                const PlanGraphOpcode code = producer->getOpcode();
+
+                const bool isFromExplorer = code == PlanGraphOpcode::PATH_EXPLORER;
+                if (isFromExplorer) {
+                    bioassert(var, "Null var.");
+                    const std::string_view varName = var->getName();
+                    std::string err =
+                        fmt::format("Fetching properties from an arbitrary path "
+                                    "({}) is not yet supported.",
+                                    varName);
+                    throw PlannerException(std::move(err));
+                }
+
+                // Check that the producer is a VarNode: well defined column to get
+                // properties from
+                const bool isFromVar = code == PlanGraphOpcode::VAR;
+                if (!isFromVar) {
+                    bioassert(var, "Null var.");
+                    const std::string_view varName = var->getName();
+                    std::string err = fmt::format(
+                        "Cannot fetch property from ambiguously sourced variable {}.",
+                        varName);
+                    throw PlannerException(std::move(err));
+                }
+            }
+
             PlanGraphNode* producer = variables.getProducer(prop->getEntityVarDecl());
-            bioassert(producer, "VarDecl not found");
+            bioassert(producer, "Variable source not found.");
 
             auto* p = dynamic_cast<VarNode*>(producer);
-            if (!p) {
-                throw PlannerException("Can only reference properties from matched variables");
-            }
+            bioassert(p, "Failed to validate VarNode.");
 
             _varDeps.emplace_back(p, expr);
         } break;

--- a/query/plan/PlanGraphGenerator.cpp
+++ b/query/plan/PlanGraphGenerator.cpp
@@ -393,10 +393,12 @@ void PlanGraphGenerator::generateShowExtensionsQuery(const ShowExtensionsQuery* 
     _tree.newOut<ProduceResultsNode>(node);
 }
 
-PlanGraphNode* PlanGraphGenerator::generateReturnStmt(const ReturnStmt* stmt, PlanGraphNode* prevNode) {
+PlanGraphNode* PlanGraphGenerator::generateReturnStmt(const ReturnStmt* stmt,
+                                                      PlanGraphNode* prevNode) {
     GetPropertyCache& propCache = _tree.getGetPropertyCache();
 
     ReturnStmtGenerator stmtGen(_ast,
+                                _variables.get(),
                                 stmt,
                                 &_tree,
                                 prevNode,

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -457,17 +457,17 @@ PlanGraphNode* ReadStmtGenerator::generatePatternElementVariableLengthPath(PlanG
     auto [edgeVar, edgeFilter] = _variables->getVarNodeAndFilter(edgeDecl);
 
     if (edgeVar) {
-        throwError("Re-using the same edge variable, this is not supported", edge);
+        throwError("Attempted to reuse edge variable.", edge);
     }
 
     const VarDecl* nodeDecl = target->getDecl();
 
     if (minHops < 0) {
-        throwError("Variable-length path minimum hops must be greater than or equal to 0", edge);
+        throwError("Variable-length path minimum hops must be greater than or equal to 0.", edge);
     }
 
     if (maxHops < 1) {
-        throwError("Variable-length path maximum hops must be greater than or equal to 1", edge);
+        throwError("Variable-length path maximum hops must be greater than or equal to 1.", edge);
     }
 
     PathExplorerNode* expandNode = _tree->newOut<PathExplorerNode>(prevNode,

--- a/query/plan/ReturnStmtGenerator.cpp
+++ b/query/plan/ReturnStmtGenerator.cpp
@@ -52,11 +52,13 @@ namespace rg = ranges;
 namespace rv = rg::views;
 
 ReturnStmtGenerator::ReturnStmtGenerator(const CypherAST* ast,
+                                         PlanGraphVariables* vars,
                                          const ReturnStmt* rtnStmt,
                                          PlanGraph* tree,
                                          PlanGraphNode* prevNode,
                                          GetPropertyCache& propCache)
     : _ast(ast),
+    _vars(vars),
     _stmt(rtnStmt),
     _tree(tree),
     _prevNode(prevNode),

--- a/query/plan/ReturnStmtGenerator.cpp
+++ b/query/plan/ReturnStmtGenerator.cpp
@@ -20,6 +20,7 @@
 #include "expr/Expr.h"
 #include "expr/LiteralExpr.h"
 #include "expr/UnaryExpr.h"
+#include "nodes/PlanGraphNode.h"
 #include "stmt/Limit.h"
 #include "stmt/OrderBy.h"
 #include "stmt/OrderByItem.h"
@@ -355,6 +356,27 @@ void ReturnStmtGenerator::fetchOrGenerateProperty(PropertyExpr* prop) {
 
     if (!entityVar) {
         throwError("Property had no enitity variable declation.", prop);
+    }
+
+    {
+        // Check if a variable is produced by a processor such as @ref
+        // PathExplorerProcessor which does not produce a single entity column
+
+        const PlanGraphNode* producer = _vars->getProducer(entityVar);
+        const PlanGraphOpcode code = producer->getOpcode();
+
+        const bool isFromExplorer = code == PlanGraphOpcode::PATH_EXPLORER;
+        if (isFromExplorer) {
+            throwError("Returning properties from a variable lengthed path is not yet "
+                       "supported.",
+                       prop);
+        }
+
+        const bool isFromVar = code == PlanGraphOpcode::VAR;
+        if (!isFromVar) {
+            throwError("Could not return properties from variable with ambiguous source.",
+                       prop);
+        }
     }
 
     const auto* cached = _propCache.cacheOrRetrieve(entityVar, propVar, propName);

--- a/query/plan/ReturnStmtGenerator.h
+++ b/query/plan/ReturnStmtGenerator.h
@@ -28,6 +28,7 @@ class GetPropertyWithNullNode;
 class ReturnStmtGenerator {
 public:
     ReturnStmtGenerator(const CypherAST* ast,
+                        PlanGraphVariables* vars,
                         const ReturnStmt* rtnStmt,
                         PlanGraph* tree,
                         PlanGraphNode* prevNode,
@@ -65,6 +66,7 @@ private:
         std::variant<ExprEvalNode*, AggregateEvalNode*, GetPropertyWithNullNode*>;
 
     const CypherAST* _ast {nullptr};
+    PlanGraphVariables* _vars {nullptr};
 
     const ReturnStmt* _stmt {nullptr};
     Projection* _proj {nullptr};

--- a/storage/iterators/GetPropertiesWithNullIterator.cpp
+++ b/storage/iterators/GetPropertiesWithNullIterator.cpp
@@ -18,6 +18,8 @@ GetPropertiesIteratorWithNull<ID, T>::GetPropertiesIteratorWithNull(const GraphV
 
 template <IteratedID ID, SupportedType T>
 void GetPropertiesIteratorWithNull<ID, T>::init() {
+    bioassert(_inputIDs, "Null input column.");
+
     if (_inputIDs->empty()) {
         return;
     }

--- a/test/query-test-suite/tests/qpp-return-path-prop-error.json
+++ b/test/query-test-suite/tests/qpp-return-path-prop-error.json
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "graph": "simpledb",
+  "query": "MATCH (n)-[e]-+(m) RETURN n.age, e.name, m.age",
+  "expect": {
+    "plan": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n)-[e]-+(m) RETURN n.age, e.name, m.age\n       |                                  ^^^^^^\n-------* Returning properties from a variable lengthed path is not yet supported.",
+    "result": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n)-[e]-+(m) RETURN n.age, e.name, m.age\n       |                                  ^^^^^^\n-------* Returning properties from a variable lengthed path is not yet supported.",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n)-[e]-+(m) RETURN n.age, e.name, m.age\\n       |                                  ^^^^^^\\n-------* Returning properties from a variable lengthed path is not yet supported.\"}"
+  },
+  "tags": [
+    "qpp",
+    "errors"
+  ],
+  "write-required": false
+}

--- a/test/query-test-suite/tests/qpp-return-path-prop-simple.json
+++ b/test/query-test-suite/tests/qpp-return-path-prop-simple.json
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "graph": "simpledb",
+  "query": "MATCH (n)-[e]->+(m) RETURN n, e.name, m",
+  "expect": {
+    "plan": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n)-[e]->+(m) RETURN n, e.name, m\n       |                               ^^^^^^\n-------* Returning properties from a variable lengthed path is not yet supported.",
+    "result": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n)-[e]->+(m) RETURN n, e.name, m\n       |                               ^^^^^^\n-------* Returning properties from a variable lengthed path is not yet supported.",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n)-[e]->+(m) RETURN n, e.name, m\\n       |                               ^^^^^^\\n-------* Returning properties from a variable lengthed path is not yet supported.\"}"
+  },
+  "tags": [
+    "qpp",
+    "errors"
+  ],
+  "write-required": false
+}

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -456,9 +456,9 @@ void tabulateWrite(tabulate::RowStream& rs, const db::EntityList& list) {
         }
 
         if (type == EntityType::Node) {
-            result += fmt::format("({}:)", val);
+            result += fmt::format("({})", val);
         } else {
-            result += fmt::format("[{}:]", val);
+            result += fmt::format("[{}]", val);
         }
     }
     rs << result;


### PR DESCRIPTION
Fixes #583 by disabling returning properties from the path produced by `PathExplorer`. Adds test to verfiy.