### PR TITLE
Fix LLVM key drift issue in install_build_tools.sh

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -100,17 +100,16 @@ jobs:
       id: version
       if: inputs.dev_version_suffix != ''
       run: |
-        DESC=$(git describe --tags --long --match 'v*' --first-parent)
-        TAG_VERSION=$(echo "$DESC" | sed 's/^v\(.*\)-[0-9]*-g[0-9a-f]*$/\1/')
-        DISTANCE=$(echo "$DESC" | sed 's/^v.*-\([0-9]*\)-g[0-9a-f]*$/\1/')
-        if [ "$DISTANCE" != "0" ]; then
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$TAG_VERSION"
-          PATCH=${PATCH:-0}
-          PATCH=$((PATCH + 1))
-          VERSION="${MAJOR}.${MINOR}.${PATCH}.dev${{ inputs.dev_version_suffix }}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed version override: $VERSION"
-        fi
+        # Always bump patch and add a dev suffix so nightlies never collide with a published tag version on PyPI,
+        # including the edge case where HEAD sits exactly on the latest tag (distance == 0).
+        DESC=$(git describe --tags --match 'v*' --first-parent --abbrev=0)
+        TAG_VERSION=${DESC#v}
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$TAG_VERSION"
+        PATCH=${PATCH:-0}
+        PATCH=$((PATCH + 1))
+        VERSION="${MAJOR}.${MINOR}.${PATCH}.dev${{ inputs.dev_version_suffix }}"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Computed version override: $VERSION"
 
     - name: Build wheel
       run: |

--- a/install_build_tools.sh
+++ b/install_build_tools.sh
@@ -81,11 +81,23 @@ else
     if command -v apt-get &> /dev/null; then
         if ! command -v "llvm-config-${LLVM_MAJOR_VERSION}" &> /dev/null; then
             echo "Installing LLVM ${LLVM_MAJOR_VERSION} via apt.llvm.org..."
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+            # Scope the key to this repo via signed-by so a stale key elsewhere on the runner image cannot shadow it
+            LLVM_KEYRING=/etc/apt/keyrings/apt.llvm.org.asc
+            sudo install -d -m 0755 /etc/apt/keyrings
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee "${LLVM_KEYRING}" >/dev/null
             CODENAME=$(lsb_release -cs)
-            echo "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_MAJOR_VERSION} main" \
+            echo "deb [signed-by=${LLVM_KEYRING}] http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_MAJOR_VERSION} main" \
                 | sudo tee /etc/apt/sources.list.d/llvm-${LLVM_MAJOR_VERSION}.list >/dev/null
-            sudo apt-get update
+            # apt.llvm.org occasionally serves a snapshot key out of sync with InRelease; retry to ride out the drift
+            for attempt in 1 2 3; do
+                if sudo apt-get update; then
+                    break
+                fi
+                if [ "${attempt}" = 3 ]; then
+                    exit 1
+                fi
+                sleep 15
+            done
             sudo apt-get install -y clang-${LLVM_MAJOR_VERSION} llvm-${LLVM_MAJOR_VERSION}-dev lld-${LLVM_MAJOR_VERSION}
         else
             echo "LLVM ${LLVM_MAJOR_VERSION} is already installed"


### PR DESCRIPTION
Fix an issue of stale apt key in github runner images that is causing transient issues in the release CI