### PR TITLE
MLIR: Add filtered columns variadic argument to db.get_out_edges

### DIFF
--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -12,16 +12,43 @@ include "DBTypes.td"
 def ScanNodes : TuringOp<"scan_nodes", [Pure]> {
   let summary = "Produce all nodes in the graph";
   let results   = (outs Column:$result);
-  let assemblyFormat = "`(`operands`)` attr-dict `:` type($result)";
+  // `qualified(...)` keeps the full `!db.column<...>` mnemonic on the result type
+  // rather than the stripped `<...>` form, matching how get_out_edges prints.
+  let assemblyFormat = "`(`operands`)` attr-dict `:` qualified(type($result))";
 }
 
 /**
 * GetOutEdges
 */
 def GetOutEdges : TuringOp<"get_out_edges", [Pure]> {
-  let summary = "Fetch node and edge successors of input";
-  let arguments = (ins Column:$input_nodes);
-  let results   = (outs Column:$srcids, Column:$eids, Column:$etypes, Column:$tgtids);
+  let summary = "Fetch node and edge successors of input, filtering carried columns alongside";
+
+  let description = [{
+    In `MATCH (a)->(b)->(c)` the `a` we return are not the raw scan but the nodes
+    with a successor `b` that itself has a successor `c`, so each hop must filter
+    the columns carried from earlier hops.
+
+    `columns_to_filter` is that carry set; each one comes back in `filtered_columns`:
+
+      %b = get_out_edges(%a, {})
+      %c, %b2, %a2 = get_out_edges(%b, {%a})   // eids/etypes omitted
+  }];
+
+  // `columns_to_filter`: the only variadic operand, after the fixed `input_nodes`.
+  let arguments = (ins Column:$input_nodes, Variadic<Column>:$columns_to_filter);
+
+  // `filtered_columns`: one per carried column, after the four fixed results.
+  let results   = (outs Column:$srcids,
+                        Column:$eids,
+                        Column:$etypes,
+                        Column:$tgtids,
+                        Variadic<Column>:$filtered_columns);
+
+  // Brace-wrap the carry set so it reads like `get_out_edges(%b, {%a})`.
+  let assemblyFormat = [{
+    `(` $input_nodes `,` `{` $columns_to_filter `}` `)` attr-dict `:`
+    functional-type(operands, results)
+  }];
 }
 
 #endif //TURINGDB_OPS

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -31,14 +31,32 @@ void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     builder.setInsertionPointToStart(&block);
     module.push_back(func);
 
-    const mlir::Type col0 = mlir::db::ColumnType::get(ctxt, "scan");
-    const mlir::Type col1 = mlir::db::ColumnType::get(ctxt, "srcs");
-    const mlir::Type col2 = mlir::db::ColumnType::get(ctxt, "eids");
-    const mlir::Type col3 = mlir::db::ColumnType::get(ctxt, "etypes");
-    const mlir::Type col4 = mlir::db::ColumnType::get(ctxt, "tgts");
+    // MATCH (a)->(b)->(c): scan `a`, then two get_out_edges hops. The second hop
+    // carries the filtered `a` column so it ends up filtered to the `a` that reach a `c`.
+    const mlir::Type colA   = mlir::db::ColumnType::get(ctxt, "a");
+    const mlir::Type colA1  = mlir::db::ColumnType::get(ctxt, "a1");
+    const mlir::Type colE0  = mlir::db::ColumnType::get(ctxt, "e0");
+    const mlir::Type colEt0 = mlir::db::ColumnType::get(ctxt, "et0");
+    const mlir::Type colB   = mlir::db::ColumnType::get(ctxt, "b");
+    const mlir::Type colB2  = mlir::db::ColumnType::get(ctxt, "b2");
+    const mlir::Type colE1  = mlir::db::ColumnType::get(ctxt, "e1");
+    const mlir::Type colEt1 = mlir::db::ColumnType::get(ctxt, "et1");
+    const mlir::Type colC   = mlir::db::ColumnType::get(ctxt, "c");
+    const mlir::Type colA2  = mlir::db::ColumnType::get(ctxt, "a2");
 
-    auto scan = builder.create<mlir::db::ScanNodes>(loc, col0);
-    builder.create<mlir::db::GetOutEdges>(loc, col1, col2, col3, col4, scan.getResult());
+    auto scan = builder.create<mlir::db::ScanNodes>(loc, colA);
+
+    // First hop a->b with an empty carry set: four fixed result columns, no filtered
+    // columns, and just the input_nodes operand.
+    auto hop1 = builder.create<mlir::db::GetOutEdges>(loc,
+                                                      mlir::TypeRange {colA1, colE0, colEt0, colB},
+                                                      mlir::ValueRange {scan.getResult()});
+
+    // Second hop b->c carrying the filtered `a` (hop1 srcids): one extra carry operand
+    // and one extra result type for its filtered counterpart.
+    builder.create<mlir::db::GetOutEdges>(loc,
+                                          mlir::TypeRange {colB2, colE1, colEt1, colC, colA2},
+                                          mlir::ValueRange {hop1.getTgtids(), hop1.getSrcids()});
 }
 
 void assembleFiles(mlir::MLIRContext& ctxt, mlir::ModuleOp& module, const std::vector<std::string>& files) {

--- a/samples/mlir/sample.mlir
+++ b/samples/mlir/sample.mlir
@@ -1,7 +1,14 @@
 module {
   func.func @main() {
-    %0 = "db.scan_nodes"() : () -> !db.column<"scan">
-    %1:4 = "db.get_out_edges"(%0) : (!db.column<"scan">) -> (!db.column<"srcs">, !db.column<"eids">, !db.column<"etypes">, !db.column<"tgts">)
+    // MATCH (a)->(b)->(c): scan `a`, then two get_out_edges hops.
+    %a = db.scan_nodes() : !db.column<"a">
+
+    // First hop a->b, nothing carried yet so the carry set is `{}`.
+    %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<"a">) -> (!db.column<"a1">, !db.column<"e0">, !db.column<"et0">, !db.column<"b">)
+
+    // Second hop b->c, carrying %a1 so it comes back as %a2 (the `a` that reach a `c`).
+    %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<"b">, !db.column<"a1">) -> (!db.column<"b2">, !db.column<"e1">, !db.column<"et1">, !db.column<"c">, !db.column<"a2">)
+
     return
   }
 }

--- a/samples/mlir/second.mlir
+++ b/samples/mlir/second.mlir
@@ -1,6 +1,6 @@
 module {
   func.func @second() {
-    %0 = "db.scan_nodes"() : () -> !db.column<"scan2">
+    %0 = db.scan_nodes() : !db.column<"scan2">
     return
   }
 }


### PR DESCRIPTION
When we do `MATCH (a)-->(b)-->(c) RETURN a` in Cypher we don't return the result a of the scan nodes but the set of NodeIDs a such that they have successors b which in turn have successors c. So nodes are filtered at each get_out_edges or get_in_edges operation along the chain.

As discussed, add a variadic argument to pass the columns to filter by a `db.get_out_edges` operation in the db dialect.
```
func.func @main() {
    // MATCH (a)->(b)->(c): scan `a`, then two get_out_edges hops.
    %a = db.scan_nodes()

    // First hop a->b, nothing carried yet so the carry set is `{}`.
    %a1, %e0, %et0, %b = db.get_out_edges(%a, {})

    // Second hop b->c, carrying %a1 so it comes back as %a2 (the `a` that reach a `c`).
    %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1})

    return
}
```