### PR TITLE
Fix use-after-free of ARCs

### DIFF
--- a/storage/indexes/IndexManager.cpp
+++ b/storage/indexes/IndexManager.cpp
@@ -15,6 +15,10 @@ IndexManager::IndexManager()
 }
 
 IndexManager::~IndexManager() {
+    // Delete WeakArcs to indexes before deleting the owning ArcManager
+    _nodeIndexes.clear();
+    _edgeIndexes.clear();
+
     _indexes.reset();
 }
 

--- a/storage/versioning/VersionController.cpp
+++ b/storage/versioning/VersionController.cpp
@@ -36,6 +36,7 @@ VersionController::VersionController(Graph* graph)
 VersionController::~VersionController() {
     _commits.clear();
     _dataManager.reset();
+    _partMap.clear(); // Delete all WeakArc<DataPart> before deleting @ref _partManager
     _partManager.reset();
     // @ref ~IndexManager() calls reset() on its arc manager
 }


### PR DESCRIPTION
Explicitly deletes some `WeakArc<T>`s before deleting their owner, to prevent `~WeakArc` from attempting to subtract 1 from a free'd reference count.

Fixes #629.

Verified with
~~~
valgrind --tool=memcheck ./turingdb -in-memory -load reactome
~~~
producing no errors.