### PR TITLE
Move `atomExpr` out of `propertyExpr`

### DIFF
--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -1030,8 +1030,8 @@ entityTypeExpr
     ;
 
 propertyExpr
-    : atomExpr { $$ = $1; }
-    | qualifiedName DOT name { $1->addName($3); $$ = PropertyExpr::create(ast, $1); LOC($$, @$); }
+    : qualifiedName DOT name { $1->addName($3); $$ = PropertyExpr::create(ast, $1); LOC($$, @$); }
+    //| atomExpr { $$ = $1; }
     ;
 
 atomExpr
@@ -1391,17 +1391,19 @@ listLitItems
     ;
 
 listLitItem
-    : literal { $$ = LiteralExpr::create(ast, $1); LOC($$, @$); }
-    | parameter { scanner.notImplemented(@$, "Parameters"); }
-    | caseExpr { scanner.notImplemented(@$, "CASE"); }
-    | countFunc { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
-    | listComprehension { scanner.notImplemented(@$, "List comprehensions"); }
+    : //literal { $$ = LiteralExpr::create(ast, $1); LOC($$, @$); }
+    //| parameter { scanner.notImplemented(@$, "Parameters"); }
+    //| caseExpr { scanner.notImplemented(@$, "CASE"); }
+    //| countFunc { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
+    //| listComprehension { scanner.notImplemented(@$, "List comprehensions"); }
     //| patternComprehension { scanner.notImplemented(@$, "Pattern comprehensions"); }
-    | filterWith { scanner.notImplemented(@$, "Filters"); }
-    | parenthesizedExpr { $$ = $1; }
-    | functionInvocation { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
-    | symbol { $$ = SymbolExpr::create(ast, $1); LOC($$, @$); }
-    | subqueryExist { scanner.notImplemented(@$, "EXISTS"); }
+    //| filterWith { scanner.notImplemented(@$, "Filters"); }
+    //| parenthesizedExpr { $$ = $1; }
+    //| functionInvocation { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
+    //| symbol { $$ = SymbolExpr::create(ast, $1); LOC($$, @$); }
+    //| subqueryExist { scanner.notImplemented(@$, "EXISTS"); }
+     propertyExpr { $$ = $1; LOC($$, @$); }
+    | atomExpr { $$ = $1; LOC($$, @$); }
     ;
 
 mapLit

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -597,7 +597,7 @@ opt_limitSSt
     ;
 
 projectionItems
-    : MULT { $$ = Projection::create(ast); $$->setReturnAll(); LOC($$, @$); }
+    : MULT { $$ = Projection::create(ast); $$->setReturnAll(); LOC($$, @$); } // wildcard
     | projectionItem { $$ = Projection::create(ast); $$->addExpr($1); LOC($$, @$); }
     | projectionItems COMMA projectionItem { $$ = $1; $$->addExpr($3); LOC($$, @$); }
     ;
@@ -1010,6 +1010,7 @@ unaryAddSubExpr
 
 atomicExpr
     : propertyOrLabelExpr { $$ = $1; }
+    | atomExpr { $$ = $1; }
     | atomicExpr OBRACK expr CBRACK {
         $$ = IndexExpr::create(ast, $1, $3); LOC($$, @$);
       }
@@ -1391,18 +1392,7 @@ listLitItems
     ;
 
 listLitItem
-    : //literal { $$ = LiteralExpr::create(ast, $1); LOC($$, @$); }
-    //| parameter { scanner.notImplemented(@$, "Parameters"); }
-    //| caseExpr { scanner.notImplemented(@$, "CASE"); }
-    //| countFunc { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
-    //| listComprehension { scanner.notImplemented(@$, "List comprehensions"); }
-    //| patternComprehension { scanner.notImplemented(@$, "Pattern comprehensions"); }
-    //| filterWith { scanner.notImplemented(@$, "Filters"); }
-    //| parenthesizedExpr { $$ = $1; }
-    //| functionInvocation { $$ = FunctionInvocationExpr::create(ast, $1); LOC($$, @$); }
-    //| symbol { $$ = SymbolExpr::create(ast, $1); LOC($$, @$); }
-    //| subqueryExist { scanner.notImplemented(@$, "EXISTS"); }
-     propertyExpr { $$ = $1; LOC($$, @$); }
+    : propertyExpr { $$ = $1; LOC($$, @$); }
     | atomExpr { $$ = $1; LOC($$, @$); }
     ;
 

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -1032,7 +1032,6 @@ entityTypeExpr
 
 propertyExpr
     : qualifiedName DOT name { $1->addName($3); $$ = PropertyExpr::create(ast, $1); LOC($$, @$); }
-    //| atomExpr { $$ = $1; }
     ;
 
 atomExpr

--- a/test/query-test-suite/tests/return-list-of-properties.json
+++ b/test/query-test-suite/tests/return-list-of-properties.json
@@ -10,7 +10,7 @@
   "tags": [
     "lists",
     "return",
-    "properties",
+    "properties"
   ],
   "write-required": false
 }

--- a/test/query-test-suite/tests/return-list-of-properties.json
+++ b/test/query-test-suite/tests/return-list-of-properties.json
@@ -1,0 +1,16 @@
+{
+  "enabled": true,
+  "graph": "simpledb",
+  "query": "MATCH (n) RETURN [n.name]",
+  "expect": {
+    "plan": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n) RETURN [n.name]\n       |                  ^^^^^^^^\n-------* Not implemented: Non-numeric list elements",
+    "result": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n) RETURN [n.name]\n       |                  ^^^^^^^^\n-------* Not implemented: Non-numeric list elements",
+    "resultJson": "{\"error\":\"PARSE_ERROR\",\"error_details\":\"-------* Cypher parser\\n     1 | MATCH (n) RETURN [n.name]\\n       |                  ^^^^^^^^\\n-------* Not implemented: Non-numeric list elements\"}"
+  },
+  "tags": [
+    "lists",
+    "return",
+    "properties",
+  ],
+  "write-required": false
+}

--- a/test/query-test-suite/tests/set-non-prop.json
+++ b/test/query-test-suite/tests/set-non-prop.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "MATCH (n) SET NOT_A_PROPERTY = 42",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\n       |               ^^^^^^^^^^^^^^\n-------* Invalid property expression.",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\n       |               ^^^^^^^^^^^^^^\n-------* Invalid property expression.",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\\n       |               ^^^^^^^^^^^^^^\\n-------* Invalid property expression.\"}"
+    "plan": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\n       |                              ^\n-------* syntax error, unexpected ASSIGN, expecting DOT",
+    "result": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\n       |                              ^\n-------* syntax error, unexpected ASSIGN, expecting DOT",
+    "resultJson": "{\"error\":\"PARSE_ERROR\",\"error_details\":\"-------* Cypher parser\\n     1 | MATCH (n) SET NOT_A_PROPERTY = 42\\n       |                              ^\\n-------* syntax error, unexpected ASSIGN, expecting DOT\"}"
   },
   "tags": [
     "errors",


### PR DESCRIPTION
Fixes #601, clarifies grammar rules, adds tests for correct parsing.