### PR TITLE
Analyzer/generator refactor; `ShortestPathStmt` made a read statement

### DIFF
--- a/query/AST/SinglePartQuery.cpp
+++ b/query/AST/SinglePartQuery.cpp
@@ -2,6 +2,7 @@
 
 #include "CypherAST.h"
 #include "decl/DeclContext.h"
+#include "stmt/StmtContainer.h"
 
 using namespace db;
 
@@ -18,4 +19,8 @@ SinglePartQuery* SinglePartQuery::create(CypherAST* ast) {
     SinglePartQuery* query = new SinglePartQuery(declContext);
     ast->addQuery(query);
     return query;
+}
+
+void SinglePartQuery::addReadStmt(Stmt* stmt) {
+    _readStmts->add(stmt);
 }

--- a/query/AST/SinglePartQuery.h
+++ b/query/AST/SinglePartQuery.h
@@ -9,6 +9,7 @@ class StmtContainer;
 class ReturnStmt;
 class DeclContext;
 class ShortestPathStmt;
+class Stmt;
 
 class SinglePartQuery : public QueryCommand {
 public:
@@ -18,20 +19,17 @@ public:
 
     const StmtContainer* getReadStmts() const { return _readStmts; }
     const StmtContainer* getUpdateStmts() const { return _updateStmts; }
-    const ShortestPathStmt* getShortestPathStmt() const {
-        return _shortestPathStmt;
-    }
     const ReturnStmt* getReturnStmt() const { return _returnStmt; }
 
     void setReadStmts(StmtContainer* stmts) { _readStmts = stmts; }
+    void addReadStmt(Stmt* stmt);
+
     void setUpdateStmts(StmtContainer* stmts) { _updateStmts = stmts; }
-    void setShortestPathStmt(ShortestPathStmt* stmt) { _shortestPathStmt = stmt; }
     void setReturnStmt(ReturnStmt* stmt) { _returnStmt = stmt; }
 
 private:
     StmtContainer* _readStmts {nullptr};
     StmtContainer* _updateStmts {nullptr};
-    ShortestPathStmt* _shortestPathStmt {nullptr};
     ReturnStmt* _returnStmt {nullptr};
 
     SinglePartQuery(DeclContext* declContext);

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -148,11 +148,8 @@ void CypherAnalyzer::analyze() {
 }
 
 void CypherAnalyzer::analyze(const SinglePartQuery* query) {
-    DeclContext* ctxt = query->getDeclContext();
-
     const StmtContainer* readStmts = query->getReadStmts();
     const StmtContainer* updateStmts = query->getUpdateStmts();
-    const ShortestPathStmt* shortestPathStmt = query->getShortestPathStmt();
     const ReturnStmt* returnStmt = query->getReturnStmt();
 
     bool returnMandatory = updateStmts == nullptr;
@@ -167,22 +164,6 @@ void CypherAnalyzer::analyze(const SinglePartQuery* query) {
             }
             _readAnalyzer->analyze(stmt);
         }
-    }
-
-    if (shortestPathStmt) {
-        const PropertyTypeMap& propTypeMap = _graphMetadata.propTypes();
-        auto propName = shortestPathStmt->getEdgeProperty()->getName();
-
-        const std::optional<PropertyType> propType = propTypeMap.get(propName);
-        if (!propType) {
-            throwError(fmt::format("Unknown property: {}", propName));
-        }
-        ctxt->getOrCreateNamedVariable(_ast,
-                                       EvaluatedType::Integer,
-                                       shortestPathStmt->getDistVar()->getName());
-        ctxt->getOrCreateNamedVariable(_ast,
-                                       EvaluatedType::GraphPath,
-                                       shortestPathStmt->getPathVar()->getName());
     }
 
     // Generate update statements (optional)

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -1,5 +1,7 @@
 #include "ReadStmtAnalyzer.h"
 
+#include <string_view>
+
 #include "AnalyzeException.h"
 #include "ExprAnalyzer.h"
 #include "FunctionInvocation.h"
@@ -15,6 +17,7 @@
 #include "decl/PatternData.h"
 #include "stmt/OrderBy.h"
 #include "stmt/OrderByItem.h"
+#include "stmt/ShortestPathStmt.h"
 #include "stmt/Skip.h"
 #include "stmt/Limit.h"
 #include "stmt/MatchStmt.h"
@@ -61,23 +64,27 @@ void ReadStmtAnalyzer::analyze(Stmt* stmt) {
     switch (stmt->getKind()) {
         case Stmt::Kind::MATCH:
             analyze(static_cast<const MatchStmt*>(stmt));
-            break;
+        break;
 
         case Stmt::Kind::CALL:
             analyze(static_cast<const CallStmt*>(stmt));
-            break;
+        break;
 
         case Stmt::Kind::LOAD_CSV:
             analyze(static_cast<LoadCSVStmt*>(stmt));
-            break;
+        break;
 
         case Stmt::Kind::VECTOR_SEARCH:
             analyze(static_cast<const VectorSearchStmt*>(stmt));
         break;
 
+        case Stmt::Kind::SHORTESTPATH:
+            analyze(static_cast<const ShortestPathStmt*>(stmt));
+        break;
+
         default:
             throwError("Unsupported read statement type", stmt);
-            break;
+        break;
     }
 }
 
@@ -524,6 +531,26 @@ void ReadStmtAnalyzer::analyze(const VectorSearchStmt* stmt) {
         yieldItemExpr->setDecl(decl);
         yieldItemExpr->setExprVarDecl(decl);
     }
+}
+
+void ReadStmtAnalyzer::analyze(const ShortestPathStmt* spSt) {
+    const PropertyTypeMap& propTypeMap = _graphMetadata.propTypes();
+    const std::string_view propName = spSt->getEdgeProperty()->getName();
+
+    const std::optional<PropertyType> propType = propTypeMap.get(propName);
+    if (!propType) {
+        throwError(fmt::format("Unknown property: {}", propName));
+    }
+
+    const Symbol* distVar = spSt->getDistVar();
+    const Symbol* pathVar = spSt->getPathVar();
+    bioassert(distVar && pathVar, "Null variables.");
+
+    const std::string_view distName = distVar->getName();
+    const std::string_view pathName = pathVar->getName();
+
+    _ctxt->getOrCreateNamedVariable(_ast, EvaluatedType::Integer, distName);
+    _ctxt->getOrCreateNamedVariable(_ast, EvaluatedType::GraphPath, pathName);
 }
 
 void ReadStmtAnalyzer::throwError(std::string_view msg, const void* obj) const {

--- a/query/analyzer/ReadStmtAnalyzer.h
+++ b/query/analyzer/ReadStmtAnalyzer.h
@@ -3,10 +3,6 @@
 #include "views/GraphView.h"
 
 namespace db {
-class GraphMetadata;
-}
-
-namespace db {
 
 class CypherAST;
 class ExprAnalyzer;
@@ -26,6 +22,8 @@ class NodePattern;
 class EdgePattern;
 class FunctionInvocation;
 class LoadCSVStmt;
+class ShortestPathStmt;
+class GraphMetadata;
 
 class ReadStmtAnalyzer {
 public:
@@ -50,6 +48,7 @@ public:
     void analyze(OrderBy* orderBySt);
     void analyze(Skip* skipSt);
     void analyze(Limit* limitSt);
+    void analyze(const ShortestPathStmt* spSt);
 
     // Pattern
     void analyze(const Pattern* pattern);

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -642,7 +642,7 @@ singlePartQuery
     | readingStatements shortestPathSt returnSt {
         $$ = SinglePartQuery::create(ast);
         $$->setReadStmts($1);
-        $$->setShortestPathStmt($2);
+        $$->addReadStmt($2);
         $$->setReturnStmt($3);
         LOC($$, @$); }
     ;

--- a/query/plan/PlanGraphGenerator.cpp
+++ b/query/plan/PlanGraphGenerator.cpp
@@ -22,9 +22,7 @@
 #include "nodes/CommitNode.h"
 #include "Literal.h"
 #include "stmt/Limit.h"
-#include "stmt/OrderBy.h"
 #include "stmt/ReturnStmt.h"
-#include "stmt/ShortestPathStmt.h"
 #include "stmt/Skip.h"
 #include "stmt/StmtContainer.h"
 #include "views/GraphView.h"
@@ -53,7 +51,6 @@
 #include "nodes/S3TransferNode.h"
 #include "nodes/ShowProceduresNode.h"
 #include "nodes/LoadCommitNode.h"
-#include "nodes/ShortestPathNode.h"
 #include "nodes/ExprEvalNode.h"
 #include "nodes/CreateVectorIndexNode.h"
 #include "nodes/LoadVectorNode.h"
@@ -95,6 +92,28 @@
 #include "PlannerException.h"
 
 using namespace db;
+
+namespace {
+
+int64_t getLimit(const Projection* proj) {
+    const Expr* limitExpr = proj->getLimit()->getExpr();
+
+    const bool isLiteral = limitExpr->getKind() == Expr::Kind::LITERAL;
+    bioassert(isLiteral, "Planner failed to stop non-literal LIMIT.");
+
+    const auto* litExpr = static_cast<const LiteralExpr*>(limitExpr);
+    const Literal* lit = litExpr->getLiteral();
+
+    const bool isIntegral = lit->getKind() == Literal::Kind::INTEGER;
+    bioassert(isIntegral, "Planned failed to stop non-integral LIMIT.");
+
+    const auto* intLit = static_cast<const IntegerLiteral*>(lit);
+    const int64_t limit = intLit->getValue();
+
+    return limit;
+}
+
+}
 
 PlanGraphGenerator::PlanGraphGenerator(const PlanGenConfig* config,
                                        const CypherAST& ast,
@@ -216,26 +235,21 @@ void PlanGraphGenerator::generateCommitQuery(const CommitQuery* query) {
 void PlanGraphGenerator::generateSinglePartQuery(const SinglePartQuery* query) {
     const StmtContainer* readStmts = query->getReadStmts();
     const StmtContainer* updateStmts = query->getUpdateStmts();
-    const ShortestPathStmt* shortestPathStmt = query->getShortestPathStmt();
     const ReturnStmt* returnStmt = query->getReturnStmt();
+    const DeclContext* declCtxt = query->getDeclContext();
 
     PlanGraphNode* currentNode = nullptr;
 
     // Generate read statements (optional)
     if (readStmts) {
-        ReadStmtGenerator readGenerator(_ast, _view, _config, &_tree, _variables.get());
+        ReadStmtGenerator readGenerator(_ast, _view, _config, &_tree, _variables.get(), declCtxt);
 
         // Pass literal LIMIT to the read generator for join planning
         if (returnStmt) {
             const Projection* proj = returnStmt->getProjection();
             if (proj && proj->hasLimit()) {
-                const Expr* limitExpr = proj->getLimit()->getExpr();
-                if (limitExpr->getKind() == Expr::Kind::LITERAL) {
-                    const auto* lit = static_cast<const LiteralExpr*>(limitExpr)->getLiteral();
-                    if (lit->getKind() == Literal::Kind::INTEGER) {
-                        readGenerator.setQueryLimit(static_cast<const IntegerLiteral*>(lit)->getValue());
-                    }
-                }
+                const int64_t limit = getLimit(proj);
+                readGenerator.setQueryLimit(limit);
             }
         }
 
@@ -251,30 +265,6 @@ void PlanGraphGenerator::generateSinglePartQuery(const SinglePartQuery* query) {
 
         // Place joins based on procedures calls
         readGenerator.placeJoinsOnProcedures();
-
-        // Insert ShortestPath Node
-        if (shortestPathStmt) {
-            const auto* declContext = query->getDeclContext();
-            auto sourceName = shortestPathStmt->getSource()->getName();
-            auto targetName = shortestPathStmt->getTarget()->getName();
-            const auto propertyType = _view.metadata().propTypes().get(shortestPathStmt->getEdgeProperty()->getName()).value();
-            auto distName = shortestPathStmt->getDistVar()->getName();
-            auto pathName = shortestPathStmt->getPathVar()->getName();
-
-            const auto* sourceDecl = declContext->getDecl(sourceName);
-            const auto* targetDecl = declContext->getDecl(targetName);
-            const auto* distDecl = declContext->getDecl(distName);
-            const auto* pathDecl = declContext->getDecl(pathName);
-
-            auto* sourceNode = _variables->getVarNode(sourceDecl);
-            auto* targetNode = _variables->getVarNode(targetDecl);
-
-            readGenerator.insertShortestPathNode(sourceNode,
-                                                 targetNode,
-                                                 propertyType,
-                                                 distDecl,
-                                                 pathDecl);
-        }
 
         // Place joins that generate the endpoint, and retrieve it
         currentNode = readGenerator.generateEndpoint();

--- a/query/plan/PlanGraphGenerator.h
+++ b/query/plan/PlanGraphGenerator.h
@@ -61,7 +61,6 @@ private:
     void generateChangeQuery(const ChangeQuery* query);
     void generateCommitQuery(const CommitQuery* query);
     void generateSinglePartQuery(const SinglePartQuery* query);
-    void generateShortestPathStmt(const ShortestPathStmt* stmt, PlanGraphNode* prevNode);
     PlanGraphNode* generateReturnStmt(const ReturnStmt* stmt, PlanGraphNode* prevNode);
     PlanGraphNode* generateReturnNone(PlanGraphNode* prevNode);
     void generateLoadGraphQuery(const LoadGraphQuery* query);

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -1,11 +1,14 @@
 #include "ReadStmtGenerator.h"
 
+#include <string_view>
+
 #include <spdlog/fmt/bundled/format.h>
 #include <spdlog/spdlog.h>
 
 #include "CypherAST.h"
 #include "DiagnosticsManager.h"
 #include "FunctionInvocation.h"
+#include "ID.h"
 #include "Literal.h"
 #include "Pattern.h"
 #include "PatternElement.h"
@@ -18,6 +21,7 @@
 #include "WhereClause.h"
 #include "YieldClause.h"
 #include "YieldItems.h"
+#include "decl/DeclContext.h"
 #include "decl/PatternData.h"
 #include "decl/VarDecl.h"
 #include "expr/BinaryExpr.h"
@@ -51,6 +55,7 @@
 #include "CardinalityEstimation.h"
 #include "PlanGenConfig.h"
 
+#include "stmt/ShortestPathStmt.h"
 #include "stmt/Stmt.h"
 #include "stmt/MatchStmt.h"
 #include "stmt/CallStmt.h"
@@ -68,14 +73,16 @@ ReadStmtGenerator::ReadStmtGenerator(const CypherAST* ast,
                                      GraphView graphView,
                                      const PlanGenConfig* config,
                                      PlanGraph* tree,
-                                     PlanGraphVariables* variables)
+                                     PlanGraphVariables* variables,
+                                     const DeclContext* declCtxt)
     : _ast(ast),
     _graphView(graphView),
     _config(config),
     _graphMetadata(graphView.metadata()),
     _tree(tree),
     _variables(variables),
-    _topology(std::make_unique<PlanGraphTopology>())
+    _topology(std::make_unique<PlanGraphTopology>()),
+    _declContext(declCtxt)
 {
 }
 
@@ -104,8 +111,15 @@ void ReadStmtGenerator::generateStmt(const Stmt* stmt) {
             generateVectorSearchStmt(static_cast<const VectorSearchStmt*>(stmt));
         break;
 
-        default:
-            throwError(fmt::format("Unsupported read statement type: {}", (uint64_t)stmt->getKind()), stmt);
+        case Stmt::Kind::SHORTESTPATH:
+            generateShortestPathStmt(static_cast<const ShortestPathStmt*>(stmt));
+        break;
+
+        case Stmt::Kind::CREATE:
+        case Stmt::Kind::SET:
+        case Stmt::Kind::DELETE:
+        case Stmt::Kind::RETURN:
+        // Not read statements
         break;
     }
 }
@@ -1074,6 +1088,37 @@ void ReadStmtGenerator::placeProcedurePredicate(Predicate* pred) {
         PlanGraphNode* tip = _topology->getBranchTip(dep._producerNode);
         tip->connectOut(cart);
     }
+}
+
+void ReadStmtGenerator::generateShortestPathStmt(const ShortestPathStmt* stmt) {
+    const Symbol* source = stmt->getSource();
+    const Symbol* target = stmt->getTarget();
+    const Symbol* edgeProp = stmt->getEdgeProperty();
+    const Symbol* distance = stmt->getDistVar();
+    const Symbol* path = stmt->getPathVar();
+
+    const std::string_view sourceName = source->getName();
+    const std::string_view targetName = target->getName();
+    const std::string_view edgePropName = edgeProp->getName();
+    const std::string_view distName = distance->getName();
+    const std::string_view pathName = path->getName();
+
+    const GraphMetadata& metadata = _graphView.metadata();
+    const PropertyTypeMap& propMan = metadata.propTypes();
+    const auto maybeProp = propMan.get(edgePropName);
+    bioassert(maybeProp.has_value(), "Invalid property.");
+
+    const PropertyType propertyType = maybeProp.value();
+
+    const VarDecl* sourceDecl = _declContext->getDecl(sourceName);
+    const VarDecl* targetDecl = _declContext->getDecl(targetName);
+    const VarDecl* distDecl = _declContext->getDecl(distName);
+    const VarDecl* pathDecl = _declContext->getDecl(pathName);
+
+    VarNode* sourceNode = _variables->getVarNode(sourceDecl);
+    VarNode* targetNode = _variables->getVarNode(targetDecl);
+
+    insertShortestPathNode(sourceNode, targetNode, propertyType, distDecl, pathDecl);
 }
 
 void ReadStmtGenerator::throwError(std::string_view msg, const void* obj) const {

--- a/query/plan/ReadStmtGenerator.h
+++ b/query/plan/ReadStmtGenerator.h
@@ -34,6 +34,8 @@ class EntityTypeExpr;
 class VarDecl;
 class PlanGenConfig;
 class Predicate;
+class ShortestPathStmt;
+class DeclContext;
 
 class ReadStmtGenerator {
 public:
@@ -41,7 +43,8 @@ public:
                       GraphView graphView,
                       const PlanGenConfig* config,
                       PlanGraph* tree,
-                      PlanGraphVariables* variables);
+                      PlanGraphVariables* variables,
+                      const DeclContext* declCtxt);
 
     ~ReadStmtGenerator();
 
@@ -57,6 +60,7 @@ public:
     void generateVectorSearchStmt(const VectorSearchStmt* stmt);
     void generateWhereClause(const WhereClause* where);
     void generatePatternElement(const PatternElement* element);
+    void generateShortestPathStmt(const ShortestPathStmt* stmt);
 
     VarNode* generatePatternElementOrigin(const NodePattern* origin);
     VarNode* generatePatternElementEdge(PlanGraphNode* prevNode, const EdgePattern* edge);
@@ -92,6 +96,7 @@ private:
     bool _isStandaloneCall {false};
     size_t _queryLimit {0};
     std::unordered_set<const VarDecl*> _edgesInPattern;
+    const DeclContext* _declContext {nullptr};
 
     bool _hasCSVLoad {false};
 


### PR DESCRIPTION
This PR migrates `ShortestPathStmt` as a more general `ReadStmt`, instead of having specialised logic for analysis/generation.

This slims down the `SinglePartQuery` class, as well as moving analysis/generation to `ReadStmtAnalyzer/Generator`.

This PR also slims the logic for adding a query limit by moving logic for setting the query limit to an anonymous function, instead of inline.