### PR TITLE
Add distinct `EmbeddingLiteral` parser rule

### DIFF
--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -192,12 +192,22 @@ void MapLiteral::set(Symbol* key, Expr* value) {
     _map[key] = value;
 }
 
+EmbeddingLiteral::EmbeddingLiteral()
+{
+}
+
 EmbeddingLiteral::EmbeddingLiteral(std::vector<float>&& data)
     : _data(std::move(data))
 {
 }
 
 EmbeddingLiteral::~EmbeddingLiteral() {
+}
+
+EmbeddingLiteral* EmbeddingLiteral::create(CypherAST* ast) {
+    EmbeddingLiteral* literal = new EmbeddingLiteral();
+    ast->addLiteral(literal);
+    return literal;
 }
 
 EmbeddingLiteral* EmbeddingLiteral::create(CypherAST* ast, std::vector<float>&& data) {

--- a/query/AST/Literal.h
+++ b/query/AST/Literal.h
@@ -209,6 +209,8 @@ private:
 
 class EmbeddingLiteral : public Literal {
 public:
+    static EmbeddingLiteral* create(CypherAST* ast);
+
     static EmbeddingLiteral* create(CypherAST* ast, std::vector<float>&& data);
 
     constexpr Kind getKind() const override { return Kind::EMBEDDING; }
@@ -219,10 +221,16 @@ public:
 
     size_t getDimension() const { return _data.size(); }
 
+    // Overload for DIGIT Parser rule
+    void addItem(int64_t x) { _data.push_back(x); }
+    // Overload for DOUBLE Parser rule
+    void addItem(double x) { _data.push_back(x); }
+
 private:
     std::vector<float> _data;
 
-    EmbeddingLiteral(std::vector<float>&& data);
+    EmbeddingLiteral();
+    explicit EmbeddingLiteral(std::vector<float>&& data);
     ~EmbeddingLiteral() override;
 };
 

--- a/query/AST/stmt/VectorSearchStmt.h
+++ b/query/AST/stmt/VectorSearchStmt.h
@@ -8,7 +8,7 @@
 namespace db {
 
 class CypherAST;
-class ListLiteral;
+class EmbeddingLiteral;
 class YieldClause;
 
 class VectorSearchStmt : public Stmt {
@@ -19,18 +19,18 @@ public:
 
     void setIndexName(std::string_view name) { _indexName = name; }
     void setK(uint64_t k) { _k = k; }
-    void setQueryVector(ListLiteral* vec) { _queryVector = vec; }
+    void setQueryVector(EmbeddingLiteral* vec) { _queryVector = vec; }
     void setYield(YieldClause* yield) { _yield = yield; }
 
     std::string_view getIndexName() const { return _indexName; }
     uint64_t getK() const { return _k; }
-    ListLiteral* getQueryVector() const { return _queryVector; }
+    EmbeddingLiteral* getQueryVector() const { return _queryVector; }
     YieldClause* getYield() const { return _yield; }
 
 private:
     std::string_view _indexName;
     uint64_t _k {10};
-    ListLiteral* _queryVector {nullptr};
+    EmbeddingLiteral* _queryVector {nullptr};
     YieldClause* _yield {nullptr};
 
     VectorSearchStmt();

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -479,19 +479,11 @@ void ReadStmtAnalyzer::analyze(const VectorSearchStmt* stmt) {
     }
 
     // Validate vector has elements
-    const ListLiteral* queryVector = stmt->getQueryVector();
-    if (!queryVector || queryVector->empty()) {
+    const EmbeddingLiteral* queryVector = stmt->getQueryVector();
+    const std::span<const float> query = queryVector->getValue();
+
+    if (!queryVector || query.empty()) {
         throwError("VECTOR SEARCH query vector cannot be empty", stmt);
-    }
-
-    // Analyze each element in the query vector
-    for (Expr* elem : queryVector->items()) {
-        _exprAnalyzer->analyzeRootExpr(elem);
-
-        const EvaluatedType elemType = elem->getType();
-        if (elemType != EvaluatedType::Integer && elemType != EvaluatedType::Double) {
-            throwError("VECTOR SEARCH query vector elements must be numeric", stmt);
-        }
     }
 
     // Process YIELD clause - create VarDecl for 'ids' variable

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -329,6 +329,9 @@
 %type<db::ShowVectorIndexesQuery*> showVectorIndexesQuery
 %type<db::VectorSearchStmt*> vectorSearchSt
 %type<vec::DistanceMetric> distanceMetric
+%type<db::EmbeddingLiteral*> embeddingLit
+%type<db::EmbeddingLiteral*> embeddingLitItems
+%type<double> embeddingLitItem
 %type<db::ListLiteral*> listLit
 %type<db::ListLiteral*> listLitItems
 %type<db::Expr*> listLitItem
@@ -500,7 +503,7 @@ showVectorIndexesQuery
 
 // VECTOR SEARCH IN vector1 FOR 10 [0.1, 0.2, ...] YIELD ids
 vectorSearchSt
-    : VECTOR SEARCH IN ID FOR DIGIT listLit yieldClause {
+    : VECTOR SEARCH IN ID FOR DIGIT embeddingLit yieldClause {
         $$ = VectorSearchStmt::create(ast);
         $$->setIndexName($4);
         $$->setK(static_cast<uint64_t>($6));
@@ -1354,13 +1357,8 @@ literal
     | numLit { $$ = $1; }
     | NULL_ { $$ = NullLiteral::create(ast); }
     | stringLit { $$ = $1; }
-    | listLit {
-        try {
-            $$ = ParserUtils::listExprToEmbeddingLiteral(ast, $1);
-        } catch (const ParserException&) {
-            $$ = $1;
-        }
-    }
+    | embeddingLit { $$ = $1; }
+    | listLit { $$ = $1; }
     | mapLit { $$ = $1; }
     ;
 
@@ -1378,13 +1376,28 @@ stringLit
     : STRING_LITERAL { $$ = StringLiteral::create(ast, $1); }
     ;
 
-// List literal: build ListExpr directly
+embeddingLit
+    : LT GT { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
+    | LT embeddingLitItems GT { $$ = $2; LOC($$, @$); }
+    ;
+
+embeddingLitItems
+    : embeddingLitItem { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
+    | embeddingLitItems COMMA embeddingLitItem { $$ = $1; $$->addItem($3); }
+    ;
+
+embeddingLitItem
+    : DIGIT { $$ = $1, LOC($$, @$); }
+    | DOUBLE { $$ = $1, LOC($$, @$); }
+    ;
+
+// List literal: build directly
 listLit
     : OBRACK CBRACK { $$ = ListLiteral::create(ast); LOC($$, @$); }
     | OBRACK listLitItems CBRACK { $$ = $2; LOC($$, @$); }
     ;
 
-// Build ListExpr recursively using addItem()
+// Build recursively using addItem()
 listLitItems
     : listLitItem { $$ = ListLiteral::create(ast); $$->addItem($1); }
     | listLitItems COMMA listLitItem { $$ = $1; $$->addItem($3); }

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -1377,8 +1377,7 @@ stringLit
     ;
 
 embeddingLit
-    : OPAREN CPAREN { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
-    | OPAREN embeddingLitItems CPAREN { $$ = $2; LOC($$, @$); }
+    : OPAREN embeddingLitItems CPAREN { $$ = $2; LOC($$, @$); }
     ;
 
 embeddingLitItems

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -1377,18 +1377,18 @@ stringLit
     ;
 
 embeddingLit
-    : LT GT { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
-    | LT embeddingLitItems GT { $$ = $2; LOC($$, @$); }
+    : OPAREN CPAREN { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
+    | OPAREN embeddingLitItems CPAREN { $$ = $2; LOC($$, @$); }
     ;
 
 embeddingLitItems
-    : embeddingLitItem { $$ = EmbeddingLiteral::create(ast); LOC($$, @$); }
+    : embeddingLitItem COMMA embeddingLitItem { $$ = EmbeddingLiteral::create(ast); $$->addItem($1); $$->addItem($3); LOC($$, @$); }
     | embeddingLitItems COMMA embeddingLitItem { $$ = $1; $$->addItem($3); }
     ;
 
 embeddingLitItem
-    : DIGIT { $$ = $1, LOC($$, @$); }
-    | DOUBLE { $$ = $1, LOC($$, @$); }
+    : DIGIT { $$ = $1; LOC($$, @$); }
+    | DOUBLE { $$ = $1; LOC($$, @$); }
     ;
 
 // List literal: build directly

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -188,28 +188,10 @@ void ReadStmtGenerator::generateLoadCSVStmt(const LoadCSVStmt* stmt) {
 }
 
 void ReadStmtGenerator::generateVectorSearchStmt(const VectorSearchStmt* stmt) {
-    // Extract float values from ListExpr
-    std::vector<float> queryVector;
-    const ListLiteral* listExpr = stmt->getQueryVector();
+    const EmbeddingLiteral* embExpr = stmt->getQueryVector();
+    std::span<const float> querySpan = embExpr->getValue();
 
-    for (Expr* elem : listExpr->items()) {
-        if (elem->getKind() != Expr::Kind::LITERAL) {
-            throwError("VECTOR SEARCH query vector elements must be literals", stmt);
-        }
-
-        const LiteralExpr* litExpr = static_cast<const LiteralExpr*>(elem);
-        const Literal* lit = litExpr->getLiteral();
-
-        if (lit->getKind() == Literal::Kind::DOUBLE) {
-            const DoubleLiteral* doubleLit = static_cast<const DoubleLiteral*>(lit);
-            queryVector.push_back(static_cast<float>(doubleLit->getValue()));
-        } else if (lit->getKind() == Literal::Kind::INTEGER) {
-            const IntegerLiteral* intLit = static_cast<const IntegerLiteral*>(lit);
-            queryVector.push_back(static_cast<float>(intLit->getValue()));
-        } else {
-            throwError("VECTOR SEARCH query vector elements must be numeric", stmt);
-        }
-    }
+    std::vector<float> queryVector(begin(querySpan), end(querySpan));
 
     VectorSearchNode* node = _tree->create<VectorSearchNode>(
         stmt->getIndexName(),

--- a/regress/embedding_properties/main.py
+++ b/regress/embedding_properties/main.py
@@ -29,9 +29,9 @@ def main():
     client.checkout(change=change)
 
     # Create nodes with embedding properties
-    client.query('CREATE (n:Vec {name: "a", vec: [0.3, 0.7, 0.5]})')
-    client.query('CREATE (n:Vec {name: "b", vec: [0.9, 0.2, 0.4]})')
-    client.query('CREATE (n:Vec {name: "c", vec: [0.1, 0.8, 0.6]})')
+    client.query('CREATE (n:Vec {name: "a", vec: (0.3, 0.7, 0.5)})')
+    client.query('CREATE (n:Vec {name: "b", vec: (0.9, 0.2, 0.4)})')
+    client.query('CREATE (n:Vec {name: "c", vec: (0.1, 0.8, 0.6)})')
 
     # Submit the change and checkout HEAD
     client.query("COMMIT")
@@ -65,7 +65,7 @@ def main():
     # --- Test 2: cosine_similarity function ---
     cos_ref = [0.4, 0.3, 0.8]
     result = client.query(
-        "MATCH (n:Vec) RETURN n.name, cosine_similarity(n.vec, [0.4, 0.3, 0.8])"
+        "MATCH (n:Vec) RETURN n.name, cosine_similarity(n.vec, (0.4, 0.3, 0.8))"
     )
     cos_names = list(result["n.name"])
     cos_col = [c for c in result.columns if c != "n.name"][0]
@@ -83,7 +83,7 @@ def main():
     # --- Test 3: euclidean_distance function ---
     euc_ref = [0.2, 0.5, 0.3]
     result = client.query(
-        "MATCH (n:Vec) RETURN n.name, euclidean_distance(n.vec, [0.2, 0.5, 0.3])"
+        "MATCH (n:Vec) RETURN n.name, euclidean_distance(n.vec, (0.2, 0.5, 0.3))"
     )
     euc_names = list(result["n.name"])
     euc_col = [c for c in result.columns if c != "n.name"][0]

--- a/regress/load_jsonl_reactome/main.py
+++ b/regress/load_jsonl_reactome/main.py
@@ -68,7 +68,7 @@ def test_vector_search_match(client: turingdb.TuringDB, data_dir: str) -> None:
     # This query previously threw "Incompatible right key type for string hash join"
     # because ids was UInt64 and n.dbId was Int64
     result = client.query(
-        "VECTOR SEARCH IN reactome_index FOR 3 [1.0, 0.0, 0.0, 0.0] "
+        "VECTOR SEARCH IN reactome_index FOR 3 (1.0, 0.0, 0.0, 0.0) "
         "YIELD ids MATCH (n) WHERE n.dbId = ids "
         "RETURN n.dbId, n.displayName"
     )

--- a/regress/vector_serialization/main.py
+++ b/regress/vector_serialization/main.py
@@ -116,13 +116,13 @@ if __name__ == "__main__":
 
         # Query for vector closest to [0,0,0,0,0,0,0,0] - should be ID 0
         results_before_1 = test_vector_search(
-            client, "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]", 0, "Query for origin"
+            client, "(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)", 0, "Query for origin"
         )
 
         # Query for vector closest to [1,0,0,0,0,0,0,0] - should be ID 1
         results_before_2 = test_vector_search(
             client,
-            "[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]",
+            "(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)",
             1,
             "Query for [1,0,0,...]",
         )
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         # Query for vector closest to [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8] - should be ID 6
         results_before_3 = test_vector_search(
             client,
-            "[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]",
+            "(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8)",
             6,
             "Query for [0.1,0.2,...]",
         )
@@ -164,19 +164,19 @@ if __name__ == "__main__":
         print(f"- {BLUE}Testing vector search after restart{NC}")
 
         results_after_1 = test_vector_search(
-            client, "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]", 0, "Query for origin"
+            client, "(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)", 0, "Query for origin"
         )
 
         results_after_2 = test_vector_search(
             client,
-            "[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]",
+            "(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)",
             1,
             "Query for [1,0,0,...]",
         )
 
         results_after_3 = test_vector_search(
             client,
-            "[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]",
+            "(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8)",
             6,
             "Query for [0.1,0.2,...]",
         )

--- a/samples/gnn/main.cpp
+++ b/samples/gnn/main.cpp
@@ -103,13 +103,13 @@ static void appendEmbeddingLiteral(std::string& s,
                                    const Matrix& m,
                                    size_t row) {
     char buf[32];
-    s += '[';
+    s += '(';
     for (size_t d = 0; d < m._cols; d++) {
         if (d > 0) s += ", ";
         int n = snprintf(buf, sizeof(buf), "%.6f", m.at(row, d));
         s.append(buf, n);
     }
-    s += ']';
+    s += ')';
 }
 
 static void appendUInt64(std::string& s, uint64_t v) {

--- a/test/query-test-suite/tests/fail-vector-search-0.json
+++ b/test/query-test-suite/tests/fail-vector-search-0.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
   "graph": "simpledb",
-  "query": "VECTOR SEARCH IN embeddings FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids",
+  "query": "VECTOR SEARCH IN embeddings FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids RETURN ids",
   "expect": {
     "plan": "flowchart TD\n    0[\"`\n        __VECTOR_SEARCH__\n    `\"]\n    1[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->1",
     "result": "EXEC ERROR\nVector index 'embeddings' not found",

--- a/test/query-test-suite/tests/fail-vector-search-match-0.json
+++ b/test/query-test-suite/tests/fail-vector-search-match-0.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
   "graph": "simpledb",
-  "query": "VECTOR SEARCH IN embeddings FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids MATCH (n) RETURN n, ids",
+  "query": "VECTOR SEARCH IN embeddings FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids MATCH (n) RETURN n, ids",
   "expect": {
     "plan": "flowchart TD\n    0[\"`\n        __VECTOR_SEARCH__\n    `\"]\n    1[\"`\n        __SCAN_NODES__\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n    `\"]\n    4[\"`\n        __CARTESIAN_PRODUCT__\n    `\"]\n    5[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->4\n    1-->3\n    2-->4\n    3-->2\n    4-->5",
     "result": "EXEC ERROR\nVector index 'embeddings' not found",

--- a/test/query-test-suite/tests/return-hetero-list.json
+++ b/test/query-test-suite/tests/return-hetero-list.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
   "graph": "simpledb",
-  "query": "return [true, \"i love turingdb\", 20.3, [1,2,3,4]] as list",
+  "query": "return [true, \"i love turingdb\", 20.3, (1,2,3,4)] as list",
   "expect": {
     "plan": "flowchart TD\n    0[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): list\n    `\"]\n    1[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->1",
     "result": "list\n\"[true, i love turingdb, 20.3, [1.000000,2.000000,3.000000,4.000000]]\"",

--- a/test/query/queries/ConstScanOptTest.cpp
+++ b/test/query/queries/ConstScanOptTest.cpp
@@ -435,7 +435,7 @@ TEST_F(ConstScanOptTest, setPropertyUsesConstScan) {
     const NodeID nid = *read().scanNodes().begin();
 
     const std::string q = fmt::format(
-        "MATCH (n) WHERE n = {} SET n.emb = [1.0, 0.0, 0.0, 0.0]",
+        "MATCH (n) WHERE n = {} SET n.emb = (1.0, 0.0, 0.0, 0.0)",
         nid.getValue());
 
     newChange();
@@ -624,7 +624,7 @@ TEST_F(ConstScanOptTest, constWriteSourceEmbeddingTwoNodes) {
     const NodeID b = *it;
 
     const std::string setQuery = fmt::format(
-        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = [0.0, 0.1], b.emb = [1.0, 0.0]",
+        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = (0.0, 0.1), b.emb = (1.0, 0.0)",
         a.getValue(), b.getValue());
 
     newChange();
@@ -686,7 +686,7 @@ TEST_F(ConstScanOptTest, constWriteSourceSameNodeTwice) {
     const NodeID nid = *read().scanNodes().begin();
 
     const std::string setQuery = fmt::format(
-        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = [0.0, 0.1], b.emb = [1.0, 0.0]",
+        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = (0.0, 0.1), b.emb = (1.0, 0.0)",
         nid.getValue(), nid.getValue());
 
     newChange();
@@ -740,7 +740,7 @@ TEST_F(ConstScanOptTest, constWriteSourceCartesianOverlap) {
 
     const std::string setQuery = fmt::format(
         "MATCH (a), (b) WHERE (a = {} OR a = {}) AND (b = {} OR b = {})"
-        " SET a.emb = [0.0, 0.1], b.emb = [0.1, 0.0]",
+        " SET a.emb = (0.0, 0.1), b.emb = (0.1, 0.0)",
         n0.getValue(), n1.getValue(), n1.getValue(), n2.getValue());
 
     newChange();

--- a/test/query/queries/EmbeddingQueriesTest.cpp
+++ b/test/query/queries/EmbeddingQueriesTest.cpp
@@ -167,7 +167,7 @@ TEST_F(EmbeddingQueriesTest, createMultipleNodesWithEmbeddings) {
 }
 
 TEST_F(EmbeddingQueriesTest, createNodeWithIntegerEmbedding) {
-    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: [1, 2, 3]}))";
+    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: (1, 2, 3)}))";
     constexpr std::string_view MATCH_QUERY = R"(MATCH (n) RETURN n.vec)";
 
     {
@@ -203,7 +203,7 @@ TEST_F(EmbeddingQueriesTest, createNodeWithIntegerEmbedding) {
 }
 
 TEST_F(EmbeddingQueriesTest, createNodeWithMixedNumericEmbedding) {
-    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: [1, 2.5, 3]}))";
+    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: (1, 2.5, 3)}))";
     constexpr std::string_view MATCH_QUERY = R"(MATCH (n) RETURN n.vec)";
 
     {
@@ -251,11 +251,11 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "n0",  vec: [1.0, 0.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n1",  vec: [0.0, 1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n2",  vec: [1.0, 0.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n3",  vec: [0.0, 0.0, 1.0]}))",
-            R"(CREATE (n:Vec {name: "n4",  vec: [1.0, 1.0, 0.0]}))",
+            R"(CREATE (n:Vec {name: "n0",  vec: (1.0, 0.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n1",  vec: (0.0, 1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n2",  vec: (1.0, 0.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n3",  vec: (0.0, 0.0, 1.0)}))",
+            R"(CREATE (n:Vec {name: "n4",  vec: (1.0, 1.0, 0.0)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -267,11 +267,11 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "n5",  vec: [0.0, 1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n6",  vec: [1.0, 0.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n7",  vec: [0.0, 0.0, 1.0]}))",
-            R"(CREATE (n:Vec {name: "n8",  vec: [1.0, 1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n9",  vec: [1.0, 0.0, 0.0]}))",
+            R"(CREATE (n:Vec {name: "n5",  vec: (0.0, 1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n6",  vec: (1.0, 0.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n7",  vec: (0.0, 0.0, 1.0)}))",
+            R"(CREATE (n:Vec {name: "n8",  vec: (1.0, 1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n9",  vec: (1.0, 0.0, 0.0)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -283,11 +283,11 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "n10", vec: [0.0, 1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n11", vec: [0.0, 0.0, 1.0]}))",
-            R"(CREATE (n:Vec {name: "n12", vec: [1.0, 0.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n13", vec: [1.0, 1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "n14", vec: [0.0, 1.0, 0.0]}))",
+            R"(CREATE (n:Vec {name: "n10", vec: (0.0, 1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n11", vec: (0.0, 0.0, 1.0)}))",
+            R"(CREATE (n:Vec {name: "n12", vec: (1.0, 0.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n13", vec: (1.0, 1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "n14", vec: (0.0, 1.0, 0.0)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -310,7 +310,7 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     // Expected: n0, n2, n6, n9, n12
     {
         constexpr std::string_view MATCH_A =
-            R"(MATCH (n:Vec {vec: [1.0, 0.0, 0.0]}) RETURN n.name)";
+            R"(MATCH (n:Vec {vec: (1.0, 0.0, 0.0)}) RETURN n.name)";
 
         std::vector<std::string> actualNames;
         auto res = query(MATCH_A, [&](const Dataframe* df) {
@@ -334,7 +334,7 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     // Expected: n1, n5, n10, n14
     {
         constexpr std::string_view MATCH_B =
-            R"(MATCH (n:Vec {vec: [0.0, 1.0, 0.0]}) RETURN n.name)";
+            R"(MATCH (n:Vec {vec: (0.0, 1.0, 0.0)}) RETURN n.name)";
 
         std::vector<std::string> actualNames;
         auto res = query(MATCH_B, [&](const Dataframe* df) {
@@ -358,7 +358,7 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     // Expected: n3, n7, n11
     {
         constexpr std::string_view MATCH_C =
-            R"(MATCH (n:Vec {vec: [0.0, 0.0, 1.0]}) RETURN n.name)";
+            R"(MATCH (n:Vec {vec: (0.0, 0.0, 1.0)}) RETURN n.name)";
 
         std::vector<std::string> actualNames;
         auto res = query(MATCH_C, [&](const Dataframe* df) {
@@ -382,7 +382,7 @@ TEST_F(EmbeddingQueriesTest, multiCommitEmbeddingEqualityMatch) {
     // Expected: n4, n8, n13
     {
         constexpr std::string_view MATCH_D =
-            R"(MATCH (n:Vec {vec: [1.0, 1.0, 0.0]}) RETURN n.name)";
+            R"(MATCH (n:Vec {vec: (1.0, 1.0, 0.0)}) RETURN n.name)";
 
         std::vector<std::string> actualNames;
         auto res = query(MATCH_D, [&](const Dataframe* df) {
@@ -410,11 +410,11 @@ TEST_F(EmbeddingQueriesTest, embeddingInequality) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "a1", vec: [1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "a2", vec: [1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "b1", vec: [0.0, 1.0]}))",
-            R"(CREATE (n:Vec {name: "a3", vec: [1.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "b2", vec: [0.0, 1.0]}))",
+            R"(CREATE (n:Vec {name: "a1", vec: (1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "a2", vec: (1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "b1", vec: (0.0, 1.0)}))",
+            R"(CREATE (n:Vec {name: "a3", vec: (1.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "b2", vec: (0.0, 1.0)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -425,7 +425,7 @@ TEST_F(EmbeddingQueriesTest, embeddingInequality) {
     // n.vec <> [1.0, 0.0] should return b1, b2
     {
         constexpr std::string_view MATCH_NEQ =
-            R"(MATCH (n:Vec) WHERE n.vec <> [1.0, 0.0] RETURN n.name)";
+            R"(MATCH (n:Vec) WHERE n.vec <> (1.0, 0.0) RETURN n.name)";
 
         std::vector<std::string> actualNames;
         auto res = query(MATCH_NEQ, [&](const Dataframe* df) {
@@ -450,9 +450,9 @@ TEST_F(EmbeddingQueriesTest, cosineSimilarity) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "a", vec: [0.3, 0.7, 0.5]}))",
-            R"(CREATE (n:Vec {name: "b", vec: [0.9, 0.2, 0.4]}))",
-            R"(CREATE (n:Vec {name: "c", vec: [0.1, 0.8, 0.6]}))",
+            R"(CREATE (n:Vec {name: "a", vec: (0.3, 0.7, 0.5)}))",
+            R"(CREATE (n:Vec {name: "b", vec: (0.9, 0.2, 0.4)}))",
+            R"(CREATE (n:Vec {name: "c", vec: (0.1, 0.8, 0.6)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -484,7 +484,7 @@ TEST_F(EmbeddingQueriesTest, cosineSimilarity) {
     std::vector<double> scores;
     {
         constexpr std::string_view QUERY =
-            R"(MATCH (n:Vec) RETURN n.name, cosine_similarity(n.vec, [0.4, 0.3, 0.8]))";
+            R"(MATCH (n:Vec) RETURN n.name, cosine_similarity(n.vec, (0.4, 0.3, 0.8)))";
 
         auto res = query(QUERY, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
@@ -523,9 +523,9 @@ TEST_F(EmbeddingQueriesTest, euclideanDistance) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "a", vec: [0.3, 0.7, 0.5]}))",
-            R"(CREATE (n:Vec {name: "b", vec: [0.9, 0.2, 0.4]}))",
-            R"(CREATE (n:Vec {name: "c", vec: [0.1, 0.8, 0.6]}))",
+            R"(CREATE (n:Vec {name: "a", vec: (0.3, 0.7, 0.5)}))",
+            R"(CREATE (n:Vec {name: "b", vec: (0.9, 0.2, 0.4)}))",
+            R"(CREATE (n:Vec {name: "c", vec: (0.1, 0.8, 0.6)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -556,7 +556,7 @@ TEST_F(EmbeddingQueriesTest, euclideanDistance) {
     std::vector<double> distances;
     {
         constexpr std::string_view QUERY =
-            R"(MATCH (n:Vec) RETURN n.name, euclidean_distance(n.vec, [0.2, 0.5, 0.3]))";
+            R"(MATCH (n:Vec) RETURN n.name, euclidean_distance(n.vec, (0.2, 0.5, 0.3)))";
 
         auto res = query(QUERY, [&](const Dataframe* df) {
             ASSERT_TRUE(df);
@@ -591,42 +591,8 @@ TEST_F(EmbeddingQueriesTest, euclideanDistance) {
     }
 }
 
-TEST_F(EmbeddingQueriesTest, createNodeWithSingleElementEmbedding) {
-    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: [4.2]}))";
-    constexpr std::string_view MATCH_QUERY = R"(MATCH (n) RETURN n.vec)";
-
-    {
-        newChange();
-        auto res = query(CREATE_QUERY, [](const Dataframe* df) { ASSERT_TRUE(df); });
-        ASSERT_TRUE(res);
-        submitCurrentChange();
-    }
-
-    std::vector<std::vector<float>> actualVecs;
-    {
-        auto res = query(MATCH_QUERY, [&](const Dataframe* df) {
-            ASSERT_TRUE(df);
-            ASSERT_EQ(df->size(), 1);
-
-            const auto* vecs = df->cols().front()->as<ColumnOptVector<types::Embedding::Primitive>>();
-            ASSERT_TRUE(vecs);
-
-            const size_t rowCount = df->getLogicalRowCount();
-            for (size_t i = 0; i < rowCount; i++) {
-                ASSERT_TRUE(vecs->at(i));
-                const auto& emb = *vecs->at(i);
-                actualVecs.emplace_back(emb.begin(), emb.end());
-            }
-        });
-        ASSERT_TRUE(res);
-    }
-
-    ASSERT_EQ(actualVecs.size(), 1);
-    expectEmbedding(actualVecs[0], {4.2f});
-}
-
 TEST_F(EmbeddingQueriesTest, createNodeWithEmptyEmbeddingFails) {
-    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: []}))";
+    constexpr std::string_view CREATE_QUERY = R"(CREATE (n:Vec {vec: ()}))";
 
     newChange();
     auto res = query(CREATE_QUERY, [](const Dataframe*) {});
@@ -634,7 +600,7 @@ TEST_F(EmbeddingQueriesTest, createNodeWithEmptyEmbeddingFails) {
 }
 
 TEST_F(EmbeddingQueriesTest, returnVectorLiteral) {
-    constexpr std::string_view QUERY = R"(RETURN [1.0, 2.0, 3.0])";
+    constexpr std::string_view QUERY = R"(RETURN (1.0, 2.0, 3.0))";
 
     std::vector<float> actual;
     {
@@ -661,8 +627,8 @@ TEST_F(EmbeddingQueriesTest, equalityDimensionMismatchReturnsEmpty) {
     {
         newChange();
         for (auto&& q : {
-            R"(CREATE (n:Vec {name: "a", vec: [1.0, 0.0, 0.0]}))",
-            R"(CREATE (n:Vec {name: "b", vec: [0.0, 1.0, 0.0]}))",
+            R"(CREATE (n:Vec {name: "a", vec: (1.0, 0.0, 0.0)}))",
+            R"(CREATE (n:Vec {name: "b", vec: (0.0, 1.0, 0.0)}))",
         }) {
             auto res = query(q, [](const Dataframe* df) { ASSERT_TRUE(df); });
             ASSERT_TRUE(res);
@@ -672,7 +638,7 @@ TEST_F(EmbeddingQueriesTest, equalityDimensionMismatchReturnsEmpty) {
 
     {
         constexpr std::string_view MATCH_SHORT =
-            R"(MATCH (n:Vec {vec: [1.0, 0.0]}) RETURN n.name)";
+            R"(MATCH (n:Vec {vec: (1.0, 0.0)}) RETURN n.name)";
 
         size_t rowCount = 0;
         auto res = query(MATCH_SHORT, [&](const Dataframe* df) {

--- a/test/query/queries/EmbeddingQueriesTest.cpp
+++ b/test/query/queries/EmbeddingQueriesTest.cpp
@@ -76,7 +76,7 @@ protected:
 
 TEST_F(EmbeddingQueriesTest, createNodeWithEmbedding) {
     constexpr std::string_view CREATE_QUERY =
-        R"(CREATE (n:Vec {name: "a", vec: [1.0, 2.0, 3.0]}))";
+        R"(CREATE (n:Vec {name: "a", vec: (1.0, 2.0, 3.0)}))";
     constexpr std::string_view MATCH_QUERY =
         R"(MATCH (n) RETURN n.name, n.vec)";
 
@@ -119,9 +119,9 @@ TEST_F(EmbeddingQueriesTest, createNodeWithEmbedding) {
 }
 
 TEST_F(EmbeddingQueriesTest, createMultipleNodesWithEmbeddings) {
-    constexpr std::string_view CREATE_A = R"(CREATE (n:Vec {name: "a", vec: [1.0, 0.0, 0.0]}))";
-    constexpr std::string_view CREATE_B = R"(CREATE (n:Vec {name: "b", vec: [0.0, 1.0, 0.0]}))";
-    constexpr std::string_view CREATE_C = R"(CREATE (n:Vec {name: "c", vec: [1.0, 0.0, 0.0]}))";
+    constexpr std::string_view CREATE_A = R"(CREATE (n:Vec {name: "a", vec: (1.0, 0.0, 0.0)}))";
+    constexpr std::string_view CREATE_B = R"(CREATE (n:Vec {name: "b", vec: (0.0, 1.0, 0.0)}))";
+    constexpr std::string_view CREATE_C = R"(CREATE (n:Vec {name: "c", vec: (1.0, 0.0, 0.0)}))";
     constexpr std::string_view MATCH_QUERY = R"(MATCH (n) RETURN n.name, n.vec)";
 
     {

--- a/test/query/queries/VectorQueriesTest.cpp
+++ b/test/query/queries/VectorQueriesTest.cpp
@@ -368,7 +368,7 @@ TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
 
     // Search for vectors closest to query
     bool executed = false;
-    const auto res = query("VECTOR SEARCH IN search_test FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
+    const auto res = query("VECTOR SEARCH IN search_test FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
             ASSERT_EQ(df->getLogicalRowCount(), k);
@@ -432,7 +432,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
 
     // Search for top 2
     bool executed = false;
-    const auto res = query("VECTOR SEARCH IN k_test FOR 2 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
+    const auto res = query("VECTOR SEARCH IN k_test FOR 2 (1.0, 0.0, 0.0, 0.0) YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->getLogicalRowCount(), k);
 
@@ -496,7 +496,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithHighPrecisionFloats) {
 
     // Search for vectors closest to query
     bool executed = false;
-    const auto res = query("VECTOR SEARCH IN precision_test FOR 3 [0.123456, 0.678901, 0.111111, 0.222222] "
+    const auto res = query("VECTOR SEARCH IN precision_test FOR 3 (0.123456, 0.678901, 0.111111, 0.222222) "
         "YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);
             ASSERT_EQ(df->cols().size(), 1);
@@ -595,7 +595,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
 
     // Step 3b: Verify vector search works standalone
     {
-        const auto searchRes = query("VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
+        const auto searchRes = query("VECTOR SEARCH IN doc_vectors FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids RETURN ids", "default", [&](const Dataframe* df) -> void {
                 ASSERT_TRUE(df != nullptr);
                 ASSERT_EQ(df->getLogicalRowCount(), 3) << "Expected 3 vector search results";
             });
@@ -614,7 +614,7 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
     const std::vector<std::string> expectedTitles = {"Doc One", "Doc Two", "Doc Three"};
 
     bool executed = false;
-    const auto res = query("VECTOR SEARCH IN doc_vectors FOR 3 [1.0, 0.0, 0.0, 0.0] YIELD ids "
+    const auto res = query("VECTOR SEARCH IN doc_vectors FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids "
         "MATCH (n:Document) WHERE n.id = ids "
         "RETURN n.id, n.title", "default", [&](const Dataframe* df) -> void {
             ASSERT_TRUE(df != nullptr);

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -3362,7 +3362,7 @@ TEST_F(WriteQueriesTest, setEmbeddingOnTwoNodesByID) {
     const NodeID b = *it;
 
     const std::string setQuery = fmt::format(
-        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = [0.0, 0.1], b.emb = [1.0, 0.0]",
+        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = (0.0, 0.1), b.emb = (1.0, 0.0)",
         a.getValue(), b.getValue());
 
     newChange();
@@ -3417,7 +3417,7 @@ TEST_F(WriteQueriesTest, setEmbeddingSameNodeTwice) {
     const NodeID nid = *read().scanNodes().begin();
 
     const std::string setQuery = fmt::format(
-        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = [0.0, 0.1], b.emb = [1.0, 0.0]",
+        "MATCH (a), (b) WHERE a = {} AND b = {} SET a.emb = (0.0, 0.1), b.emb = (1.0, 0.0)",
         nid.getValue(), nid.getValue());
 
     newChange();
@@ -3464,7 +3464,7 @@ TEST_F(WriteQueriesTest, setEmbeddingCartesianOverlap) {
 
     const std::string setQuery = fmt::format(
         "MATCH (a), (b) WHERE (a = {} OR a = {}) AND (b = {} OR b = {})"
-        " SET a.emb = [0.0, 0.1], b.emb = [0.1, 0.0]",
+        " SET a.emb = (0.0, 0.1), b.emb = (0.1, 0.0)",
         n0.getValue(), n1.getValue(), n1.getValue(), n2.getValue());
 
     newChange();


### PR DESCRIPTION
This PR changes embeddings in the parser to use `()` rather than `[]` to prevent conflicts with lists in parsing, analysis, and generation.

A new constraint is added that the embedding has a dimension of at least 2.