### PR TITLE
Fix Rule of 5 violations with ListBuffer and co.

### DIFF
--- a/storage/list/ListByteBuffer.h
+++ b/storage/list/ListByteBuffer.h
@@ -28,6 +28,11 @@ public:
     /// Deallocates all owned chunks
     ~ListByteBuffer();
 
+    ListByteBuffer(const ListByteBuffer&) = delete;
+    ListByteBuffer(ListByteBuffer&&) = delete;
+    ListByteBuffer& operator=(const ListByteBuffer&) = delete;
+    ListByteBuffer& operator=(ListByteBuffer&&) = delete;
+
     static consteval size_t tagSize() { return _tagSize; }
 
     /**
@@ -88,9 +93,12 @@ public:
     {
     }
 
-    ~ByteChunk() {
-        delete[] _buf;
-    }
+    ~ByteChunk() { delete[] _buf; }
+
+    ByteChunk(const ByteChunk&) = delete;
+    ByteChunk(ByteChunk&&) = delete;
+    ByteChunk& operator=(const ByteChunk&) = delete;
+    ByteChunk& operator=(ByteChunk&&) = delete;
 
     /// Returns true if @ref _buf has at least @param numBytes remaining capacity
     [[nodiscard]] bool canFit(size_t numBytes) const;

--- a/storage/list/ListElementViewBuffer.h
+++ b/storage/list/ListElementViewBuffer.h
@@ -26,6 +26,11 @@ public:
     /// Deallocates all owned chunks
     ~ListElementViewBuffer();
 
+    ListElementViewBuffer(const ListElementViewBuffer&) = delete;
+    ListElementViewBuffer(ListElementViewBuffer&&) = delete;
+    ListElementViewBuffer& operator=(const ListElementViewBuffer&) = delete;
+    ListElementViewBuffer& operator=(ListElementViewBuffer&&) = delete;
+
     /**
      * @brief Ensures that after this call is complete, the current @ref Chunk
      * contains at least enough free space at the end of the its internal buffer to store
@@ -90,6 +95,11 @@ public:
     ~Chunk() {
         delete[] _buf;
     }
+
+    Chunk(const Chunk&) = delete;
+    Chunk(Chunk&&) = delete;
+    Chunk& operator=(const Chunk&) = delete;
+    Chunk& operator=(Chunk&&) = delete;
 
     /// Returns true if @ref _buf has at least @param numViews remaining capacity
     [[nodiscard]] bool canFit(size_t numViews) const;


### PR DESCRIPTION
`ListByteBuffer` and `ListElementViewBuffer` manually managed memory, but had implicitly defined copy and move constructors/assignment which did not serve that memory management. Deleted to prevent misuse.