### PR TITLE
Allow literal arguments to `CALL` procedures

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -21,6 +21,7 @@
 #include "StringBucket.h"
 
 #include "expr/All.h"
+#include "expr/Expr.h"
 
 using namespace db;
 
@@ -631,7 +632,8 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
 
         for (Expr* arg : providedArgs) {
             // Type is validated above
-            const VarDecl* decl = _ctxt->createUnnamedVariable(_ast, arg->getType());
+            const EvaluatedType type = arg->getType();
+            const VarDecl* decl = _ctxt->createUnnamedVariable(_ast, type);
             arg->setExprVarDecl(decl);
         }
 

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -630,7 +630,16 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
             continue;
         }
 
+        // Register variables for each argument
         for (Expr* arg : providedArgs) {
+            const VarDecl* var = arg->getExprVarDecl();
+            // Already registered: skip
+            if (var) {
+                continue;
+            }
+
+            // Not yet registered: create variable
+
             // Type is validated above
             const EvaluatedType type = arg->getType();
             const VarDecl* decl = _ctxt->createUnnamedVariable(_ast, type);

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -588,12 +588,12 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
     }
 
     const ExprChain* argsChain = invoc->getArguments();
-    const auto& requestedArgs = argsChain->getExprs();
+    const ExprChain::ExprVector& providedArgs = argsChain->getExprs();
 
     bool isDynamic = false;
     bool isAggregate = false;
 
-    for (Expr* arg : requestedArgs) {
+    for (Expr* arg : providedArgs) {
         analyzeExpr(arg);
 
         isDynamic |= arg->isDynamic();
@@ -611,25 +611,28 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
     }
 
     // For each overload, check if the argument types match
-    for (auto it = signatures.begin(); it != signatures.end(); it++) {
-        FunctionSignature* signature = *it;
-
+    for (FunctionSignature* signature : signatures) {
         const auto& expectedArgs = signature->argumentTypes();
 
-        if (requestedArgs.size() != expectedArgs.size()) {
+        if (providedArgs.size() != expectedArgs.size()) {
             // Number of arguments does not match
             continue;
         }
 
-        const bool matchingArgs = std::equal(
-            expectedArgs.begin(), expectedArgs.end(), requestedArgs.begin(),
-            [](const EvaluatedType& expected, const Expr* arg) {
-                return arg->getType() == expected;
-            });
+        const bool matchingArgs = std::ranges::equal(expectedArgs, providedArgs,
+                               [](const EvaluatedType& expected, const Expr* arg) {
+                                   return arg->getType() == expected;
+                               });
 
         if (!matchingArgs) {
             // Argument types do not match
             continue;
+        }
+
+        for (Expr* arg : providedArgs) {
+            // Type is validated above
+            const VarDecl* decl = _ctxt->createUnnamedVariable(_ast, arg->getType());
+            arg->setExprVarDecl(decl);
         }
 
         // Found a valid signature
@@ -652,6 +655,7 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
         return;
     }
 
+    // Checked all overloaded signatures, none match: error
     throwError(fmt::format("Invalid arguments for function '{}'", name), expr);
 }
 

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1238,8 +1238,7 @@ PipelineOutputInterface* PipelineGenerator::translateProcedureEvalNode(Procedure
             col = exprGen.generateExpr(argExpr);
         } else {
             auto it = _declToColumn.find(argDecl);
-            bioassert(it != _declToColumn.end(),
-                      "Argument does not have a variable declaration");
+            bioassert(it != _declToColumn.end(), "Argument does not have a variable declaration");
             const ColumnTag tag = it->second;
             const NamedColumn* namedCol = inDf->getColumn(tag);
 

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1237,7 +1237,7 @@ PipelineOutputInterface* PipelineGenerator::translateProcedureEvalNode(Procedure
             ExprProgramGenerator exprGen(this, exprProg, _builder.getPendingOutput());
             col = exprGen.generateExpr(argExpr);
         } else {
-            auto it = _declToColumn.find(argDecl);
+            const auto it = _declToColumn.find(argDecl);
             bioassert(it != _declToColumn.end(), "Argument does not have a variable declaration");
             const ColumnTag tag = it->second;
             const NamedColumn* namedCol = inDf->getColumn(tag);

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -8,6 +8,7 @@
 
 #include "CypherAST.h"
 #include "DiagnosticsManager.h"
+#include "ExprProgramGenerator.h"
 #include "FunctionInvocation.h"
 #include "ID.h"
 #include "Literal.h"
@@ -36,6 +37,7 @@
 #include "expr/SymbolExpr.h"
 #include "metadata/LabelSet.h"
 #include "nodes/CartesianProductNode.h"
+#include "nodes/ExprEvalNode.h"
 #include "nodes/FilterNode.h"
 #include "nodes/GetEdgeTargetNode.h"
 #include "nodes/GetEdgesNode.h"
@@ -175,7 +177,25 @@ void ReadStmtGenerator::generateCallStmt(const CallStmt* callStmt) {
     const FunctionInvocationExpr* funcExpr = callStmt->getFunc();
     YieldClause* yield = callStmt->getYield();
 
+    ExprEvalNode* exprEval = nullptr;
     ProcedureEvalNode* procNode = _tree->create<ProcedureEvalNode>(funcExpr, yield);
+
+    const FunctionInvocation* invok = funcExpr->getFunctionInvocation();
+    const ExprChain* args = invok->getArguments();
+
+    for (const Expr* arg : *args) {
+        // Arg does not need evaluation: perhaps supplied from an earlier proc
+        if (!ExprEvalNode::needsEvaluation(arg)) {
+            continue;
+        }
+
+        // Arg needs evaluation: ensure we have an ExprEvalNode
+        if (!exprEval) {
+            exprEval = _tree->insertBefore<ExprEvalNode>(procNode);
+        }
+
+        exprEval->addExpr(arg);
+    }
 
     if (yield && yield->getItems()) {
         YieldItems* yieldItems = yield->getItems();

--- a/test/query-test-suite/tests/call-literal-arg.json
+++ b/test/query-test-suite/tests/call-literal-arg.json
@@ -1,0 +1,12 @@
+{
+  "enabled": true,
+  "graph": "simpledb",
+  "query": "call db.describeCommit(\"not-a-commit\")",
+  "expect": {
+    "plan": "flowchart TD\n    0[\"`\n        __PROCEDURE_EVAL__\n        __func__ db.describeCommit\n    `\"]\n    1[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v0\n    `\"]\n    2[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->0",
+    "result": ",nodeCount,edgeCount,partCount\nnot-a-commit,0,0,0",
+    "resultJson": "{\"header\":{\"column_names\":[\"$0\",\"nodeCount\",\"edgeCount\",\"partCount\"],\"column_types\":[\"String\",\"UInt64\",\"UInt64\",\"UInt64\"]},\"data\":[[[\"not-a-commit\"],[0],[0],[0]]]}"
+  },
+  "tags": [],
+  "write-required": false
+}

--- a/test/query-test-suite/tests/call-literal-arg.json
+++ b/test/query-test-suite/tests/call-literal-arg.json
@@ -1,12 +1,12 @@
 {
   "enabled": true,
   "graph": "simpledb",
-  "query": "call db.describeCommit(\"not-a-commit\")",
+  "query": "MATCH (n) CALL db.describeCommit(\"not-a-commit\") YIELD partCount AS p RETURN n",
   "expect": {
-    "plan": "flowchart TD\n    0[\"`\n        __PROCEDURE_EVAL__\n        __func__ db.describeCommit\n    `\"]\n    1[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v0\n    `\"]\n    2[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->0",
-    "result": ",nodeCount,edgeCount,partCount\nnot-a-commit,0,0,0",
-    "resultJson": "{\"header\":{\"column_names\":[\"$0\",\"nodeCount\",\"edgeCount\",\"partCount\"],\"column_types\":[\"String\",\"UInt64\",\"UInt64\",\"UInt64\"]},\"data\":[[[\"not-a-commit\"],[0],[0],[0]]]}"
+    "plan": "",
+    "result": ""
   },
-  "tags": [],
+  "tags": [
+  ],
   "write-required": false
 }

--- a/test/query-test-suite/tests/call-literal-arg.json
+++ b/test/query-test-suite/tests/call-literal-arg.json
@@ -3,10 +3,15 @@
   "graph": "simpledb",
   "query": "MATCH (n) CALL db.describeCommit(\"not-a-commit\") YIELD partCount AS p RETURN n",
   "expect": {
-    "plan": "",
-    "result": ""
+    "plan": "flowchart TD\n    0[\"`\n        __SCAN_NODES__\n    `\"]\n    1[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    2[\"`\n        __FILTER_NODE__\n    `\"]\n    3[\"`\n        __PROCEDURE_EVAL__\n        __func__ db.describeCommit\n        __yield__\n        __yield_item__: p\n        __args__\n        __arg__: unnamed\n    `\"]\n    4[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v0\n    `\"]\n    5[\"`\n        __CARTESIAN_PRODUCT__\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->5\n    2-->1\n    3-->5\n    4-->3\n    5-->6",
+    "result": "n\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17",
+    "resultJson": "{\"header\":{\"column_names\":[\"n\"],\"column_types\":[\"UInt64\"]},\"data\":[[[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]]]}"
   },
   "tags": [
+    "call",
+    "cartprod",
+    "yield",
+    "scan"
   ],
   "write-required": false
 }

--- a/test/query-test-suite/tests/standalone-call-literal-arg.json
+++ b/test/query-test-suite/tests/standalone-call-literal-arg.json
@@ -1,0 +1,12 @@
+{
+  "enabled": true,
+  "graph": "simpledb",
+  "query": "call db.describeCommit(\"not-a-commit\")",
+  "expect": {
+    "plan": "flowchart TD\n    0[\"`\n        __PROCEDURE_EVAL__\n        __func__ db.describeCommit\n    `\"]\n    1[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v0\n    `\"]\n    2[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->0",
+    "result": ",nodeCount,edgeCount,partCount\nnot-a-commit,0,0,0",
+    "resultJson": "{\"header\":{\"column_names\":[\"$0\",\"nodeCount\",\"edgeCount\",\"partCount\"],\"column_types\":[\"String\",\"UInt64\",\"UInt64\",\"UInt64\"]},\"data\":[[[\"not-a-commit\"],[0],[0],[0]]]}"
+  },
+  "tags": [],
+  "write-required": false
+}


### PR DESCRIPTION
`CALL` procedures cannot currently take literals as arguments, shown in #646. This PR allows for literals to be passed to procedures, by suppling an `ExprEvalNode` prior, to provide the arguments in columns.

Fixes #646 