### PR TITLE
Add test for var-length edge joined with shared start node

### DIFF
--- a/test/query-test-suite/tests/match-var-length-shared-start.json
+++ b/test/query-test-suite/tests/match-var-length-shared-start.json
@@ -1,0 +1,17 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n)-[e]-*(O), (n)<-[f]-(m) RETURN n, e, m, f",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __SCAN_NODES__\n    `\"]\n    1[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    2[\"`\n        __FILTER_NODE__\n    `\"]\n    3[\"`\n        __PATH_EXPLORER__\n    `\"]\n    4[\"`\n        __VAR__\n        __name__: O\n    `\"]\n    5[\"`\n        __FILTER_NODE__\n    `\"]\n    6[\"`\n        __GET_IN_EDGES__\n    `\"]\n    7[\"`\n        __VAR__\n        __name__: f\n    `\"]\n    8[\"`\n        __FILTER_EDGE__\n    `\"]\n    9[\"`\n        __GET_EDGE_TARGET__\n    `\"]\n    10[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    11[\"`\n        __FILTER_NODE__\n    `\"]\n    12[\"`\n        __JOIN__\n        __key1__: n\n        __key2__: n\n    `\"]\n    13[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->3\n    1-->6\n    2-->1\n    3-->5\n    4-->12\n    5-->4\n    6-->8\n    7-->9\n    8-->7\n    9-->11\n    10-->12\n    11-->10\n    12-->13",
+        "result": "EXEC ERROR\nLeft input column is not trivially copyable",
+        "resultJson": "{\"header\":{\"column_names\":[\"n\",\"e\",\"m\",\"f\"],\"column_types\":[\"UInt64\",\"List\",\"UInt64\",\"UInt64\"]},\"data\":[],\"error\":\"EXEC_ERROR\",\"error_details\":\"Left input column is not trivially copyable\"}"
+    },
+    "tags": [
+        "variable-length",
+        "quantified-path",
+        "multi-pattern",
+        "shared-vars"
+    ],
+    "write-required": false
+}


### PR DESCRIPTION
Test for issue #582 

Captures current EXEC error on `MATCH (n)-[e]-*(O), (n)<-[f]-(m) RETURN n, e, m, f` — the join can't yet handle a variable-length edge list column on its left input.