### PR TITLE
Fix dependency and versioning issues on older builds

### DIFF
--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1948,8 +1948,8 @@ PipelineOutputInterface* PipelineGenerator::translateUnwindNode(UnwindNode* node
 
     const PipelineValuesOutputInterface* unwindOut {nullptr};
 
-    std::optional<EvaluatedType> maybeEvalHomogeneity = node->homogeneity();
-    std::optional<ValueType> maybeHomogeneity =
+    const std::optional<EvaluatedType> maybeEvalHomogeneity = node->homogeneity();
+    const std::optional<ValueType> maybeHomogeneity =
         maybeEvalHomogeneity ? toValueType(*maybeEvalHomogeneity) : std::nullopt;
 
     const bool canHomogenise = maybeHomogeneity.has_value();

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1948,7 +1948,9 @@ PipelineOutputInterface* PipelineGenerator::translateUnwindNode(UnwindNode* node
 
     const PipelineValuesOutputInterface* unwindOut {nullptr};
 
-    std::optional<ValueType> maybeHomogeneity = node->homogeneity().and_then(toValueType);
+    std::optional<EvaluatedType> maybeEvalHomogeneity = node->homogeneity();
+    std::optional<ValueType> maybeHomogeneity =
+        maybeEvalHomogeneity ? toValueType(*maybeEvalHomogeneity) : std::nullopt;
 
     const bool canHomogenise = maybeHomogeneity.has_value();
     if (canHomogenise) {

--- a/storage/DebugDump.cpp
+++ b/storage/DebugDump.cpp
@@ -1,5 +1,7 @@
 #include "DebugDump.h"
 
+#include <sstream>
+
 #include <range/v3/view/drop.hpp>
 
 #include "ListElementView.h"


### PR DESCRIPTION
- Adds required include of `<sstream>`
- Removes use of C++23 monadic `std::optional<T>::and_then`

CI Full matrix passing: https://github.com/turing-db/turingdb/actions/runs/25428939392