### PR TITLE
Fix python version discrepencies in local builds between wheel and native python module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,23 @@ find_package(ZLIB REQUIRED)
 # openssl
 find_package(OpenSSL REQUIRED)
 
+# Resolve the Python used for the nanobind modules before any find_package(Python).
+# The first one runs inside add_subdirectory(external) via nanobind, so this must
+# come before it. Priority: explicit -DPython_EXECUTABLE, then the active
+# virtualenv, then the project .venv. Without this, FindPython picks the system
+# python3, whose ABI tag can differ from the Python running the wheel build and
+# the regression tests.
+if(NOT DEFINED Python_EXECUTABLE)
+    if(DEFINED ENV{VIRTUAL_ENV} AND EXISTS "$ENV{VIRTUAL_ENV}/bin/python")
+        set(Python_EXECUTABLE "$ENV{VIRTUAL_ENV}/bin/python")
+    elseif(EXISTS "${CMAKE_SOURCE_DIR}/.venv/bin/python")
+        set(Python_EXECUTABLE "${CMAKE_SOURCE_DIR}/.venv/bin/python")
+    endif()
+endif()
+if(DEFINED Python_EXECUTABLE)
+    message(STATUS "Python for native modules: ${Python_EXECUTABLE}")
+endif()
+
 enable_testing()
 
 # ======== Git Info =================

--- a/build_backend.py
+++ b/build_backend.py
@@ -5,6 +5,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import sysconfig
 import tempfile
 from pathlib import Path
 
@@ -85,6 +86,9 @@ def _run_cmake_build():
         "-G", "Unix Makefiles",
         "-DCMAKE_MAKE_PROGRAM=/usr/bin/make",
         "-DCMAKE_BUILD_TYPE=Release",
+        # Pin CMake's FindPython to the interpreter building the wheel, so the
+        # nanobind modules get the same ABI tag as the wheel itself.
+        f"-DPython_EXECUTABLE={sys.executable}",
     ]
 
     # Read CMAKE_ARGS from environment (used by CI for compiler paths)
@@ -97,6 +101,24 @@ def _run_cmake_build():
     subprocess.check_call(cmake_args, cwd=str(build_dir))
     subprocess.check_call(["make", f"-j{os.cpu_count() or 4}"], cwd=str(build_dir))
     subprocess.check_call(["make", "install"], cwd=str(build_dir))
+
+
+def _check_native_modules_abi(*module_dirs: Path) -> None:
+    """Fail if a bundled native module was built for a different Python ABI."""
+    expected_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    mismatched = []
+    for module_dir in module_dirs:
+        for module_file in list(module_dir.glob("*.so")) + list(module_dir.glob("*.pyd")):
+            if not module_file.name.endswith(expected_suffix):
+                mismatched.append(module_file)
+    if mismatched:
+        names = ", ".join(str(path) for path in mismatched)
+        raise RuntimeError(
+            f"Native module(s) built for a different Python ABI: {names}. "
+            f"This interpreter expects '*{expected_suffix}'. Rebuild against it:\n"
+            f"  cd build && cmake -DPython_EXECUTABLE={sys.executable} .. && make && make install\n"
+            "then delete the stale module file(s) and run the wheel build again."
+        )
 
 
 def _resolve_executable(name: str) -> Path:
@@ -152,6 +174,9 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     # Ensure all shipped executables exist
     exe_paths = _ensure_executables_built()
 
+    # Refuse to bundle native modules whose ABI tag doesn't match this interpreter
+    _check_native_modules_abi(binary_dir, local_dir)
+
     bin_dir = _get_package_bin_dir()
     build_lib_dir = project_root / "build" / "lib"
     ext_src_dir = _get_build_extensions_dir()
@@ -161,6 +186,14 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     if build_lib_dir.exists():
         for f in build_lib_dir.glob("*.a"):
             f.unlink()
+
+    # Purge native modules from setuptools' staging dirs (build/lib.*): setuptools
+    # never removes stale files there, so a module built for an older Python ABI
+    # would be bundled alongside the current one. They get re-copied fresh from
+    # python/turingdb/ during the build.
+    for staging_dir in (project_root / "build").glob("lib.*"):
+        for stale_module in list(staging_dir.glob("turingdb/_binary/_turingproto*")) + list(staging_dir.glob("turingdb/_local/_turinglocal*")):
+            stale_module.unlink()
 
     # Track which binaries we copied so cleanup removes only those.
     copied_binaries: list[Path] = []

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ def _run_cmake_build():
         "-G", "Unix Makefiles",
         "-DCMAKE_MAKE_PROGRAM=/usr/bin/make",
         "-DCMAKE_BUILD_TYPE=Release",
+        # Pin CMake's FindPython to the interpreter running the build, so the
+        # nanobind modules get the same ABI tag as the installing Python.
+        f"-DPython_EXECUTABLE={sys.executable}",
         str(source_dir),
     ]
     subprocess.check_call(cmake_args, cwd=str(build_dir))


### PR DESCRIPTION
* The wheel build for the pure python module uses correctly the python version of the .venv
* The native python module using nanobind for the binary protocol client used cmake that was doing a python version lookup inside cmake, based on find_package, without necessarily taking the exact same python version as the .venv
* Worked on the github CI because each CI build fixes explicitly the python version of the build environment globally beforehand
* On local builds the wheel and the native module could be compiled on different python versions which broke local runs of the regress