### PR TITLE
Use `memcpy` in `YCypherScanner`

### DIFF
--- a/query/AST/CypherASTDumper.cpp
+++ b/query/AST/CypherASTDumper.cpp
@@ -943,6 +943,11 @@ void CypherASTDumper::dump(std::ostream& out, const LiteralExpr* expr) {
             out << "        CharLiteral '" << charLiteral->getValue() << "'\n";
             break;
         }
+        case Literal::Kind::LIST: {
+            const ListLiteral* listLiteral = dynamic_cast<const ListLiteral*>(literal);
+            out << "        ListLiteral _" << listLiteral << "\n";
+            break;
+        }
         case Literal::Kind::MAP: {
             const MapLiteral* mapLiteral = dynamic_cast<const MapLiteral*>(literal);
             out << "        MapLiteral _" << mapLiteral << "\n";

--- a/query/parser/YCypherScanner.h
+++ b/query/parser/YCypherScanner.h
@@ -32,15 +32,12 @@ public:
         loc.columns(yyleng);
     }
 
-    void locationNewLine(SourceLocation& loc) {
-        loc.lines(1);
-    }
+    static void locationNewLine(SourceLocation& loc) { loc.lines(1); }
 
-    [[noreturn]] void syntaxError(const SourceLocation& loc,
-                                  const std::string& msg);
+    [[noreturn]] void syntaxError(const SourceLocation& loc, const std::string& msg);
 
-    void notImplemented(const SourceLocation& loc,
-                        std::string_view rawMsg);
+    void notImplemented(const SourceLocation& loc, std::string_view rawMsg);
+
 protected:
     int LexerInput(char* buf, int max_size) override {
         size_t remaining = _query.size() - _readPos;

--- a/query/parser/YCypherScanner.h
+++ b/query/parser/YCypherScanner.h
@@ -40,8 +40,8 @@ public:
 
 protected:
     int LexerInput(char* buf, int max_size) override {
-        size_t remaining = _query.size() - _readPos;
-        size_t toRead = std::min<size_t>(max_size, remaining);
+        const size_t remaining = _query.size() - _readPos;
+        const size_t toRead = std::min<size_t>(max_size, remaining);
         if (toRead == 0) {
             return 0;
         }

--- a/query/parser/YCypherScanner.h
+++ b/query/parser/YCypherScanner.h
@@ -39,6 +39,7 @@ public:
     void notImplemented(const SourceLocation& loc, std::string_view rawMsg);
 
 protected:
+    /// Allows the scanner to batch copy query string bytes into the @ref _query buffer
     int LexerInput(char* buf, int max_size) override {
         const size_t remaining = _query.size() - _readPos;
         const size_t toRead = std::min<size_t>(max_size, remaining);
@@ -53,6 +54,7 @@ protected:
 private:
     size_t _nextOffset {0};
     size_t _offset {0};
+    /// Character position in @ref _query which has been consumed so far (inclusive)
     size_t _readPos {0};
     std::string_view _query;
 

--- a/query/parser/YCypherScanner.h
+++ b/query/parser/YCypherScanner.h
@@ -18,7 +18,12 @@ class YCypherScanner : public yyFlexLexer {
 public:
     virtual YCypherParser::token_type lex(YCypherParser::semantic_type* yylval, SourceLocation* yylloc);
 
-    void setQuery(std::string_view query) { _query = query; }
+    void setQuery(std::string_view query) {
+        _query = query;
+        _nextOffset = 0;
+        _offset = 0;
+        _readPos = 0;
+    }
 
     void advanceLocation(SourceLocation& loc, uint64_t yyleng) {
         _offset = _nextOffset;
@@ -36,10 +41,22 @@ public:
 
     void notImplemented(const SourceLocation& loc,
                         std::string_view rawMsg);
+protected:
+    int LexerInput(char* buf, int max_size) override {
+        size_t remaining = _query.size() - _readPos;
+        size_t toRead = std::min<size_t>(max_size, remaining);
+        if (toRead == 0) {
+            return 0;
+        }
+        std::memcpy(buf, _query.data() + _readPos, toRead);
+        _readPos += toRead;
+        return static_cast<int>(toRead);
+    }
 
 private:
     size_t _nextOffset {0};
     size_t _offset {0};
+    size_t _readPos {0};
     std::string_view _query;
 
     std::string_view getStringView(size_t offset, size_t length) const {

--- a/query/plan/PlanGraphTopology.h
+++ b/query/plan/PlanGraphTopology.h
@@ -22,8 +22,7 @@ public:
 
     using PathInfo = std::pair<PlanGraphTopology::PathToDependency, PlanGraphNode*>;
 
-    PathInfo getShortestPath(PlanGraphNode* origin,
-                             PlanGraphNode* target);
+    PathInfo getShortestPath(PlanGraphNode* origin, PlanGraphNode* target);
     PlanGraphNode* getBranchTip(PlanGraphNode* origin);
     bool detectLoopsFrom(PlanGraphNode* origin);
     PlanGraphNode* findCommonSuccessor(PlanGraphNode* a, PlanGraphNode* b);


### PR DESCRIPTION
Override default Flex behaviour to more efficiently read query strings.