### PR TITLE
Debug Corrupted Dump/Load issue

### DIFF
--- a/storage/dump/GraphDumper.cpp
+++ b/storage/dump/GraphDumper.cpp
@@ -163,33 +163,30 @@ DumpResult<void> GraphDumper::dumpMissingCommits(const Graph& graph, const fs::P
         return fileHeaderRes.get_unexpected();
     }
 
-    // update the total number of commits
-    writer.write(graph._versionController->getNumCommits());
-    writer.flush();
-
-    if (writer.errorOccured()) {
-        return DumpError::result(DumpErrorType::COULD_NOT_WRITE_COMMIT_LOG,
-                                 *writer.error());
-    }
-
-    // skip to the last entry (each Commit Log Entry is just the commit hash)
+    //Seek to the end of the file to get the last commit in order to check if all the commits
+    //have been dumped already. This can happen with concurrent writes - we treat dumps
+    //on the same version of a branch as idempotent.
     reader.file().seekEnd(-(off_t)sizeof(uint64_t));
     reader.read(sizeof(uint64_t));
 
     fs::ByteBufferIterator entryIt = reader.iterateBuffer();
 
-    // Use the dumped commitLog to get the last commit dumped - so
-    // we know to dump all commits from the new head until ( and exluding) the last dumped commit
     const uint64_t prevCommitHash = entryIt.get<uint64_t>();
+    const Commit* headCommit = graph._versionController->_head.load();
 
-    const Commit* commit = graph._versionController->_head.load();
+    //Check if the last dumped commit is the current head commit - this means 
+    //we have already dumped all the commits in the branch and can return safely.
+    if(prevCommitHash == headCommit->hash().get()) {
+        return {};
+    }
+
     std::vector<CommitHash> commitList;
-
+    // we know to dump all commits from the new head until (excluding) the last dumped commit.
     // collect all the new commits so we can iterate and append them to file later
-    while (commit && commit->hash().get() != prevCommitHash) {
-        commitList.emplace_back(commit->hash());
+    while (headCommit && headCommit->hash().get() != prevCommitHash) {
+        commitList.emplace_back(headCommit->hash());
 
-        const std::string fileName = fmt::format("{}", commit->hash().get());
+        const std::string fileName = fmt::format("{}", headCommit->hash().get());
         const fs::Path commitDir = graphDir / "commits" / fileName;
         const fs::Path partsDir = graphDir / "dataparts";
 
@@ -198,10 +195,21 @@ DumpResult<void> GraphDumper::dumpMissingCommits(const Graph& graph, const fs::P
             return DumpError::result(DumpErrorType::COMMIT_ALREADY_EXISTS);
         }
 
-        if (auto res = CommitDumper::dump(*commit, commitDir, partsDir); !res) {
+        if (auto res = CommitDumper::dump(*headCommit, commitDir, partsDir); !res) {
             return res;
         }
-        commit = commit->getPreviousCommit();
+        headCommit= headCommit->getPreviousCommit();
+    }
+
+    //seek back to the offset right after the headers
+    writer.file().seek(DumpConfig::FILE_HEADER_STRIDE);
+    // update the total number of commits
+    writer.write(graph._versionController->getNumCommits());
+    writer.flush();
+
+    if (writer.errorOccured()) {
+        return DumpError::result(DumpErrorType::COULD_NOT_WRITE_COMMIT_LOG,
+                                 *writer.error());
     }
 
     // Seek to EOF before appending new commit log entries

--- a/storage/dump/GraphLoader.cpp
+++ b/storage/dump/GraphLoader.cpp
@@ -7,6 +7,8 @@
 #include "versioning/VersionController.h"
 #include "versioning/CommitView.h"
 
+#include <spdlog/spdlog.h>
+
 using namespace db;
 
 DumpResult<void> GraphLoader::load(Graph* graph, const fs::Path& graphDir) {
@@ -61,6 +63,16 @@ DumpResult<void> GraphLoader::load(Graph* graph, const fs::Path& graphDir) {
     }
 
     const size_t numEntries = it.get<uint64_t>();
+
+    //Expected size of the file = Size of File Header + uint64_t numEntries + uint64_t eachCommitHash * numEntries
+    const uint64_t expectedSize = DumpConfig::FILE_HEADER_STRIDE + sizeof(uint64_t) * (numEntries + 1);
+    const uint64_t actualSize = reader.file().getInfo()._size;
+    if (expectedSize != actualSize) {
+        spdlog::error("commitlog size mismatch: header claims {} entries "
+                      "(expected {} bytes) but file is {} bytes",
+                      numEntries, expectedSize, actualSize);
+        return DumpError::result(DumpErrorType::COULD_NOT_READ_COMMIT_LOG);
+    }
 
     const Commit* prevCommit = nullptr;
     for (size_t i = 0; i < numEntries; ++i) {

--- a/storage/versioning/CommitHash.cpp
+++ b/storage/versioning/CommitHash.cpp
@@ -4,9 +4,9 @@
 
 using namespace db;
 
-static inline std::random_device _rd;
-static inline std::mt19937_64 _generator(_rd());
-static inline std::uniform_int_distribution<uint64_t> _distribution {
+thread_local std::random_device _rd;
+thread_local std::mt19937_64 _generator(_rd());
+thread_local std::uniform_int_distribution<uint64_t> _distribution {
     1,
     std::numeric_limits<uint64_t>::max() - 1,
 };


### PR DESCRIPTION
Managed to find a data race bug that would occur during many concurrent writes. There are two dump paths - one for the initial dump of the graph and then the incremental dump. A lock was missing on the incremental dump step. I also added some checks to harden the graph loader and identify bugs.