### PR TITLE
Log the reason on LOAD GRAPH failure (#618)

### DIFF
--- a/system/SystemManager.cpp
+++ b/system/SystemManager.cpp
@@ -175,10 +175,14 @@ Graph* SystemManager::loadGraph(const std::string& name) {
     Graph* graphPtr = graph.get();
 
     if (const auto res = graph->getSerializer().load(); !res) {
+        spdlog::error("Failed to load graph '{}' from {}: {}",
+                      name, graphPath.get(), res.error().fmtMessage());
         return nullptr;
     }
 
     if (!addGraph(std::move(graph))) {
+        spdlog::error("Failed to register graph '{}': "
+                      "a graph with this name is already loaded", name);
         return nullptr;
     }
 


### PR DESCRIPTION
## Summary
- Both failure paths in `SystemManager::loadGraph` were returning `nullptr` silently, so the `GRAPH_LOAD_ERROR` seen on the server endpoint surfaced to the client with no diagnostic anywhere in the TuringDB log (see #618 for the symptom).
- Mirror the pattern already used in `createGraph` a few lines below: emit `spdlog::error` with the underlying `DumpError::fmtMessage()` on serializer failure, plus a distinct line for the `addGraph` "name already loaded" collision case.