### PR TITLE
Fix invalid HashJoins

### DIFF
--- a/query/AST/decl/EvaluatedType.h
+++ b/query/AST/decl/EvaluatedType.h
@@ -87,6 +87,7 @@ using EvaluatedTypeName = EnumToString<EvaluatedType>::Create<
 
 // Evaluated Type to ValueType conversion
 static constexpr size_t VALUE_TYPE_COUNT = std::to_underlying(ValueType::_SIZE);
+static_assert(VALUE_TYPE_COUNT == 7, "ValueType added: please update below map.");
 
 static constexpr std::pair<ValueType, EvaluatedType> EVConversions[VALUE_TYPE_COUNT + 1] = {
     {ValueType::Int64,     EvaluatedType::Integer  },

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -69,8 +69,6 @@
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnVector.h"
 #include "columns/ColumnEdgeTypes.h"
-#include "columns/ColumnDispatcher.h"
-#include "TypeUtils.h"
 
 #include "dataframe/ColumnTag.h"
 #include "dataframe/NamedColumn.h"
@@ -165,22 +163,6 @@ void createHashJoinDataFrameShape(LocalMemory* mem,
     dest->addColumn(newNamedCol);
 }
 
-//The left and right key  need to be of the same type unless they are string/string_view
-template<typename LeftJoinKeyType,typename RightJoinKeyType>
-concept isValidHashJoinTypes =
-(std::is_same_v<LeftJoinKeyType, NodeID> ||
-std::is_same_v<LeftJoinKeyType, EdgeID> ||
-std::is_same_v<LeftJoinKeyType, LabelID> ||
-std::is_same_v<LeftJoinKeyType, EdgeTypeID> ||
-std::is_same_v<LeftJoinKeyType, PropertyTypeID> ||
-std::is_same_v<LeftJoinKeyType, ValueType> ||
-std::is_same_v<LeftJoinKeyType, int64_t> ||
-std::is_same_v<LeftJoinKeyType, uint64_t> ||
-std::is_same_v<LeftJoinKeyType, double> ||
-std::is_same_v<LeftJoinKeyType, CustomBool> ||
-std::is_same_v<LeftJoinKeyType, std::string> ||
-std::is_same_v<LeftJoinKeyType, std::string_view>) &&
-(std::is_same_v<LeftJoinKeyType,RightJoinKeyType> || Stringy<LeftJoinKeyType, RightJoinKeyType>);
 }
 
 PipelineNodeOutputInterface& PipelineBuilder::addScanNodes() {
@@ -574,60 +556,42 @@ PipelineBlockOutputInterface& PipelineBuilder::addHashJoin(PipelineOutputInterfa
     const Dataframe* rhsDf = rhs->getDataframe();
     Column* rightKeyCol = rhsDf->getColumn(rightJoinKey)->getColumn();
 
+    PipelineBlockOutputInterface* result = nullptr;
     {
+        const auto createValueHashJoin = [&]<typename T, typename U>
+            (const ColumnVector<T>*, const ColumnVector<U>*) -> void {
+            // T and U are guaranteed to be a valid VHJ combination due to the dispatcher
+            // taking @ref ValueHashJoinPairs as restrictions
 
-        if (leftKeyCol->getContainerKind() != ContainerKind::code<ColumnVector>()) {
-            throw PipelineException("Can only join on ColumnVectors");
-        }
+            auto* join = HashJoinProcessor<T, U>::create(_pipeline, leftJoinKey, rightJoinKey);
 
-        if (rightKeyCol->getContainerKind() != ContainerKind::code<ColumnVector>()) {
-            throw PipelineException("Can only join on ColumnVectors");
-        }
+            _pendingOutput.connectTo(join->leftInput());
+            rhs->connectTo(join->rightInput());
+
+            const Dataframe* leftDf = join->leftInput().getDataframe();
+            const Dataframe* rightDf = join->rightInput().getDataframe();
+
+            PipelineBlockOutputInterface& outInterface = join->output();
+            Dataframe* outDf = outInterface.getDataframe();
+
+            createHashJoinDataFrameShape(_mem, _dfMan, leftDf, rightDf, outDf,
+                                         leftJoinKey, rightJoinKey);
+
+            _pendingOutput.setInterface(&outInterface);
+
+            _lastProc = join;
+            result = &outInterface;
+        };
+
+        using Types = ValueHashJoinPairs;
+        using FunctorT = decltype(createValueHashJoin);
+        using Dispatcher = ColumnDoubleDispatcher<Types::Allowed, Types::AllowedMixed,
+                                                  FunctorT, Types::Excluded>;
+
+        Dispatcher::dispatch(leftKeyCol, rightKeyCol, createValueHashJoin);
     }
 
-    // Do the hash join connectivity and setup interfaces
-    auto setupJoin = [&](auto* join) -> PipelineBlockOutputInterface& {
-        _pendingOutput.connectTo(join->leftInput());
-        rhs->connectTo(join->rightInput());
-
-        const Dataframe* leftDf = join->leftInput().getDataframe();
-        const Dataframe* rightDf = join->rightInput().getDataframe();
-
-        PipelineBlockOutputInterface& outInterface = join->output();
-        Dataframe* outDf = outInterface.getDataframe();
-
-        createHashJoinDataFrameShape(_mem, _dfMan, leftDf, rightDf, outDf,
-                                     leftJoinKey, rightJoinKey);
-
-        _pendingOutput.setInterface(&outInterface);
-
-        _lastProc = join;
-        return outInterface;
-    };
-
-    // Create the join depending on the type combination of the keys
-    PipelineBlockOutputInterface* result = nullptr;
-
-    dispatchColumnVector(leftKeyCol, [&](auto* typedCol) {
-        using LeftJoinKeyType = typename std::decay_t<decltype(*typedCol)>::ValueType;
-        using UnwrappedLeftKey = TypeUtils::unwrap_optional_t<LeftJoinKeyType>;
-
-        dispatchColumnVector(rightKeyCol, [&](auto* rightTypedCol) {
-            using RightJoinKeyType = typename std::decay_t<decltype(*rightTypedCol)>::ValueType;
-            using UnwrappedRightKey = TypeUtils::unwrap_optional_t<RightJoinKeyType>;
-
-            if constexpr ((isValidHashJoinTypes<UnwrappedLeftKey, UnwrappedRightKey>)) {
-                auto* join = HashJoinProcessor<LeftJoinKeyType, RightJoinKeyType>::create(_pipeline,
-                                                                                          leftJoinKey,
-                                                                                          rightJoinKey);
-                result = &setupJoin(join);
-            } else {
-                throw PipelineException("Incompatible right key type for string hash join");
-            }
-        });
-    });
-
-    bioassert(result, "HashJoin Processor Result Is A Null Pointer");
+    bioassert(result, "Failed to add HashJoinProcessor.");
     return *result;
 }
 

--- a/query/plan/CMakeLists.txt
+++ b/query/plan/CMakeLists.txt
@@ -20,6 +20,7 @@ set(plan_sources
     nodes/ExprEvalNode.cpp
     nodes/ConstScanNode.cpp
     nodes/ConstWriteSourceNode.cpp
+    nodes/JoinNode.cpp
 )
 
 add_library(turing_db_plan_s STATIC ${plan_sources})

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -709,12 +709,13 @@ bool ReadStmtGenerator::shouldPlaceValueHashJoin(VarNode* localVar, PlanGraphNod
             }
         }
         return !estimation.shouldPreferCartesian(leftLabels, rightLabels, _queryLimit);
-    } else {
-        // In the case where we have a Call procedure yield in the expression (for now
-        // this would only work if the yield item is on the rhs), we default the
-        // right side cardinality to 10
-        return !estimation.shouldPreferCartesian(leftLabels, 10, _queryLimit);
     }
+
+    // In the case where we have a Call procedure yield in the expression (for now
+    // this would only work if the yield item is on the rhs), we default the
+    // right side cardinality to 10
+    constexpr size_t naiveCardinalityEstimation = 10;
+    return !estimation.shouldPreferCartesian(leftLabels, naiveCardinalityEstimation, _queryLimit);
 }
 
 void ReadStmtGenerator::placeJoinsOnProcedures() {

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -998,6 +998,16 @@ bool ReadStmtGenerator::tryPlaceValueHashJoin(FilterNode* filter, VarNode* node,
     const Expr* lhs = binExpr->getLHS();
     const Expr* rhs = binExpr->getRHS();
 
+    const EvaluatedType lhsType = lhs->getType();
+    const EvaluatedType rhsType = rhs->getType();
+
+    // @ref ExprAnalyzer is more liberal with types that can be compared with equality
+    // than the VHJ. Perform an additional check to ensure the types are actually
+    // joinable.
+    if (!JoinNode::joinableTypes(lhsType, rhsType)) {
+        return false;
+    }
+
     const bool isValidLhs = lhs->getKind() == Expr::Kind::SYMBOL || lhs->getKind() == Expr::Kind::PROPERTY;
     const bool isValidRhs = rhs->getKind() == Expr::Kind::SYMBOL || rhs->getKind() == Expr::Kind::PROPERTY;
     const bool isEqualityPred = binExpr->getOperator() == BinaryOperator::Equal;

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -709,13 +709,13 @@ bool ReadStmtGenerator::shouldPlaceValueHashJoin(VarNode* localVar, PlanGraphNod
             }
         }
         return !estimation.shouldPreferCartesian(leftLabels, rightLabels, _queryLimit);
+    } else {
+        // In the case where we have a Call procedure yield in the expression (for now
+        // this would only work if the yield item is on the rhs), we default the
+        // right side cardinality to 10
+        constexpr size_t naiveCardinalityEstimation = 10;
+        return !estimation.shouldPreferCartesian(leftLabels, naiveCardinalityEstimation, _queryLimit);
     }
-
-    // In the case where we have a Call procedure yield in the expression (for now
-    // this would only work if the yield item is on the rhs), we default the
-    // right side cardinality to 10
-    constexpr size_t naiveCardinalityEstimation = 10;
-    return !estimation.shouldPreferCartesian(leftLabels, naiveCardinalityEstimation, _queryLimit);
 }
 
 void ReadStmtGenerator::placeJoinsOnProcedures() {

--- a/query/plan/nodes/JoinNode.cpp
+++ b/query/plan/nodes/JoinNode.cpp
@@ -1,0 +1,10 @@
+#include "JoinNode.h"
+#include "decl/EvaluatedType.h"
+
+using namespace db;
+
+// NOTE: This should be synced with @ref ValueHashJoinPairs
+bool JoinNode::joinableTypes(EvaluatedType a, EvaluatedType b) {
+    const bool same = a == b;
+    return same;
+}

--- a/query/plan/nodes/JoinNode.h
+++ b/query/plan/nodes/JoinNode.h
@@ -43,6 +43,8 @@ public:
     const VarDecl* getDependencyVarDecl() const { return _dependencyVarDecl; }
     JoinType getJoinType() const { return _type; };
 
+    static bool joinableTypes(EvaluatedType a, EvaluatedType b);
+
 private:
     const VarDecl* _fstJoinKeyVar {nullptr};
     const VarDecl* _sndJoinKeyVar {nullptr};

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -533,6 +533,7 @@ struct ListableTypes {
     >;
 };
 
+// NOTE: This should be synced with @ref JoinNode::joinableTypes
 struct ValueHashJoinPairs {
     using Allowed = GenerateKindPairList<
         // Non-optionals on ID types
@@ -546,7 +547,7 @@ struct ValueHashJoinPairs {
             KindPair<ValueType, ValueType>
         >,
 
-        /// Property types, and adjacent: all optional variations
+        /// Property types: all optional variations
         OptionalKindPairs<types::Int64::Primitive, types::Int64::Primitive>::Pairs,
         OptionalKindPairs<types::UInt64::Primitive, types::UInt64::Primitive>::Pairs,
         OptionalKindPairs<types::Double::Primitive, types::Double::Primitive>::Pairs,

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -533,4 +533,40 @@ struct ListableTypes {
     >;
 };
 
+struct ValueHashJoinPairs {
+    using Allowed = GenerateKindPairList<
+        // Non-optionals on ID types
+        std::tuple<
+            KindPair<NodeID, NodeID>,
+            KindPair<EdgeID, EdgeID>,
+
+            KindPair<LabelID, LabelID>,
+            KindPair<EdgeTypeID, EdgeTypeID>,
+
+            KindPair<ValueType, ValueType>
+        >,
+
+        /// Property types, and adjacent: all optional variations
+        OptionalKindPairs<types::Int64::Primitive, types::Int64::Primitive>::Pairs,
+        OptionalKindPairs<types::UInt64::Primitive, types::UInt64::Primitive>::Pairs,
+        OptionalKindPairs<types::Double::Primitive, types::Double::Primitive>::Pairs,
+        OptionalKindPairs<types::Bool::Primitive, types::Bool::Primitive>::Pairs,
+        OptionalKindPairs<types::String::Primitive, types::String::Primitive>::Pairs,
+
+        // Occasionally need owning strings
+        OptionalKindPairs<std::string, std::string>::Pairs,
+        /// Enabled due to transparent string hashing in @ref HashJoinProcessor
+        OptionalKindPairs<std::string, std::string_view>::Pairs,
+        OptionalKindPairs<std::string_view, std::string_view>::Pairs
+    >;
+
+    using AllowedMixed = AllowedMixedList<>;
+
+    using Excluded = ExcludedContainers<
+        ContainerKind::code<ColumnConst>(),
+        ContainerKind::code<ColumnSet>(),
+        ContainerKind::code<ColumnMask>()
+    >;
+};
+
 }

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -21,6 +21,10 @@ namespace {
 struct TuringEqual;
 struct TuringNotEqual;
 
+// Static storage duration sentinals to avoid reconstructing each iteration
+static constexpr CustomBool sentinalFalse(false);
+static constexpr CustomBool sentinalTrue(true);
+
 template <typename T>
 concept BooleanOpt = std::same_as<TypeUtils::unwrap_optional_t<T>, types::Bool::Primitive>
                   || std::same_as<ColumnMask::Bool_t, T>;
@@ -34,10 +38,10 @@ concept TestsEquality =
 // short-circuiting) so are defined explicitly rather than generically
 template <BooleanOpt T, BooleanOpt U>
 inline std::optional<bool> optionalOr(const T& a, const U& b) {
-    if (a == CustomBool {true} || b == CustomBool {true}) {
+    if (a == sentinalTrue || b == sentinalTrue) {
         return true;
     }
-    if (a == CustomBool {false} && b == CustomBool {false}) {
+    if (a == sentinalFalse && b == sentinalFalse) {
         return false;
     }
     return std::nullopt;
@@ -45,10 +49,10 @@ inline std::optional<bool> optionalOr(const T& a, const U& b) {
 
 template <BooleanOpt T, BooleanOpt U>
 inline std::optional<bool> optionalAnd(const T& a, const U& b) {
-    if (a == CustomBool {true} && b == CustomBool {true}) {
+    if (a == sentinalTrue && b == sentinalTrue) {
         return true;
     }
-    if (a == CustomBool {false} || b == CustomBool {false}) {
+    if (a == sentinalFalse || b == sentinalFalse) {
         return false;
     }
     return std::nullopt;

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -21,9 +21,9 @@ namespace {
 struct TuringEqual;
 struct TuringNotEqual;
 
-// Static storage duration sentinals to avoid reconstructing each iteration
-static constexpr CustomBool sentinalFalse(false);
-static constexpr CustomBool sentinalTrue(true);
+// Static storage duration sentinels to avoid reconstructing each iteration
+static constexpr CustomBool sentinelFalse(false);
+static constexpr CustomBool sentinelTrue(true);
 
 template <typename T>
 concept BooleanOpt = std::same_as<TypeUtils::unwrap_optional_t<T>, types::Bool::Primitive>
@@ -38,10 +38,10 @@ concept TestsEquality =
 // short-circuiting) so are defined explicitly rather than generically
 template <BooleanOpt T, BooleanOpt U>
 inline std::optional<bool> optionalOr(const T& a, const U& b) {
-    if (a == sentinalTrue || b == sentinalTrue) {
+    if (a == sentinelTrue || b == sentinelTrue) {
         return true;
     }
-    if (a == sentinalFalse && b == sentinalFalse) {
+    if (a == sentinelFalse && b == sentinelFalse) {
         return false;
     }
     return std::nullopt;
@@ -49,10 +49,10 @@ inline std::optional<bool> optionalOr(const T& a, const U& b) {
 
 template <BooleanOpt T, BooleanOpt U>
 inline std::optional<bool> optionalAnd(const T& a, const U& b) {
-    if (a == sentinalTrue && b == sentinalTrue) {
+    if (a == sentinelTrue && b == sentinelTrue) {
         return true;
     }
-    if (a == sentinalFalse || b == sentinalFalse) {
+    if (a == sentinelFalse || b == sentinelFalse) {
         return false;
     }
     return std::nullopt;

--- a/storage/metadata/PropertyType.h
+++ b/storage/metadata/PropertyType.h
@@ -35,7 +35,7 @@ using ValueTypeName = EnumToString<ValueType>::Create<
 
 struct CustomBool {
     CustomBool() = default;
-    CustomBool(bool v)
+    constexpr CustomBool(bool v)
         : _boolean(v)
     {
     }


### PR DESCRIPTION
- Update `PipelineBuilder::addHashJoin` to use new column dispatcher, which strictly enforces types declaratively in `AllowedKinds`.
- Perform plan-time type checking of join arguments to avoid invalid joins which slip past analysis stage