### PR TITLE
Allow wheel and run_visualizer.sh into docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 *
 !Dockerfile
 !docker/turing_install/**
+!run_visualizer.sh
+!wheel
+!wheel/**


### PR DESCRIPTION
Fix .dockerignore for docker CI