### PR TITLE
StringHashMap: transparent std::unordered_map for both std::string_view and std::string

### DIFF
--- a/common/StringHashMap.h
+++ b/common/StringHashMap.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <unordered_map>
+#include <functional>
+
+#include "StringHasher.h"
+
+template <class K, class V>
+struct StringHashMap : std::unordered_map<K, V, StringHasher, std::equal_to<>> {
+    using std::unordered_map<K, V, StringHasher, std::equal_to<>>::unordered_map;
+};

--- a/common/StringHasher.h
+++ b/common/StringHasher.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <functional>
+#include <type_traits>
+
+struct StringHasher {
+    using is_transparent = void;
+
+    template <class T>
+    std::size_t operator()(const T& s) const {
+        static_assert(std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>,
+                      "StringHasher only supports std::string and std::string_view");
+        return std::hash<T>{}(s);
+    }
+};


### PR DESCRIPTION
Implement StringHashMap specialization of std::unordered_map to support both std::string and std::string_view keys transparently with a custom StringHasher