### PR TITLE
Enable `ColumnConst<T>` as argument to `CartesianProductProcessor`

### DIFF
--- a/memory/LocalMemory.h
+++ b/memory/LocalMemory.h
@@ -99,6 +99,7 @@ public:
         MakeMemoryPool<ColumnSet<EdgeID>>::type,
         MakeMemoryPool<ColumnStringTable>::type,
 
+        MakeMemoryPool<ColumnVector<ListView>>::type,
         MakeMemoryPool<ColumnConst<ListView>>::type,
         MakeMemoryPool<ColumnVector<ListElementView>>::type
     >;

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -109,7 +109,7 @@ void duplicateDataframeShape(LocalMemory* mem,
 /*
 * @brief Column-wise concatenation of @param src onto @param dest
 */
-void concatDataframeShape(LocalMemory* mem,
+[[maybe_unused]] void concatDataframeShape(LocalMemory* mem,
                           DataframeManager* dfMan,
                           db::Dataframe* src,
                           db::Dataframe* dest) {
@@ -118,6 +118,57 @@ void concatDataframeShape(LocalMemory* mem,
         populateStringTableShape(mem, newCol, col->getColumn());
         auto* newNamedCol = NamedColumn::create(dfMan, newCol, col->getTag());
         dest->addColumn(newNamedCol);
+    }
+}
+
+// Functor for ColumnSingleDispatcher: allocates a ColumnVector<T> in the output
+// dataframe regardless of whether the source column is a ColumnVector or ColumnConst.
+struct AllocAsColumnVector {
+public:
+    AllocAsColumnVector(LocalMemory* mem, DataframeManager* dfMan, Dataframe* dest, ColumnTag tag)
+        : _mem(mem),
+        _dfMan(dfMan),
+        _dest(dest),
+        _tag(tag)
+    {
+    }
+
+    template <template <typename> class Container, typename T>
+    void operator()(const Container<T>*) {
+        ColumnVector<T>* newCol = _mem->alloc<ColumnVector<T>>();
+        _dest->addColumn(NamedColumn::create(_dfMan, newCol, _tag));
+    }
+
+private:
+    LocalMemory* _mem;
+    DataframeManager* _dfMan;
+    Dataframe* _dest;
+    ColumnTag _tag;
+};
+
+void duplicateDataframeShapeAsVectors(LocalMemory* mem,
+                                      DataframeManager* dfMan,
+                                      db::Dataframe* src,
+                                      db::Dataframe* dest) {
+    using Types = CartesianProductKinds;
+    using Dispatcher = ColumnSingleDispatcher<Types::Allowed, AllocAsColumnVector, Types::Excluded>;
+
+    for (const NamedColumn* col : src->cols()) {
+        AllocAsColumnVector alloc(mem, dfMan, dest, col->getTag());
+        Dispatcher::dispatch(col->getColumn(), alloc);
+    }
+}
+
+void concatDataframeShapeAsVectors(LocalMemory* mem,
+                                   DataframeManager* dfMan,
+                                   db::Dataframe* src,
+                                   db::Dataframe* dest) {
+    using Types = CartesianProductKinds;
+    using Dispatcher = ColumnSingleDispatcher<Types::Allowed, AllocAsColumnVector, Types::Excluded>;
+
+    for (const NamedColumn* col : src->cols()) {
+        AllocAsColumnVector alloc(mem, dfMan, dest, col->getTag());
+        Dispatcher::dispatch(col->getColumn(), alloc);
     }
 }
 
@@ -267,9 +318,10 @@ PipelineBlockOutputInterface& PipelineBuilder::addCartesianProduct(PipelineOutpu
     Dataframe* leftDf = cartProd->leftHandSide().getDataframe();
     Dataframe* rightDf = cartProd->rightHandSide().getDataframe();
 
-    // The output DF should be the same as the inputs, concatenated
-    duplicateDataframeShape(_mem, _dfMan, leftDf, outDf);
-    concatDataframeShape(_mem, _dfMan, rightDf, outDf);
+    // Output columns are always ColumnVector, even when an input column is ColumnConst,
+    // because the processor must write multiple values per output row.
+    duplicateDataframeShapeAsVectors(_mem, _dfMan, leftDf, outDf);
+    concatDataframeShapeAsVectors(_mem, _dfMan, rightDf, outDf);
 
     // Stream does not change when adding CartesianProduct
     output.setStream(_pendingOutput.getInterface()->getStream());

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -328,8 +328,8 @@ PipelineBlockOutputInterface& PipelineBuilder::addCartesianProduct(PipelineOutpu
     _pendingOutput.updateInterface(&output);
 
     // Initialise the processor's "memory" stores for left and right ports
-    duplicateDataframeShape(_mem, _dfMan, leftDf, &cartProd->leftMemory());
-    duplicateDataframeShape(_mem, _dfMan, rightDf, &cartProd->rightMemory());
+    duplicateDataframeShapeAsVectors(_mem, _dfMan, leftDf, &cartProd->leftMemory());
+    duplicateDataframeShapeAsVectors(_mem, _dfMan, rightDf, &cartProd->rightMemory());
 
     _lastProc = cartProd;
     return output;

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -17,13 +17,6 @@ using namespace db;
 
 namespace {
 
-void clearDataframe(Dataframe* df) {
-    for (NamedColumn* nCol : df->cols()) {
-        Column* col = nCol->getColumn();
-        dispatchColumnVector(col, [](auto* colVec) { colVec->clear(); });
-    }
-}
-
 void verifyAllColumnVectors(const Dataframe* df) {
     for (const NamedColumn* nCol : df->cols()) {
         const Column* col = nCol->getColumn();
@@ -554,6 +547,9 @@ void CartesianProductProcessor::init() {
 }
 
 void CartesianProductProcessor::execute() {
+    PipelineInputPort* leftPort = _lhs.getPort();
+    PipelineInputPort* rightPort = _rhs.getPort();
+
     // We start with our output port being empty, and not having written any rows
     _rowsWrittenThisCycle = 0;
 
@@ -578,14 +574,14 @@ void CartesianProductProcessor::execute() {
 
     if (_rowsWrittenSinceLastFinished == _rowsToWriteBeforeFinished) {
         // Memorise the new chunks
-        if (_lhs.getPort()->hasData()) {
+        if (leftPort->hasData()) {
             _leftMemory.append(_lhs.getDataframe());
-            _lhs.getPort()->consume();
+            leftPort->consume();
         }
 
-        if (_rhs.getPort()->hasData()) {
+        if (rightPort->hasData()) {
             _rightMemory.append(_rhs.getDataframe());
-            _rhs.getPort()->consume();
+            rightPort->consume();
         }
 
         // Edge case: if we didn't need to write any rows, @ref fillOutput would not have
@@ -593,11 +589,11 @@ void CartesianProductProcessor::execute() {
         // only in the case where we are not to recieve any more inputs (i.e. both ports
         // closed), so that the following processor evaluates @ref hasData() to true, and
         // can therefore execute.
-        if (_rowsToWriteBeforeFinished == 0) {
-            if (_lhs.getPort()->isClosed() && _rhs.getPort()->isClosed()) {
-                clearDataframe(_out.getDataframe());
-                _out.getPort()->writeData();
-            }
+        const bool inputsClosed = leftPort->isClosed() && rightPort->isClosed();
+        const bool nothingToWrite = _rowsToWriteBeforeFinished == 0;
+        if (nothingToWrite && inputsClosed) {
+            _out.getDataframe()->clear();
+            _out.getPort()->writeData();
         }
 
         finish();

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -85,6 +85,7 @@ public:
         const bool canWriteLeftovers = _remainingSpace % _m != 0;
 
         for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
+            // If @ref lhsCol is a ColumnConst, this will always return the same value
             const T& currentLhsElement = lhsCol->at(_lhsPtr);
 
             const auto startIt = begin(outRaw) + _rowPtr;
@@ -107,6 +108,7 @@ public:
         bioassert(_remainingSpace < _m, "Not enough remaining space");
         bioassert(_rhsPtr == 0, "ourRhsPtr must be 0");
 
+        // If @ref lhsCol is a ColumnConst, this will always return the same value
         const T& lhsElement = lhsCol->at(_lhsPtr);
         const auto startIt = begin(outRaw) + _rowPtr;
         const auto endIt = startIt + _remainingSpace;

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -153,6 +153,115 @@ private:
     size_t _n {0};
 };
 
+struct CopyFromRightCol {
+public:
+    CopyFromRightCol(Column* outCol, size_t rhsPtr, size_t lhsPtr, size_t rowPtr, size_t remainingSpace, size_t m, size_t n)
+        : _outCol(outCol),
+        _rhsPtr(rhsPtr),
+        _lhsPtr(lhsPtr),
+        _rowPtr(rowPtr),
+        _remainingSpace(remainingSpace),
+        _m(m),
+        _n(n)
+    {
+    }
+
+    template <typename T>
+    void operator()(const ColumnVector<T>* rhsCol) {
+        auto* outCol = dynamic_cast<ColumnVector<T>*>(_outCol);
+
+        std::vector<T>& outRaw = outCol->getRaw();
+        const std::vector<T>& rhsRaw = rhsCol->getRaw();
+
+        // If we were halfway through writing tuples for a left hand row, try and finish
+        if (_rhsPtr != 0) {
+            const size_t needToWrite = _m - _rhsPtr;
+            const size_t canWrite = std::min(_remainingSpace, needToWrite);
+
+            // Copy as much of the column as we can
+            const auto rStart = begin(rhsRaw) + _rhsPtr;
+            const auto rEnd = rStart + canWrite;
+            const auto outStart = begin(outRaw) + _rowPtr;
+
+            std::copy(rStart, rEnd, outStart);
+
+            _remainingSpace -= canWrite;
+            _rowPtr += canWrite;
+            _rhsPtr += canWrite;
+            // If we copied all the remainder of the column, we start again on RHS
+            if (canWrite == needToWrite) {
+                _lhsPtr++;
+                _rhsPtr = 0;
+            }
+        }
+
+        if (_lhsPtr == _n + 1) {
+            return;
+        }
+
+        if (_remainingSpace == 0) {
+            return;
+        }
+
+        const size_t rowsLeftToWrite = _n - _lhsPtr;
+        const size_t numCompleteLhsRowsCanWrite =
+            std::min(rowsLeftToWrite, _remainingSpace / _m);
+        const bool canWriteAll = rowsLeftToWrite == numCompleteLhsRowsCanWrite;
+        const bool canWriteLeftovers = _remainingSpace % _m != 0;
+
+        bioassert(_rhsPtr == 0, "ourRhsPtr must be zero");
+        for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
+            const auto rStart = begin(rhsRaw) + _rhsPtr;
+            const auto rEnd = rStart + _m; // We know we can fit m rows here
+            bioassert(rEnd == end(rhsRaw), "rEnd is not valid");
+            const auto outStart = begin(outRaw) + _rowPtr;
+
+            std::copy(rStart, rEnd, outStart);
+
+            _lhsPtr++;
+            _rhsPtr = 0;
+
+            _rowPtr += _m;
+
+            _remainingSpace -= _m;
+        }
+
+        if (canWriteAll || !canWriteLeftovers) {
+            return;
+        }
+
+        bioassert(_remainingSpace < _m, "not enough remaining space");
+        bioassert(_rhsPtr == 0, "ourRhsPtr must be zero");
+
+        const auto rStart = begin(rhsRaw) + _rhsPtr;
+        const auto rEnd = rStart + _remainingSpace;
+        bioassert(rEnd != end(rhsRaw), "invalid rEnd");
+
+        const auto outStart = begin(outRaw) + _rowPtr;
+        bioassert(outStart + _remainingSpace == end(outRaw), "invalid outStart");
+
+        std::copy(rStart, rEnd, outStart);
+
+        _rhsPtr += _remainingSpace;
+        _rowPtr += _remainingSpace;
+        _remainingSpace -= _remainingSpace;
+
+        bioassert(_remainingSpace == 0, "we must not have remainingSpace here");
+    }
+
+private:
+    Column* _outCol {nullptr};
+
+    size_t _rhsPtr {0};
+    size_t _lhsPtr {0};
+    size_t _rowPtr {0};
+
+    size_t _remainingSpace {0};
+
+    size_t _m {0};
+    size_t _n {0};
+};
+
 }
 
 CartesianProductProcessor* CartesianProductProcessor::create(PipelineV2* pipeline) {
@@ -253,101 +362,22 @@ void CartesianProductProcessor::copyFromRightColumn(Dataframe* left,
                                                     size_t colIdx,
                                                     size_t fromRow,
                                                     size_t spaceAvailable) {
-    size_t remainingSpace = spaceAvailable;
-    size_t ourRowPtr = fromRow;
-
     const size_t n = left->getLogicalRowCount();
     const size_t m = right->getLogicalRowCount();
     const size_t p = left->size();
 
-    size_t ourLhsPtr = _lhsPtr;
-    size_t ourRhsPtr = _rhsPtr;
-
     Dataframe* oDF = _out.getDataframe();
-    Column* outColumnErased = oDF->cols().at(p + colIdx)->getColumn();
+    Column* outCol = oDF->cols().at(p + colIdx)->getColumn();
 
     Column* rightColumnErased = right->cols().at(colIdx)->getColumn();
 
-    dispatchColumnVector(rightColumnErased, [&](auto* rhsCol) {
-        auto* outCol = static_cast<decltype(rhsCol)>(outColumnErased);
-        auto& outRaw = outCol->getRaw();
+    // NOTE: Functor takes @ref _rhsPtr, _lhsPtr by value, and doesn't modify global state
+    CopyFromRightCol copier(outCol, _rhsPtr, _lhsPtr, fromRow, spaceAvailable, m, n);
 
-        const auto& rhsRaw = rhsCol->getRaw();
-        // If we were halfway through writing tuples for a left hand row, try and finish
-        if (ourRhsPtr != 0) {
-            const size_t needToWrite = m - ourRhsPtr;
-            const size_t canWrite = std::min(remainingSpace, needToWrite);
+    using Types = CartesianProductKinds;
+    using Dispatcher = ColumnSingleDispatcher<Types::Allowed, CopyFromRightCol, Types::Excluded>;
 
-            // Copy as much of the column as we can
-            const auto rStart = begin(rhsRaw) + ourRhsPtr;
-            const auto rEnd = rStart + canWrite;
-            const auto outStart = begin(outRaw) + ourRowPtr;
-
-            std::copy(rStart, rEnd, outStart);
-
-            remainingSpace -= canWrite;
-            ourRowPtr += canWrite;
-            ourRhsPtr += canWrite;
-            // If we copied all the remainder of the column, we start again on RHS
-            if (canWrite == needToWrite) {
-                ourLhsPtr++;
-                ourRhsPtr = 0;
-            }
-        }
-
-        if (ourLhsPtr == n + 1) {
-            return;
-        }
-
-        if (remainingSpace == 0) {
-            return;
-        }
-
-        const size_t rowsLeftToWrite = n - ourLhsPtr;
-        const size_t numCompleteLhsRowsCanWrite =
-            std::min(rowsLeftToWrite, remainingSpace / m);
-        const bool canWriteAll = rowsLeftToWrite == numCompleteLhsRowsCanWrite;
-        const bool canWriteLeftovers = remainingSpace % m != 0;
-
-        bioassert(ourRhsPtr == 0, "ourRhsPtr must be zero");
-        for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
-            const auto rStart = begin(rhsRaw) + ourRhsPtr;
-            const auto rEnd = rStart + m; // We know we can fit m rows here
-            bioassert(rEnd == end(rhsRaw), "rEnd is not valid");
-            const auto outStart = begin(outRaw) + ourRowPtr;
-
-            std::copy(rStart, rEnd, outStart);
-
-            ourLhsPtr++;
-            ourRhsPtr = 0;
-
-            ourRowPtr += m;
-
-            remainingSpace -= m;
-        }
-
-        if (canWriteAll || !canWriteLeftovers) {
-            return;
-        }
-
-        bioassert(remainingSpace < m, "not enough remaining space");
-        bioassert(ourRhsPtr == 0, "ourRhsPtr must be zero");
-
-        const auto rStart = begin(rhsRaw) + ourRhsPtr;
-        const auto rEnd = rStart + remainingSpace;
-        bioassert(rEnd != end(rhsRaw), "invalid rEnd");
-
-        const auto outStart = begin(outRaw) + ourRowPtr;
-        bioassert(outStart + remainingSpace == end(outRaw), "invalid outStart");
-
-        std::copy(rStart, rEnd, outStart);
-
-        ourRhsPtr += remainingSpace;
-        ourRowPtr += remainingSpace;
-        remainingSpace -= remainingSpace;
-
-        bioassert(remainingSpace == 0, "we must not have remainingSpace here");
-    });
+    Dispatcher::dispatch(rightColumnErased, copier);
 }
 
 size_t CartesianProductProcessor::fillOutput(Dataframe* left, Dataframe* right) {

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -1,6 +1,7 @@
 #include "CartesianProductProcessor.h"
 
 #include <algorithm>
+#include <type_traits>
 
 #include "PipelineV2.h"
 #include "PipelinePort.h"
@@ -63,8 +64,11 @@ public:
     {
     }
 
-    template <typename T>
-    void operator()(const ColumnVector<T>* lhsCol) {
+    template <template <typename> class Container, typename T>
+    void operator()(const Container<T>* lhsCol) {
+        static_assert(std::is_same_v<const ColumnConst<T>*, decltype(lhsCol)>
+                      || std::is_same_v<const ColumnVector<T>*, decltype(lhsCol)>);
+
         auto* outCol = dynamic_cast<ColumnVector<T>*>(_outCol);
 
         std::vector<T>& outRaw = outCol->getRaw();
@@ -166,24 +170,37 @@ public:
     {
     }
 
-    template <typename T>
-    void operator()(const ColumnVector<T>* rhsCol) {
+    template <template <typename> class Container, typename T>
+    void operator()(const Container<T>* rhsCol) {
+        static_assert(std::is_same_v<const ColumnConst<T>*, decltype(rhsCol)>
+                      || std::is_same_v<const ColumnVector<T>*, decltype(rhsCol)>);
+
         auto* outCol = dynamic_cast<ColumnVector<T>*>(_outCol);
 
         std::vector<T>& outRaw = outCol->getRaw();
-        const std::vector<T>& rhsRaw = rhsCol->getRaw();
+
+        // Abstraction to copy over a range of a vector, or copy n elements from a ColumnConst
+        const auto copySlice = [&](size_t rhsStart, size_t count, size_t outPos) {
+            if constexpr (std::is_same_v<Container<T>, ColumnConst<T>>) {
+                auto startIt = begin(outRaw) + outPos;
+                const T& val = rhsCol->getRaw();
+                std::fill_n(startIt, count, val);
+            } else {
+                const std::vector<T>& rhsRaw = rhsCol->getRaw();
+                const auto startIt = begin(rhsRaw) + rhsStart;
+                const auto endIt = startIt + count;
+                const auto fromIt = begin(outRaw) + outPos;
+
+                std::copy(startIt, endIt, fromIt);
+            }
+        };
 
         // If we were halfway through writing tuples for a left hand row, try and finish
         if (_rhsPtr != 0) {
             const size_t needToWrite = _m - _rhsPtr;
             const size_t canWrite = std::min(_remainingSpace, needToWrite);
 
-            // Copy as much of the column as we can
-            const auto rStart = begin(rhsRaw) + _rhsPtr;
-            const auto rEnd = rStart + canWrite;
-            const auto outStart = begin(outRaw) + _rowPtr;
-
-            std::copy(rStart, rEnd, outStart);
+            copySlice(_rhsPtr, canWrite, _rowPtr);
 
             _remainingSpace -= canWrite;
             _rowPtr += canWrite;
@@ -211,12 +228,12 @@ public:
 
         bioassert(_rhsPtr == 0, "ourRhsPtr must be zero");
         for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
-            const auto rStart = begin(rhsRaw) + _rhsPtr;
-            const auto rEnd = rStart + _m; // We know we can fit m rows here
-            bioassert(rEnd == end(rhsRaw), "rEnd is not valid");
-            const auto outStart = begin(outRaw) + _rowPtr;
+            if constexpr (!std::is_same_v<Container<T>, ColumnConst<T>>) {
+                const std::vector<T>& rhsRaw = rhsCol->getRaw();
+                bioassert(begin(rhsRaw) + _m == end(rhsRaw), "rEnd is not valid");
+            }
 
-            std::copy(rStart, rEnd, outStart);
+            copySlice(_rhsPtr, _m, _rowPtr);
 
             _lhsPtr++;
             _rhsPtr = 0;
@@ -233,14 +250,15 @@ public:
         bioassert(_remainingSpace < _m, "not enough remaining space");
         bioassert(_rhsPtr == 0, "ourRhsPtr must be zero");
 
-        const auto rStart = begin(rhsRaw) + _rhsPtr;
-        const auto rEnd = rStart + _remainingSpace;
-        bioassert(rEnd != end(rhsRaw), "invalid rEnd");
+        if constexpr (!std::is_same_v<Container<T>, ColumnConst<T>>) {
+            const std::vector<T>& rhsRaw = rhsCol->getRaw();
+            bioassert(begin(rhsRaw) + _remainingSpace != end(rhsRaw), "invalid rEnd");
+        }
 
         const auto outStart = begin(outRaw) + _rowPtr;
         bioassert(outStart + _remainingSpace == end(outRaw), "invalid outStart");
 
-        std::copy(rStart, rEnd, outStart);
+        copySlice(_rhsPtr, _remainingSpace, _rowPtr);
 
         _rhsPtr += _remainingSpace;
         _rowPtr += _remainingSpace;

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -4,13 +4,15 @@
 #include <type_traits>
 
 #include "PipelineV2.h"
-#include "PipelinePort.h"
 #include "ExecutionContext.h"
+#include "PipelinePort.h"
+
 #include "columns/AllowedKinds.h"
+#include "columns/ColumnDispatcher.h"
 #include "columns/ColumnOperatorDispatcher.h"
 #include "columns/ColumnVector.h"
+
 #include "dataframe/Dataframe.h"
-#include "columns/ColumnDispatcher.h"
 #include "dataframe/NamedColumn.h"
 
 #include "FatalException.h"
@@ -19,37 +21,6 @@
 using namespace db;
 
 namespace {
-
-void verifyAllColumnVectors(const Dataframe* df) {
-    for (const NamedColumn* nCol : df->cols()) {
-        const Column* col = nCol->getColumn();
-
-        const ColumnKind::Code kind = col->getKind();
-        const ContainerKind::Code containerKind = ColumnKind::extractContainerKind(kind);
-        constexpr ContainerKind::Code ColumnVectorKind = ContainerKind::code<ColumnVector<size_t>>();
-
-        if (containerKind != ColumnVectorKind) {
-            std::string err =
-                fmt::format("Attempt to calulate the CartesianProduct of a "
-                            "Dataframe whose column is not a ColumnVector, but a {}.",
-                            col->getTypeName());
-            throw FatalException(std::move(err));
-        }
-    }
-}
-
-void verifyRectangular(const Dataframe* df) {
-    const size_t rowCount = df->getLogicalRowCount();
-
-    const bool rectangular = std::ranges::all_of(df->cols(), [rowCount](const NamedColumn* ncol) {
-        return ncol->getColumn()->size() == rowCount;
-    });
-
-    if (!rectangular) {
-        throw FatalException("CartesianProductProcessor was provided with "
-                             "non-rectangular dataframe as input.");
-    }
-}
 
 struct SetFromLeftCol {
 public:
@@ -605,12 +576,6 @@ void CartesianProductProcessor::emitFromLeftMemory() {
 }
 
 void CartesianProductProcessor::init() {
-    verifyAllColumnVectors(_lhs.getDataframe());
-    verifyAllColumnVectors(_rhs.getDataframe());
-    verifyAllColumnVectors(_out.getDataframe());
-    verifyRectangular(_lhs.getDataframe());
-    verifyRectangular(_rhs.getDataframe());
-
     const size_t n = _lhs.getPort()->hasData() ? _lhs.getDataframe()->getLogicalRowCount() : 0;
     const size_t m = _rhs.getPort()->hasData() ? _rhs.getDataframe()->getLogicalRowCount() : 0;
 

--- a/query/pipeline/processors/CartesianProductProcessor.cpp
+++ b/query/pipeline/processors/CartesianProductProcessor.cpp
@@ -5,6 +5,8 @@
 #include "PipelineV2.h"
 #include "PipelinePort.h"
 #include "ExecutionContext.h"
+#include "columns/AllowedKinds.h"
+#include "columns/ColumnOperatorDispatcher.h"
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
 #include "columns/ColumnDispatcher.h"
@@ -47,6 +49,109 @@ void verifyRectangular(const Dataframe* df) {
                              "non-rectangular dataframe as input.");
     }
 }
+
+struct SetFromLeftCol {
+public:
+    SetFromLeftCol(Column* outCol, size_t rhsPtr, size_t lhsPtr, size_t rowPtr, size_t remainingSpace, size_t m, size_t n)
+        : _outCol(outCol),
+        _rhsPtr(rhsPtr),
+        _lhsPtr(lhsPtr),
+        _rowPtr(rowPtr),
+        _remainingSpace(remainingSpace),
+        _m(m),
+        _n(n)
+    {
+    }
+
+    template <typename T>
+    void operator()(const ColumnVector<T>* lhsCol) {
+        auto* outCol = dynamic_cast<ColumnVector<T>*>(_outCol);
+
+        std::vector<T>& outRaw = outCol->getRaw();
+
+        // If we were halfway through writing tuples for a left hand row, try and finish
+        if (_rhsPtr != 0) {
+            // Write as many as we need, or as many as we can
+            const size_t needToWrite = _m - _rhsPtr;
+            const size_t canWrite = std::min(_remainingSpace, needToWrite);
+
+            const auto startIt = begin(outRaw) + _rowPtr;
+            const auto endIt = startIt + canWrite;
+
+            const T& val = lhsCol->at(_lhsPtr);
+
+            std::fill(startIt, endIt, val);
+
+            // Reduce the space we have left to right
+            _remainingSpace -= canWrite;
+            _rhsPtr += canWrite;
+            _rowPtr += canWrite;
+            // If we wrote all `m` rows for this LHS row, then reset,
+            // otherwise increment
+            if (canWrite == needToWrite) { // If we wrote all we needed
+                _lhsPtr++;               // We now need to write the next LHS
+                _rhsPtr = 0;             // And start from the first RHS
+            }
+        }
+
+        if (_lhsPtr == _n + 1) { // We have written all rows from LHS
+            return;
+        }
+
+        if (_remainingSpace == 0) { // We have ran out of space
+            return;
+        }
+
+        // Work out how for how many rows in LHS can we write all tuples with RHS for
+        // Each row in LHS needs m rows to fit all tuples: one for for each row on RHS
+        const size_t rowsLeftToWrite = _n - _lhsPtr;
+        const size_t numCompleteLhsRowsCanWrite = std::min(rowsLeftToWrite, _remainingSpace / _m);
+        const bool canWriteAll = rowsLeftToWrite == numCompleteLhsRowsCanWrite;
+        const bool canWriteLeftovers = _remainingSpace % _m != 0;
+
+        for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
+            const T& currentLhsElement = lhsCol->at(_lhsPtr);
+
+            const auto startIt = begin(outRaw) + _rowPtr;
+            const auto endIt = startIt + _m; // We know we can fit m rows here
+
+            std::fill(startIt, endIt, currentLhsElement);
+
+            _lhsPtr++;
+            _rhsPtr = 0;
+
+            _rowPtr += _m;
+
+            _remainingSpace -= _m;
+        }
+
+        if (canWriteAll || !canWriteLeftovers) {
+            return;
+        }
+
+        bioassert(_remainingSpace < _m, "Not enough remaining space");
+        bioassert(_rhsPtr == 0, "ourRhsPtr must be 0");
+
+        const T& lhsElement = lhsCol->at(_lhsPtr);
+        const auto startIt = begin(outRaw) + _rowPtr;
+        const auto endIt = startIt + _remainingSpace;
+        bioassert(endIt == end(outRaw), "Invalid endIt iterator");
+
+        std::fill(startIt, endIt, lhsElement);
+    }
+
+private:
+    Column* _outCol {nullptr};
+
+    size_t _rhsPtr {0};
+    size_t _lhsPtr {0};
+    size_t _rowPtr {0};
+    
+    size_t _remainingSpace {0};
+
+    size_t _m {0};
+    size_t _n {0};
+};
 
 }
 
@@ -125,94 +230,22 @@ void CartesianProductProcessor::setFromLeftColumn(Dataframe* left,
                                                   size_t fromRow,
                                                   size_t spaceAvailable) {
     size_t remainingSpace = spaceAvailable;
-    size_t ourRowPtr = fromRow;
 
     const size_t n = left->getLogicalRowCount();
     const size_t m = right->getLogicalRowCount();
 
-    // Keep local copies, because each column needs to reuse the global state
-    size_t ourLhsPtr = _lhsPtr;
-    size_t ourRhsPtr = _rhsPtr;
-
     Dataframe* oDF = _out.getDataframe();
-    Column* outColumnErased = oDF->cols().at(colIdx)->getColumn();
+    Column* outCol = oDF->cols().at(colIdx)->getColumn();
 
     Column* leftColumnErased = left->cols().at(colIdx)->getColumn();
 
-    dispatchColumnVector(leftColumnErased, [&](auto* lhsCol) {
-        auto* outCol = static_cast<decltype(lhsCol)>(outColumnErased);
-        auto& outRaw = outCol->getRaw();
+    // NOTE: Functor takes @ref _rhsPtr, _lhsPtr by value, and doesn't modify global state
+    SetFromLeftCol setter(outCol, _rhsPtr, _lhsPtr, fromRow, remainingSpace, m, n);
 
-        // If we were halfway through writing tuples for a left hand row, try and finish
-        if (ourRhsPtr != 0) {
-            // Write as many as we need, or as many as we can
-            const size_t needToWrite = m - ourRhsPtr;
-            const size_t canWrite = std::min(remainingSpace, needToWrite);
+    using Types = CartesianProductKinds;
+    using Dispatcher = ColumnSingleDispatcher<Types::Allowed, SetFromLeftCol, Types::Excluded>;
 
-            const auto startIt = begin(outRaw) + ourRowPtr;
-            const auto endIt = startIt + canWrite;
-
-            const auto& val = lhsCol->at(ourLhsPtr);
-
-            std::fill(startIt, endIt, val);
-
-            // Reduce the space we have left to right
-            remainingSpace -= canWrite;
-            ourRowPtr += canWrite;
-            ourRhsPtr += canWrite;
-            // If we wrote all `m` rows for this LHS row, then reset,
-            // otherwise increment
-            if (canWrite == needToWrite) { // If we wrote all we needed
-                ourLhsPtr++;               // We now need to write the next LHS
-                ourRhsPtr = 0;             // And start from the first RHS
-            }
-        }
-
-        if (ourLhsPtr == n + 1) { // We have written all rows from LHS
-            return;
-        }
-
-        if (remainingSpace == 0) { // We have ran out of space
-            return;
-        }
-
-        // Work out how for how many rows in LHS can we write all tuples with RHS for
-        // Each row in LHS needs m rows to fit all tuples: one for for each row on RHS
-        const size_t rowsLeftToWrite = n - ourLhsPtr;
-        const size_t numCompleteLhsRowsCanWrite = std::min(rowsLeftToWrite, remainingSpace / m);
-        const bool canWriteAll = rowsLeftToWrite == numCompleteLhsRowsCanWrite;
-        const bool canWriteLeftovers = remainingSpace % m != 0;
-
-        for (size_t i = 0; i < numCompleteLhsRowsCanWrite; i++) {
-            const auto& currentLhsElement = lhsCol->at(ourLhsPtr);
-
-            const auto startIt = begin(outRaw) + ourRowPtr;
-            const auto endIt = startIt + m; // We know we can fit m rows here
-
-            std::fill(startIt, endIt, currentLhsElement);
-
-            ourLhsPtr++;
-            ourRhsPtr = 0;
-
-            ourRowPtr += m;
-
-            remainingSpace -= m;
-        }
-
-        if (canWriteAll || !canWriteLeftovers) {
-            return;
-        }
-
-        bioassert(remainingSpace < m, "Not enough remaining space");
-        bioassert(ourRhsPtr == 0, "ourRhsPtr must be 0");
-
-        const auto& lhsElement = lhsCol->at(ourLhsPtr);
-        const auto startIt = begin(outRaw) + ourRowPtr;
-        const auto endIt = startIt + remainingSpace;
-        bioassert(endIt == end(outRaw), "Invalid endIt iterator");
-
-        std::fill(startIt, endIt, lhsElement);
-    });
+    Dispatcher::dispatch(leftColumnErased, setter);
 }
 
 void CartesianProductProcessor::copyFromRightColumn(Dataframe* left,

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -607,7 +607,6 @@ struct CartesianProductKinds {
 
     using Excluded = ExcludedContainers<
         ContainerKind::code<ColumnSet>(),
-        ContainerKind::code<ColumnConst>(),
         ContainerKind::code<ColumnMask>()
     >;
 };

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <type_traits>
 
+#include "columns/ColumnConst.h"
 #include "list/ListBuffer.h"
 #include "ID.h"
 #include "versioning/ChangeID.h"
@@ -566,6 +567,45 @@ struct ValueHashJoinPairs {
     using Excluded = ExcludedContainers<
         ContainerKind::code<ColumnConst>(),
         ContainerKind::code<ColumnSet>(),
+        ContainerKind::code<ColumnMask>()
+    >;
+};
+
+// Column types allowed as an input to @ref CartesianProductProcessor
+struct CartesianProductKinds {
+    using Allowed = GenerateKindList<std::tuple<
+        // All property types and their optional variants
+        types::Int64::Primitive,
+        types::UInt64::Primitive,
+        types::Double::Primitive,
+        types::String::Primitive,
+        types::Bool::Primitive,
+
+        std::optional<types::Int64::Primitive>,
+        std::optional<types::UInt64::Primitive>,
+        std::optional<types::Double::Primitive>,
+        std::optional<types::String::Primitive>,
+        std::optional<types::Bool::Primitive>,
+
+        // Entities
+        NodeID,
+        EdgeID,
+        EdgeTypeID,
+        PropertyTypeID,
+        LabelID,
+        LabelSetID,
+
+        // Lists
+        ListView,
+        ListElementView,
+
+        // Owning strings occasionally needed for procedures; tests
+        std::string
+    >>;
+
+    using Excluded = ExcludedContainers<
+        ContainerKind::code<ColumnSet>(),
+        ContainerKind::code<ColumnConst>(),
         ContainerKind::code<ColumnMask>()
     >;
 };

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -587,17 +587,19 @@ struct CartesianProductKinds {
         std::optional<types::String::Primitive>,
         std::optional<types::Bool::Primitive>,
 
-        // Entities
+        // Entities and metadata
         NodeID,
         EdgeID,
         EdgeTypeID,
         PropertyTypeID,
         LabelID,
         LabelSetID,
+        ValueType,
 
         // Lists
         ListView,
         ListElementView,
+        EntityList,
 
         // Owning strings occasionally needed for procedures; tests
         std::string

--- a/storage/dataframe/Dataframe.cpp
+++ b/storage/dataframe/Dataframe.cpp
@@ -146,21 +146,20 @@ void Dataframe::append(const Dataframe* other) {
         Column* dst = dstNamed->getColumn();
         Column* src = srcNamed->getColumn();
 
-        // Resize destination to fit new data
         dispatchColumnVector(dst, [&](auto* dstColumnVector) {
-            const auto* srcColumnVector = dynamic_cast<decltype(dstColumnVector)>(src);
-            if (!srcColumnVector) {
-                throw FatalException(
-                    fmt::format("Attempted to append to a Dataframe whose column at "
-                                "index {} is not a ColumnVector<T>.",
-                                i));
-            }
+            using T = typename std::remove_reference_t<decltype(dstColumnVector->getRaw())>::value_type;
 
             dstColumnVector->resize(newRows);
-            const auto& srcRaw = srcColumnVector->getRaw();
             auto& dstRaw = dstColumnVector->getRaw();
 
-            std::copy(begin(srcRaw),end(srcRaw),begin(dstRaw) + oldRows);
+            if (const auto* srcConst = dynamic_cast<const ColumnConst<T>*>(src)) {
+                std::fill(begin(dstRaw) + oldRows, end(dstRaw), srcConst->getRaw());
+            } else if (const auto* srcVec = dynamic_cast<const ColumnVector<T>*>(src)) {
+                const auto& srcRaw = srcVec->getRaw();
+                std::copy(begin(srcRaw), end(srcRaw), begin(dstRaw) + oldRows);
+            } else {
+                throw FatalException("Unknown source column type.");
+            }
         });
     }
 }

--- a/storage/dataframe/Dataframe.cpp
+++ b/storage/dataframe/Dataframe.cpp
@@ -4,8 +4,10 @@
 #include <sstream>
 
 #include "NamedColumn.h"
+#include "columns/AllowedKinds.h"
 #include "columns/Column.h"
-#include "columns/ColumnDispatcher.h"
+#include "columns/ColumnOperatorDispatcher.h"
+#include "columns/ColumnVector.h"
 
 #include "FatalException.h"
 #include "columns/ContainerKind.h"
@@ -127,11 +129,9 @@ void Dataframe::copyFromLine(const Dataframe* other, size_t startRow, size_t row
 }
 
 void Dataframe::append(const Dataframe* other) {
-    if (this->size() != other->size()) {
-        throw FatalException(fmt::format(
-            "Attempted to append a Dataframe of size {} to a Dataframe of size {}.",
-            other->size(), this->size()));
-    }
+    bioassert(this->size() == other->size(),
+              "Attempted to append a Dataframe of size {} to a Dataframe of size {}.",
+              other->size(), this->size());
 
     const size_t oldRows = this->getLogicalRowCount();
     const size_t addRows = other->getLogicalRowCount();
@@ -140,27 +140,32 @@ void Dataframe::append(const Dataframe* other) {
     const NamedColumns& otherCols = other->cols();
 
     for (size_t i = 0; i < _cols.size(); i++) {
-        NamedColumn* dstNamed = _cols[i];
-        NamedColumn* srcNamed = otherCols[i];
+        Column* dst = _cols[i]->getColumn();
+        const Column* src = otherCols[i]->getColumn();
 
-        Column* dst = dstNamed->getColumn();
-        Column* src = srcNamed->getColumn();
+        const auto appendCol = [dst, oldRows, newRows]
+                         <template <typename> class Container, typename T>
+                         (const Container<T>* srcCol) {
+            auto* dstVec = dynamic_cast<ColumnVector<T>*>(dst);
+            bioassert(dstVec, "Invalid destination vector to append.");
 
-        dispatchColumnVector(dst, [&](auto* dstColumnVector) {
-            using T = typename std::remove_reference_t<decltype(dstColumnVector->getRaw())>::value_type;
+            dstVec->resize(newRows);
+            auto& dstRaw = dstVec->getRaw();
 
-            dstColumnVector->resize(newRows);
-            auto& dstRaw = dstColumnVector->getRaw();
-
-            if (const auto* srcConst = dynamic_cast<const ColumnConst<T>*>(src)) {
-                std::fill(begin(dstRaw) + oldRows, end(dstRaw), srcConst->getRaw());
-            } else if (const auto* srcVec = dynamic_cast<const ColumnVector<T>*>(src)) {
-                const auto& srcRaw = srcVec->getRaw();
-                std::copy(begin(srcRaw), end(srcRaw), begin(dstRaw) + oldRows);
+            if constexpr (std::is_same_v<Container<T>, ColumnConst<T>>) {
+                auto start = begin(dstRaw) + oldRows;
+                const T& value = srcCol->getRaw();
+                std::fill(start, end(dstRaw), value);
             } else {
-                throw FatalException("Unknown source column type.");
+                const std::vector<T>& srcRaw = srcCol->getRaw();
+                auto fromIt = begin(dstRaw) + oldRows;
+                std::ranges::copy(srcRaw, fromIt);
             }
-        });
+        };
+
+        using Types = CartesianProductKinds;
+        using Dispatcher = ColumnSingleDispatcher<Types::Allowed, decltype(appendCol), Types::Excluded>;
+        Dispatcher::dispatch(src, appendCol);
     }
 }
 

--- a/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
+++ b/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
@@ -1696,11 +1696,15 @@ TEST_F(CartesianProductProcessorTest, constValueChangesAcrossChunks) {
         lhsCallCount++;
         auto* vecCol = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
         auto* constCol = dynamic_cast<ConstNodeIDs*>(df->cols()[1]->getColumn());
+        // Clear explicitly: the source may be called for the next chunk before the
+        // CartProd has consumed the previous one, so the df may have stale data.
         if (lhsCallCount == 1) {
-            vecCol->push_back(1);
+            vecCol->resize(1);
+            vecCol->at(0) = 1;
             constCol->set(CONST_VAL_1);
         } else {
-            vecCol->push_back(2);
+            vecCol->resize(1);
+            vecCol->at(0) = 2;
             constCol->set(CONST_VAL_2);
             isFinished = true;
         }

--- a/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
+++ b/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
@@ -10,6 +10,7 @@
 #include "processors/ProcessorTester.h"
 
 #include "processors/CartesianProductProcessor.h"
+#include "columns/ColumnConst.h"
 #include "dataframe/Dataframe.h"
 #include "processors/LambdaProcessor.h"
 #include "processors/LambdaSourceProcessor.h"
@@ -1470,6 +1471,204 @@ TEST_F(CartesianProductProcessorTest, bothEmpty) {
     EXECUTE(view, ChunkConfig::CHUNK_SIZE);
     ASSERT_TRUE(executed);
     ASSERT_TRUE(actualRow.empty());
+}
+
+TEST_F(CartesianProductProcessorTest, constLhsColumn) {
+    using ConstNodeIDs = ColumnConst<NodeID>;
+
+    auto [transaction, view, reader] = readGraph();
+
+    constexpr size_t LHS_NUM_ROWS = 3;
+    constexpr size_t RHS_NUM_ROWS = 2;
+    const NodeID CONST_LHS_VAL = NodeID(42);
+
+    // LHS:
+    // [col 0: vector]  [col 1: const]
+    //        1               42
+    //        2               42
+    //        3               42
+    const auto genLDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        auto* vecCol = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        vecCol->push_back(1);
+        vecCol->push_back(2);
+        vecCol->push_back(3);
+
+        auto* constCol = dynamic_cast<ConstNodeIDs*>(df->cols()[1]->getColumn());
+        constCol->set(CONST_LHS_VAL);
+
+        isFinished = true;
+    };
+
+    // RHS:
+    // [col 0: vector]
+    //        10
+    //        20
+    const auto genRDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        auto* col = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        col->push_back(10);
+        col->push_back(20);
+        isFinished = true;
+    };
+
+    {
+        auto& rhsIF = _builder->addLambdaSource(genRDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        [[maybe_unused]] auto& lhsIF = _builder->addLambdaSource(genLDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+        _builder->addColumnToOutput<ConstNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        const auto& cartProd = _builder->addCartesianProduct(&rhsIF);
+        ASSERT_EQ(cartProd.getDataframe()->cols().size(), 3);
+    }
+
+    // Output:
+    // [col 0: lhs vector]  [col 1: lhs const]  [col 2: rhs vector]
+    //        1                    42                   10
+    //        1                    42                   20
+    //        2                    42                   10
+    //        2                    42                   20
+    //        3                    42                   10
+    //        3                    42                   20
+    bool executed = false;
+    const auto VERIFY_CALLBACK = [&](const Dataframe* df, LambdaProcessor::Operation operation) -> void {
+        if (operation == LambdaProcessor::Operation::RESET) {
+            return;
+        }
+        executed = true;
+
+        ASSERT_EQ(df->size(), 3);
+        ASSERT_EQ(df->getLogicalRowCount(), LHS_NUM_ROWS * RHS_NUM_ROWS);
+
+        {
+            const ColumnNodeIDs expected = {1, 1, 2, 2, 3, 3};
+            const auto* col = df->cols().at(0)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
+        }
+        {
+            const auto* col = df->cols().at(1)->as<ConstNodeIDs>();
+            ASSERT_TRUE(col != nullptr);
+            EXPECT_EQ(col->getRaw(), CONST_LHS_VAL);
+        }
+        {
+            const ColumnNodeIDs expected = {10, 20, 10, 20, 10, 20};
+            const auto* col = df->cols().at(2)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
+        }
+    };
+
+    _builder->addLambda(VERIFY_CALLBACK);
+    EXECUTE(view, LHS_NUM_ROWS * RHS_NUM_ROWS);
+    ASSERT_TRUE(executed);
+}
+
+TEST_F(CartesianProductProcessorTest, constRhsColumn) {
+    using ConstNodeIDs = ColumnConst<NodeID>;
+
+    auto [transaction, view, reader] = readGraph();
+
+    constexpr size_t LHS_NUM_ROWS = 3;
+    constexpr size_t RHS_NUM_ROWS = 2;
+    const NodeID CONST_RHS_VAL = NodeID(99);
+
+    // LHS:
+    // [col 0: vector]
+    //        1
+    //        2
+    //        3
+    const auto genLDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        auto* col = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        col->push_back(1);
+        col->push_back(2);
+        col->push_back(3);
+        isFinished = true;
+    };
+
+    // RHS:
+    // [col 0: vector]  [col 1: const]
+    //        10              99
+    //        20              99
+    const auto genRDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        auto* vecCol = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        vecCol->push_back(10);
+        vecCol->push_back(20);
+
+        auto* constCol = dynamic_cast<ConstNodeIDs*>(df->cols()[1]->getColumn());
+        constCol->set(CONST_RHS_VAL);
+
+        isFinished = true;
+    };
+
+    {
+        auto& rhsIF = _builder->addLambdaSource(genRDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+        _builder->addColumnToOutput<ConstNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        [[maybe_unused]] auto& lhsIF = _builder->addLambdaSource(genLDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        const auto& cartProd = _builder->addCartesianProduct(&rhsIF);
+        ASSERT_EQ(cartProd.getDataframe()->cols().size(), 3);
+    }
+
+    // Output:
+    // [col 0: lhs vector]  [col 1: rhs vector]  [col 2: rhs const]
+    //        1                    10                   99
+    //        1                    20                   99
+    //        2                    10                   99
+    //        2                    20                   99
+    //        3                    10                   99
+    //        3                    20                   99
+    bool executed = false;
+    const auto VERIFY_CALLBACK = [&](const Dataframe* df, LambdaProcessor::Operation operation) -> void {
+        if (operation == LambdaProcessor::Operation::RESET) {
+            return;
+        }
+        executed = true;
+
+        ASSERT_EQ(df->size(), 3);
+        ASSERT_EQ(df->getLogicalRowCount(), LHS_NUM_ROWS * RHS_NUM_ROWS);
+
+        {
+            const ColumnNodeIDs expected = {1, 1, 2, 2, 3, 3};
+            const auto* col = df->cols().at(0)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
+        }
+        {
+            const ColumnNodeIDs expected = {10, 20, 10, 20, 10, 20};
+            const auto* col = df->cols().at(1)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
+        }
+        {
+            const auto* col = df->cols().at(2)->as<ConstNodeIDs>();
+            ASSERT_TRUE(col != nullptr);
+            EXPECT_EQ(col->getRaw(), CONST_RHS_VAL);
+        }
+    };
+
+    _builder->addLambda(VERIFY_CALLBACK);
+    EXECUTE(view, LHS_NUM_ROWS * RHS_NUM_ROWS);
+    ASSERT_TRUE(executed);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
+++ b/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
@@ -1554,9 +1554,11 @@ TEST_F(CartesianProductProcessorTest, constLhsColumn) {
             }
         }
         {
-            const auto* col = df->cols().at(1)->as<ConstNodeIDs>();
-            ASSERT_TRUE(col != nullptr);
-            EXPECT_EQ(col->getRaw(), CONST_LHS_VAL);
+            const ColumnNodeIDs expected = {42, 42, 42, 42, 42, 42};
+            const auto* col = df->cols().at(1)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
         }
         {
             const ColumnNodeIDs expected = {10, 20, 10, 20, 10, 20};
@@ -1660,15 +1662,121 @@ TEST_F(CartesianProductProcessorTest, constRhsColumn) {
             }
         }
         {
-            const auto* col = df->cols().at(2)->as<ConstNodeIDs>();
-            ASSERT_TRUE(col != nullptr);
-            EXPECT_EQ(col->getRaw(), CONST_RHS_VAL);
+            const ColumnNodeIDs expected = {99, 99, 99, 99, 99, 99};
+            const auto* col = df->cols().at(2)->as<ColumnNodeIDs>();
+            for (const auto& [exp, actual] : rv::zip(expected, *col)) {
+                EXPECT_EQ(exp, actual);
+            }
         }
     };
 
     _builder->addLambda(VERIFY_CALLBACK);
     EXECUTE(view, LHS_NUM_ROWS * RHS_NUM_ROWS);
     ASSERT_TRUE(executed);
+}
+
+TEST_F(CartesianProductProcessorTest, constValueChangesAcrossChunks) {
+    using ConstNodeIDs = ColumnConst<NodeID>;
+
+    auto [transaction, view, reader] = readGraph();
+
+    const NodeID CONST_VAL_1 = NodeID(42);
+    const NodeID CONST_VAL_2 = NodeID(99);
+
+    // LHS emits two separate chunks:
+    //   chunk 1: vecCol=[1], constCol=42  (isFinished=false)
+    //   chunk 2: vecCol=[2], constCol=99  (isFinished=true)
+    // The memory bank must store both const values as a ColumnVector [42, 99],
+    // not as a ColumnConst (which could only hold one value).
+    int lhsCallCount = 0;
+    const auto genLDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        lhsCallCount++;
+        auto* vecCol = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        auto* constCol = dynamic_cast<ConstNodeIDs*>(df->cols()[1]->getColumn());
+        if (lhsCallCount == 1) {
+            vecCol->push_back(1);
+            constCol->set(CONST_VAL_1);
+        } else {
+            vecCol->push_back(2);
+            constCol->set(CONST_VAL_2);
+            isFinished = true;
+        }
+    };
+
+    // RHS emits one chunk: [10, 20]
+    const auto genRDF = [&](Dataframe* df, bool& isFinished, auto operation) -> void {
+        if (operation != LambdaSourceProcessor::Operation::EXECUTE) {
+            return;
+        }
+        auto* col = dynamic_cast<ColumnNodeIDs*>(df->cols()[0]->getColumn());
+        col->push_back(10);
+        col->push_back(20);
+        isFinished = true;
+    };
+
+    {
+        auto& rhsIF = _builder->addLambdaSource(genRDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        [[maybe_unused]] auto& lhsIF = _builder->addLambdaSource(genLDF);
+        _builder->addColumnToOutput<ColumnNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+        _builder->addColumnToOutput<ConstNodeIDs>(_pipeline.getDataframeManager()->allocTag());
+
+        const auto& cartProd = _builder->addCartesianProduct(&rhsIF);
+        ASSERT_EQ(cartProd.getDataframe()->cols().size(), 3);
+    }
+
+    // With chunkSize=2 (1 LHS row × 2 RHS rows), each LHS chunk fills exactly one output chunk:
+    //   output chunk 1: lhs chunk1 × rhs   → (1,42,10), (1,42,20)
+    //   output chunk 2: lhs chunk2 × rhs   → (2,99,10), (2,99,20)
+    std::vector<NodeID> actualLhsVec;
+    std::vector<NodeID> actualLhsConst;
+    std::vector<NodeID> actualRhsVec;
+
+    bool executed = false;
+    const auto VERIFY_CALLBACK = [&](const Dataframe* df, LambdaProcessor::Operation operation) -> void {
+        if (operation == LambdaProcessor::Operation::RESET) {
+            return;
+        }
+        executed = true;
+
+        ASSERT_EQ(df->size(), 3);
+        const auto* lhsVecCol = df->cols().at(0)->as<ColumnNodeIDs>();
+        const auto* lhsConstCol = df->cols().at(1)->as<ColumnNodeIDs>();
+        const auto* rhsVecCol = df->cols().at(2)->as<ColumnNodeIDs>();
+
+        const size_t rowCount = df->getLogicalRowCount();
+        for (size_t row = 0; row < rowCount; row++) {
+            actualLhsVec.push_back(lhsVecCol->at(row));
+            actualLhsConst.push_back(lhsConstCol->at(row));
+            actualRhsVec.push_back(rhsVecCol->at(row));
+        }
+    };
+
+    _builder->addLambda(VERIFY_CALLBACK);
+    EXECUTE(view, 2);
+    ASSERT_TRUE(executed);
+
+    const ColumnNodeIDs expectedLhsVec   = {1, 1, 2, 2};
+    const ColumnNodeIDs expectedLhsConst = {42, 42, 99, 99};
+    const ColumnNodeIDs expectedRhsVec   = {10, 20, 10, 20};
+
+    ASSERT_EQ(actualLhsVec.size(), 4);
+    ASSERT_EQ(actualLhsConst.size(), 4);
+    ASSERT_EQ(actualRhsVec.size(), 4);
+
+    for (const auto& [exp, actual] : rv::zip(expectedLhsVec, actualLhsVec)) {
+        EXPECT_EQ(exp, actual);
+    }
+    for (const auto& [exp, actual] : rv::zip(expectedLhsConst, actualLhsConst)) {
+        EXPECT_EQ(exp, actual);
+    }
+    for (const auto& [exp, actual] : rv::zip(expectedRhsVec, actualRhsVec)) {
+        EXPECT_EQ(exp, actual);
+    }
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Currently, `CartesianProductProcessor` can only take input dataframes where all columns are `ColumnVector<T>`.

There is no reason why we cannot support `ColumnConst<T>` (and it is required to implement #648).

This PR migrates the use of `dispatchColumnVector` to the new `ColumnSingleDispatcher`, and adds logic to handle `ColumnConst` inputs to the processor.