### PR TITLE
Fix segfault when full-dumping a loaded graph

### DIFF
--- a/storage/dump/GraphDumper.cpp
+++ b/storage/dump/GraphDumper.cpp
@@ -16,10 +16,29 @@
 
 using namespace db;
 
-DumpResult<void> GraphDumper::dump(const Graph* graph, const fs::Path& graphDir) {
+DumpResult<void> GraphDumper::dump(Graph* graph, const fs::Path& graphDir) {
     Profile profile("GraphDumper::dump");
 
     spdlog::info("Dumping graph {}", graph->getName());
+
+    // We dump from scratch and write every commit. After a load only the HEAD
+    // commit is hydrated — ancestors are skeletons with no CommitData. Each
+    // commit owns the dataparts created in it, which later commits still
+    // reference, and CommitDumper reads CommitData, so the skeletons must be
+    // materialised first or the dump is incomplete and dereferences a null
+    // WeakArc. loadCommit() takes the version controller's shared lock, so this
+    // runs before the exclusive dump lock below to avoid deadlocking on it.
+    // Hydrating a commit leaves the chain pointers intact, so we can walk and
+    // load in a single pass.
+    const Commit* commit = graph->_versionController->_head.load();
+    while (commit) {
+        if (!commit->hasData()) {
+            if (auto res = graph->loadCommit(commit->hash()); !res) {
+                return res;
+            }
+        }
+        commit = commit->getPreviousCommit();
+    }
 
     auto lock = graph->_versionController->lock();
 
@@ -139,7 +158,7 @@ DumpResult<void> GraphDumper::dump(const Graph* graph, const fs::Path& graphDir)
     return {};
 }
 
-DumpResult<void> GraphDumper::dumpMissingCommits(const Graph* graph, const fs::Path& graphDir) {
+DumpResult<void> GraphDumper::dumpMissingCommits(Graph* graph, const fs::Path& graphDir) {
     const fs::Path logFile = graphDir / "commitlog";
     auto fileRes = fs::File::open(logFile);
     if (!fileRes) {

--- a/storage/dump/GraphDumper.h
+++ b/storage/dump/GraphDumper.h
@@ -9,10 +9,10 @@ class Graph;
 
 class GraphDumper {
 public:
-    [[nodiscard]] static DumpResult<void> dump(const Graph* graph, const fs::Path& graphDir);
+    [[nodiscard]] static DumpResult<void> dump(Graph* graph, const fs::Path& graphDir);
 
 private:
-    [[nodiscard]] static DumpResult<void> dumpMissingCommits(const Graph* graph, const fs::Path& graphDir);
+    [[nodiscard]] static DumpResult<void> dumpMissingCommits(Graph* graph, const fs::Path& graphDir);
 };
 
 }

--- a/test/storage/dump/LoadCommitDataTest.cpp
+++ b/test/storage/dump/LoadCommitDataTest.cpp
@@ -128,6 +128,38 @@ TEST_F(LoadCommitDataTest, openTransactionAfterLoadCommit) {
     EXPECT_TRUE(tx.isValid());
 }
 
+TEST_F(LoadCommitDataTest, fullDumpOfLoadedGraphHydratesSkeletonCommits) {
+    // Regression: re-dumping a loaded graph to a fresh location used to
+    // segfault — GraphDumper read CommitData on the skeleton (non-HEAD) commits
+    // the load had left un-hydrated. The dump must now materialise those
+    // skeletons so every delta datapart is written; otherwise the HEAD's
+    // metadata references dataparts that were never dumped and the re-dump
+    // fails to reload ("Datapart does not exist").
+    const fs::Path redumpPath = fs::Path {_outDir} / "redump";
+
+    const auto dumpRes = GraphDumper::dump(_loadedGraph.get(), redumpPath);
+    ASSERT_TRUE(dumpRes) << dumpRes.error().fmtMessage();
+
+    auto reloaded = Graph::create("reloaded", redumpPath);
+    const auto loadRes = GraphLoader::load(reloaded.get(), redumpPath);
+    ASSERT_TRUE(loadRes) << loadRes.error().fmtMessage();
+
+    // Full history survived the round trip: every commit was written (none
+    // dropped), and the HEAD's accumulated counts are intact — which they would
+    // not be if an ancestor's dataparts had gone missing.
+    auto& reloadedCtl = reloaded->getVersionController();
+    auto& loadedCtl = _loadedGraph->getVersionController();
+    EXPECT_EQ(reloadedCtl.getNumCommits(), loadedCtl.getNumCommits());
+
+    const Commit* head = reloadedCtl.getCommitSafe(_newHeadHash);
+    ASSERT_NE(head, nullptr);
+    const Commit* origHead = loadedCtl.getCommitSafe(_newHeadHash);
+    ASSERT_NE(origHead, nullptr);
+    EXPECT_EQ(head->getNumNodes(), origHead->getNumNodes());
+    EXPECT_EQ(head->getNumEdges(), origHead->getNumEdges());
+    EXPECT_EQ(head->getNumDataParts(), origHead->getNumDataParts());
+}
+
 int main(int argc, char** argv) {
     return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
 }


### PR DESCRIPTION
## Problem

When dumping a graph from scratch and some of its commits are not hydrated. Segfault in GraphDumper on the null WeakARCs.

## Fix

If we want to dump from scratch a loaded graph in another location, load all the commits when dumping.
