### PR TITLE
Implement ObjectMap

### DIFF
--- a/common/StringHashMap.h
+++ b/common/StringHashMap.h
@@ -10,8 +10,8 @@ template <class K, class V>
 struct StringHashMap : std::unordered_map<K, V, StringHasher, std::equal_to<>> {
     using Base = std::unordered_map<K, V, StringHasher, std::equal_to<>>;
 
-    using Base::unordered_map;
-    using Base::erase;
+    using typename Base::unordered_map;
+    using typename Base::erase;
 
     // The standard unordered_map::erase(key) is not heterogeneous, so erasing
     // by string_view requires a transparent lookup followed by an erase by

--- a/common/StringHashMap.h
+++ b/common/StringHashMap.h
@@ -2,10 +2,27 @@
 
 #include <unordered_map>
 #include <functional>
+#include <string_view>
 
 #include "StringHasher.h"
 
 template <class K, class V>
 struct StringHashMap : std::unordered_map<K, V, StringHasher, std::equal_to<>> {
-    using std::unordered_map<K, V, StringHasher, std::equal_to<>>::unordered_map;
+    using Base = std::unordered_map<K, V, StringHasher, std::equal_to<>>;
+
+    using Base::unordered_map;
+    using Base::erase;
+
+    // The standard unordered_map::erase(key) is not heterogeneous, so erasing
+    // by string_view requires a transparent lookup followed by an erase by
+    // iterator.
+    size_t erase(std::string_view key) {
+        const auto it = this->find(key);
+        if (it == this->end()) {
+            return 0;
+        }
+
+        this->erase(it);
+        return 1;
+    }
 };

--- a/common/StringHashMap.h
+++ b/common/StringHashMap.h
@@ -8,10 +8,8 @@
 
 template <class K, class V>
 struct StringHashMap : std::unordered_map<K, V, StringHasher, std::equal_to<>> {
-    using Base = std::unordered_map<K, V, StringHasher, std::equal_to<>>;
-
-    using typename Base::unordered_map;
-    using typename Base::erase;
+    using std::unordered_map<K, V, StringHasher, std::equal_to<>>::unordered_map;
+    using std::unordered_map<K, V, StringHasher, std::equal_to<>>::erase;
 
     // The standard unordered_map::erase(key) is not heterogeneous, so erasing
     // by string_view requires a transparent lookup followed by an erase by

--- a/storage/ObjectMap.h
+++ b/storage/ObjectMap.h
@@ -2,6 +2,7 @@
 
 #include <string_view>
 #include <string>
+#include <vector>
 #include <memory>
 #include <shared_mutex>
 #include <mutex>
@@ -14,12 +15,22 @@ namespace db {
 template <typename ObjectT>
 class ObjectMap {
 public:
-    struct ObjectSlot {
-        std::unique_ptr<ObjectT> _obj;
+    class SlotReservation;
+
+    class ObjectSlot {
+    public:
+        friend SlotReservation;
 
         bool isFree() const {
             return _obj == nullptr;
         }
+
+        ObjectT* getObject() const {
+            return _obj.get();
+        }
+
+    private:
+        std::unique_ptr<ObjectT> _obj;
     };
 
     class SlotReservation {
@@ -54,6 +65,7 @@ public:
             {
                 std::unique_lock<RWSpinLock> lock(_map->_mapLock);
                 _slot->_obj = std::move(obj);
+                ++_map->_size;
             }
 
             _slot = nullptr;
@@ -113,9 +125,25 @@ public:
         return slot;
     }
 
+    size_t size() const {
+        std::shared_lock<RWSpinLock> lock(_mapLock);
+        return _size;
+    }
+
+    void listNames(std::vector<std::string_view>& names) const {
+        std::shared_lock<RWSpinLock> lock(_mapLock);
+
+        for (const auto& [name, slot] : _map) {
+            if (slot && !slot->isFree()) {
+                names.push_back(name);
+            }
+        }
+    }
+
 private:
     mutable RWSpinLock _mapLock;
     StringHashMap<std::string, std::unique_ptr<ObjectSlot>> _map;
+    size_t _size {0};
 
     void removeSlot(std::string_view name) {
         _map.erase(name);

--- a/storage/ObjectMap.h
+++ b/storage/ObjectMap.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <string_view>
+#include <string>
+#include <memory>
+#include <shared_mutex>
+#include <mutex>
+
+#include "RWSpinLock.h"
+#include "StringHashMap.h"
+
+namespace db {
+
+template <typename ObjectT>
+class ObjectMap {
+public:
+    struct ObjectSlot {
+        std::unique_ptr<ObjectT> _obj;
+
+        bool isFree() const {
+            return _obj == nullptr;
+        }
+    };
+
+    class SlotReservation {
+    public:
+        SlotReservation() = default;
+
+        SlotReservation(const SlotReservation&) = delete;
+        SlotReservation& operator=(const SlotReservation&) = delete;
+
+        SlotReservation(ObjectMap* map,
+                        ObjectSlot* slot,
+                        std::string_view name)
+            : _map(map),
+            _slot(slot),
+            _name(name)
+        {
+        }
+
+        ~SlotReservation() {
+            if (_slot && _map) {
+                // Slot has not been published, erase
+                _map->removeSlot(_name);
+            }
+        }
+
+        bool isValid() const {
+            return _slot && _map;
+        }
+
+        void publish(std::unique_ptr<ObjectT>&& obj) {
+            // We acquire a short lock on the spinlock to publish
+            {
+                std::unique_lock<RWSpinLock> lock(_map->_mapLock);
+                _slot->_obj = std::move(obj);
+            }
+
+            _slot = nullptr;
+            _map = nullptr;
+        }
+
+    private:
+        ObjectMap* _map {nullptr};
+        ObjectSlot* _slot {nullptr};
+        std::string_view _name;
+    };
+
+    explicit ObjectMap()
+    {
+    }
+
+    ObjectMap(const ObjectMap&) = delete;
+    ObjectMap& operator=(const ObjectMap&) = delete;
+
+    ~ObjectMap() {
+    }
+
+    SlotReservation reserve(std::string_view name) {
+        std::unique_lock<RWSpinLock> lock(_mapLock);
+
+        const auto [it, inserted] = _map.try_emplace(std::string(name));
+        if (!inserted) {
+            return SlotReservation();
+        }
+
+        // We allocate the slot in the critical section 
+        // to not do an allocation for nothing if try_emplace fails
+        auto slot = std::make_unique<ObjectSlot>();
+        ObjectSlot* slotPtr = slot.get();
+        it->second = std::move(slot);
+
+        return SlotReservation(this, slotPtr, name);
+    }
+
+    ObjectSlot* getObject(std::string_view name) const {
+        std::shared_lock<RWSpinLock> lock(_mapLock);
+
+        const auto it = _map.find(name);
+        if (it == _map.end()) {
+            return nullptr;
+        }
+
+        ObjectSlot* slot = it->second.get();
+
+        // An object slot should not be visible
+        // if the slot is nullptr (being constructed) or
+        // if the object contained in the slot is not published yet
+        if (!slot || slot->isFree()) {
+            return nullptr;
+        }
+
+        return slot;
+    }
+
+private:
+    mutable RWSpinLock _mapLock;
+    StringHashMap<std::string, std::unique_ptr<ObjectSlot>> _map;
+
+    void removeSlot(std::string_view name) {
+        _map.erase(name);
+    }
+};
+
+}

--- a/test/storage/CMakeLists.txt
+++ b/test/storage/CMakeLists.txt
@@ -38,4 +38,5 @@ add_storage_tests(test_storage_dump_loadcommit dump/LoadCommitDataTest.cpp)
 add_storage_tests(test_storage_dump_embedding_graph dump/EmbeddingGraphDumpLoadTest.cpp)
 
 add_storage_tests(test_storage_columns_dispatcher ColumnDispatcherTest.cpp)
+add_storage_tests(test_storage_objectmap ObjectMapTest.cpp)
 

--- a/test/storage/ObjectMapTest.cpp
+++ b/test/storage/ObjectMapTest.cpp
@@ -1,0 +1,243 @@
+#include "gtest/gtest.h"
+
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "ObjectMap.h"
+
+using namespace db;
+
+namespace {
+
+struct TestObject {
+    int _value {0};
+
+    static inline int _liveCount {0};
+
+    explicit TestObject(int value)
+        : _value(value)
+    {
+        ++_liveCount;
+    }
+
+    ~TestObject() {
+        --_liveCount;
+    }
+};
+
+std::unique_ptr<TestObject> makeObject(int value) {
+    return std::make_unique<TestObject>(value);
+}
+
+}
+
+class ObjectMapTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        TestObject::_liveCount = 0;
+    }
+};
+
+TEST_F(ObjectMapTest, reserveReturnsValid) {
+    ObjectMap<TestObject> map;
+
+    auto reservation = map.reserve("a");
+    ASSERT_TRUE(reservation.isValid());
+}
+
+TEST_F(ObjectMapTest, reserveSameNameTwiceFails) {
+    ObjectMap<TestObject> map;
+
+    auto first = map.reserve("a");
+    ASSERT_TRUE(first.isValid());
+
+    auto second = map.reserve("a");
+    ASSERT_FALSE(second.isValid());
+}
+
+TEST_F(ObjectMapTest, getUnknownReturnsNull) {
+    ObjectMap<TestObject> map;
+
+    ASSERT_EQ(map.getObject("missing"), nullptr);
+}
+
+TEST_F(ObjectMapTest, reservedButNotPublishedIsInvisible) {
+    ObjectMap<TestObject> map;
+
+    auto reservation = map.reserve("a");
+    ASSERT_TRUE(reservation.isValid());
+
+    // The name is reserved but no object has been published yet,
+    // so it must not be visible to readers.
+    ASSERT_EQ(map.getObject("a"), nullptr);
+}
+
+TEST_F(ObjectMapTest, publishMakesObjectVisible) {
+    ObjectMap<TestObject> map;
+
+    auto reservation = map.reserve("a");
+    ASSERT_TRUE(reservation.isValid());
+
+    reservation.publish(makeObject(42));
+
+    const auto* slot = map.getObject("a");
+    ASSERT_NE(slot, nullptr);
+    ASSERT_FALSE(slot->isFree());
+    ASSERT_EQ(slot->_obj->_value, 42);
+}
+
+TEST_F(ObjectMapTest, publishInvalidatesReservation) {
+    ObjectMap<TestObject> map;
+
+    auto reservation = map.reserve("a");
+    reservation.publish(makeObject(1));
+
+    ASSERT_FALSE(reservation.isValid());
+}
+
+TEST_F(ObjectMapTest, cancelledReservationReleasesName) {
+    ObjectMap<TestObject> map;
+
+    {
+        auto reservation = map.reserve("a");
+        ASSERT_TRUE(reservation.isValid());
+        // Reservation goes out of scope without publishing: the name
+        // reservation is cancelled.
+    }
+
+    ASSERT_EQ(map.getObject("a"), nullptr);
+
+    // The name is free again and can be reserved.
+    auto reservation = map.reserve("a");
+    ASSERT_TRUE(reservation.isValid());
+}
+
+TEST_F(ObjectMapTest, publishedNameCannotBeReserved) {
+    ObjectMap<TestObject> map;
+
+    {
+        auto reservation = map.reserve("a");
+        reservation.publish(makeObject(7));
+    }
+
+    // The slot is published, so the name stays occupied even after the
+    // reservation handle is destroyed.
+    auto reservation = map.reserve("a");
+    ASSERT_FALSE(reservation.isValid());
+
+    const auto* slot = map.getObject("a");
+    ASSERT_NE(slot, nullptr);
+    ASSERT_EQ(slot->_obj->_value, 7);
+}
+
+TEST_F(ObjectMapTest, multipleDistinctObjects) {
+    ObjectMap<TestObject> map;
+
+    auto first = map.reserve("a");
+    auto second = map.reserve("b");
+    ASSERT_TRUE(first.isValid());
+    ASSERT_TRUE(second.isValid());
+
+    first.publish(makeObject(1));
+    second.publish(makeObject(2));
+
+    ASSERT_EQ(map.getObject("a")->_obj->_value, 1);
+    ASSERT_EQ(map.getObject("b")->_obj->_value, 2);
+}
+
+TEST_F(ObjectMapTest, destructionFreesPublishedObjects) {
+    {
+        ObjectMap<TestObject> map;
+
+        auto first = map.reserve("a");
+        auto second = map.reserve("b");
+        first.publish(makeObject(1));
+        second.publish(makeObject(2));
+
+        ASSERT_EQ(TestObject::_liveCount, 2);
+    }
+
+    // The map owns the published objects and frees them on destruction.
+    ASSERT_EQ(TestObject::_liveCount, 0);
+}
+
+TEST_F(ObjectMapTest, cancelledReservationDoesNotLeak) {
+    {
+        ObjectMap<TestObject> map;
+
+        auto reservation = map.reserve("a");
+        // Never published: nothing was constructed.
+        ASSERT_EQ(TestObject::_liveCount, 0);
+    }
+
+    ASSERT_EQ(TestObject::_liveCount, 0);
+}
+
+TEST_F(ObjectMapTest, concurrentReserveDistinctNames) {
+    ObjectMap<TestObject> map;
+
+    constexpr int threadCount = 16;
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+
+    for (int i = 0; i < threadCount; ++i) {
+        threads.emplace_back([&map, i]() {
+            const std::string name = "obj_" + std::to_string(i);
+
+            auto reservation = map.reserve(name);
+            ASSERT_TRUE(reservation.isValid());
+
+            reservation.publish(makeObject(i));
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    for (int i = 0; i < threadCount; ++i) {
+        const std::string name = "obj_" + std::to_string(i);
+
+        const auto* slot = map.getObject(name);
+        ASSERT_NE(slot, nullptr);
+        ASSERT_EQ(slot->_obj->_value, i);
+    }
+
+    ASSERT_EQ(TestObject::_liveCount, threadCount);
+}
+
+TEST_F(ObjectMapTest, concurrentReserveSameNameSingleWinner) {
+    ObjectMap<TestObject> map;
+
+    constexpr int threadCount = 16;
+    std::atomic<int> validCount {0};
+    std::atomic<int> arrived {0};
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+
+    for (int i = 0; i < threadCount; ++i) {
+        threads.emplace_back([&]() {
+            auto reservation = map.reserve("contended");
+            if (reservation.isValid()) {
+                validCount.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            // Hold every reservation alive until all threads have tried,
+            // so that no cancellation frees the name mid-test and lets a
+            // second thread win.
+            arrived.fetch_add(1, std::memory_order_acq_rel);
+            while (arrived.load(std::memory_order_acquire) < threadCount) {
+                std::this_thread::yield();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    ASSERT_EQ(validCount.load(), 1);
+}

--- a/test/storage/ObjectMapTest.cpp
+++ b/test/storage/ObjectMapTest.cpp
@@ -86,7 +86,7 @@ TEST_F(ObjectMapTest, publishMakesObjectVisible) {
     const auto* slot = map.getObject("a");
     ASSERT_NE(slot, nullptr);
     ASSERT_FALSE(slot->isFree());
-    ASSERT_EQ(slot->_obj->_value, 42);
+    ASSERT_EQ(slot->getObject()->_value, 42);
 }
 
 TEST_F(ObjectMapTest, publishInvalidatesReservation) {
@@ -130,7 +130,7 @@ TEST_F(ObjectMapTest, publishedNameCannotBeReserved) {
 
     const auto* slot = map.getObject("a");
     ASSERT_NE(slot, nullptr);
-    ASSERT_EQ(slot->_obj->_value, 7);
+    ASSERT_EQ(slot->getObject()->_value, 7);
 }
 
 TEST_F(ObjectMapTest, multipleDistinctObjects) {
@@ -144,8 +144,8 @@ TEST_F(ObjectMapTest, multipleDistinctObjects) {
     first.publish(makeObject(1));
     second.publish(makeObject(2));
 
-    ASSERT_EQ(map.getObject("a")->_obj->_value, 1);
-    ASSERT_EQ(map.getObject("b")->_obj->_value, 2);
+    ASSERT_EQ(map.getObject("a")->getObject()->_value, 1);
+    ASSERT_EQ(map.getObject("b")->getObject()->_value, 2);
 }
 
 TEST_F(ObjectMapTest, destructionFreesPublishedObjects) {
@@ -203,7 +203,7 @@ TEST_F(ObjectMapTest, concurrentReserveDistinctNames) {
 
         const auto* slot = map.getObject(name);
         ASSERT_NE(slot, nullptr);
-        ASSERT_EQ(slot->_obj->_value, i);
+        ASSERT_EQ(slot->getObject()->_value, i);
     }
 
     ASSERT_EQ(TestObject::_liveCount, threadCount);


### PR DESCRIPTION
Implement an ObjectMap class with name reservation to be used in the new accessor & catalog system.

Uses an RAII pattern to reserve the name of an object in the map, for example the name of a new graph. It returns a SlotReservation object. Other threads can execute concurrently while the current thread is doing IO on that object to load it in memory. The creator thread does not need to block the map during the IO time. It just holds a reservation for the name.

When the IO for the object is complete, the creator thread can publish the object so that it becomes visible to other threads.

An object is only visible to other threads when the slot associated to its name exist AND the object has been published inside the slot.

Usage:
```c++
SlotReservation reserve = objMap.reserve("graphA");
if (!reserve.isValid()) {
     // The reservation will be automatically cancelled and reclaimed here
     // because we reach destruction without calling publish
     throw TuringException();
}

auto graph = std::make_unique<Graph>();

// Do some long IO
// The ObjectMap is not locked during this time
// ...
if (ioLoader.hasFailed()) {
    // If loading or dumping fails and we throw/early return 
    // the slot reservation is automatically cleaned up thanks to RAII
     throw TuringException();
}

reserve.publish(std::move(graph));
``` 

Choices: we hold short spinlocks during the structural modification and lookup of the hashmap because other threads can concurrently realloc the map during a rehash. The slot publish is not atomic because ObjectMap owns the objects themselves with a std::unique_ptr and we can't have `std::atomic<std::unique_ptr>`