### PR TITLE
Cleanup of TuringDB::query function

### DIFF
--- a/db/QueryState.h
+++ b/db/QueryState.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string_view>
+
+#include "QueryConfig.h"
+#include "QueryCallbacks.h"
+#include "versioning/CommitHash.h"
+#include "versioning/ChangeID.h"
+
+namespace db {
+
+class LocalMemory;
+
+class QueryState {
+public:
+    QueryState(std::string_view graphName,
+               LocalMemory* mem,
+               const QueryConfig* queryConfig,
+               const QueryCallbacks* callbacks,
+               CommitHash hash = CommitHash::head(),
+               ChangeID change = ChangeID::head())
+        : _graphName(graphName),
+        _mem(mem),
+        _queryConfig(queryConfig),
+        _callbacks(callbacks),
+        _hash(hash),
+        _change(change)
+    {
+    }
+
+    std::string_view getGraphName() const { return _graphName; }
+    LocalMemory* getMemory() const { return _mem; }
+    const QueryConfig* getQueryConfig() const { return _queryConfig; }
+    const QueryCallbacks* getCallbacks() const { return _callbacks; }
+    CommitHash getCommitHash() const { return _hash; }
+    ChangeID getChangeID() const { return _change; }
+
+private:
+    std::string_view _graphName;
+    LocalMemory* _mem {nullptr};
+    const QueryConfig* _queryConfig {nullptr};
+    const QueryCallbacks* _callbacks {nullptr};
+    CommitHash _hash {CommitHash::head()};
+    ChangeID _change {ChangeID::head()};
+};
+
+}

--- a/db/TuringDB.cpp
+++ b/db/TuringDB.cpp
@@ -17,14 +17,14 @@
 using namespace db;
 
 TuringDB::TuringDB(const TuringConfig* config)
-    : _config(config),
-    _systemManager(std::make_unique<SystemManager>(config)),
-    _jobSystem(JobSystem::create()),
-    _procedures(ProcedureManager::create()),
-    _extensions(std::make_unique<ExtensionManager>(config->getUserExtensionsDir(),
-                                                   config->getInstallExtensionsDir(),
-                                                   _procedures.get()))
+    : _config(config)
 {
+    _systemManager = std::make_unique<SystemManager>(config);
+    _jobSystem = JobSystem::create();
+    _procedures = ProcedureManager::create();
+    _extensions = std::make_unique<ExtensionManager>(config->getUserExtensionsDir(),
+                                                     config->getInstallExtensionsDir(),
+                                                     _procedures.get());
 }
 
 TuringDB::~TuringDB() {
@@ -103,18 +103,18 @@ void TuringDB::init() {
         }
     }
 
-    // Create vector database
-    if (auto res = vec::VectorDatabase::create(vectorDir)) {
-        _vectorDatabase = std::move(res.value());
-    } else {
-        panic("Could not create vector database: {}", res.error().fmtMessage());
-    }
-
     // Acquire lock file
     _lockFile.setPath(fs::Path(_config->getLockFilePath()));
     const auto lockRes = _lockFile.tryLock();
     if (!lockRes) {
         panic("Could not acquire lock file: {}", lockRes.error().fmtMessage());
+    }
+
+    // Create vector database
+    if (auto res = vec::VectorDatabase::create(vectorDir)) {
+        _vectorDatabase = std::move(res.value());
+    } else {
+        panic("Could not create vector database: {}", res.error().fmtMessage());
     }
 
     // Initialize socket/signal communication system
@@ -166,28 +166,4 @@ QueryStatus TuringDB::query(std::string_view query,
     interp.execute(ctxt, status, query, graphName);
 
     return status;
-}
-
-QueryStatus TuringDB::query(std::string_view query,
-                            std::string_view graphName,
-                            LocalMemory* mem,
-                            const QueryConfig* queryConfig,
-                            const QueryCallbacks::OnOutputData& callback,
-                            CommitHash hash,
-                            ChangeID change) {
-    QueryCallbacks callbacks;
-    callbacks.setOnOutputData(callback);
-
-    return this->query(query, graphName, mem, queryConfig, callbacks, hash, change);
-}
-
-QueryStatus TuringDB::query(std::string_view query,
-                            std::string_view graphName,
-                            LocalMemory* mem,
-                            const QueryConfig* queryConfig,
-                            CommitHash hash,
-                            ChangeID change) {
-    const QueryCallbacks handler;
-
-    return this->query(query, graphName, mem, queryConfig, handler, hash, change);
 }

--- a/db/TuringDB.cpp
+++ b/db/TuringDB.cpp
@@ -145,25 +145,19 @@ void TuringDB::init() {
     }
 }
 
-QueryStatus TuringDB::query(std::string_view query,
-                            std::string_view graphName,
-                            LocalMemory* mem,
-                            const QueryConfig* queryConfig,
-                            const QueryCallbacks& callbacks,
-                            CommitHash hash,
-                            ChangeID change) {
+QueryStatus TuringDB::query(std::string_view query, const QueryState& state) {
     QueryInterpreterV2 interp(_systemManager.get(), _jobSystem.get());
 
     QueryStatus status;
-    InterpreterContext ctxt(mem,
-                            &callbacks,
+    InterpreterContext ctxt(state.getMemory(),
+                            state.getCallbacks(),
                             _procedures.get(),
                             _extensions.get(),
                             _vectorDatabase.get(),
-                            hash,
-                            change);
-    ctxt.setQueryConfig(queryConfig);
-    interp.execute(ctxt, status, query, graphName);
+                            state.getCommitHash(),
+                            state.getChangeID());
+    ctxt.setQueryConfig(state.getQueryConfig());
+    interp.execute(ctxt, status, query, state.getGraphName());
 
     return status;
 }

--- a/db/TuringDB.cpp
+++ b/db/TuringDB.cpp
@@ -19,12 +19,12 @@ using namespace db;
 TuringDB::TuringDB(const TuringConfig* config)
     : _config(config)
 {
-    _systemManager = std::make_unique<SystemManager>(config);
+    _systemManager = SystemManager::create(config);
     _jobSystem = JobSystem::create();
     _procedures = ProcedureManager::create();
-    _extensions = std::make_unique<ExtensionManager>(config->getUserExtensionsDir(),
-                                                     config->getInstallExtensionsDir(),
-                                                     _procedures.get());
+    _extensions = ExtensionManager::create(config->getUserExtensionsDir(),
+                                           config->getInstallExtensionsDir(),
+                                           _procedures.get());
 }
 
 TuringDB::~TuringDB() {

--- a/db/TuringDB.h
+++ b/db/TuringDB.h
@@ -4,10 +4,8 @@
 
 #include "LockFile.h"
 #include "QueryConfig.h"
+#include "QueryState.h"
 #include "QueryStatus.h"
-#include "QueryCallbacks.h"
-#include "versioning/CommitHash.h"
-#include "versioning/ChangeID.h"
 
 namespace vec {
 class VectorDatabase;
@@ -17,7 +15,6 @@ namespace db {
 
 class TuringConfig;
 class SystemManager;
-class LocalMemory;
 class JobSystem;
 class ExtensionManager;
 class ProcedureManager;
@@ -31,13 +28,7 @@ public:
 
     void stop();
 
-    QueryStatus query(std::string_view query,
-                      std::string_view graphName,
-                      LocalMemory* mem,
-                      const QueryConfig* queryConfig,
-                      const QueryCallbacks& callbacks,
-                      CommitHash hash = CommitHash::head(),
-                      ChangeID change = ChangeID::head());
+    QueryStatus query(std::string_view query, const QueryState& state);
 
     const QueryConfig& getDefaultQueryConfig() const { return _defaultQueryConfig; }
 

--- a/db/TuringDB.h
+++ b/db/TuringDB.h
@@ -19,10 +19,8 @@ class TuringConfig;
 class SystemManager;
 class LocalMemory;
 class JobSystem;
-class Block;
 class ExtensionManager;
 class ProcedureManager;
-class SystemEventHandler;
 
 class TuringDB {
 public:
@@ -30,6 +28,8 @@ public:
     ~TuringDB();
 
     void init();
+
+    void stop();
 
     QueryStatus query(std::string_view query,
                       std::string_view graphName,
@@ -39,29 +39,15 @@ public:
                       CommitHash hash = CommitHash::head(),
                       ChangeID change = ChangeID::head());
 
-    QueryStatus query(std::string_view query,
-                      std::string_view graphName,
-                      LocalMemory* mem,
-                      const QueryConfig* queryConfig,
-                      const QueryCallbacks::OnOutputData& callback,
-                      CommitHash hash = CommitHash::head(),
-                      ChangeID change = ChangeID::head());
-
-    QueryStatus query(std::string_view query,
-                      std::string_view graphName,
-                      LocalMemory* mem,
-                      const QueryConfig* queryConfig,
-                      CommitHash hash = CommitHash::head(),
-                      ChangeID change = ChangeID::head());
-
     const QueryConfig& getDefaultQueryConfig() const { return _defaultQueryConfig; }
 
     SystemManager& getSystemManager() { return *_systemManager; }
-    JobSystem& getJobSystem() { return *_jobSystem; }
-    const ProcedureManager* getProcedures() const { return _procedures.get(); }
-    ExtensionManager* getExtensions() { return _extensions.get(); }
 
-    void stop();
+    JobSystem& getJobSystem() { return *_jobSystem; }
+
+    const ProcedureManager* getProcedures() const { return _procedures.get(); }
+
+    ExtensionManager* getExtensions() { return _extensions.get(); }
 
 private:
     const TuringConfig* _config {nullptr};

--- a/extensions/ExtensionManager.cpp
+++ b/extensions/ExtensionManager.cpp
@@ -32,6 +32,12 @@ ExtensionManager::~ExtensionManager() {
     }
 }
 
+std::unique_ptr<ExtensionManager> ExtensionManager::create(const fs::Path& userExtensionsDir,
+                                                           const fs::Path& installExtensionsDir,
+                                                           ProcedureManager* procedures) {
+    return std::unique_ptr<ExtensionManager>(new ExtensionManager(userExtensionsDir, installExtensionsDir, procedures));
+}
+
 void ExtensionManager::installExtension(std::string_view name) {
     std::unique_lock<std::shared_mutex> lock(_mutex);
 

--- a/extensions/ExtensionManager.h
+++ b/extensions/ExtensionManager.h
@@ -18,10 +18,11 @@ class ExtensionManager {
 public:
     using Extensions = std::vector<ExtensionDescriptor*>;
 
-    ExtensionManager(const fs::Path& userExtensionsDir,
-                     const fs::Path& installExtensionsDir,
-                     ProcedureManager* procedures);
     ~ExtensionManager();
+
+    static std::unique_ptr<ExtensionManager> create(const fs::Path& userExtensionsDir,
+                                                    const fs::Path& installExtensionsDir,
+                                                    ProcedureManager* procedures);
 
     void installExtension(std::string_view name);
     bool isInstalled(std::string_view name) const;
@@ -34,6 +35,10 @@ private:
     ProcedureManager* _procedures {nullptr};
     Extensions _installed;
     std::unordered_map<std::string_view, ExtensionDescriptor*> _installedMap;
+
+    ExtensionManager(const fs::Path& userExtensionsDir,
+                     const fs::Path& installExtensionsDir,
+                     ProcedureManager* procedures);
 
     void loadExtensionDef(const TuringExtensionDef* def,
                           ExtensionDescriptor::Handle handle);

--- a/query/interpreter/QueryInterpreterV2.cpp
+++ b/query/interpreter/QueryInterpreterV2.cpp
@@ -212,6 +212,7 @@ void QueryInterpreterV2::executeImpl(const InterpreterContext& ctxt,
         if (outDf) {
             callbacks->onOutputHeader(outDf);
         }
+
         executor.execute();
     } catch (const PipelineException& e) {
         status.setStatus(QueryStatus::Status::EXEC_ERROR);

--- a/query/pipeline/procedures/ProcedureManager.cpp
+++ b/query/pipeline/procedures/ProcedureManager.cpp
@@ -23,7 +23,7 @@ ProcedureManager::~ProcedureManager() {
 }
 
 std::unique_ptr<ProcedureManager> ProcedureManager::create() {
-    return std::make_unique<ProcedureManager>();
+    return std::unique_ptr<ProcedureManager>(new ProcedureManager());
 }
 
 void ProcedureManager::init() {

--- a/query/pipeline/procedures/ProcedureManager.h
+++ b/query/pipeline/procedures/ProcedureManager.h
@@ -16,7 +16,6 @@ class ProcedureManager {
 public:
     using Namespaces = std::vector<ProcedureNamespace*>;
 
-    ProcedureManager();
     ~ProcedureManager();
 
     void init();
@@ -35,6 +34,8 @@ private:
     mutable std::shared_mutex _mutex;
     Namespaces _namespaces;
     std::unordered_map<std::string_view, ProcedureNamespace*> _namespaceMap;
+
+    ProcedureManager();
 };
 
 }

--- a/samples/gnn/main.cpp
+++ b/samples/gnn/main.cpp
@@ -170,22 +170,21 @@ int main(int argc, const char** argv) {
     // -----------------------------------------------------------------
     std::string q;
 
-    const auto mustQuery = [&](std::string_view q, ChangeID chg = ChangeID::head()) {
-        const auto res = db.query(q, graphName, &mem, &queryConfig, CommitHash::head(), chg);
+    const auto queryWithCb = [&](std::string_view q,
+                                 const QueryCallbacks::OnOutputData& cb,
+                                 ChangeID chg = ChangeID::head()) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(cb);
+        const auto res = db.query(q, graphName, &mem, &queryConfig, callbacks,
+                                  CommitHash::head(), chg);
         if (!res.isOk()) {
             spdlog::error("Query failed: {}\n  {}", q, res.getError());
             exit(EXIT_FAILURE);
         }
     };
 
-    const auto queryWithCb = [&](std::string_view q,
-                                 const QueryCallbacks::OnOutputData& cb,
-                                 ChangeID chg = ChangeID::head()) {
-        const auto res = db.query(q, graphName, &mem, &queryConfig, cb, CommitHash::head(), chg);
-        if (!res.isOk()) {
-            spdlog::error("Query failed: {}\n  {}", q, res.getError());
-            exit(EXIT_FAILURE);
-        }
+    const auto mustQuery = [&](std::string_view q, ChangeID chg = ChangeID::head()) {
+        queryWithCb(q, [](const Dataframe*) {}, chg);
     };
 
     // -----------------------------------------------------------------

--- a/samples/gnn/main.cpp
+++ b/samples/gnn/main.cpp
@@ -175,8 +175,8 @@ int main(int argc, const char** argv) {
                                  ChangeID chg = ChangeID::head()) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(cb);
-        const auto res = db.query(q, graphName, &mem, &queryConfig, callbacks,
-                                  CommitHash::head(), chg);
+        const QueryState state(graphName, &mem, &queryConfig, &callbacks, CommitHash::head(), chg);
+        const auto res = db.query(q, state);
         if (!res.isOk()) {
             spdlog::error("Query failed: {}\n  {}", q, res.getError());
             exit(EXIT_FAILURE);

--- a/samples/tfl/main.cpp
+++ b/samples/tfl/main.cpp
@@ -92,7 +92,17 @@ int main(int argc, const char** argv) {
     std::set<std::string> stationSet;
 
     QueryConfig queryConfig;
-    const auto status = db.query(loadQuery, graphName, &mem, &queryConfig,
+
+    const auto runQuery = [&](std::string_view q,
+                              const QueryCallbacks::OnOutputData& cb,
+                              ChangeID chg = ChangeID::head()) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(cb);
+        return db.query(q, graphName, &mem, &queryConfig, callbacks,
+                        CommitHash::head(), chg);
+    };
+
+    const auto status = runQuery(loadQuery,
         [&](const Dataframe* df) {
             using StringCol = ColumnVector<std::string>;
 
@@ -265,15 +275,13 @@ int main(int argc, const char** argv) {
     }
     Change* change = changeRes.value();
 
-    const auto createStatus = db.query(createQuery, graphName, &mem, &queryConfig,
-                                        CommitHash::head(), change->id());
+    const auto createStatus = runQuery(createQuery, [](const Dataframe*) {}, change->id());
     if (!createStatus.isOk()) {
         spdlog::error("CREATE failed: {}", createStatus.getError());
         return EXIT_FAILURE;
     }
 
-    const auto submitStatus = db.query("CHANGE SUBMIT", graphName, &mem, &queryConfig,
-                                        CommitHash::head(), change->id());
+    const auto submitStatus = runQuery("CHANGE SUBMIT", [](const Dataframe*) {}, change->id());
     if (!submitStatus.isOk()) {
         spdlog::error("CHANGE SUBMIT failed: {}",
                       submitStatus.getError());
@@ -296,7 +304,7 @@ int main(int argc, const char** argv) {
     double distance = 0;
     Path pathResult;
 
-    const auto spStatus = db.query(spQuery, graphName, &mem, &queryConfig,
+    const auto spStatus = runQuery(spQuery,
         [&](const Dataframe* df) {
             auto* distCol =
                 df->cols()[0]->as<ColumnVector<double>>();

--- a/samples/tfl/main.cpp
+++ b/samples/tfl/main.cpp
@@ -98,8 +98,8 @@ int main(int argc, const char** argv) {
                               ChangeID chg = ChangeID::head()) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(cb);
-        return db.query(q, graphName, &mem, &queryConfig, callbacks,
-                        CommitHash::head(), chg);
+        const QueryState state(graphName, &mem, &queryConfig, &callbacks, CommitHash::head(), chg);
+        return db.query(q, state);
     };
 
     const auto status = runQuery(loadQuery,

--- a/samples/v2/main.cpp
+++ b/samples/v2/main.cpp
@@ -35,8 +35,8 @@ int main(int argc, char** argv) {
     config.setSyncedOnDisk(false);
 
     const auto jobSystem = JobSystem::create();
-    SystemManager sysMan(&config);
-    Graph* graph = sysMan.createGraph("simpledb");
+    auto sysMan = SystemManager::create(&config);
+    Graph* graph = sysMan->createGraph("simpledb");
     SimpleGraph::createSimpleGraph(graph);
 
     auto procedures = ProcedureManager::create();
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
                                           view,
                                           &pipeline,
                                           &mem,
-                                          &sysMan,
+                                          sysMan.get(),
                                           procedures.get(),
                                           &callbacks);
             try {
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
         {
             fmt::print("\n=== Execution ===\n\n");
 
-            ExecutionContext execCtxt(&sysMan, view);
+            ExecutionContext execCtxt(sysMan.get(), view);
             execCtxt.setTransaction(&transaction);
             execCtxt.setJobSystem(jobSystem.get());
 

--- a/server/DBServerProcessor.cpp
+++ b/server/DBServerProcessor.cpp
@@ -1395,5 +1395,6 @@ void DBServerProcessor::queryImpl(std::string_view query,
         encoder.finish();
     });
 
-    _db.query(query, graphName, &mem, &_db.getDefaultQueryConfig(), queryCallbacks, commit, change);
+    const QueryState state(graphName, &mem, &_db.getDefaultQueryConfig(), &queryCallbacks, commit, change);
+    _db.query(query, state);
 }

--- a/system/SystemManager.cpp
+++ b/system/SystemManager.cpp
@@ -30,6 +30,10 @@ SystemManager::SystemManager(const TuringConfig* config)
 SystemManager::~SystemManager() {
 }
 
+std::unique_ptr<SystemManager> SystemManager::create(const TuringConfig* config) {
+    return std::unique_ptr<SystemManager>(new SystemManager(config));
+}
+
 void SystemManager::init() {
     const auto list = _config->getGraphsDir().listDir();
 

--- a/system/SystemManager.h
+++ b/system/SystemManager.h
@@ -27,13 +27,14 @@ class Change;
 
 class SystemManager {
 public:
-    explicit SystemManager(const TuringConfig* config);
     ~SystemManager();
 
     SystemManager(const SystemManager&) = delete;
     SystemManager(SystemManager&&) = delete;
     SystemManager& operator=(const SystemManager&) = delete;
     SystemManager& operator=(SystemManager&&) = delete;
+
+    static std::unique_ptr<SystemManager> create(const TuringConfig* config);
 
     const TuringConfig* getConfig() const { return _config; }
 
@@ -96,6 +97,8 @@ private:
     std::unordered_map<std::string, std::unique_ptr<Graph>> _graphs;
     std::unique_ptr<ChangeManager> _changes;
     GraphLoadStatus _graphLoadStatus;
+
+    explicit SystemManager(const TuringConfig* config);
 
     bool loadJsonlDB(const std::string& graphName, const fs::Path& dbPath, JobSystem&);
     bool loadGmlDB(const std::string& graphName, const fs::Path& dbPath, JobSystem&);

--- a/test/query-test-suite/QueryTestRunner.cpp
+++ b/test/query-test-suite/QueryTestRunner.cpp
@@ -566,23 +566,13 @@ QueryTestResult QueryTestRunner::runTest(const QueryTestSpec& spec,
             changeID = c[0];
         });
 
-        db->query("CHANGE NEW",
-                  spec._graphName,
-                  &env->getMem(),
-                  &queryConfig,
-                  changeNewCallbacks,
-                  CommitHash::head(),
-                  ChangeID::head());
+        const db::QueryState changeNewState(spec._graphName, &env->getMem(), &queryConfig, &changeNewCallbacks);
+        db->query("CHANGE NEW", changeNewState);
     }
 
+    const db::QueryState queryState(spec._graphName, &env->getMem(), &queryConfig, &queryCallbacks, db::CommitHash::head(), changeID);
     const auto queryStart = Clock::now();
-    const db::QueryStatus status = db->query(spec._query,
-                                             spec._graphName,
-                                             &env->getMem(),
-                                             &queryConfig,
-                                             queryCallbacks,
-                                             db::CommitHash::head(),
-                                             changeID);
+    const db::QueryStatus status = db->query(spec._query, queryState);
     const auto queryEnd = Clock::now();
 
     if (!status.isOk() && !jsonErrorEncoded) {
@@ -621,13 +611,8 @@ QueryTestResult QueryTestRunner::runTest(const QueryTestSpec& spec,
 
     if (spec._writeRequired) {
         db::QueryCallbacks submitCallbacks;
-        db->query("CHANGE SUBMIT",
-                  spec._graphName,
-                  &env->getMem(),
-                  &queryConfig,
-                  submitCallbacks,
-                  db::CommitHash::head(),
-                  changeID);
+        const db::QueryState submitState(spec._graphName, &env->getMem(), &queryConfig, &submitCallbacks, db::CommitHash::head(), changeID);
+        db->query("CHANGE SUBMIT", submitState);
     }
 
     normalizeOutput(result._planOutput, planOut.str());

--- a/test/query-test-suite/QueryTestRunner.cpp
+++ b/test/query-test-suite/QueryTestRunner.cpp
@@ -555,7 +555,8 @@ QueryTestResult QueryTestRunner::runTest(const QueryTestSpec& spec,
     db::ChangeID changeID = db::ChangeID::head();
 
     if (spec._writeRequired) {
-        const auto callback = [&](const db::Dataframe* df) {
+        db::QueryCallbacks changeNewCallbacks;
+        changeNewCallbacks.setOnOutputData([&](const db::Dataframe* df) {
             NamedColumn* col = df->getColumn(ColumnTag {0});
             bioassert(col, "Column not found");
 
@@ -563,13 +564,13 @@ QueryTestResult QueryTestRunner::runTest(const QueryTestSpec& spec,
             bioassert(c.size() == 1, "Expected 1 change");
 
             changeID = c[0];
-        };
+        });
 
         db->query("CHANGE NEW",
                   spec._graphName,
                   &env->getMem(),
                   &queryConfig,
-                  callback,
+                  changeNewCallbacks,
                   CommitHash::head(),
                   ChangeID::head());
     }
@@ -619,10 +620,12 @@ QueryTestResult QueryTestRunner::runTest(const QueryTestSpec& spec,
     }
 
     if (spec._writeRequired) {
+        db::QueryCallbacks submitCallbacks;
         db->query("CHANGE SUBMIT",
                   spec._graphName,
                   &env->getMem(),
                   &queryConfig,
+                  submitCallbacks,
                   db::CommitHash::head(),
                   changeID);
     }

--- a/test/query/pipeline/processors/ShortestPathProcessorTest.cpp
+++ b/test/query/pipeline/processors/ShortestPathProcessorTest.cpp
@@ -638,8 +638,8 @@ public:
                                 ChangeID changeId = ChangeID::head()) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(onData);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), changeId);
+        const QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeId);
+        return _db->query(q, state);
     }
 
 protected:

--- a/test/query/pipeline/processors/ShortestPathProcessorTest.cpp
+++ b/test/query/pipeline/processors/ShortestPathProcessorTest.cpp
@@ -574,12 +574,10 @@ public:
             Change* change = changeResult.value();
             auto changeId = change->id();
 
-            auto status = _db->query(ROAD_NETWORK_CYPHER, _graphName, &_env->getMem(), &_queryConfig,
-                                     [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto status = runQuery(ROAD_NETWORK_CYPHER, _graphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(status.isOk()) << "Failed to create road network: " << status.getError();
 
-            auto submitStatus = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                           [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto submitStatus = runQuery("CHANGE SUBMIT", _graphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(submitStatus.isOk()) << "Failed to submit change: "
                                              << submitStatus.getError();
         }
@@ -593,13 +591,11 @@ public:
             Change* change = changeResult.value();
             auto changeId = change->id();
 
-            auto status = _db->query(NEGATIVE_WEIGHT_GRAPH_CYPHER, _negGraphName, &_env->getMem(), &_queryConfig,
-                                     [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto status = runQuery(NEGATIVE_WEIGHT_GRAPH_CYPHER, _negGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(status.isOk()) << "Failed to create negative weight graph: "
                                        << status.getError();
 
-            auto submitStatus = _db->query("CHANGE SUBMIT", _negGraphName, &_env->getMem(), &_queryConfig,
-                                           [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto submitStatus = runQuery("CHANGE SUBMIT", _negGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(submitStatus.isOk()) << "Failed to submit negative weight change: "
                                              << submitStatus.getError();
         }
@@ -613,12 +609,10 @@ public:
             Change* change = changeResult.value();
             auto changeId = change->id();
 
-            auto status = _db->query(DISJOINT_GRAPH_CYPHER, _disjGraphName, &_env->getMem(), &_queryConfig,
-                                     [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto status = runQuery(DISJOINT_GRAPH_CYPHER, _disjGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(status.isOk()) << "Failed to create disjoint graph: " << status.getError();
 
-            auto submitStatus = _db->query("CHANGE SUBMIT", _disjGraphName, &_env->getMem(), &_queryConfig,
-                                           [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto submitStatus = runQuery("CHANGE SUBMIT", _disjGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(submitStatus.isOk()) << "Failed to submit disjoint change: "
                                              << submitStatus.getError();
         }
@@ -636,6 +630,16 @@ public:
         // Create per-test builder and pipeline (don't call ProcessorTester::initialize
         // since we use static _env)
         _builder = std::make_unique<PipelineBuilder>(&_env->getMem(), &_pipeline);
+    }
+
+    static QueryStatus runQuery(std::string_view q,
+                                std::string_view graphName,
+                                QueryCallbacks::OnOutputData onData = [](const Dataframe*) {},
+                                ChangeID changeId = ChangeID::head()) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(onData);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), changeId);
     }
 
 protected:
@@ -658,15 +662,14 @@ protected:
         std::string query = fmt::format(
             "MATCH (n:{}) WHERE n.id = '{}' RETURN n", label, nodeID);
 
-        auto status = _db->query(query, graphName, &_env->getMem(), &_queryConfig,
-                                 [&](const Dataframe* df) -> void {
-                                     if (df && !df->cols().empty()) {
-                                         const auto* nodeCol = df->cols()[0]->as<ColumnNodeIDs>();
-                                         if (nodeCol && !nodeCol->empty()) {
-                                             result = (*nodeCol)[0];
-                                         }
-                                     }
-                                 });
+        auto status = runQuery(query, graphName, [&](const Dataframe* df) -> void {
+            if (df && !df->cols().empty()) {
+                const auto* nodeCol = df->cols()[0]->as<ColumnNodeIDs>();
+                if (nodeCol && !nodeCol->empty()) {
+                    result = (*nodeCol)[0];
+                }
+            }
+        });
 
         if (!status.isOk() || !result.isValid()) {
             throw std::runtime_error(fmt::format("Node not found: {}", nodeID));
@@ -790,15 +793,15 @@ protected:
 TEST_F(ShortestPathProcessorTest, graphLoadedCorrectly) {
     // Verify node count
     uint64_t nodeCount = 0;
-    auto status = _db->query("MATCH (n:City) RETURN COUNT(n) AS cnt", _graphName, &_env->getMem(), &_queryConfig,
-                             [&](const Dataframe* df) -> void {
-                                 if (df && !df->cols().empty()) {
-                                     const auto* col = df->cols()[0]->as<ColumnConst<uint64_t>>();
-                                     if (col) {
-                                         nodeCount = col->getRaw();
-                                     }
-                                 }
-                             });
+    auto status = runQuery("MATCH (n:City) RETURN COUNT(n) AS cnt", _graphName,
+                           [&](const Dataframe* df) -> void {
+                               if (df && !df->cols().empty()) {
+                                   const auto* col = df->cols()[0]->as<ColumnConst<uint64_t>>();
+                                   if (col) {
+                                       nodeCount = col->getRaw();
+                                   }
+                               }
+                           });
 
     ASSERT_TRUE(status.isOk());
     ASSERT_EQ(nodeCount, 100) << "Expected 100 cities in the graph";
@@ -810,15 +813,15 @@ TEST_F(ShortestPathProcessorTest, graphLoadedCorrectly) {
 TEST_F(ShortestPathProcessorTest, edgesLoadedCorrectly) {
     // Count edges
     uint64_t edgeCount = 0;
-    auto status = _db->query("MATCH ()-[r:ROAD]->() RETURN COUNT(r) AS cnt", _graphName, &_env->getMem(), &_queryConfig,
-                             [&](const Dataframe* df) -> void {
-                                 if (df && !df->cols().empty()) {
-                                     const auto* col = df->cols()[0]->as<ColumnConst<uint64_t>>();
-                                     if (col) {
-                                         edgeCount = col->getRaw();
-                                     }
-                                 }
-                             });
+    auto status = runQuery("MATCH ()-[r:ROAD]->() RETURN COUNT(r) AS cnt", _graphName,
+                           [&](const Dataframe* df) -> void {
+                               if (df && !df->cols().empty()) {
+                                   const auto* col = df->cols()[0]->as<ColumnConst<uint64_t>>();
+                                   if (col) {
+                                       edgeCount = col->getRaw();
+                                   }
+                               }
+                           });
 
     ASSERT_TRUE(status.isOk());
     ASSERT_EQ(edgeCount, 400) << "Expected 400 roads in the graph";

--- a/test/query/queries/AutoCreateCommandTest.cpp
+++ b/test/query/queries/AutoCreateCommandTest.cpp
@@ -48,16 +48,18 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(), &_queryConfig, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
-    }
-
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), _currentChange);
         return res;
+    }
+
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 
     void setWorkingGraph(std::string_view name) {

--- a/test/query/queries/AutoCreateCommandTest.cpp
+++ b/test/query/queries/AutoCreateCommandTest.cpp
@@ -51,9 +51,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/AutoJoinTest.cpp
+++ b/test/query/queries/AutoJoinTest.cpp
@@ -251,8 +251,10 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
         auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callback, CommitHash::head(), ChangeID::head());
+                              callbacks, CommitHash::head(), ChangeID::head());
         if (!res) {
             spdlog::error("Query failed: {}", res.getError());
         }

--- a/test/query/queries/AutoJoinTest.cpp
+++ b/test/query/queries/AutoJoinTest.cpp
@@ -253,8 +253,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callbacks, CommitHash::head(), ChangeID::head());
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        auto res = _db->query(query, state);
         if (!res) {
             spdlog::error("Query failed: {}", res.getError());
         }

--- a/test/query/queries/CallProcedureTest.cpp
+++ b/test/query/queries/CallProcedureTest.cpp
@@ -25,6 +25,13 @@ public:
         _db = &_env->getDB();
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
 protected:
     std::unique_ptr<TuringTestEnv> _env;
     TuringDB* _db {nullptr};
@@ -33,9 +40,7 @@ protected:
 
 TEST_F(CallProcedureTest, Labels) {
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.labels()", "simpledb", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CALL db.labels()", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 2);
             ASSERT_EQ(df->getLogicalRowCount(), 9);
@@ -49,9 +54,7 @@ TEST_F(CallProcedureTest, Labels) {
 
 TEST_F(CallProcedureTest, EdgeTypes) {
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.edgeTypes()", "simpledb", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CALL db.edgeTypes()", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 2);
             ASSERT_EQ(df->getLogicalRowCount(), 2);
@@ -65,9 +68,7 @@ TEST_F(CallProcedureTest, EdgeTypes) {
 
 TEST_F(CallProcedureTest, PropertyTypes) {
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.propertyTypes()", "simpledb", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CALL db.propertyTypes()", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 3);
             ASSERT_EQ(df->getLogicalRowCount(), 8);
@@ -81,9 +82,7 @@ TEST_F(CallProcedureTest, PropertyTypes) {
 
 TEST_F(CallProcedureTest, History) {
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.propertyTypes()", "simpledb", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CALL db.propertyTypes()", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 3);
             ASSERT_EQ(df->getLogicalRowCount(), 8);
@@ -97,13 +96,9 @@ TEST_F(CallProcedureTest, History) {
 
 TEST_F(CallProcedureTest, DescribeCommit) {
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.history() YIELD commit AS c "
+    const auto res = query("CALL db.history() YIELD commit AS c "
         "CALL db.describeCommit(c) YIELD nodeCount, edgeCount "
-        "RETURN nodeCount, edgeCount",
-        "simpledb",
-        &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+        "RETURN nodeCount, edgeCount", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 2);
             ASSERT_EQ(df->getLogicalRowCount(), 8);
@@ -141,13 +136,9 @@ TEST_F(CallProcedureTest, YieldWhereSelfJoin) {
     // Self-join on label names: CALL db.labels() twice with WHERE a = b
     // Should return 9 (one per label), not 81 (9 * 9 cartesian)
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.labels() YIELD label AS a "
+    const auto res = query("CALL db.labels() YIELD label AS a "
         "CALL db.labels() YIELD label AS b "
-        "WHERE a = b RETURN count(*)",
-        "simpledb",
-        &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+        "WHERE a = b RETURN count(*)", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
 
@@ -167,13 +158,9 @@ TEST_F(CallProcedureTest, YieldWhereCrossJoin) {
     // Labels: 9 entries (label), PropertyTypes: 8 entries (propertyType)
     // WHERE a = b should only match where a label name equals a property type name
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.labels() YIELD label AS a "
+    const auto res = query("CALL db.labels() YIELD label AS a "
         "CALL db.propertyTypes() YIELD propertyType AS b "
-        "WHERE a = b RETURN count(*)",
-        "simpledb",
-        &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+        "WHERE a = b RETURN count(*)", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
 
@@ -193,13 +180,9 @@ TEST_F(CallProcedureTest, YieldWhereSelfJoinByID) {
     // Self-join on label IDs: both sides are LabelID, so hash join works
     // Should return 9 (one per label), not 81 (9 * 9 cartesian)
     bool executed = false;
-    const auto res = _db->query(
-        "CALL db.labels() YIELD id AS l "
+    const auto res = query("CALL db.labels() YIELD id AS l "
         "CALL db.labels() YIELD id AS m "
-        "WHERE l = m RETURN count(*)",
-        "simpledb",
-        &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+        "WHERE l = m RETURN count(*)", "simpledb", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
 
@@ -216,13 +199,9 @@ TEST_F(CallProcedureTest, YieldWhereSelfJoinByID) {
 
 TEST_F(CallProcedureTest, YieldWhereCrossJoinIncompatibleTypes) {
     // Exact query from issue #549: LabelID != PropertyTypeID
-    const auto res = _db->query(
-        "CALL db.labels() YIELD id AS l "
+    const auto res = query("CALL db.labels() YIELD id AS l "
         "CALL db.propertyTypes() YIELD id AS p "
-        "WHERE l = p RETURN count(*)",
-        "simpledb",
-        &_env->getMem(), &_queryConfig,
-        [&](const Dataframe*) -> void {});
+        "WHERE l = p RETURN count(*)", "simpledb", [&](const Dataframe*) -> void {});
 
     EXPECT_EQ(res.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
 }

--- a/test/query/queries/CallProcedureTest.cpp
+++ b/test/query/queries/CallProcedureTest.cpp
@@ -28,8 +28,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
 protected:

--- a/test/query/queries/ChangeQueriesTest.cpp
+++ b/test/query/queries/ChangeQueriesTest.cpp
@@ -61,29 +61,32 @@ protected:
         _currentChange = change->id();
     }
 
+    auto query(std::string_view query, auto callback, ChangeID change) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
+                                CommitHash::head(), change);
+        return res;
+    }
+
+    auto query(std::string_view q, auto callback) {
+        return query(q, callback, _currentChange);
+    }
+
     void submitCurrentChange() {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                emptyCallback, CommitHash::head(), _currentChange);
+        auto res = query("CHANGE SUBMIT", emptyCallback);
         ASSERT_TRUE(res);
         _currentChange = ChangeID::head();
     }
 
     void submitChange(ChangeID chid) {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                emptyCallback, CommitHash::head(), chid);
-
+        auto res = query("CHANGE SUBMIT", emptyCallback, chid);
         ASSERT_TRUE(res) << res.getError();
         _currentChange = ChangeID::head();
     }
 
     void setChange(ChangeID chid) {
         _currentChange = chid;
-    }
-
-    auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
-                                CommitHash::head(), _currentChange);
-        return res;
     }
 
     void setWorkingGraph(std::string_view name) {

--- a/test/query/queries/ChangeQueriesTest.cpp
+++ b/test/query/queries/ChangeQueriesTest.cpp
@@ -64,9 +64,8 @@ protected:
     auto query(std::string_view query, auto callback, ChangeID change) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                                CommitHash::head(), change);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), change);
+        return _db->query(query, state);
     }
 
     auto query(std::string_view q, auto callback) {

--- a/test/query/queries/ComplexNullPredicatesTest.cpp
+++ b/test/query/queries/ComplexNullPredicatesTest.cpp
@@ -47,9 +47,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), ChangeID::head());
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(query, state);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/ComplexNullPredicatesTest.cpp
+++ b/test/query/queries/ComplexNullPredicatesTest.cpp
@@ -45,7 +45,9 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), ChangeID::head());
         return res;
     }

--- a/test/query/queries/ConstScanOptTest.cpp
+++ b/test/query/queries/ConstScanOptTest.cpp
@@ -170,10 +170,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(),
-                              &_db->getDefaultQueryConfig(),
-                              callbacks, CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_db->getDefaultQueryConfig(), &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/ConstScanOptTest.cpp
+++ b/test/query/queries/ConstScanOptTest.cpp
@@ -167,19 +167,19 @@ protected:
         _currentChange = res.value()->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(),
-                              &_db->getDefaultQueryConfig(),
-                              CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
-    }
-
     auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
         auto res = _db->query(query, _graphName, &_env->getMem(),
                               &_db->getDefaultQueryConfig(),
-                              callback, CommitHash::head(), _currentChange);
+                              callbacks, CommitHash::head(), _currentChange);
         return res;
+    }
+
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {
@@ -192,10 +192,7 @@ protected:
     }
 
     void exec(std::string_view q) {
-        auto res = _db->query(q, _graphName, &_env->getMem(),
-                              &_db->getDefaultQueryConfig(),
-                              [](const Dataframe*) {},
-                              CommitHash::head(), _currentChange);
+        auto res = query(q, [](const Dataframe*) {});
         ASSERT_TRUE(res);
     }
 

--- a/test/query/queries/CreateGraphTest.cpp
+++ b/test/query/queries/CreateGraphTest.cpp
@@ -21,6 +21,13 @@ public:
         _db = &_env->getDB();
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
 protected:
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
@@ -32,7 +39,7 @@ protected:
 TEST_F(CreateGraphTest, createGraph) {
     bool executed = false;
 
-    const auto res = _db->query("CREATE GRAPH testDB", "default", &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    const auto res = query("CREATE GRAPH testDB", "default", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
         ASSERT_EQ(df->getLogicalRowCount(), 1);

--- a/test/query/queries/CreateGraphTest.cpp
+++ b/test/query/queries/CreateGraphTest.cpp
@@ -24,8 +24,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
 protected:

--- a/test/query/queries/DeleteQueriesTest.cpp
+++ b/test/query/queries/DeleteQueriesTest.cpp
@@ -46,16 +46,18 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(), &_queryConfig, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
-    }
-
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), _currentChange);
         return res;
+    }
+
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 };
 

--- a/test/query/queries/DeleteQueriesTest.cpp
+++ b/test/query/queries/DeleteQueriesTest.cpp
@@ -49,9 +49,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/EmbeddingQueriesTest.cpp
+++ b/test/query/queries/EmbeddingQueriesTest.cpp
@@ -45,17 +45,18 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(),
-                              &_queryConfig, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
+    auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
+                              callbacks, CommitHash::head(), _currentChange);
+        return res;
     }
 
-    auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callback, CommitHash::head(), _currentChange);
-        return res;
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 
     static void expectEmbedding(const types::Embedding::Primitive& actual,

--- a/test/query/queries/EmbeddingQueriesTest.cpp
+++ b/test/query/queries/EmbeddingQueriesTest.cpp
@@ -48,9 +48,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callbacks, CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/FilterPredicatesTest.cpp
+++ b/test/query/queries/FilterPredicatesTest.cpp
@@ -44,9 +44,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), ChangeID::head());
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(query, state);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/FilterPredicatesTest.cpp
+++ b/test/query/queries/FilterPredicatesTest.cpp
@@ -42,7 +42,9 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), ChangeID::head());
         return res;
     }

--- a/test/query/queries/GreeterExtensionTest.cpp
+++ b/test/query/queries/GreeterExtensionTest.cpp
@@ -22,8 +22,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
     auto query(std::string_view q, std::string_view graphName) {

--- a/test/query/queries/GreeterExtensionTest.cpp
+++ b/test/query/queries/GreeterExtensionTest.cpp
@@ -19,6 +19,17 @@ public:
         _db = &_env->getDB();
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
+    auto query(std::string_view q, std::string_view graphName) {
+        return query(q, graphName, [](const Dataframe*) {});
+    }
+
 protected:
     std::unique_ptr<TuringTestEnv> _env;
     TuringDB* _db {nullptr};
@@ -26,12 +37,10 @@ protected:
 };
 
 TEST_F(GreeterExtensionTest, callGreeterHello) {
-    _db->query("INSTALL greeter", "default", &_env->getMem(), &_queryConfig);
+    query("INSTALL greeter", "default");
 
     bool executed = false;
-    const auto res = _db->query(
-        "CALL greeter.hello()", "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CALL greeter.hello()", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), 1);

--- a/test/query/queries/IncorrectQueryTest.cpp
+++ b/test/query/queries/IncorrectQueryTest.cpp
@@ -33,8 +33,8 @@ protected:
 
     QueryStatus query(std::string_view q) {
         QueryCallbacks callbacks;
-        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 };
 
@@ -101,9 +101,8 @@ TEST_F(IncorrectQueryTest, validQuerySucceeds) {
 
 TEST_F(IncorrectQueryTest, queryNonExistentGraph) {
     QueryCallbacks callbacks;
-    auto result = _db->query("MATCH (n) RETURN n", "no_such_graph",
-                             &_env->getMem(), &_queryConfig, callbacks,
-                             CommitHash::head(), ChangeID::head());
+    const QueryState state("no_such_graph", &_env->getMem(), &_queryConfig, &callbacks);
+    auto result = _db->query("MATCH (n) RETURN n", state);
 
     EXPECT_FALSE(result);
     EXPECT_EQ(result.getStatus(), QueryStatus::Status::GRAPH_NOT_FOUND);

--- a/test/query/queries/IncorrectQueryTest.cpp
+++ b/test/query/queries/IncorrectQueryTest.cpp
@@ -32,8 +32,8 @@ protected:
     Graph* _graph {nullptr};
 
     QueryStatus query(std::string_view q) {
-        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig,
-                          [](const Dataframe*) {},
+        QueryCallbacks callbacks;
+        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                           CommitHash::head(), ChangeID::head());
     }
 };
@@ -100,8 +100,9 @@ TEST_F(IncorrectQueryTest, validQuerySucceeds) {
 }
 
 TEST_F(IncorrectQueryTest, queryNonExistentGraph) {
+    QueryCallbacks callbacks;
     auto result = _db->query("MATCH (n) RETURN n", "no_such_graph",
-                             &_env->getMem(), &_queryConfig, [](const Dataframe*) {},
+                             &_env->getMem(), &_queryConfig, callbacks,
                              CommitHash::head(), ChangeID::head());
 
     EXPECT_FALSE(result);

--- a/test/query/queries/IndexQueriesTest.cpp
+++ b/test/query/queries/IndexQueriesTest.cpp
@@ -63,8 +63,8 @@ protected:
     auto query(std::string_view q, auto callback, ChangeID change) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), change);
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), change);
+        return _db->query(q, state);
     }
 
     auto query(std::string_view q, auto callback) {

--- a/test/query/queries/IndexQueriesTest.cpp
+++ b/test/query/queries/IndexQueriesTest.cpp
@@ -60,27 +60,31 @@ protected:
         _currentChange = change->id();
     }
 
+    auto query(std::string_view q, auto callback, ChangeID change) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), change);
+    }
+
+    auto query(std::string_view q, auto callback) {
+        return query(q, callback, _currentChange);
+    }
+
     void submitCurrentChange() {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                emptyCallback, CommitHash::head(), _currentChange);
+        auto res = query("CHANGE SUBMIT", emptyCallback);
         ASSERT_TRUE(res);
         _currentChange = ChangeID::head();
     }
 
     void submitChange(ChangeID chid) {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                emptyCallback, CommitHash::head(), chid);
+        auto res = query("CHANGE SUBMIT", emptyCallback, chid);
         ASSERT_TRUE(res) << res.getError();
         _currentChange = ChangeID::head();
     }
 
     void setChange(ChangeID chid) {
         _currentChange = chid;
-    }
-
-    auto query(std::string_view q, auto callback) {
-        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig, callback,
-                          CommitHash::head(), _currentChange);
     }
 
     // Counts the total number of indexes visible at the current head.

--- a/test/query/queries/LoadCSVTest.cpp
+++ b/test/query/queries/LoadCSVTest.cpp
@@ -56,9 +56,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     std::string writeTempCSV(const std::string& name,

--- a/test/query/queries/LoadCSVTest.cpp
+++ b/test/query/queries/LoadCSVTest.cpp
@@ -54,7 +54,9 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), _currentChange);
         return res;
     }
@@ -98,8 +100,7 @@ protected:
     }
 
     void submitCurrentChange() {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                emptyCallback, CommitHash::head(), _currentChange);
+        auto res = query("CHANGE SUBMIT", emptyCallback);
         ASSERT_TRUE(res);
         _currentChange = ChangeID::head();
     }

--- a/test/query/queries/LoadCommitTest.cpp
+++ b/test/query/queries/LoadCommitTest.cpp
@@ -45,9 +45,10 @@ public:
             const ChangeID chid = changeRes.value()->id();
 
             QueryConfig buildQueryConfig;
+            QueryCallbacks submitCallbacks;
             const auto submitRes = buildEnv->getDB().query(
                 "CHANGE SUBMIT", "testdb", &buildEnv->getMem(), &buildQueryConfig,
-                CommitHash::head(), chid);
+                submitCallbacks, CommitHash::head(), chid);
             bioassert(submitRes, "change submit failed");
             _newHeadHash = graph->getHeadHash(); // HEAD commit (loaded after LOAD GRAPH)
 
@@ -58,8 +59,9 @@ public:
         }
 
         // Step 4: Load the graph via query so the SystemManager registers it.
+        QueryCallbacks loadCallbacks;
         auto loadRes = _db->query("LOAD GRAPH testdb", "default", &_env->getMem(), &_queryConfig,
-                                  [](const Dataframe*) {});
+                                  loadCallbacks, CommitHash::head(), ChangeID::head());
         bioassert(loadRes, "LOAD GRAPH failed");
     }
 
@@ -72,7 +74,8 @@ protected:
 
     QueryStatus query(std::string_view q,
                       CommitHash hash = CommitHash::head()) {
-        return _db->query(q, "testdb", &_env->getMem(), &_queryConfig, [](const Dataframe*) {}, hash, ChangeID::head());
+        QueryCallbacks callbacks;
+        return _db->query(q, "testdb", &_env->getMem(), &_queryConfig, callbacks, hash, ChangeID::head());
     }
 
     // Build the LOAD COMMIT query string for a given hash (hex-encoded).

--- a/test/query/queries/LoadCommitTest.cpp
+++ b/test/query/queries/LoadCommitTest.cpp
@@ -46,9 +46,8 @@ public:
 
             QueryConfig buildQueryConfig;
             QueryCallbacks submitCallbacks;
-            const auto submitRes = buildEnv->getDB().query(
-                "CHANGE SUBMIT", "testdb", &buildEnv->getMem(), &buildQueryConfig,
-                submitCallbacks, CommitHash::head(), chid);
+            const QueryState submitState("testdb", &buildEnv->getMem(), &buildQueryConfig, &submitCallbacks, CommitHash::head(), chid);
+            const auto submitRes = buildEnv->getDB().query("CHANGE SUBMIT", submitState);
             bioassert(submitRes, "change submit failed");
             _newHeadHash = graph->getHeadHash(); // HEAD commit (loaded after LOAD GRAPH)
 
@@ -60,8 +59,8 @@ public:
 
         // Step 4: Load the graph via query so the SystemManager registers it.
         QueryCallbacks loadCallbacks;
-        auto loadRes = _db->query("LOAD GRAPH testdb", "default", &_env->getMem(), &_queryConfig,
-                                  loadCallbacks, CommitHash::head(), ChangeID::head());
+        const QueryState loadState("default", &_env->getMem(), &_queryConfig, &loadCallbacks);
+        auto loadRes = _db->query("LOAD GRAPH testdb", loadState);
         bioassert(loadRes, "LOAD GRAPH failed");
     }
 
@@ -75,7 +74,8 @@ protected:
     QueryStatus query(std::string_view q,
                       CommitHash hash = CommitHash::head()) {
         QueryCallbacks callbacks;
-        return _db->query(q, "testdb", &_env->getMem(), &_queryConfig, callbacks, hash, ChangeID::head());
+        const QueryState state("testdb", &_env->getMem(), &_queryConfig, &callbacks, hash);
+        return _db->query(q, state);
     }
 
     // Build the LOAD COMMIT query string for a given hash (hex-encoded).

--- a/test/query/queries/LoadGraphTest.cpp
+++ b/test/query/queries/LoadGraphTest.cpp
@@ -29,6 +29,13 @@ public:
         bioassert(dumpRes, "failed to dump simpledb graph");
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
 protected:
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
@@ -40,7 +47,7 @@ protected:
 TEST_F(LoadGraphTest, loadGraph) {
     bool executed = false;
 
-    const auto res = _db->query("LOAD GRAPH simpledb", "default", &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    const auto res = query("LOAD GRAPH simpledb", "default", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
         ASSERT_EQ(df->getLogicalRowCount(), 1);

--- a/test/query/queries/LoadGraphTest.cpp
+++ b/test/query/queries/LoadGraphTest.cpp
@@ -32,8 +32,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
 protected:

--- a/test/query/queries/MatchCreateTest.cpp
+++ b/test/query/queries/MatchCreateTest.cpp
@@ -48,16 +48,18 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(), &_queryConfig, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
-    }
-
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), _currentChange);
         return res;
+    }
+
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 
     void setWorkingGraph(std::string_view name) {

--- a/test/query/queries/MatchCreateTest.cpp
+++ b/test/query/queries/MatchCreateTest.cpp
@@ -51,9 +51,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/MergeDataPartsTest.cpp
+++ b/test/query/queries/MergeDataPartsTest.cpp
@@ -47,16 +47,17 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                              emptyCallback, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res);
-        _currentChange = ChangeID::head();
+    auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), _currentChange);
     }
 
-    auto query(std::string_view query, auto callback) {
-        return _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
-                          CommitHash::head(), _currentChange);
+    void submitCurrentChange() {
+        auto res = query("CHANGE SUBMIT", emptyCallback);
+        ASSERT_TRUE(res);
+        _currentChange = ChangeID::head();
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/MergeDataPartsTest.cpp
+++ b/test/query/queries/MergeDataPartsTest.cpp
@@ -50,8 +50,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), _currentChange);
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/MixedPredicateOrTest.cpp
+++ b/test/query/queries/MixedPredicateOrTest.cpp
@@ -31,8 +31,10 @@ protected:
     Graph* _graph {nullptr};
 
     auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
         auto res = _db->query(query, _graphName, &_env->getMem(),
-                              &_db->getDefaultQueryConfig(), callback,
+                              &_db->getDefaultQueryConfig(), callbacks,
                               CommitHash::head(), ChangeID::head());
         return res;
     }

--- a/test/query/queries/MixedPredicateOrTest.cpp
+++ b/test/query/queries/MixedPredicateOrTest.cpp
@@ -33,10 +33,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(),
-                              &_db->getDefaultQueryConfig(), callbacks,
-                              CommitHash::head(), ChangeID::head());
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_db->getDefaultQueryConfig(), &callbacks);
+        return _db->query(query, state);
     }
 };
 

--- a/test/query/queries/MultiHopPatternTest.cpp
+++ b/test/query/queries/MultiHopPatternTest.cpp
@@ -52,9 +52,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), ChangeID::head());
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(query, state);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/MultiHopPatternTest.cpp
+++ b/test/query/queries/MultiHopPatternTest.cpp
@@ -50,7 +50,9 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), ChangeID::head());
         return res;
     }

--- a/test/query/queries/QueriesTest.cpp
+++ b/test/query/queries/QueriesTest.cpp
@@ -50,10 +50,13 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     // To test queries which require multiple changes, use WriteQueriesTest.cpp
-    auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callback, CommitHash::head(), ChangeID::head());
-        return res;
+    auto runQuery(std::string_view q, auto callback,
+                  CommitHash hash = CommitHash::head(),
+                  ChangeID change = ChangeID::head()) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig,
+                          callbacks, hash, change);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {
@@ -96,7 +99,7 @@ TEST_F(QueriesTest, scanAll) {
     const std::string query = "MATCH (n) RETURN n";
 
     std::vector<NodeID> returnedNodeIDs;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
         ASSERT_EQ(df->size(), 1);
@@ -146,7 +149,7 @@ TEST_F(QueriesTest, scanAllSkip) {
 
         std::vector<NodeID> returnedNodeIDs;
         bool executedLambda = false;
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        runQuery(query, [&](const Dataframe* df) -> void {
             executedLambda = true;
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
@@ -174,7 +177,7 @@ TEST_F(QueriesTest, scanAllSkip) {
 
 TEST_F(QueriesTest, negativeSkip) {
     const std::string query = "MATCH (n) RETURN n SKIP -1";
-    const auto result = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {});
+    const auto result = runQuery(query, [](const Dataframe* df) -> void {});
     ASSERT_FALSE(result.isOk());
 }
 
@@ -199,7 +202,7 @@ TEST_F(QueriesTest, scanAllLimit) {
 
         std::vector<NodeID> returnedNodeIDs;
         bool executedLambda = false;
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        runQuery(query, [&](const Dataframe* df) -> void {
             executedLambda = true;
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
@@ -246,7 +249,7 @@ TEST_F(QueriesTest, scanAllSkipLimit) {
 
             returnedNodeIDs.clear();
             bool executedLambda = false;
-            _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+            runQuery(query, [&](const Dataframe* df) -> void {
                 executedLambda = true;
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->cols().size(), 1);
@@ -272,7 +275,7 @@ TEST_F(QueriesTest, scanExpand1) {
     const size_t numEdges = read().getEdgeCount();
 
     LineContainer<NodeID, NodeID, EdgeID> returned;
-    auto res = query(queryStr, [&returned, numEdges](const Dataframe* df) -> void {
+    auto res = runQuery(queryStr, [&returned, numEdges](const Dataframe* df) -> void {
         ASSERT_TRUE(df);
         ASSERT_EQ(df->size(), 3);
 
@@ -309,7 +312,7 @@ TEST_F(QueriesTest, scanExpand2) {
     std::vector<NodeID> returnedTargets1;
     std::vector<NodeID> returnedTargets2;
     std::vector<NodeID> returnedSources;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 3);
         ASSERT_EQ(df->size(), 3);
@@ -373,7 +376,7 @@ TEST_F(QueriesTest, scanExpandIn) {
 
     LineContainer<NodeID, NodeID> returned;
     LineContainer<NodeID, NodeID> expected;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 2);
         ASSERT_EQ(df->size(), 2);
@@ -421,7 +424,7 @@ TEST_F(QueriesTest, scanExpandIn2) {
 
     LineContainer<NodeID, EdgeID, NodeID, EdgeID, NodeID> returnedLines;
     LineContainer<NodeID, EdgeID, NodeID, EdgeID, NodeID> expectedLines;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 5);
         ASSERT_EQ(df->size(), 5);
@@ -492,7 +495,7 @@ TEST_F(QueriesTest, scanEdges) {
 
     LineContainer<NodeID, EdgeID, NodeID> returnedLines;
     LineContainer<NodeID, EdgeID, NodeID> expectedLines;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 3);
         ASSERT_EQ(df->size(), 3);
@@ -549,7 +552,7 @@ TEST_F(QueriesTest, undirectedAnonymousEdge) {
 
     LineContainer<NodeID, NodeID> returned;
     LineContainer<NodeID, NodeID> expected;
-    auto res = query(queryStr, [&](const Dataframe* df) {
+    auto res = runQuery(queryStr, [&](const Dataframe* df) {
         ASSERT_TRUE(df);
         ASSERT_EQ(df->cols().size(), 2);
         ASSERT_EQ(df->size(), 2);
@@ -612,7 +615,7 @@ TEST_F(QueriesTest, scanPropertiesWithNull) {
     ASSERT_TRUE(agePropType.has_value());
     ASSERT_TRUE(namePropType.has_value());
 
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 3);
         ASSERT_EQ(df->size(), 3);
@@ -702,8 +705,7 @@ TEST_F(QueriesTest, scanNodesCartProd) {
     }
 
     {
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                     [&](const Dataframe* df) -> void {
+        runQuery(query, [&](const Dataframe* df) -> void {
                          ASSERT_TRUE(df != nullptr);
                          ASSERT_EQ(df->size(), 2);
                          ASSERT_EQ(df->getLogicalRowCount(), expectedLines.size());
@@ -729,8 +731,7 @@ TEST_F(QueriesTest, getOutSrcXgetOutTgt) {
     ColumnNodeIDs ns;
     constexpr std::string_view nQuery = "match (n)-->(a) return n";
     {
-        auto res = _db->query(nQuery, _graphName, &_env->getMem(), &_queryConfig,
-                                [&ns](const Dataframe* df) -> void {
+        auto res = runQuery(nQuery, [&ns](const Dataframe* df) -> void {
                                     ASSERT_TRUE(df);
                                     ASSERT_EQ(1, df->size());
                                     auto* nCol = df->cols().front()->as<ColumnNodeIDs>();
@@ -742,8 +743,7 @@ TEST_F(QueriesTest, getOutSrcXgetOutTgt) {
     ColumnNodeIDs bs;
     constexpr std::string_view bQuery = "match (m)-->(b) return b";
     {
-        auto res = _db->query(bQuery, _graphName, &_env->getMem(), &_queryConfig,
-                                [&bs](const Dataframe* df) -> void {
+        auto res = runQuery(bQuery, [&bs](const Dataframe* df) -> void {
                                     ASSERT_TRUE(df);
                                     ASSERT_EQ(1, df->size());
                                     auto* bCol = df->cols().front()->as<ColumnNodeIDs>();
@@ -760,8 +760,7 @@ TEST_F(QueriesTest, getOutSrcXgetOutTgt) {
 
     Rows actualRows;
     {
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
                 ASSERT_EQ(df->size(), 2);
                 const auto& nCols = df->cols();
@@ -790,8 +789,7 @@ TEST_F(QueriesTest, twoHopXOneHop) {
         ColumnNodeIDs ms;
         ColumnNodeIDs os;
         constexpr std::string_view nQuery = "match (n)-->(m)-->(o) return n, m, o";
-        _db->query(nQuery, _graphName, &_env->getMem(), &_queryConfig,
-                     [&](const Dataframe* df) -> void {
+        runQuery(nQuery, [&](const Dataframe* df) -> void {
                          ns = *df->cols().at(0)->as<ColumnNodeIDs>();
                          ms = *df->cols().at(1)->as<ColumnNodeIDs>();
                          os = *df->cols().at(2)->as<ColumnNodeIDs>();
@@ -800,8 +798,7 @@ TEST_F(QueriesTest, twoHopXOneHop) {
         ColumnNodeIDs ps;
         ColumnNodeIDs qs;
         constexpr std::string_view bQuery = "match (p)-->(q) return p, q";
-        _db->query(bQuery, _graphName, &_env->getMem(), &_queryConfig,
-                     [&](const Dataframe* df) -> void {
+        runQuery(bQuery, [&](const Dataframe* df) -> void {
                          ps = *df->cols().front()->as<ColumnNodeIDs>();
                          qs = *df->cols().back()->as<ColumnNodeIDs>();
                      });
@@ -817,8 +814,7 @@ TEST_F(QueriesTest, twoHopXOneHop) {
 
     Rows actualRows;
     {
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 5);
                 const auto& nCols = df->cols();
@@ -850,8 +846,7 @@ TEST_F(QueriesTest, threeCascadingScanNodesCartProd) {
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n) RETURN n";
         for (auto column : {ss, ts, vs}) {
-            auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                                    [&](const Dataframe* df) -> void {
+            auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                         ASSERT_EQ(df->size(), 1);
                                         column = *df->cols().front()->as<ColumnNodeIDs>();
                                     });
@@ -869,8 +864,7 @@ TEST_F(QueriesTest, threeCascadingScanNodesCartProd) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (s), (t), (v), RETURN s,t,v";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 3);
                 const auto& nCols = df->cols();
@@ -897,8 +891,7 @@ TEST_F(QueriesTest, simpleAncestorJoinTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n)-->(m) RETURN n,m";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 2);
                                   const auto& cols = df->cols();
                                   people = cols[0]->as<ColumnNodeIDs>();
@@ -923,8 +916,7 @@ TEST_F(QueriesTest, simpleAncestorJoinTest) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (a)-->(c),(a)-->(b) RETURN a,b,c";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 3);
                 const auto& nCols = df->cols();
@@ -951,8 +943,7 @@ TEST_F(QueriesTest, doubleAncestorJoinTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n)-->(m) RETURN n,m";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 2);
                                   const auto& cols = df->cols();
                                   people = cols[0]->as<ColumnNodeIDs>();
@@ -978,8 +969,7 @@ TEST_F(QueriesTest, doubleAncestorJoinTest) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (a)-->(c),(a)-->(b), (a)-->(d) RETURN a,b,c,d";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 4);
                 const auto& nCols = df->cols();
@@ -1007,8 +997,7 @@ TEST_F(QueriesTest, simpleSucessorJoinTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n)-->(m) RETURN n,m";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 2);
                                   const auto& cols = df->cols();
                                   people = cols[0]->as<ColumnNodeIDs>();
@@ -1032,8 +1021,7 @@ TEST_F(QueriesTest, simpleSucessorJoinTest) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (a)-->(c),(b)-->(c) RETURN a,b,c";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 3);
                 const auto& nCols = df->cols();
@@ -1060,8 +1048,7 @@ TEST_F(QueriesTest, doubleSucessorJoinTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n)-->(m) RETURN n,m";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 2);
                                   const auto& cols = df->cols();
                                   people = cols[0]->as<ColumnNodeIDs>();
@@ -1089,8 +1076,7 @@ TEST_F(QueriesTest, doubleSucessorJoinTest) {
         // The insertion order of the join column in the return must match the insertion
         // order of the join column in the expectedRow line container
         constexpr std::string_view query = "MATCH (a)-->(c),(d)-->(c),(b)-->(c) RETURN a,b,d,c";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 4);
                 const auto& nCols = df->cols();
@@ -1119,8 +1105,7 @@ TEST_F(QueriesTest, sucessorJoinToExpandEdgeTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (n)-->(m) RETURN n,m";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 2);
                                   const auto& cols = df->cols();
                                   col1 = cols[0]->as<ColumnNodeIDs>();
@@ -1147,8 +1132,7 @@ TEST_F(QueriesTest, sucessorJoinToExpandEdgeTest) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (a)-->(c),(b)-->(c)-->(d) RETURN a,b,c,d";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 4);
                 const auto& nCols = df->cols();
@@ -1186,8 +1170,7 @@ TEST_F(QueriesTest, xShapedJoinTest) {
 
     {
         constexpr std::string_view scanNodesQuery = "MATCH (l)-->(m), (n)-->(m)-->(p) RETURN l,n,m,p";
-        auto res = _db->query(scanNodesQuery, _graphName, &_env->getMem(), &_queryConfig,
-                                [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanNodesQuery, [&](const Dataframe* df) -> void {
                                     ASSERT_TRUE(df != nullptr);
                                     ASSERT_EQ(df->size(), 4);
                                     const auto& nCols = df->cols();
@@ -1217,8 +1200,7 @@ TEST_F(QueriesTest, xShapedJoinTest) {
     Rows actualRows;
     {
         constexpr std::string_view query = "MATCH (a)-->(c)-->(d), (b)-->(c)-->(e) RETURN a,b,c,d,e";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 5);
                 const auto& nCols = df->cols();
@@ -1251,8 +1233,7 @@ TEST_F(QueriesTest, joinOnEdgeIDTest) {
 
     {
         constexpr std::string_view scanQuery = "MATCH (n)-[e]->(m) RETURN n,e,m";
-        auto res = _db->query(scanQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 3);
                                   const auto& cols = df->cols();
                                   sources = cols[0]->as<ColumnNodeIDs>();
@@ -1273,8 +1254,7 @@ TEST_F(QueriesTest, joinOnEdgeIDTest) {
     {
         constexpr std::string_view query =
             "MATCH (a)-[e]->(b), (c)-[e]->(d) RETURN a,b,c,d,e";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_EQ(df->size(), 5);
                 const auto& nCols = df->cols();
                 const auto* a = nCols.at(0)->as<ColumnNodeIDs>();
@@ -1311,8 +1291,7 @@ TEST_F(QueriesTest, joinOnEdgeIDWhereTest) {
 
     {
         constexpr std::string_view scanQuery = "MATCH (n)-[e]->(m) RETURN n,e,m";
-        auto res = _db->query(scanQuery, _graphName, &_env->getMem(), &_queryConfig,
-                              [&](const Dataframe* df) -> void {
+        auto res = runQuery(scanQuery, [&](const Dataframe* df) -> void {
                                   ASSERT_EQ(df->size(), 3);
                                   const auto& cols = df->cols();
                                   sources = cols[0]->as<ColumnNodeIDs>();
@@ -1333,8 +1312,7 @@ TEST_F(QueriesTest, joinOnEdgeIDWhereTest) {
     {
         constexpr std::string_view query =
             "MATCH (a)-[e]->(b), (c)-[f]->(d) WHERE e = f RETURN a,e,b,c,f,d";
-        QueryStatus res = _db->query(
-            query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+        QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->size(), 6);
                 const auto& nCols = df->cols();
@@ -1359,8 +1337,7 @@ TEST_F(QueriesTest, joinOnEdgeIDWhereTest) {
 // The type of join for this test has not been implemented yet - so it is disabled for now
 TEST_F(QueriesTest, blockedBinaryQuery) {
     constexpr std::string_view query = "MATCH (n)-[e]->(m), (n)<-[f]-(m) return n, e, m, f";
-    QueryStatus res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                                   [&](const Dataframe* df) -> void {});
+    QueryStatus res = runQuery(query, [&](const Dataframe* df) -> void {});
     ASSERT_FALSE(res);
     ASSERT_TRUE(res.hasErrorMessage());
     EXPECT_EQ(res.getError(), std::string("Common Successor Joins With Common Ancestor Unsupported"));
@@ -1381,7 +1358,7 @@ TEST_F(QueriesTest, db_labels) {
         expectedRows.add({id, *name});
     }
 
-    _db->query("CALL db.labels()", _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.labels()", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), expectedRows.lineSize());
         ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1397,8 +1374,7 @@ TEST_F(QueriesTest, db_labels) {
     EXPECT_TRUE(expectedRows.equals(actualRows));
     actualRows.clear();
 
-    _db->query("CALL db.labels() YIELD id, label",
-                 _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.labels() YIELD id, label", [&](const Dataframe* df) -> void {
                      ASSERT_TRUE(df != nullptr);
                      ASSERT_EQ(df->cols().size(), 2);
                      ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1431,7 +1407,7 @@ TEST_F(QueriesTest, db_edgeTypes) {
         expectedRows.add({id, *name});
     }
 
-    _db->query("CALL db.edgeTypes()", _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.edgeTypes()", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), expectedRows.lineSize());
         ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1447,8 +1423,7 @@ TEST_F(QueriesTest, db_edgeTypes) {
     EXPECT_TRUE(expectedRows.equals(actualRows));
     actualRows.clear();
 
-    _db->query("CALL db.edgeTypes() YIELD id, edgeType",
-                 _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.edgeTypes() YIELD id, edgeType", [&](const Dataframe* df) -> void {
                      ASSERT_TRUE(df != nullptr);
                      ASSERT_EQ(df->cols().size(), 2);
                      ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1481,7 +1456,7 @@ TEST_F(QueriesTest, db_propertyTypes) {
         expectedRows.add({pt._id, *name, pt._valueType});
     }
 
-    _db->query("CALL db.propertyTypes()", _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.propertyTypes()", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), expectedRows.lineSize());
         ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1498,8 +1473,7 @@ TEST_F(QueriesTest, db_propertyTypes) {
     EXPECT_TRUE(expectedRows.equals(actualRows));
     actualRows.clear();
 
-    _db->query("CALL db.propertyTypes() YIELD id, propertyType, valueType",
-                 _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.propertyTypes() YIELD id, propertyType, valueType", [&](const Dataframe* df) -> void {
                      ASSERT_TRUE(df != nullptr);
                      ASSERT_EQ(df->cols().size(), 3);
                      ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1542,7 +1516,7 @@ TEST_F(QueriesTest, db_history) {
         commit = commit->getPreviousCommit();
     }
 
-    _db->query("CALL db.history()", _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.history()", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), expectedRows.lineSize());
         ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1560,8 +1534,7 @@ TEST_F(QueriesTest, db_history) {
     EXPECT_TRUE(expectedRows.equals(actualRows));
     actualRows.clear();
 
-    _db->query("CALL db.history() YIELD commit, nodeCount, edgeCount, partCount",
-                 _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("CALL db.history() YIELD commit, nodeCount, edgeCount, partCount", [&](const Dataframe* df) -> void {
                      ASSERT_TRUE(df != nullptr);
                      ASSERT_EQ(df->cols().size(), 4);
                      ASSERT_EQ(df->getLogicalRowCount(), expectedRows.size());
@@ -1586,7 +1559,7 @@ TEST_F(QueriesTest, matchCrossProductWithCountStar) {
     const size_t expectedCount = nodeCount * nodeCount;
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (n), (m) RETURN count(*)", [&](const Dataframe* df) {
+    auto result = runQuery("MATCH (n), (m) RETURN count(*)", [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
         ASSERT_EQ(df->getLogicalRowCount(), 1);
@@ -1604,7 +1577,7 @@ TEST_F(QueriesTest, scanByLabelOutEdges) {
 
     LineContainer<NodeID, EdgeID, NodeID> returnedLines;
     LineContainer<NodeID, EdgeID, NodeID> expectedLines;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 3);
         ASSERT_EQ(df->size(), 3);
@@ -1666,7 +1639,7 @@ TEST_F(QueriesTest, scanNodesByLabel) {
 
     LineContainer<NodeID> returnedLines;
     LineContainer<NodeID> expectedLines;
-    _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery(query, [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
 
@@ -1701,7 +1674,7 @@ TEST_F(QueriesTest, scanNodesByLabel) {
 TEST_F(QueriesTest, change) {
     {
         const std::string query = "CHANGE NEW";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1718,7 +1691,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE LIST";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1735,7 +1708,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE SUBMIT";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1752,7 +1725,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE LIST";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1766,7 +1739,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE NEW";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1783,7 +1756,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE DELETE";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1800,7 +1773,7 @@ TEST_F(QueriesTest, change) {
 
     {
         const std::string query = "CHANGE LIST";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 1);
             ASSERT_EQ(df->cols().size(), 1);
@@ -1819,7 +1792,7 @@ TEST_F(QueriesTest, db_listGraph) {
     _env->getSystemManager().listGraphs(expectedGraphNames.getRaw());
 
     bool callBackExecuted = false;
-    _db->query("list graph", _graphName, &_env->getMem(), &_queryConfig, [&](const Dataframe* df) -> void {
+    runQuery("list graph", [&](const Dataframe* df) -> void {
         callBackExecuted = true;
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -1842,7 +1815,7 @@ TEST_F(QueriesTest, db_commit) {
 
     {
         const std::string query = "COMMIT";
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        auto res = runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 0);
             ASSERT_EQ(df->cols().size(), 0);
@@ -1854,7 +1827,7 @@ TEST_F(QueriesTest, db_commit) {
 
     {
         const std::string query = "CHANGE NEW";
-        _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [&changeID](const Dataframe* df) -> void {
+        runQuery(query, [&changeID](const Dataframe* df) -> void {
             const ColumnVector<ChangeID>* changeIDs = df->cols().front()->as<ColumnVector<ChangeID>>();
 
             changeID = changeIDs->at(0);
@@ -1869,7 +1842,7 @@ TEST_F(QueriesTest, db_commit) {
 
     {
         const std::string query = "COMMIT";
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, [](const Dataframe* df) -> void {
+        auto res = runQuery(query, [](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->size(), 0);
             ASSERT_EQ(df->cols().size(), 0); }, CommitHash::head(), changeID);
@@ -1907,7 +1880,7 @@ TEST_F(QueriesTest, whereName) {
     Rows actual;
     {
         for (std::string_view name : names) {
-            auto res = query(MATCH_QUERY(name), [&](const Dataframe* df) -> void {
+            auto res = runQuery(MATCH_QUERY(name), [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
                 ASSERT_EQ(1, df->size()); // Just the 'n' column
                 auto* ns = df->cols().front()->as<ColumnNodeIDs>();
@@ -1944,7 +1917,7 @@ TEST_F(QueriesTest, predicateOR) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(1, df->size()); // Just the 'n' column
             auto* ns = df->cols().front()->as<ColumnNodeIDs>();
@@ -1983,7 +1956,7 @@ TEST_F(QueriesTest, predicateAND) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(1, df->size()); // Just the 'n' column
             auto* ns = df->cols().front()->as<ColumnNodeIDs>();
@@ -2020,7 +1993,7 @@ TEST_F(QueriesTest, predicateNOT) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(2, df->size());
             auto* ns = df->cols().front()->as<ColumnNodeIDs>();
@@ -2069,7 +2042,7 @@ TEST_F(QueriesTest, cartProdThenFilter) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(2, df->size());
             auto* nnames = df->cols().front()->as<ColumnVector<std::optional<String>>>();
@@ -2117,7 +2090,7 @@ TEST_F(QueriesTest, complexPredicate) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(2, df->size());
             auto* ns = df->cols().front()->as<ColumnNodeIDs>();
@@ -2147,7 +2120,7 @@ TEST_F(QueriesTest, emptyResultProjectDifferentProp) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(1, df->size());
             auto* names = df->cols().front()->as<ColumnVector<std::optional<String>>>();
@@ -2182,7 +2155,7 @@ TEST_F(QueriesTest, edgeTypeFilter) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(1, df->size());
             auto* es = df->cols().front()->as<ColumnEdgeIDs>();
@@ -2229,7 +2202,7 @@ TEST_F(QueriesTest, pitchDeckPersonInterest) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(2, df->size());
             auto* ps = df->cols().front()->as<ColumnNodeIDs>();
@@ -2270,7 +2243,7 @@ TEST_F(QueriesTest, int64FilterOperands) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "e")->as<ColumnEdgeIDs>();
@@ -2353,7 +2326,7 @@ TEST_F(QueriesTest, int64FilterOperandsConjunction) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "e")->as<ColumnEdgeIDs>();
@@ -2417,7 +2390,7 @@ TEST_F(QueriesTest, int64FilterOperandsDisjunction) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "e")->as<ColumnEdgeIDs>();
@@ -2479,7 +2452,7 @@ TEST_F(QueriesTest, notEqualFilter) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual, propertyName](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual, propertyName](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "n")->as<ColumnNodeIDs>();
@@ -2539,7 +2512,7 @@ TEST_F(QueriesTest, isNotNullFilter) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual, propertyName](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual, propertyName](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "n")->as<ColumnNodeIDs>();
@@ -2596,7 +2569,7 @@ TEST_F(QueriesTest, isNullFilter) {
 
         Rows actual;
         {
-            auto res = query(matchQuery, [&actual](const Dataframe* df) -> void {
+            auto res = runQuery(matchQuery, [&actual](const Dataframe* df) -> void {
                 ASSERT_TRUE(df);
 
                 auto* es = findColumn(df, "n")->as<ColumnNodeIDs>();
@@ -2705,7 +2678,7 @@ TEST_F(QueriesTest, indirectLabelFilter) {
         }
 
         Rows actual;
-        auto res = query(matchQuery, [&actual](const Dataframe* df) {
+        auto res = runQuery(matchQuery, [&actual](const Dataframe* df) {
             ASSERT_TRUE(df);
             auto* inames = findColumn(df, "i.name")->as<ColumnOptVector<types::String::Primitive>>();
             ASSERT_TRUE(inames);
@@ -2756,7 +2729,7 @@ TEST_F(QueriesTest, labelsFunction) {
 
     Rows actual;
     {
-        auto res = query(matchLabels, [&actual](const Dataframe* df) {
+        auto res = runQuery(matchLabels, [&actual](const Dataframe* df) {
             ASSERT_TRUE(df);
             auto* ns = findColumn(df, "n")->as<ColumnNodeIDs>();
             auto* labels = findColumn(df, "labels")->as<ColumnVector<std::string>>();
@@ -2779,7 +2752,7 @@ TEST_F(QueriesTest, ancestorJoinCountStar) {
     std::unordered_map<NodeID, std::vector<NodeID>> srcToTgtMap;
 
     {
-        auto res = query("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
+        auto res = runQuery("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
             ASSERT_EQ(df->size(), 2);
             sources = df->cols()[0]->as<ColumnNodeIDs>();
             targets = df->cols()[1]->as<ColumnNodeIDs>();
@@ -2799,7 +2772,7 @@ TEST_F(QueriesTest, ancestorJoinCountStar) {
     }
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (x)-->(a), (x)-->(b) RETURN count(*)",
+    auto result = runQuery("MATCH (x)-->(a), (x)-->(b) RETURN count(*)",
                         [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -2822,7 +2795,7 @@ TEST_F(QueriesTest, ancestorJoinCountVar) {
     std::unordered_map<NodeID, std::vector<NodeID>> srcToTgtMap;
 
     {
-        auto res = query("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
+        auto res = runQuery("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
             ASSERT_EQ(df->size(), 2);
             sources = df->cols()[0]->as<ColumnNodeIDs>();
             targets = df->cols()[1]->as<ColumnNodeIDs>();
@@ -2841,7 +2814,7 @@ TEST_F(QueriesTest, ancestorJoinCountVar) {
     }
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (x)-->(a), (x)-->(b) RETURN count(x)",
+    auto result = runQuery("MATCH (x)-->(a), (x)-->(b) RETURN count(x)",
                         [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -2905,7 +2878,7 @@ TEST_F(QueriesTest, successorJoinWithCrossFilter) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* xnames = df->cols().at(0)->as<ColumnVector<std::optional<String>>>();
@@ -2937,7 +2910,7 @@ TEST_F(QueriesTest, successorJoinCountStar) {
     std::unordered_map<NodeID, std::vector<NodeID>> tgtToSrcMap;
 
     {
-        auto res = query("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
+        auto res = runQuery("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
             ASSERT_EQ(df->size(), 2);
             sources = df->cols()[0]->as<ColumnNodeIDs>();
             targets = df->cols()[1]->as<ColumnNodeIDs>();
@@ -2957,7 +2930,7 @@ TEST_F(QueriesTest, successorJoinCountStar) {
     }
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (a)-->(x), (b)-->(x) RETURN count(*)",
+    auto result = runQuery("MATCH (a)-->(x), (b)-->(x) RETURN count(*)",
                         [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -2980,7 +2953,7 @@ TEST_F(QueriesTest, successorJoinCountVar) {
     std::unordered_map<NodeID, std::vector<NodeID>> tgtToSrcMap;
 
     {
-        auto res = query("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
+        auto res = runQuery("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
             ASSERT_EQ(df->size(), 2);
             sources = df->cols()[0]->as<ColumnNodeIDs>();
             targets = df->cols()[1]->as<ColumnNodeIDs>();
@@ -2999,7 +2972,7 @@ TEST_F(QueriesTest, successorJoinCountVar) {
     }
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (a)-->(x), (b)-->(x) RETURN count(x)",
+    auto result = runQuery("MATCH (a)-->(x), (b)-->(x) RETURN count(x)",
                         [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -3065,7 +3038,7 @@ TEST_F(QueriesTest, ancestorJoinWithCrossFilter) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* xnames = df->cols().at(0)->as<ColumnVector<std::optional<String>>>();
@@ -3150,7 +3123,7 @@ TEST_F(QueriesTest, tripleAncestorJoinWithChainAndCrossFilter) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* xnames = df->cols().at(0)->as<ColumnVector<std::optional<String>>>();
@@ -3182,7 +3155,7 @@ TEST_F(QueriesTest, doubleAncestorJoinCountStar) {
     std::unordered_map<NodeID, std::vector<NodeID>> srcToTgtMap;
 
     {
-        auto res = query("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
+        auto res = runQuery("MATCH (n)-->(m) RETURN n,m", [&](const Dataframe* df) {
             ASSERT_EQ(df->size(), 2);
             sources = df->cols()[0]->as<ColumnNodeIDs>();
             targets = df->cols()[1]->as<ColumnNodeIDs>();
@@ -3202,7 +3175,7 @@ TEST_F(QueriesTest, doubleAncestorJoinCountStar) {
     }
 
     uint64_t actualCount = 0;
-    auto result = query("MATCH (x)-->(a), (x)-->(b), (x)-->(c) RETURN count(*)",
+    auto result = runQuery("MATCH (x)-->(a), (x)-->(b), (x)-->(c) RETURN count(*)",
                         [&](const Dataframe* df) {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
@@ -3284,7 +3257,7 @@ TEST_F(QueriesTest, predicateJoinSharedInterest) {
             "(b:Person)-[:INTERESTED_IN]->(i2:Interest) "
             "WHERE i1.name = i2.name AND a.name <> b.name "
             "RETURN a.name, b.name, i1.name";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(3, df->size());
             auto* aNames = findColumn(df, "a.name")
@@ -3366,7 +3339,7 @@ TEST_F(QueriesTest, predicateJoinSameGroupTraversal) {
             "(b:Person)-[:INTERESTED_IN]->(i2) "
             "WHERE a.isFrench = b.isFrench "
             "RETURN a.name, i1.name, b.name, i2.name, a.isFrench";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* aNames = findColumn(df, "a.name")
@@ -3456,7 +3429,7 @@ TEST_F(QueriesTest, predicateJoinEdgeProficiency) {
             "(c:Person)-[e2:INTERESTED_IN]->(d) "
             "WHERE e1.proficiency = e2.proficiency "
             "RETURN a.name, b.name, c.name, d.name, e1.proficiency";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* aNames = findColumn(df, "a.name")
@@ -3540,7 +3513,7 @@ TEST_F(QueriesTest, predicateJoinWithInequalityFilter) {
             "MATCH (a:Person), (b:Person) "
             "WHERE a.isFrench = b.isFrench AND a.hasPhD <> b.hasPhD "
             "RETURN a.name, b.name, a.isFrench, a.hasPhD, b.hasPhD";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(5, df->size());
             auto* aNames = findColumn(df, "a.name")
@@ -3609,7 +3582,7 @@ TEST_F(QueriesTest, predicateJoinDivergentAge) {
         constexpr std::string_view q =
             "MATCH (x)-->(a), (x)-->(b) "
             "WHERE a.age = b.age RETURN a, b, x";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(3, df->size());
             auto* aCol = findColumn(df, "a")->as<ColumnNodeIDs>();
@@ -3664,7 +3637,7 @@ TEST_F(QueriesTest, predicateJoinDivergentNameNeq) {
         constexpr std::string_view q =
             "MATCH (x)-->(a), (x)-->(b) "
             "WHERE a.name <> b.name RETURN a, b, x";
-        auto res = query(q, [&](const Dataframe* df) {
+        auto res = runQuery(q, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
             ASSERT_EQ(3, df->size());
             auto* aCol = findColumn(df, "a")->as<ColumnNodeIDs>();
@@ -3690,7 +3663,7 @@ TEST_F(QueriesTest, threeNodeCartProdFilterByID) {
 
     Rows actual;
     {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) -> void {
+        auto res = runQuery(MATCH_QUERY, [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df);
             ASSERT_EQ(3, df->size());
             auto* nCol = findColumn(df, "n")->as<ColumnNodeIDs>();
@@ -3713,7 +3686,7 @@ TEST_F(QueriesTest, threeNodeCartProdFilterByID) {
 
 TEST_F(QueriesTest, returnLiteralLimitZero) {
     size_t totalRows = 0;
-    auto result = query("RETURN 5 LIMIT 0", [&](const Dataframe* df) -> void {
+    auto result = runQuery("RETURN 5 LIMIT 0", [&](const Dataframe* df) -> void {
         totalRows += df->getLogicalRowCount();
     });
 
@@ -3723,7 +3696,7 @@ TEST_F(QueriesTest, returnLiteralLimitZero) {
 
 TEST_F(QueriesTest, matchReturnLimitZero) {
     size_t totalRows = 0;
-    auto result = query("MATCH (n) RETURN n LIMIT 0", [&](const Dataframe* df) -> void {
+    auto result = runQuery("MATCH (n) RETURN n LIMIT 0", [&](const Dataframe* df) -> void {
         totalRows += df->getLogicalRowCount();
     });
 

--- a/test/query/queries/QueriesTest.cpp
+++ b/test/query/queries/QueriesTest.cpp
@@ -55,8 +55,8 @@ protected:
                   ChangeID change = ChangeID::head()) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, _graphName, &_env->getMem(), &_queryConfig,
-                          callbacks, hash, change);
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, hash, change);
+        return _db->query(q, state);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/ReactomeTest.cpp
+++ b/test/query/queries/ReactomeTest.cpp
@@ -419,8 +419,10 @@ protected:
     GraphReader read() { return _graph->openTransaction().readGraph(); }
 
     auto query(std::string_view query, auto callback) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
         auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callback, CommitHash::head(), ChangeID::head());
+                              callbacks, CommitHash::head(), ChangeID::head());
         if (!res) {
             spdlog::error("Query failed: {}", res.getError());
         }
@@ -1260,8 +1262,8 @@ TEST_F(ReactomeVHJTest, sameCompartmentReactionsMatchesNonVHJ) {
     QueryConfig noVhjConfig;
     noVhjConfig.getPlanGenConfig().setUseValueHashJoin(false);
     Rows nonVhjActual;
-    auto res2 = _db->query(QUERY, _graphName, &_env->getMem(), &noVhjConfig,
-                           [&](const Dataframe* df) {
+    QueryCallbacks noVhjCallbacks;
+    noVhjCallbacks.setOnOutputData([&](const Dataframe* df) {
         ASSERT_TRUE(df);
         auto* rCol = findColumn(df, "r.displayName")->as<ColumnOptVector<String>>();
         auto* r2Col = findColumn(df, "r2.displayName")->as<ColumnOptVector<String>>();
@@ -1270,7 +1272,9 @@ TEST_F(ReactomeVHJTest, sameCompartmentReactionsMatchesNonVHJ) {
         for (size_t i = 0; i < rCol->size(); i++) {
             nonVhjActual.add({rCol->at(i), r2Col->at(i), cCol->at(i)});
         }
-    }, CommitHash::head(), ChangeID::head());
+    });
+    auto res2 = _db->query(QUERY, _graphName, &_env->getMem(), &noVhjConfig,
+                           noVhjCallbacks, CommitHash::head(), ChangeID::head());
     ASSERT_TRUE(res2);
 
     EXPECT_TRUE(vhjActual.equals(nonVhjActual));

--- a/test/query/queries/ReactomeTest.cpp
+++ b/test/query/queries/ReactomeTest.cpp
@@ -421,8 +421,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig,
-                              callbacks, CommitHash::head(), ChangeID::head());
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        auto res = _db->query(query, state);
         if (!res) {
             spdlog::error("Query failed: {}", res.getError());
         }
@@ -1273,8 +1273,8 @@ TEST_F(ReactomeVHJTest, sameCompartmentReactionsMatchesNonVHJ) {
             nonVhjActual.add({rCol->at(i), r2Col->at(i), cCol->at(i)});
         }
     });
-    auto res2 = _db->query(QUERY, _graphName, &_env->getMem(), &noVhjConfig,
-                           noVhjCallbacks, CommitHash::head(), ChangeID::head());
+    const QueryState noVhjState(_graphName, &_env->getMem(), &noVhjConfig, &noVhjCallbacks);
+    auto res2 = _db->query(QUERY, noVhjState);
     ASSERT_TRUE(res2);
 
     EXPECT_TRUE(vhjActual.equals(nonVhjActual));

--- a/test/query/queries/ShortestPathQueryTest.cpp
+++ b/test/query/queries/ShortestPathQueryTest.cpp
@@ -54,8 +54,8 @@ public:
                       ChangeID change = ChangeID::head()) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, graphName, &_env->getMem(), &_queryConfig,
-                              callbacks, CommitHash::head(), change);
+        const QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), change);
+        auto res = _db->query(query, state);
         if (!res) {
             spdlog::error("Query failed: {}", res.getError());
         }

--- a/test/query/queries/ShortestPathQueryTest.cpp
+++ b/test/query/queries/ShortestPathQueryTest.cpp
@@ -50,6 +50,18 @@ CREATE (n1:City {name: 'CityA'}),
 
 class ShortestPathQueryTest : public TuringTest {
 public:
+    static auto query(std::string_view query, std::string_view graphName, auto callback,
+                      ChangeID change = ChangeID::head()) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, graphName, &_env->getMem(), &_queryConfig,
+                              callbacks, CommitHash::head(), change);
+        if (!res) {
+            spdlog::error("Query failed: {}", res.getError());
+        }
+        return res;
+    }
+
     static void SetUpTestSuite() {
         _suiteOutDir = "ShortestPathQueryTest_suite.out";
         if (FileUtils::exists(_suiteOutDir)) {
@@ -69,12 +81,10 @@ public:
             Change* change = changeResult.value();
             auto changeId = change->id();
 
-            auto status = _db->query(TEST_GRAPH_CYPHER, _graphName, &_env->getMem(), &_queryConfig,
-                                     [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto status = query(TEST_GRAPH_CYPHER, _graphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(status.isOk()) << "Failed to create graph: " << status.getError();
 
-            auto submitStatus = _db->query("CHANGE SUBMIT", _graphName, &_env->getMem(), &_queryConfig,
-                                           [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto submitStatus = query("CHANGE SUBMIT", _graphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(submitStatus.isOk()) << "Failed to submit change: "
                                              << submitStatus.getError();
         }
@@ -88,12 +98,10 @@ public:
             Change* change = changeResult.value();
             auto changeId = change->id();
 
-            auto status = _db->query(TEST_STAR_GRAPH_CYPHER, _starGraphName, &_env->getMem(), &_queryConfig,
-                                     [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto status = query(TEST_STAR_GRAPH_CYPHER, _starGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(status.isOk()) << "Failed to create graph: " << status.getError();
 
-            auto submitStatus = _db->query("CHANGE SUBMIT", _starGraphName, &_env->getMem(), &_queryConfig,
-                                           [](const Dataframe*) {}, CommitHash::head(), changeId);
+            auto submitStatus = query("CHANGE SUBMIT", _starGraphName, [](const Dataframe*) {}, changeId);
             ASSERT_TRUE(submitStatus.isOk()) << "Failed to submit change: "
                                              << submitStatus.getError();
         }
@@ -120,14 +128,6 @@ protected:
     static inline Graph* _stargraph = nullptr;
     static inline QueryConfig _queryConfig;
 
-    auto query(std::string_view query, std::string_view graphName, auto callback) {
-        auto res = _db->query(query, graphName, &_env->getMem(), &_queryConfig,
-                              callback, CommitHash::head(), ChangeID::head());
-        if (!res) {
-            spdlog::error("Query failed: {}", res.getError());
-        }
-        return res;
-    }
 };
 
 TEST_F(ShortestPathQueryTest, sucessfullTest) {

--- a/test/query/queries/ShowExtensionsTest.cpp
+++ b/test/query/queries/ShowExtensionsTest.cpp
@@ -18,6 +18,17 @@ public:
         _db = &_env->getDB();
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
+    auto query(std::string_view q, std::string_view graphName) {
+        return query(q, graphName, [](const Dataframe*) {});
+    }
+
 protected:
     std::unique_ptr<TuringTestEnv> _env;
     TuringDB* _db {nullptr};
@@ -25,11 +36,10 @@ protected:
 };
 
 TEST_F(ShowExtensionsTest, showExtensions) {
-    _db->query("INSTALL greeter", "default", &_env->getMem(), &_queryConfig);
+    query("INSTALL greeter", "default");
 
     bool executed = false;
-    const auto res = _db->query("SHOW EXTENSIONS", "default", &_env->getMem(), &_queryConfig,
-                                [&](const Dataframe* df) -> void {
+    const auto res = query("SHOW EXTENSIONS", "default", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 1);
         ASSERT_GE(df->getLogicalRowCount(), 1);

--- a/test/query/queries/ShowExtensionsTest.cpp
+++ b/test/query/queries/ShowExtensionsTest.cpp
@@ -21,8 +21,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
     auto query(std::string_view q, std::string_view graphName) {

--- a/test/query/queries/ShowProceduresTest.cpp
+++ b/test/query/queries/ShowProceduresTest.cpp
@@ -22,8 +22,8 @@ public:
     auto query(std::string_view q, std::string_view graphName, auto callback) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          CommitHash::head(), ChangeID::head());
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(q, state);
     }
 
     auto query(std::string_view q, std::string_view graphName) {

--- a/test/query/queries/ShowProceduresTest.cpp
+++ b/test/query/queries/ShowProceduresTest.cpp
@@ -19,6 +19,17 @@ public:
         _db = &_env->getDB();
     }
 
+    auto query(std::string_view q, std::string_view graphName, auto callback) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          CommitHash::head(), ChangeID::head());
+    }
+
+    auto query(std::string_view q, std::string_view graphName) {
+        return query(q, graphName, [](const Dataframe*) {});
+    }
+
 protected:
     std::unique_ptr<TuringTestEnv> _env;
     TuringDB* _db {nullptr};
@@ -26,11 +37,10 @@ protected:
 };
 
 TEST_F(ShowProceduresTest, showProcedures) {
-    _db->query("INSTALL greeter", "default", &_env->getMem(), &_queryConfig);
+    query("INSTALL greeter", "default");
 
     bool executed = false;
-    const auto res = _db->query("SHOW PROCEDURES", "default", &_env->getMem(), &_queryConfig,
-                                [&](const Dataframe* df) -> void {
+    const auto res = query("SHOW PROCEDURES", "default", [&](const Dataframe* df) -> void {
         ASSERT_TRUE(df != nullptr);
         ASSERT_EQ(df->cols().size(), 2);
         ASSERT_EQ(df->getLogicalRowCount(), 8);

--- a/test/query/queries/StringFilterTest.cpp
+++ b/test/query/queries/StringFilterTest.cpp
@@ -123,7 +123,9 @@ protected:
     QueryConfig _queryConfig;
 
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), ChangeID::head());
         return res;
     }

--- a/test/query/queries/StringFilterTest.cpp
+++ b/test/query/queries/StringFilterTest.cpp
@@ -125,9 +125,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), ChangeID::head());
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks);
+        return _db->query(query, state);
     }
 
     static NamedColumn* findColumn(const Dataframe* df, std::string_view name) {

--- a/test/query/queries/VectorQueriesTest.cpp
+++ b/test/query/queries/VectorQueriesTest.cpp
@@ -70,8 +70,8 @@ public:
                db::ChangeID change = db::ChangeID::head()) {
         db::QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
-                          db::CommitHash::head(), change);
+        const db::QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks, db::CommitHash::head(), change);
+        return _db->query(q, state);
     }
 
     void initialize() override {

--- a/test/query/queries/VectorQueriesTest.cpp
+++ b/test/query/queries/VectorQueriesTest.cpp
@@ -66,6 +66,14 @@ void findKNearestNeighbors(std::vector<int64_t>& result,
 
 class VectorQueriesTest : public TuringTest {
 public:
+    auto query(std::string_view q, std::string_view graphName, auto callback,
+               db::ChangeID change = db::ChangeID::head()) {
+        db::QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        return _db->query(q, graphName, &_env->getMem(), &_queryConfig, callbacks,
+                          db::CommitHash::head(), change);
+    }
+
     void initialize() override {
         const auto testTuringDir = fs::Path {_outDir} / "turing";
         _env = TuringTestEnv::createSyncedOnDisk(testTuringDir);
@@ -80,10 +88,7 @@ protected:
 
 TEST_F(VectorQueriesTest, createVectorIndex) {
     bool executed = false;
-    const auto res = _db->query(
-        "CREATE VECTOR INDEX embeddings WITH DIMENSION 128 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CREATE VECTOR INDEX embeddings WITH DIMENSION 128 METRIC EUCLID", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), 1);
@@ -106,10 +111,7 @@ TEST_F(VectorQueriesTest, createVectorIndex) {
 
     // Verify the index was actually created by showing indexes
     bool showExecuted = false;
-    const auto showRes = _db->query(
-        "SHOW VECTOR INDEXES",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto showRes = query("SHOW VECTOR INDEXES", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_GE(df->getLogicalRowCount(), 1);
 
@@ -139,17 +141,12 @@ TEST_F(VectorQueriesTest, createVectorIndex) {
 
 TEST_F(VectorQueriesTest, showVectorIndexes) {
     // First create an index
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX test_index WITH DIMENSION 64 METRIC COSINE",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX test_index WITH DIMENSION 64 METRIC COSINE", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Then show indexes
     bool executed = false;
-    const auto res = _db->query(
-        "SHOW VECTOR INDEXES",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("SHOW VECTOR INDEXES", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 2);  // name and dimension columns
             ASSERT_GE(df->getLogicalRowCount(), 1);
@@ -186,17 +183,12 @@ TEST_F(VectorQueriesTest, showVectorIndexes) {
 
 TEST_F(VectorQueriesTest, deleteVectorIndex) {
     // First create an index
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX to_delete WITH DIMENSION 32 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX to_delete WITH DIMENSION 32 METRIC EUCLID", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Then delete it
     bool executed = false;
-    const auto res = _db->query(
-        "DELETE VECTOR INDEX to_delete",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("DELETE VECTOR INDEX to_delete", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), 1);
@@ -219,10 +211,7 @@ TEST_F(VectorQueriesTest, deleteVectorIndex) {
 
     // Verify the index was actually deleted by showing indexes
     bool showExecuted = false;
-    const auto showRes = _db->query(
-        "SHOW VECTOR INDEXES",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto showRes = query("SHOW VECTOR INDEXES", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
 
             // Check that "to_delete" is NOT in the list
@@ -246,10 +235,7 @@ TEST_F(VectorQueriesTest, deleteVectorIndex) {
 
 TEST_F(VectorQueriesTest, createVectorIndexWithCosineMetric) {
     bool executed = false;
-    const auto res = _db->query(
-        "CREATE VECTOR INDEX cosine_index WITH DIMENSION 256 METRIC COSINE",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("CREATE VECTOR INDEX cosine_index WITH DIMENSION 256 METRIC COSINE", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), 1);
@@ -272,10 +258,7 @@ TEST_F(VectorQueriesTest, createVectorIndexWithCosineMetric) {
 
     // Verify the index was created with COSINE metric by showing indexes
     bool showExecuted = false;
-    const auto showRes = _db->query(
-        "SHOW VECTOR INDEXES",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto showRes = query("SHOW VECTOR INDEXES", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
 
             const auto& cols = df->cols();
@@ -303,9 +286,7 @@ TEST_F(VectorQueriesTest, createVectorIndexWithCosineMetric) {
 
 TEST_F(VectorQueriesTest, loadVectorFromFile) {
     // Create a vector index with dimension 4
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX load_test WITH DIMENSION 4 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX load_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Create a temporary CSV file with test vectors in the data directory
@@ -324,10 +305,7 @@ TEST_F(VectorQueriesTest, loadVectorFromFile) {
     // Load vectors from file (path relative to data directory)
     bool executed = false;
     std::string loadQuery = "LOAD VECTOR FROM \"test_vectors.csv\" IN load_test";
-    const auto res = _db->query(
-        loadQuery,
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query(loadQuery, "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), 1);
@@ -351,9 +329,7 @@ TEST_F(VectorQueriesTest, loadVectorFromFile) {
 
 TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
     // Create a vector index with dimension 4
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX search_test WITH DIMENSION 4 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX search_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Define test vectors
@@ -381,7 +357,7 @@ TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
 
     // Load vectors (path relative to data directory)
     std::string loadQuery = "LOAD VECTOR FROM \"search_vectors.csv\" IN search_test";
-    auto loadRes = _db->query(loadQuery, "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto loadRes = query(loadQuery, "default", [](const Dataframe*) {});
     ASSERT_TRUE(loadRes.isOk()) << "Load failed: " << loadRes.getError();
 
     // Define query vector and compute expected results
@@ -392,10 +368,7 @@ TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
 
     // Search for vectors closest to query
     bool executed = false;
-    const auto res = _db->query(
-        "VECTOR SEARCH IN search_test FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("VECTOR SEARCH IN search_test FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), k);
@@ -420,9 +393,7 @@ TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
 
 TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
     // Create a vector index
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX k_test WITH DIMENSION 4 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX k_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Define test vectors
@@ -450,7 +421,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
 
     // Load vectors (path relative to data directory)
     std::string loadQuery = "LOAD VECTOR FROM \"k_test_vectors.csv\" IN k_test";
-    auto loadRes = _db->query(loadQuery, "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto loadRes = query(loadQuery, "default", [](const Dataframe*) {});
     ASSERT_TRUE(loadRes.isOk()) << "Load failed: " << loadRes.getError();
 
     // Define query vector and compute expected results for k=2
@@ -461,10 +432,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
 
     // Search for top 2
     bool executed = false;
-    const auto res = _db->query(
-        "VECTOR SEARCH IN k_test FOR 2 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("VECTOR SEARCH IN k_test FOR 2 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->getLogicalRowCount(), k);
 
@@ -488,9 +456,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
 
 TEST_F(VectorQueriesTest, vectorSearchWithHighPrecisionFloats) {
     // Create a vector index with dimension 4
-    auto createRes = _db->query(
-        "CREATE VECTOR INDEX precision_test WITH DIMENSION 4 METRIC EUCLID",
-        "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto createRes = query("CREATE VECTOR INDEX precision_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
     ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
 
     // Define test vectors with high-precision floating point values (6 decimals)
@@ -519,7 +485,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithHighPrecisionFloats) {
 
     // Load vectors (path relative to data directory)
     std::string loadQuery = "LOAD VECTOR FROM \"precision_vectors.csv\" IN precision_test";
-    auto loadRes = _db->query(loadQuery, "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+    auto loadRes = query(loadQuery, "default", [](const Dataframe*) {});
     ASSERT_TRUE(loadRes.isOk()) << "Load failed: " << loadRes.getError();
 
     // Define query vector (matches vector 100 exactly) and compute expected results
@@ -530,11 +496,8 @@ TEST_F(VectorQueriesTest, vectorSearchWithHighPrecisionFloats) {
 
     // Search for vectors closest to query
     bool executed = false;
-    const auto res = _db->query(
-        "VECTOR SEARCH IN precision_test FOR 3 [0.123456, 0.678901, 0.111111, 0.222222] "
-        "YIELD ids RETURN ids",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+    const auto res = query("VECTOR SEARCH IN precision_test FOR 3 [0.123456, 0.678901, 0.111111, 0.222222] "
+        "YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), k);
@@ -568,28 +531,21 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
         ASSERT_TRUE(changeRes) << "Failed to create change";
         const ChangeID changeId = changeRes.value()->id();
 
-        const auto createRes = _db->query(
-            R"(CREATE (n1:Document {id: 1, title: "Doc One"}),
+        const auto createRes = query(R"(CREATE (n1:Document {id: 1, title: "Doc One"}),
                       (n2:Document {id: 2, title: "Doc Two"}),
                       (n3:Document {id: 3, title: "Doc Three"}),
                       (n4:Document {id: 4, title: "Doc Four"}),
-                      (n5:Document {id: 5, title: "Doc Five"}))",
-            "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {},
-            CommitHash::head(), changeId);
+                      (n5:Document {id: 5, title: "Doc Five"}))", "default", [](const Dataframe*) {}, changeId);
         ASSERT_TRUE(createRes.isOk()) << "CREATE nodes failed: " << createRes.getError();
 
-        const auto commitRes = _db->query(
-            "change submit", "default", &_env->getMem(), &_queryConfig, CommitHash::head(), changeId);
+        const auto commitRes = query("change submit", "default", [](const Dataframe*) {}, changeId);
         ASSERT_TRUE(commitRes.isOk()) << "COMMIT failed: " << commitRes.getError();
     }
 
     // Step 1b: Verify nodes were created
     {
         size_t nodeCount = 0;
-        const auto matchRes = _db->query(
-            "MATCH (n:Document) RETURN n.id",
-            "default", &_env->getMem(), &_queryConfig,
-            [&](const Dataframe* df) -> void {
+        const auto matchRes = query("MATCH (n:Document) RETURN n.id", "default", [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 nodeCount = df->getLogicalRowCount();
             });
@@ -599,9 +555,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
 
     // Step 2: Create vector index
     {
-        const auto createIndexRes = _db->query(
-            "CREATE VECTOR INDEX doc_vectors WITH DIMENSION 4 METRIC EUCLID",
-            "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+        const auto createIndexRes = query("CREATE VECTOR INDEX doc_vectors WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
         ASSERT_TRUE(createIndexRes.isOk())
             << "Create index failed: " << createIndexRes.getError();
     }
@@ -636,15 +590,12 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
 
     const std::string loadQuery = "LOAD VECTOR FROM \"doc_vectors.csv\" IN doc_vectors";
     const auto loadRes =
-        _db->query(loadQuery, "default", &_env->getMem(), &_queryConfig, [](const Dataframe*) {});
+        query(loadQuery, "default", [](const Dataframe*) {});
     ASSERT_TRUE(loadRes.isOk()) << "Load vectors failed: " << loadRes.getError();
 
     // Step 3b: Verify vector search works standalone
     {
-        const auto searchRes = _db->query(
-            "VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids",
-            "default", &_env->getMem(), &_queryConfig,
-            [&](const Dataframe* df) -> void {
+        const auto searchRes = query("VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->getLogicalRowCount(), 3) << "Expected 3 vector search results";
             });
@@ -663,12 +614,9 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
     const std::vector<std::string> expectedTitles = {"Doc One", "Doc Two", "Doc Three"};
 
     bool executed = false;
-    const auto res = _db->query(
-        "VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids "
+    const auto res = query("VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids "
         "MATCH (n:Document) WHERE n.id = ids "
-        "RETURN n.id, n.title",
-        "default", &_env->getMem(), &_queryConfig,
-        [&](const Dataframe* df) -> void {
+        "RETURN n.id, n.title", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 2) << "Expected 2 columns (n.id, n.title)";
             ASSERT_EQ(df->getLogicalRowCount(), k) << "Expected " << k << " rows";

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -58,9 +58,8 @@ protected:
     auto query(std::string_view query, auto callback) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(callback);
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
-                              CommitHash::head(), _currentChange);
-        return res;
+        const QueryState state(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), _currentChange);
+        return _db->query(query, state);
     }
 
     void submitCurrentChange() {

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -55,16 +55,18 @@ protected:
         _currentChange = change->id();
     }
 
-    void submitCurrentChange() {
-        auto res = _db->query("change submit", _graphName, &_env->getMem(), &_queryConfig, CommitHash::head(), _currentChange);
-        ASSERT_TRUE(res) << res.getError();
-        _currentChange = ChangeID::head();
-    }
-
     auto query(std::string_view query, auto callback) {
-        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callback,
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(callback);
+        auto res = _db->query(query, _graphName, &_env->getMem(), &_queryConfig, callbacks,
                               CommitHash::head(), _currentChange);
         return res;
+    }
+
+    void submitCurrentChange() {
+        auto res = query("change submit", [](const Dataframe*) {});
+        ASSERT_TRUE(res) << res.getError();
+        _currentChange = ChangeID::head();
     }
 
     void setWorkingGraph(std::string_view name) {

--- a/test/serialisation/CommitJournalSerialisationTest.cpp
+++ b/test/serialisation/CommitJournalSerialisationTest.cpp
@@ -65,8 +65,8 @@ protected:
 
     QueryStatus query(std::string_view q, std::string_view graphName, ChangeID changeID) {
         QueryCallbacks callbacks;
-        return _env->getDB().query(q, graphName, &_env->getMem(), &_queryConfig,
-                                   callbacks, CommitHash::head(), changeID);
+        const QueryState state(graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        return _env->getDB().query(q, state);
     }
 };
 

--- a/test/serialisation/CommitJournalSerialisationTest.cpp
+++ b/test/serialisation/CommitJournalSerialisationTest.cpp
@@ -62,6 +62,12 @@ protected:
         ChangeID changeID = change->id();
         return changeID;
     }
+
+    QueryStatus query(std::string_view q, std::string_view graphName, ChangeID changeID) {
+        QueryCallbacks callbacks;
+        return _env->getDB().query(q, graphName, &_env->getMem(), &_queryConfig,
+                                   callbacks, CommitHash::head(), changeID);
+    }
 };
 
 TEST_F(CommitJournalSerialisationTest, emptyOnCreation) {
@@ -113,12 +119,10 @@ TEST_F(CommitJournalSerialisationTest, createNodeThenLoad) {
     // Make a change to the graph
     {
         ChangeID changeID = newChange();
-        auto res1 = _env->getDB().query("create (n:NEWNODE)", graphName, &_env->getMem(), &_queryConfig,
-                                        CommitHash::head(), changeID);
+        auto res1 = query("create (n:NEWNODE)", graphName, changeID);
         ASSERT_TRUE(res1);
 
-        auto res2 = _env->getDB().query("change submit", graphName, &_env->getMem(), &_queryConfig,
-                                        CommitHash::head(), changeID);
+        auto res2 = query("change submit", graphName, changeID);
         ASSERT_TRUE(res2);
     }
 
@@ -171,16 +175,13 @@ TEST_F(CommitJournalSerialisationTest, createNodesAndEdgesThenLoad) {
     // Make a change to the graph
     {
         ChangeID changeID = newChange();
-        auto res1 = _env->getDB().query("create (n:NEWNODE)", graphName, &_env->getMem(), &_queryConfig,
-                                        CommitHash::head(), changeID);
-
+        auto res1 = query("create (n:NEWNODE)", graphName, changeID);
         ASSERT_TRUE(res1);
-        auto res2 = _env->getDB().query("create (n:NEWNODE)-[e:NEWEDGE]->(m:NEWNODE)", graphName,
-                                        &_env->getMem(), &_queryConfig, CommitHash::head(), changeID);
+
+        auto res2 = query("create (n:NEWNODE)-[e:NEWEDGE]->(m:NEWNODE)", graphName, changeID);
         ASSERT_TRUE(res2);
 
-        auto res3 = _env->getDB().query("change submit", graphName, &_env->getMem(), &_queryConfig,
-                                        CommitHash::head(), changeID);
+        auto res3 = query("change submit", graphName, changeID);
         ASSERT_TRUE(res3);
     }
 

--- a/test/serialisation/TombstoneSerialisationTest.cpp
+++ b/test/serialisation/TombstoneSerialisationTest.cpp
@@ -33,7 +33,6 @@ public:
     }
 
     void populateAndDump() {
-        auto& db = _env->getDB();
         auto& sysMan = _env->getSystemManager();
 
         auto res = sysMan.newChange(_workingGraphName);
@@ -49,19 +48,14 @@ public:
             const std::string queryStr = "create (n:Person{id:"+std::to_string(origin)
                                       +"})-[e:FRIENDSWITH{id: "+std::to_string(i)
                                       +"}]->(m:Person{id:"+std::to_string(target)+"})";
-            const auto res = db.query(queryStr,
-                                      _workingGraphName,
-                                      &_env->getMem(), &_queryConfig,
-                                      CommitHash::head(),
-                                      change->id());
+            const auto res = query(queryStr, change->id());
             ASSERT_TRUE(res);
         }
 
         spdlog::info("Ran create queries");
 
         // implicit dump on change submit
-        ASSERT_TRUE(db.query("change submit", _workingGraphName, &_env->getMem(), &_queryConfig,
-                             CommitHash::head(), change->id()));
+        ASSERT_TRUE(query("change submit", change->id()));
         spdlog::info("Submitted change");
 
         const auto VERIFY = [](const Dataframe* df) {
@@ -73,14 +67,12 @@ public:
             }
         };
 
-        ASSERT_TRUE(db.query("match (n) return n", _workingGraphName, &_env->getMem(), &_queryConfig,
-                             VERIFY, CommitHash::head(), ChangeID::head()));
+        ASSERT_TRUE(query("match (n) return n", ChangeID::head(), VERIFY));
 
         spdlog::info("Successfully populated graph");
     }
 
     void applyDeletesAndDump() {
-        auto& db = _env->getDB();
         auto& sysMan = _env->getSystemManager();
 
         auto delRes = sysMan.newChange(_workingGraphName);
@@ -91,29 +83,28 @@ public:
 
         for (size_t node : DELETED_NODES) {
             const std::string queryStr = "match (n{id: " + std::to_string(node) + "}) delete n";
-            const auto res = db.query(queryStr,
-                                      _workingGraphName,
-                                      &_env->getMem(), &_queryConfig,
-                                      CommitHash::head(),
-                                      delChange->id());
+            const auto res = query(queryStr, delChange->id());
             spdlog::info(queryStr);
             ASSERT_TRUE(res);
         }
         for (size_t edge : DELETED_EDGES) {
             const std::string queryStr = "match (n)-[e{id: "+ std::to_string(edge)+"}]->(m) delete e";
-            const auto res = db.query(queryStr,
-                                      _workingGraphName,
-                                      &_env->getMem(), &_queryConfig,
-                                      CommitHash::head(),
-                                      delChange->id());
+            const auto res = query(queryStr, delChange->id());
             spdlog::info(queryStr);
             ASSERT_TRUE(res);
         }
         // implicit dump on change submit
-        ASSERT_TRUE(db.query("change submit", _workingGraphName, &_env->getMem(), &_queryConfig,
-                             CommitHash::head(), delChange->id()));
+        ASSERT_TRUE(query("change submit", delChange->id()));
 
         spdlog::info("Submitted deletions change");
+    }
+
+    QueryStatus query(std::string_view q, ChangeID changeID,
+                      QueryCallbacks::OnOutputData onData = [](const Dataframe*) {}) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData(onData);
+        return _env->getDB().query(q, _workingGraphName, &_env->getMem(), &_queryConfig,
+                                   callbacks, CommitHash::head(), changeID);
     }
 
 protected:
@@ -171,8 +162,6 @@ TEST_F(TombstoneSerialisationTest, deleteNodesThenLoad) {
 
     // Get actual nodes & edges
     {
-        TuringDB& db = _env->getDB();
-
         using ColumnIDProp = ColumnOptVector<types::Int64::Primitive>;
         auto callback = [&actualNodes](const Dataframe* df) {
             ASSERT_TRUE(df->size() == 1);
@@ -184,17 +173,12 @@ TEST_F(TombstoneSerialisationTest, deleteNodesThenLoad) {
             }
         };
 
-        const auto res = db.query("match (n) return n.id",
-                                  _workingGraphName,
-                                  &_env->getMem(), &_queryConfig,
-                                  callback);
+        const auto res = query("match (n) return n.id", ChangeID::head(), callback);
         ASSERT_TRUE(res);
         ASSERT_TRUE(!actualNodes.empty());
         ASSERT_EQ(actualNodes.size(), NUM_NODES-DELETED_NODES.size());
     }
     {
-        TuringDB& db = _env->getDB();
-
         using ColumnIDProp = ColumnOptVector<types::Int64::Primitive>;
         auto callback = [&actualEdges](const Dataframe* df) {
             ASSERT_TRUE(df->size() == 1);
@@ -206,10 +190,7 @@ TEST_F(TombstoneSerialisationTest, deleteNodesThenLoad) {
             }
         };
 
-        const auto res = db.query("match (n)-[e]->(m) return e.id",
-                                  _workingGraphName,
-                                  &_env->getMem(), &_queryConfig,
-                                  callback);
+        const auto res = query("match (n)-[e]->(m) return e.id", ChangeID::head(), callback);
         ASSERT_TRUE(res);
         ASSERT_TRUE(!actualEdges.empty());
         ASSERT_EQ(actualEdges.size(), NUM_EDGES-DELETED_EDGES.size());

--- a/test/serialisation/TombstoneSerialisationTest.cpp
+++ b/test/serialisation/TombstoneSerialisationTest.cpp
@@ -103,8 +103,8 @@ public:
                       QueryCallbacks::OnOutputData onData = [](const Dataframe*) {}) {
         QueryCallbacks callbacks;
         callbacks.setOnOutputData(onData);
-        return _env->getDB().query(q, _workingGraphName, &_env->getMem(), &_queryConfig,
-                                   callbacks, CommitHash::head(), changeID);
+        const QueryState state(_workingGraphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        return _env->getDB().query(q, state);
     }
 
 protected:

--- a/tools/turingdb/StartCmd.cpp
+++ b/tools/turingdb/StartCmd.cpp
@@ -251,8 +251,9 @@ int StartCmd::execute() {
 
         // Load graphs
         const auto& queryConfig = turingDB.getDefaultQueryConfig();
+        const QueryCallbacks callbacks;
         for (const auto& graphName : _graphsToLoad) {
-            const QueryStatus res = turingDB.query("load graph " + graphName, "", &mem, &queryConfig);
+            const QueryStatus res = turingDB.query("load graph " + graphName, "", &mem, &queryConfig, callbacks);
             if (!res.isOk()) {
                 return EXIT_FAILURE;
             }

--- a/tools/turingdb/StartCmd.cpp
+++ b/tools/turingdb/StartCmd.cpp
@@ -253,7 +253,8 @@ int StartCmd::execute() {
         const auto& queryConfig = turingDB.getDefaultQueryConfig();
         const QueryCallbacks callbacks;
         for (const auto& graphName : _graphsToLoad) {
-            const QueryStatus res = turingDB.query("load graph " + graphName, "", &mem, &queryConfig, callbacks);
+            const QueryState state("", &mem, &queryConfig, &callbacks);
+            const QueryStatus res = turingDB.query("load graph " + graphName, state);
             if (!res.isOk()) {
                 return EXIT_FAILURE;
             }

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -599,7 +599,6 @@ void TuringShell::formatMessage(std::string& msg) {
 }
 
 void TuringShell::processLine(std::string& line) {
-
     {
         std::string profilerOutput;
         Profiler::dumpAndClear(profilerOutput);
@@ -634,7 +633,8 @@ void TuringShell::processLine(std::string& line) {
     {
         size_t execCount = 0;
 
-        auto callback = [&table, &execCount, &rowCount, this](const Dataframe* df) -> void {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([&table, &execCount, &rowCount, this](const Dataframe* df) -> void {
             rowCount += df->getLogicalRowCount();
 
             if (_quiet) {
@@ -642,9 +642,9 @@ void TuringShell::processLine(std::string& line) {
             }
 
             queryCallback(execCount++, df, table);
-        };
+        });
 
-        res = _turingDB.query(line, _graphName, _mem, &_turingDB.getDefaultQueryConfig(), callback, _hash, _changeID);
+        res = _turingDB.query(line, _graphName, _mem, &_turingDB.getDefaultQueryConfig(), callbacks, _hash, _changeID);
     }
 
     checkShellContext();

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -644,7 +644,8 @@ void TuringShell::processLine(std::string& line) {
             queryCallback(execCount++, df, table);
         });
 
-        res = _turingDB.query(line, _graphName, _mem, &_turingDB.getDefaultQueryConfig(), callbacks, _hash, _changeID);
+        const QueryState state(_graphName, _mem, &_turingDB.getDefaultQueryConfig(), &callbacks, _hash, _changeID);
+        res = _turingDB.query(line, state);
     }
 
     checkShellContext();


### PR DESCRIPTION
* Remove the many ugly overloads of the TuringDB::query function
* Few cosmetic changes in the TuringDB class (formatting of the constructor, cleaning forward declarations)
* Add static create method to SystemManager and ExtensionManager so that it is coherent with the other top level components