### PR TITLE
MLIR: First version of nested loop dialect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Key points:
 - Never `using namespace std`
 - Never use `const_cast`. If you need a mutable reference, expose it through the type's API (e.g., add a non-const overload of the getter) rather than casting away const on an existing one. Reaching for `const_cast` is a sign that the type's API is wrong — fix the API instead.
 - Use `const` extensively — all local variables should be `const` unless they need mutation
+- **Never call the same getter repeatedly when the result can be reused.** Capture it once in a named local and use that everywhere. Writing `loop.getBody()` on several consecutive lines (`setInsertionPointToStart(loop.getBody())` then `loop.getBody()->getArgument(0)` then `loop.getBody()->getArgument(3)`) is bad style: it is noisy, hides that all the calls operate on the same object, and re-evaluates the call for nothing. Write `mlir::Block* loopBody = loop.getBody();` once and use `loopBody`. This applies to any getter or accessor chain, not just MLIR.
 - When a conditional expression is long or compound, extract each part into a descriptively named `const bool` before the `if` statement
 - Use `bioassert` for assertions (from BioAssert.h)
 - Exceptions must derive from `TuringException`

--- a/query/ir/dialect/CMakeLists.txt
+++ b/query/ir/dialect/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(db)
+add_subdirectory(nl)

--- a/query/ir/dialect/nl/CMakeLists.txt
+++ b/query/ir/dialect/nl/CMakeLists.txt
@@ -38,6 +38,7 @@ add_mlir_library(turing_db_ir_nldialect_s
   MLIRIR
   MLIRSupport
   MLIRFuncDialect
+  MLIRInferTypeOpInterface
   MLIRBuiltinToLLVMIRTranslation
 )
 

--- a/query/ir/dialect/nl/CMakeLists.txt
+++ b/query/ir/dialect/nl/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Set the root tablegen file of all subsequent calls to
+# `mlir_tablegen` to be NLDialect.td
+set(LLVM_TARGET_DEFINITIONS NLDialect.td)
+
+# Perform codegen from TableGen
+#             Generated file     File type          Current dialect  Add needed mlir headers
+mlir_tablegen(NLDialect.h.inc    -gen-dialect-decls -dialect nl  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+mlir_tablegen(NLDialect.cpp.inc  -gen-dialect-defs  -dialect nl  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+
+set(LLVM_TARGET_DEFINITIONS NLOps.td)
+mlir_tablegen(NLOps.h.inc        -gen-op-decls      -dialect nl  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+mlir_tablegen(NLOps.cpp.inc      -gen-op-defs       -dialect nl  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+
+set(LLVM_TARGET_DEFINITIONS NLTypes.td)
+mlir_tablegen(NLTypes.h.inc      -gen-typedef-decls     -dialect nl EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+mlir_tablegen(NLTypes.cpp.inc    -gen-typedef-defs      -dialect nl EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+
+# Creates CMAKE target with all included .inc files, the lib depends on this
+add_public_tablegen_target(NLDialectIncGen)
+
+set_source_files_properties(
+  NLDialect.cpp
+  NLOps.cpp
+  NLTypes.cpp
+  PROPERTIES COMPILE_FLAGS "-Wno-uninitialized"
+)
+
+# Compiles .cpp files; needs the codegen first, hence the DEPENDS clause
+add_mlir_library(turing_db_ir_nldialect_s
+  NLDialect.cpp
+  NLOps.cpp
+  NLTypes.cpp
+
+  DEPENDS
+  NLDialectIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRSupport
+  MLIRFuncDialect
+  MLIRBuiltinToLLVMIRTranslation
+)
+
+# Ensure we have MLIR and LLVM includes, as well as the headers in current dir
+target_include_directories(turing_db_ir_nldialect_s PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${MLIR_INCLUDE_DIRS}
+  ${LLVM_INCLUDE_DIRS}
+)

--- a/query/ir/dialect/nl/CMakeLists.txt
+++ b/query/ir/dialect/nl/CMakeLists.txt
@@ -22,7 +22,7 @@ set_source_files_properties(
   NLDialect.cpp
   NLOps.cpp
   NLTypes.cpp
-  PROPERTIES COMPILE_FLAGS "-Wno-uninitialized"
+  PROPERTIES COMPILE_FLAGS "-Wno-uninitialized -Wno-ambiguous-reversed-operator"
 )
 
 # Compiles .cpp files; needs the codegen first, hence the DEPENDS clause

--- a/query/ir/dialect/nl/NLDialect.cpp
+++ b/query/ir/dialect/nl/NLDialect.cpp
@@ -1,0 +1,15 @@
+#include "NLDialect.h"
+#include "NLOps.h"
+
+using namespace mlir;
+using namespace mlir::nl;
+
+#include "NLDialect.cpp.inc"
+
+void NL::initialize() {
+    addOperations<
+#define GET_OP_LIST
+#include "NLOps.cpp.inc"
+    >();
+    registerTypes();
+}

--- a/query/ir/dialect/nl/NLDialect.h
+++ b/query/ir/dialect/nl/NLDialect.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+
+#include "NLDialect.h.inc"

--- a/query/ir/dialect/nl/NLDialect.td
+++ b/query/ir/dialect/nl/NLDialect.td
@@ -1,0 +1,30 @@
+#ifndef TURINGDB_NL_DIALECT
+#define TURINGDB_NL_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+def NL : Dialect {
+    let name = "nl";
+    let summary = "TuringDB nested-loop dialect";
+    let description = [{
+        Imperative lowering target of the db dialect. Where db expresses
+        whole-column dataflow, nl makes the execution explicit: database
+        iterators driven by for loops that produce one set of chunks per step.
+    }];
+    let cppNamespace = "::mlir::nl";
+
+    // Removes the need to define custom printers for our custom types
+    let useDefaultTypePrinterParser = 1;
+
+    // Declare other functions: mlir::nl::f()
+    let extraClassDeclaration = [{
+        void registerTypes(); // Makes MLIR aware of our custom types
+    }];
+
+}
+
+// Base, from which all nested-loop dialect ops are derived
+class NLOp<string mnemonic, list<Trait> traits = []>
+    : Op<NL, mnemonic, traits>;
+
+#endif //TURINGDB_NL_DIALECT

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -25,15 +25,21 @@ Type getEdgeTypeIDChunkType(MLIRContext* context) {
 }
 
 // Out- and in-edge fetches expose the same row of chunks - source node IDs,
-// edge IDs, edge type IDs and target node IDs - so a loop body written for one
-// direction works unchanged for the other.
-Type getEdgeIteratorType(MLIRContext* context) {
+// edge IDs, edge type IDs and target node IDs - followed by one filtered chunk
+// per carried column, so a loop body written for one direction works unchanged
+// for the other.
+Type getEdgeIteratorType(MLIRContext* context, TypeRange carriedChunkTypes) {
     const Type sources = getNodeIDChunkType(context);
     const Type edgeIDs = getEdgeIDChunkType(context);
     const Type edgeTypeIDs = getEdgeTypeIDChunkType(context);
     const Type targets = getNodeIDChunkType(context);
 
-    return IteratorType::get(context, {sources, edgeIDs, edgeTypeIDs, targets});
+    // The four fixed edge chunks, then the carry set comes back with the same
+    // chunk types, mirroring db.get_out_edges' filtered_columns.
+    llvm::SmallVector<Type> chunkTypes {sources, edgeIDs, edgeTypeIDs, targets};
+    chunkTypes.append(carriedChunkTypes.begin(), carriedChunkTypes.end());
+
+    return IteratorType::get(context, chunkTypes);
 }
 
 }
@@ -47,23 +53,23 @@ LogicalResult ScanNodes::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
-// An out-edges fetch produces one row of edge chunks per step, mirroring
-// db.get_out_edges
+// An out-edges fetch produces one row of edge chunks per step, then one
+// filtered chunk per carried column, mirroring db.get_out_edges
 LogicalResult GetOutEdges::inferReturnTypes(MLIRContext* context,
                                             std::optional<Location> location,
                                             GetOutEdges::Adaptor adaptor,
                                             SmallVectorImpl<Type>& inferredReturnTypes) {
-    inferredReturnTypes.push_back(getEdgeIteratorType(context));
+    inferredReturnTypes.push_back(getEdgeIteratorType(context, adaptor.getColumnsToFilter()));
     return success();
 }
 
-// An in-edges fetch produces the same row of edge chunks as out-edges; the
-// input chunk names the nodes whose in-edges are gathered
+// An in-edges fetch produces the same row of edge chunks as out-edges, plus the
+// same carried chunks; the input chunk names the nodes whose in-edges are gathered
 LogicalResult GetInEdges::inferReturnTypes(MLIRContext* context,
                                            std::optional<Location> location,
                                            GetInEdges::Adaptor adaptor,
                                            SmallVectorImpl<Type>& inferredReturnTypes) {
-    inferredReturnTypes.push_back(getEdgeIteratorType(context));
+    inferredReturnTypes.push_back(getEdgeIteratorType(context, adaptor.getColumnsToFilter()));
     return success();
 }
 

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -12,56 +12,60 @@ using namespace mlir::nl;
 
 namespace {
 
-bool isChunkOf(Type type, auto isElement) {
-    const auto chunkType = dyn_cast<ChunkType>(type);
-    return chunkType && isElement(chunkType.getElementType());
+Type getNodeIDChunkType(MLIRContext* context) {
+    return ChunkType::get(context, NodeIDType::get(context));
 }
 
-bool isNodeIDChunk(Type type) {
-    return isChunkOf(type, [](Type element) { return isa<NodeIDType>(element); });
+Type getEdgeIDChunkType(MLIRContext* context) {
+    return ChunkType::get(context, EdgeIDType::get(context));
 }
 
-bool isEdgeIDChunk(Type type) {
-    return isChunkOf(type, [](Type element) { return isa<EdgeIDType>(element); });
-}
-
-bool isEdgeTypeIDChunk(Type type) {
-    return isChunkOf(type, [](Type element) { return isa<EdgeTypeIDType>(element); });
+Type getEdgeTypeIDChunkType(MLIRContext* context) {
+    return ChunkType::get(context, EdgeTypeIDType::get(context));
 }
 
 }
 
-LogicalResult ScanNodes::verify() {
-    const auto iteratorType = cast<IteratorType>(getResult().getType());
-    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
-
-    const bool yieldsNodeIDChunk = chunkTypes.size() == 1 && isNodeIDChunk(chunkTypes[0]);
-    if (!yieldsNodeIDChunk) {
-        return emitOpError("must return an iterator yielding one chunk of node IDs");
-    }
-
+// A node scan always produces one chunk of node IDs per step
+LogicalResult ScanNodes::inferReturnTypes(MLIRContext* context,
+                                          std::optional<Location> location,
+                                          ScanNodes::Adaptor adaptor,
+                                          SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(IteratorType::get(context, {getNodeIDChunkType(context)}));
     return success();
 }
 
-LogicalResult GetOutEdges::verify() {
-    const auto inputType = cast<ChunkType>(getInputNodes().getType());
-    const auto iteratorType = cast<IteratorType>(getResult().getType());
-    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+// An out-edges fetch always produces one chunk of source node IDs, edge IDs,
+// edge type IDs and target node IDs per step, mirroring db.get_out_edges
+LogicalResult GetOutEdges::inferReturnTypes(MLIRContext* context,
+                                            std::optional<Location> location,
+                                            GetOutEdges::Adaptor adaptor,
+                                            SmallVectorImpl<Type>& inferredReturnTypes) {
+    const Type sources = getNodeIDChunkType(context);
+    const Type edgeIDs = getEdgeIDChunkType(context);
+    const Type edgeTypeIDs = getEdgeTypeIDChunkType(context);
+    const Type targets = getNodeIDChunkType(context);
 
-    const bool yieldsEdgeChunks = chunkTypes.size() == 4
-                                  && isNodeIDChunk(chunkTypes[0])
-                                  && isEdgeIDChunk(chunkTypes[1])
-                                  && isEdgeTypeIDChunk(chunkTypes[2])
-                                  && isNodeIDChunk(chunkTypes[3]);
-
-    if (!isa<NodeIDType>(inputType.getElementType())) {
-        return emitOpError("expects a chunk of node IDs as input");
-    } else if (!yieldsEdgeChunks) {
-        return emitOpError("must return an iterator yielding chunks of source node IDs, "
-                           "edge IDs, edge type IDs and target node IDs");
-    }
-
+    inferredReturnTypes.push_back(IteratorType::get(context, {sources, edgeIDs, edgeTypeIDs, targets}));
     return success();
+}
+
+// Build a loop from just the iterator value: its iterator type carries the
+// chunk types, which become the loop variables (the body block arguments).
+// The body is created with its implicit nl.yield terminator, ready for the
+// caller to set the insertion point into it.
+void For::build(OpBuilder& builder, OperationState& state, Value iterator) {
+    const OpBuilder::InsertionGuard guard(builder);
+
+    state.addOperands(iterator);
+
+    const auto iteratorType = cast<IteratorType>(iterator.getType());
+    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+    const llvm::SmallVector<Location> chunkLocations(chunkTypes.size(), state.location);
+
+    Region* bodyRegion = state.addRegion();
+    builder.createBlock(bodyRegion, bodyRegion->end(), chunkTypes, chunkLocations);
+    For::ensureTerminator(*bodyRegion, builder, state.location);
 }
 
 // Custom syntax, in the style of scf.for / LingoDB's dsa.for:

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -24,6 +24,18 @@ Type getEdgeTypeIDChunkType(MLIRContext* context) {
     return ChunkType::get(context, EdgeTypeIDType::get(context));
 }
 
+// Out- and in-edge fetches expose the same row of chunks - source node IDs,
+// edge IDs, edge type IDs and target node IDs - so a loop body written for one
+// direction works unchanged for the other.
+Type getEdgeIteratorType(MLIRContext* context) {
+    const Type sources = getNodeIDChunkType(context);
+    const Type edgeIDs = getEdgeIDChunkType(context);
+    const Type edgeTypeIDs = getEdgeTypeIDChunkType(context);
+    const Type targets = getNodeIDChunkType(context);
+
+    return IteratorType::get(context, {sources, edgeIDs, edgeTypeIDs, targets});
+}
+
 }
 
 // A node scan always produces one chunk of node IDs per step
@@ -35,18 +47,23 @@ LogicalResult ScanNodes::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
-// An out-edges fetch always produces one chunk of source node IDs, edge IDs,
-// edge type IDs and target node IDs per step, mirroring db.get_out_edges
+// An out-edges fetch produces one row of edge chunks per step, mirroring
+// db.get_out_edges
 LogicalResult GetOutEdges::inferReturnTypes(MLIRContext* context,
                                             std::optional<Location> location,
                                             GetOutEdges::Adaptor adaptor,
                                             SmallVectorImpl<Type>& inferredReturnTypes) {
-    const Type sources = getNodeIDChunkType(context);
-    const Type edgeIDs = getEdgeIDChunkType(context);
-    const Type edgeTypeIDs = getEdgeTypeIDChunkType(context);
-    const Type targets = getNodeIDChunkType(context);
+    inferredReturnTypes.push_back(getEdgeIteratorType(context));
+    return success();
+}
 
-    inferredReturnTypes.push_back(IteratorType::get(context, {sources, edgeIDs, edgeTypeIDs, targets}));
+// An in-edges fetch produces the same row of edge chunks as out-edges; the
+// input chunk names the nodes whose in-edges are gathered
+LogicalResult GetInEdges::inferReturnTypes(MLIRContext* context,
+                                           std::optional<Location> location,
+                                           GetInEdges::Adaptor adaptor,
+                                           SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(getEdgeIteratorType(context));
     return success();
 }
 

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -1,0 +1,160 @@
+#include "NLOps.h"
+#include "NLDialect.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+using namespace mlir::nl;
+
+#define GET_OP_CLASSES
+#include "NLOps.cpp.inc"
+
+namespace {
+
+bool isChunkOf(Type type, auto isElement) {
+    const auto chunkType = dyn_cast<ChunkType>(type);
+    return chunkType && isElement(chunkType.getElementType());
+}
+
+bool isNodeIDChunk(Type type) {
+    return isChunkOf(type, [](Type element) { return isa<NodeIDType>(element); });
+}
+
+bool isEdgeIDChunk(Type type) {
+    return isChunkOf(type, [](Type element) { return isa<EdgeIDType>(element); });
+}
+
+bool isEdgeTypeIDChunk(Type type) {
+    return isChunkOf(type, [](Type element) { return isa<EdgeTypeIDType>(element); });
+}
+
+}
+
+LogicalResult ScanNodes::verify() {
+    const auto iteratorType = cast<IteratorType>(getResult().getType());
+    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+
+    const bool yieldsNodeIDChunk = chunkTypes.size() == 1 && isNodeIDChunk(chunkTypes[0]);
+    if (!yieldsNodeIDChunk) {
+        return emitOpError("must return an iterator yielding one chunk of node IDs");
+    }
+
+    return success();
+}
+
+LogicalResult GetOutEdges::verify() {
+    const auto inputType = cast<ChunkType>(getInputNodes().getType());
+    const auto iteratorType = cast<IteratorType>(getResult().getType());
+    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+
+    const bool yieldsEdgeChunks = chunkTypes.size() == 4
+                                  && isNodeIDChunk(chunkTypes[0])
+                                  && isEdgeIDChunk(chunkTypes[1])
+                                  && isEdgeTypeIDChunk(chunkTypes[2])
+                                  && isNodeIDChunk(chunkTypes[3]);
+
+    if (!isa<NodeIDType>(inputType.getElementType())) {
+        return emitOpError("expects a chunk of node IDs as input");
+    } else if (!yieldsEdgeChunks) {
+        return emitOpError("must return an iterator yielding chunks of source node IDs, "
+                           "edge IDs, edge type IDs and target node IDs");
+    }
+
+    return success();
+}
+
+// Custom syntax, in the style of scf.for / LingoDB's dsa.for:
+//
+//   nl.for %chunk0, %chunk1, ... in %iterator : !nl.iter<...> { body }
+//
+// The loop variables are the entry block arguments of the body region. Their
+// types are not spelled out in the text: each variable takes the corresponding
+// chunk type of the iterator.
+ParseResult For::parse(OpAsmParser& parser, OperationState& result) {
+    llvm::SmallVector<OpAsmParser::Argument, 4> chunkArguments;
+    OpAsmParser::UnresolvedOperand iterator;
+
+    // Loop variables, `in` keyword, iterator operand, `:` of the iterator type
+    const bool headerFailed = parser.parseArgumentList(chunkArguments)
+                              || parser.parseKeyword("in")
+                              || parser.parseOperand(iterator)
+                              || parser.parseColon();
+    if (headerFailed) {
+        return failure();
+    }
+
+    const llvm::SMLoc typeLocation = parser.getCurrentLocation();
+    Type iteratorType;
+    if (parser.parseType(iteratorType)) {
+        return failure();
+    }
+
+    const auto chunkIteratorType = dyn_cast<IteratorType>(iteratorType);
+    if (!chunkIteratorType) {
+        return parser.emitError(typeLocation, "expected an !nl.iter iterator type");
+    }
+
+    // Bind one loop variable per chunk produced by an iterator step
+    const ArrayRef<Type> chunkTypes = chunkIteratorType.getChunkTypes();
+    if (chunkArguments.size() != chunkTypes.size()) {
+        return parser.emitError(typeLocation, "expected one loop variable per iterator chunk");
+    }
+
+    for (size_t chunkIndex = 0; chunkIndex < chunkArguments.size(); chunkIndex++) {
+        chunkArguments[chunkIndex].type = chunkTypes[chunkIndex];
+    }
+
+    if (parser.resolveOperand(iterator, iteratorType, result.operands)) {
+        return failure();
+    }
+
+    // The body region, with the loop variables as entry block arguments
+    Region* bodyRegion = result.addRegion();
+    if (parser.parseRegion(*bodyRegion, chunkArguments)) {
+        return failure();
+    } else if (parser.parseOptionalAttrDict(result.attributes)) {
+        return failure();
+    }
+
+    // The nl.yield terminator may be left out in the text; insert it
+    For::ensureTerminator(*bodyRegion, parser.getBuilder(), result.location);
+
+    return success();
+}
+
+void For::print(OpAsmPrinter& printer) {
+    // Loop variables: the entry block arguments of the body region
+    printer << " ";
+    llvm::interleaveComma(getBody()->getArguments(), printer, [&](BlockArgument chunkArgument) {
+        printer << chunkArgument;
+    });
+
+    printer << " in " << getIterator() << " : " << getIterator().getType() << " ";
+
+    // The loop variables are already printed in the loop header, and the
+    // implicit nl.yield terminator carries nothing: elide both.
+    printer.printRegion(getBodyRegion(), /*printEntryBlockArgs=*/false, /*printBlockTerminators=*/false);
+    printer.printOptionalAttrDict((*this)->getAttrs());
+}
+
+LogicalResult For::verify() {
+    const auto iteratorType = cast<IteratorType>(getIterator().getType());
+    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+    Block* body = getBody();
+
+    if (body->getNumArguments() != chunkTypes.size()) {
+        return emitOpError("expects the body to take one block argument per iterator chunk");
+    }
+
+    for (size_t chunkIndex = 0; chunkIndex < chunkTypes.size(); chunkIndex++) {
+        const Type argumentType = body->getArgument(static_cast<unsigned>(chunkIndex)).getType();
+        if (argumentType != chunkTypes[chunkIndex]) {
+            return emitOpError("body argument ") << chunkIndex
+                                                 << " must have the iterator chunk type "
+                                                 << chunkTypes[chunkIndex];
+        }
+    }
+
+    return success();
+}

--- a/query/ir/dialect/nl/NLOps.h
+++ b/query/ir/dialect/nl/NLOps.h
@@ -5,6 +5,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "NLDialect.h"

--- a/query/ir/dialect/nl/NLOps.h
+++ b/query/ir/dialect/nl/NLOps.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "NLDialect.h"
+#include "NLTypes.h"
+
+#define GET_OP_CLASSES
+#include "NLOps.h.inc"

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1,6 +1,7 @@
 #ifndef TURINGDB_NL_OPS
 #define TURINGDB_NL_OPS
 
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 include "NLDialect.td"
@@ -9,31 +10,31 @@ include "NLTypes.td"
 /**
 * ScanNodes
 */
-def ScanNodes : NLOp<"scan_nodes", [Pure]> {
+def ScanNodes : NLOp<"scan_nodes", [Pure, InferTypeOpAdaptor]> {
   let summary = "Create a database iterator over all nodes in the graph";
   let description = [{
     Imperative counterpart of db.scan_nodes. Each step of an enclosing
-    nl.for fills one chunk of node IDs.
+    nl.for fills one chunk of node IDs. The result type is always
+    !nl.iter<!nl.chunk<!nl.node_id>> and is inferred, not spelled out.
   }];
   let results   = (outs NLIterator:$result);
-  let assemblyFormat = "`(`operands`)` attr-dict `:` qualified(type($result))";
-  let hasVerifier = 1;
+  let assemblyFormat = "`(`operands`)` attr-dict";
 }
 
 /**
 * GetOutEdges
 */
-def GetOutEdges : NLOp<"get_out_edges", [Pure]> {
+def GetOutEdges : NLOp<"get_out_edges", [Pure, InferTypeOpAdaptor]> {
   let summary = "Create a database iterator over the out-edges of a chunk of nodes";
   let description = [{
     Imperative counterpart of db.get_out_edges. Each step of an enclosing
     nl.for fills one chunk of source node IDs, edge IDs, edge type IDs and
-    target node IDs.
+    target node IDs. Both the input chunk type and the result iterator type
+    are fixed and inferred, not spelled out.
   }];
-  let arguments = (ins NLChunk:$input_nodes);
+  let arguments = (ins NLNodeIDChunk:$input_nodes);
   let results   = (outs NLIterator:$result);
-  let assemblyFormat = "`(` $input_nodes `)` attr-dict `:` functional-type($input_nodes, $result)";
-  let hasVerifier = 1;
+  let assemblyFormat = "`(` $input_nodes `)` attr-dict";
 }
 
 /**
@@ -54,6 +55,14 @@ def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
   let regions = (region SizedRegion<1>:$bodyRegion);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  // The only builder takes just the iterator value: the loop variables are
+  // created by looking up the chunk types on the iterator type, so C++ users
+  // never spell any type
+  let skipDefaultBuilders = 1;
+  let builders = [
+      OpBuilder<(ins "::mlir::Value":$iterator)>
+  ];
 }
 
 /**

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1,0 +1,67 @@
+#ifndef TURINGDB_NL_OPS
+#define TURINGDB_NL_OPS
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+include "NLDialect.td"
+include "NLTypes.td"
+
+/**
+* ScanNodes
+*/
+def ScanNodes : NLOp<"scan_nodes", [Pure]> {
+  let summary = "Create a database iterator over all nodes in the graph";
+  let description = [{
+    Imperative counterpart of db.scan_nodes. Each step of an enclosing
+    nl.for fills one chunk of node IDs.
+  }];
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(`operands`)` attr-dict `:` qualified(type($result))";
+  let hasVerifier = 1;
+}
+
+/**
+* GetOutEdges
+*/
+def GetOutEdges : NLOp<"get_out_edges", [Pure]> {
+  let summary = "Create a database iterator over the out-edges of a chunk of nodes";
+  let description = [{
+    Imperative counterpart of db.get_out_edges. Each step of an enclosing
+    nl.for fills one chunk of source node IDs, edge IDs, edge type IDs and
+    target node IDs.
+  }];
+  let arguments = (ins NLChunk:$input_nodes);
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(` $input_nodes `)` attr-dict `:` functional-type($input_nodes, $result)";
+  let hasVerifier = 1;
+}
+
+/**
+* For
+*/
+def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
+  let summary = "Drive a database iterator chunk by chunk";
+  let description = [{
+    Runs the body once per iterator step until the iterator is exhausted.
+    Each step fills the next chunks of the iterator and binds them to the
+    loop variables, one variable per chunk:
+
+    nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+        ...
+    }
+  }];
+  let arguments = (ins NLIterator:$iterator);
+  let regions = (region SizedRegion<1>:$bodyRegion);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+/**
+* Yield
+*/
+def Yield : NLOp<"yield", [Pure, Terminator, HasParent<"For">]> {
+  let summary = "End one step of an nl.for loop";
+  let assemblyFormat = "attr-dict";
+}
+
+#endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -38,6 +38,24 @@ def GetOutEdges : NLOp<"get_out_edges", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* GetInEdges
+*/
+def GetInEdges : NLOp<"get_in_edges", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Create a database iterator over the in-edges of a chunk of nodes";
+  let description = [{
+    The reverse-direction sibling of nl.get_out_edges: where that walks each
+    node's successors, this walks its predecessors. Each step of an enclosing
+    nl.for fills one chunk of source node IDs, edge IDs, edge type IDs and
+    target node IDs - the same chunk shape as out-edges, so the two are
+    interchangeable in a loop. Both the input chunk type and the result
+    iterator type are fixed and inferred, not spelled out.
+  }];
+  let arguments = (ins NLNodeIDChunk:$input_nodes);
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(` $input_nodes `)` attr-dict";
+}
+
+/**
 * For
 */
 def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
@@ -71,6 +89,35 @@ def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
 def Yield : NLOp<"yield", [Pure, Terminator, HasParent<"For">]> {
   let summary = "End one step of an nl.for loop";
   let assemblyFormat = "attr-dict";
+}
+
+/**
+* Output
+*/
+def Output : NLOp<"output"> {
+  let summary = "Send a row of chunks out as columns of the query result";
+  let description = [{
+    The sink of the nested loop, mirroring a result builder (LingoDB's
+    dsa.append): inside an nl.for body it hands the current chunks to the
+    query result, one output column per chunk. The columns are typically loop
+    variables, so each nl.for step emits one chunk per column:
+
+    nl.output(%targets) : !nl.chunk<!nl.node_id>
+    nl.output(%sources, %targets) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+
+    Variadic<NLChunk> accepts any number of chunks of any element type. The op
+    is deliberately not Pure: emitting output is its whole point, so it must
+    survive dead-code elimination even though it has no results.
+  }];
+  let arguments = (ins Variadic<NLChunk>:$columns);
+
+  // The chunk element types vary from call to call and - unlike the source
+  // ops - cannot be inferred, so they are spelled after the colon. This keeps
+  // the text self-describing: the parser builds each operand's type from the
+  // printed list rather than looking it up on the defining nl.for (which MLIR
+  // cannot do during a parse), the same reason nl.for keeps its : !nl.iter<...>
+  // annotation. qualified(...) forces the leading !nl. on every printed type.
+  let assemblyFormat = "`(` $columns `)` attr-dict `:` qualified(type($columns))";
 }
 
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -29,12 +29,39 @@ def GetOutEdges : NLOp<"get_out_edges", [Pure, InferTypeOpAdaptor]> {
   let description = [{
     Imperative counterpart of db.get_out_edges. Each step of an enclosing
     nl.for fills one chunk of source node IDs, edge IDs, edge type IDs and
-    target node IDs. Both the input chunk type and the result iterator type
-    are fixed and inferred, not spelled out.
+    target node IDs.
+
+    `columns_to_filter` is the carry set, mirroring db.get_out_edges: chunks
+    bound by an outer nl.for that this hop must filter down to the rows that
+    survive the traversal. Each carried chunk comes back - same type, filtered -
+    as a trailing chunk of the result iterator, so an enclosing nl.for binds it
+    as an extra loop variable after the four fixed edge chunks:
+
+      %edges = nl.get_out_edges(%a, {})
+      nl.for %srcs, %eids, %etypes, %b in %edges {
+        // second hop b->c, carrying the `a` of this step (here %srcs)
+        %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!nl.node_id>
+        nl.for %srcs2, %eids2, %etypes2, %c, %aFiltered in %hop { ... }
+      }
+
+    The input chunk type and the four fixed result chunks are inferred; only
+    the carried chunk types are spelled out, after the colon.
   }];
-  let arguments = (ins NLNodeIDChunk:$input_nodes);
+
+  // `columns_to_filter`: the variadic carry set, after the fixed input_nodes.
+  // NLChunk, not NLNodeIDChunk, so chunks of any element type can be carried.
+  let arguments = (ins NLNodeIDChunk:$input_nodes, Variadic<NLChunk>:$columns_to_filter);
   let results   = (outs NLIterator:$result);
-  let assemblyFormat = "`(` $input_nodes `)` attr-dict";
+
+  // The carried chunk element types vary from call to call and - unlike
+  // input_nodes and the inferred result - cannot be built from a recipe, so
+  // they are spelled after the colon, the same as nl.output. The optional
+  // group (anchored on the carried types) drops the colon when the carry set
+  // is empty, keeping the first-hop syntax `(%nodes, {})`.
+  let assemblyFormat = [{
+    `(` $input_nodes `,` `{` $columns_to_filter `}` `)` attr-dict
+    ( `:` qualified(type($columns_to_filter))^ )?
+  }];
 }
 
 /**
@@ -47,12 +74,21 @@ def GetInEdges : NLOp<"get_in_edges", [Pure, InferTypeOpAdaptor]> {
     node's successors, this walks its predecessors. Each step of an enclosing
     nl.for fills one chunk of source node IDs, edge IDs, edge type IDs and
     target node IDs - the same chunk shape as out-edges, so the two are
-    interchangeable in a loop. Both the input chunk type and the result
-    iterator type are fixed and inferred, not spelled out.
+    interchangeable in a loop.
+
+    Like nl.get_out_edges it takes a `columns_to_filter` carry set: chunks from
+    an outer nl.for that this hop filters and hands back as trailing chunks of
+    the result iterator. The input chunk type and the four fixed result chunks
+    are inferred; only the carried chunk types are spelled out, after the colon.
   }];
-  let arguments = (ins NLNodeIDChunk:$input_nodes);
+
+  let arguments = (ins NLNodeIDChunk:$input_nodes, Variadic<NLChunk>:$columns_to_filter);
   let results   = (outs NLIterator:$result);
-  let assemblyFormat = "`(` $input_nodes `)` attr-dict";
+
+  let assemblyFormat = [{
+    `(` $input_nodes `,` `{` $columns_to_filter `}` `)` attr-dict
+    ( `:` qualified(type($columns_to_filter))^ )?
+  }];
 }
 
 /**

--- a/query/ir/dialect/nl/NLTypes.cpp
+++ b/query/ir/dialect/nl/NLTypes.cpp
@@ -1,0 +1,19 @@
+#include "NLTypes.h"
+
+#include "NLDialect.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir::nl;
+
+#define GET_TYPEDEF_CLASSES
+#include "NLTypes.cpp.inc"
+
+void NL::registerTypes() {
+    addTypes<
+#define GET_TYPEDEF_LIST
+#include "NLTypes.cpp.inc"
+    >();
+}

--- a/query/ir/dialect/nl/NLTypes.h
+++ b/query/ir/dialect/nl/NLTypes.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "mlir/IR/BuiltinTypes.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "NLTypes.h.inc"

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -40,4 +40,29 @@ def NLIterator : NLType<"Iterator", "iter"> {
     let assemblyFormat = "`<` $chunkTypes `>`";
 }
 
+// NLNodeIDChunk is a type *constraint*, not a new type: it restricts an op
+// operand to !nl.chunk<!nl.node_id> without defining anything new. Ops use it
+// in their (ins ...) clause where NLChunk would accept a chunk of anything.
+//
+// It is built from two tablegen pieces:
+//
+// - Type<predicate, summary, cppClassName>: a constraint over types.
+//   * The CPred is a C++ expression evaluated against the operand type
+//     ($_self) by the generated op verifier: the type must be a ChunkType
+//     and its element type must be NodeIDType.
+//   * "chunk of node IDs" is the wording used in verifier error messages.
+//   * ::mlir::nl::ChunkType makes the generated operand accessor return
+//     ChunkType instead of the generic mlir::Type.
+//
+// - BuildableType<builderCall>: a recipe to construct, via an OpBuilder
+//   ($_builder), the single concrete type satisfying the constraint. This is
+//   what lets assembly formats omit the operand type entirely: the parser
+//   does not read the type from the text, it builds it from this recipe.
+def NLNodeIDChunk : Type<
+        CPred<"::llvm::isa<::mlir::nl::ChunkType>($_self) && "
+              "::llvm::isa<::mlir::nl::NodeIDType>(::llvm::cast<::mlir::nl::ChunkType>($_self).getElementType())">,
+        "chunk of node IDs", "::mlir::nl::ChunkType">,
+    BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
+                  "::mlir::nl::NodeIDType::get($_builder.getContext()))">;
+
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -1,0 +1,43 @@
+#ifndef TURINGDB_NL_TYPES
+#define TURINGDB_NL_TYPES
+
+include "mlir/IR/AttrTypeBase.td"
+
+include "NLDialect.td"
+
+// Base type. All nested-loop dialect types derived from this.
+class NLType<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<NL, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def NLNodeID : NLType<"NodeID", "node_id"> {
+    let summary = "A node identifier";
+    let description = "The element type of a chunk holding node IDs";
+}
+
+def NLEdgeID : NLType<"EdgeID", "edge_id"> {
+    let summary = "An edge identifier";
+    let description = "The element type of a chunk holding edge IDs";
+}
+
+def NLEdgeTypeID : NLType<"EdgeTypeID", "edge_type_id"> {
+    let summary = "An edge type identifier";
+    let description = "The element type of a chunk holding edge type IDs";
+}
+
+def NLChunk : NLType<"Chunk", "chunk"> {
+    let summary = "A bounded batch of values";
+    let description = "One column chunk filled by a single database iterator step";
+    let parameters = (ins "::mlir::Type":$elementType);
+    let assemblyFormat = "`<` $elementType `>`";
+}
+
+def NLIterator : NLType<"Iterator", "iter"> {
+    let summary = "A database iterator producing chunks";
+    let description = "Each step of the iterator fills one chunk per parameter type";
+    let parameters = (ins ArrayRefParameter<"::mlir::Type">:$chunkTypes);
+    let assemblyFormat = "`<` $chunkTypes `>`";
+}
+
+#endif // TURINGDB_NL_TYPES

--- a/samples/mlir/CMakeLists.txt
+++ b/samples/mlir/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(${SAMPLE_NAME}
     turing_db_ir_assembler_s
     turing_db_ir_common_s
     turing_db_ir_dbdialect_s
+    turing_db_ir_nldialect_s
     turing_db_io_fs_s
     turing_common_s
     argparse

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -85,10 +85,26 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto nodeLoop = builder.create<mlir::nl::For>(loc, nodes.getResult());
     builder.create<mlir::func::ReturnOp>(loc);
 
-    // Fill the node loop body: iterate the out-edges of each chunk of nodes
+    // Fill the node loop body: walk each chunk of nodes both forwards
+    // (out-edges) and backwards (in-edges)
     builder.setInsertionPointToStart(nodeLoop.getBody());
-    auto edges = builder.create<mlir::nl::GetOutEdges>(loc, nodeLoop.getBody()->getArgument(0));
-    builder.create<mlir::nl::For>(loc, edges.getResult());
+    const mlir::Value nodeChunk = nodeLoop.getBody()->getArgument(0);
+
+    // Out-edges: send each step's target (successor) node IDs to the result.
+    // The edge loop binds the chunks in order: sources, edge IDs, edge type
+    // IDs, targets - so argument 3 is the targets column.
+    auto outEdges = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk);
+    auto outLoop = builder.create<mlir::nl::For>(loc, outEdges.getResult());
+    builder.setInsertionPointToStart(outLoop.getBody());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoop.getBody()->getArgument(3)});
+
+    // In-edges of the same node chunk: send the source (predecessor) node IDs.
+    // Same chunk order, so argument 0 is the sources column.
+    builder.setInsertionPointAfter(outLoop);
+    auto inEdges = builder.create<mlir::nl::GetInEdges>(loc, nodeChunk);
+    auto inLoop = builder.create<mlir::nl::For>(loc, inEdges.getResult());
+    builder.setInsertionPointToStart(inLoop.getBody());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoop.getBody()->getArgument(0)});
 }
 
 void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 
 #include "DBOps.h"
+#include "NLDialect.h"
 #include "IRAssembler.h"
 #include "IRModuleInspector.h"
 
@@ -99,6 +100,7 @@ int main(int argc, char** argv) {
     try {
         mlir::MLIRContext ctxt;
         ctxt.loadDialect<mlir::db::DB>();
+        ctxt.loadDialect<mlir::nl::NL>();
         ctxt.loadDialect<mlir::func::FuncDialect>();
 
         mlir::OpBuilder builder(&ctxt);

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -88,24 +88,27 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     // Fill the node loop body with three walks over each chunk of nodes:
     // forwards (out-edges), backwards (in-edges), and a two-hop
     // MATCH (a)->(b)->(c) that carries `a` through the second hop.
-    builder.setInsertionPointToStart(nodeLoop.getBody());
-    const mlir::Value nodeChunk = nodeLoop.getBody()->getArgument(0);
+    mlir::Block* nodeLoopBody = nodeLoop.getBody();
+    builder.setInsertionPointToStart(nodeLoopBody);
+    const mlir::Value nodeChunk = nodeLoopBody->getArgument(0);
 
     // Out-edges: send each step's target (successor) node IDs to the result.
     // The edge loop binds the chunks in order: sources, edge IDs, edge type
     // IDs, targets - so argument 3 is the targets column.
     auto outEdges = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk, mlir::ValueRange {});
     auto outLoop = builder.create<mlir::nl::For>(loc, outEdges.getResult());
-    builder.setInsertionPointToStart(outLoop.getBody());
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoop.getBody()->getArgument(3)});
+    mlir::Block* outLoopBody = outLoop.getBody();
+    builder.setInsertionPointToStart(outLoopBody);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoopBody->getArgument(3)});
 
     // In-edges of the same node chunk: send the source (predecessor) node IDs.
     // Same chunk order, so argument 0 is the sources column.
     builder.setInsertionPointAfter(outLoop);
     auto inEdges = builder.create<mlir::nl::GetInEdges>(loc, nodeChunk, mlir::ValueRange {});
     auto inLoop = builder.create<mlir::nl::For>(loc, inEdges.getResult());
-    builder.setInsertionPointToStart(inLoop.getBody());
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoop.getBody()->getArgument(0)});
+    mlir::Block* inLoopBody = inLoop.getBody();
+    builder.setInsertionPointToStart(inLoopBody);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoopBody->getArgument(0)});
 
     // MATCH (a)->(b)->(c): two out-edge hops where the second carries the `a`
     // of the current step. First hop a->b with an empty carry set; its loop
@@ -113,9 +116,10 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     builder.setInsertionPointAfter(inLoop);
     auto firstHop = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk, mlir::ValueRange {});
     auto firstHopLoop = builder.create<mlir::nl::For>(loc, firstHop.getResult());
-    builder.setInsertionPointToStart(firstHopLoop.getBody());
-    const mlir::Value aChunk = firstHopLoop.getBody()->getArgument(0);
-    const mlir::Value bChunk = firstHopLoop.getBody()->getArgument(3);
+    mlir::Block* firstHopLoopBody = firstHopLoop.getBody();
+    builder.setInsertionPointToStart(firstHopLoopBody);
+    const mlir::Value aChunk = firstHopLoopBody->getArgument(0);
+    const mlir::Value bChunk = firstHopLoopBody->getArgument(3);
 
     // Second hop b->c carrying `a`: each second-hop edge binds its source (=b)
     // at argument 0 and its target (=c) at argument 3, and the carried `a` comes
@@ -124,10 +128,11 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     // triple.
     auto secondHop = builder.create<mlir::nl::GetOutEdges>(loc, bChunk, mlir::ValueRange {aChunk});
     auto secondHopLoop = builder.create<mlir::nl::For>(loc, secondHop.getResult());
-    builder.setInsertionPointToStart(secondHopLoop.getBody());
-    const mlir::Value bFiltered = secondHopLoop.getBody()->getArgument(0);
-    const mlir::Value cChunk = secondHopLoop.getBody()->getArgument(3);
-    const mlir::Value filteredA = secondHopLoop.getBody()->getArgument(4);
+    mlir::Block* secondHopLoopBody = secondHopLoop.getBody();
+    builder.setInsertionPointToStart(secondHopLoopBody);
+    const mlir::Value bFiltered = secondHopLoopBody->getArgument(0);
+    const mlir::Value cChunk = secondHopLoopBody->getArgument(3);
+    const mlir::Value filteredA = secondHopLoopBody->getArgument(4);
     builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk});
 }
 

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -85,15 +85,16 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto nodeLoop = builder.create<mlir::nl::For>(loc, nodes.getResult());
     builder.create<mlir::func::ReturnOp>(loc);
 
-    // Fill the node loop body: walk each chunk of nodes both forwards
-    // (out-edges) and backwards (in-edges)
+    // Fill the node loop body with three walks over each chunk of nodes:
+    // forwards (out-edges), backwards (in-edges), and a two-hop
+    // MATCH (a)->(b)->(c) that carries `a` through the second hop.
     builder.setInsertionPointToStart(nodeLoop.getBody());
     const mlir::Value nodeChunk = nodeLoop.getBody()->getArgument(0);
 
     // Out-edges: send each step's target (successor) node IDs to the result.
     // The edge loop binds the chunks in order: sources, edge IDs, edge type
     // IDs, targets - so argument 3 is the targets column.
-    auto outEdges = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk);
+    auto outEdges = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk, mlir::ValueRange {});
     auto outLoop = builder.create<mlir::nl::For>(loc, outEdges.getResult());
     builder.setInsertionPointToStart(outLoop.getBody());
     builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoop.getBody()->getArgument(3)});
@@ -101,10 +102,33 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     // In-edges of the same node chunk: send the source (predecessor) node IDs.
     // Same chunk order, so argument 0 is the sources column.
     builder.setInsertionPointAfter(outLoop);
-    auto inEdges = builder.create<mlir::nl::GetInEdges>(loc, nodeChunk);
+    auto inEdges = builder.create<mlir::nl::GetInEdges>(loc, nodeChunk, mlir::ValueRange {});
     auto inLoop = builder.create<mlir::nl::For>(loc, inEdges.getResult());
     builder.setInsertionPointToStart(inLoop.getBody());
     builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoop.getBody()->getArgument(0)});
+
+    // MATCH (a)->(b)->(c): two out-edge hops where the second carries the `a`
+    // of the current step. First hop a->b with an empty carry set; its loop
+    // binds sources(=a) at argument 0 and targets(=b) at argument 3.
+    builder.setInsertionPointAfter(inLoop);
+    auto firstHop = builder.create<mlir::nl::GetOutEdges>(loc, nodeChunk, mlir::ValueRange {});
+    auto firstHopLoop = builder.create<mlir::nl::For>(loc, firstHop.getResult());
+    builder.setInsertionPointToStart(firstHopLoop.getBody());
+    const mlir::Value aChunk = firstHopLoop.getBody()->getArgument(0);
+    const mlir::Value bChunk = firstHopLoop.getBody()->getArgument(3);
+
+    // Second hop b->c carrying `a`: each second-hop edge binds its source (=b)
+    // at argument 0 and its target (=c) at argument 3, and the carried `a` comes
+    // back as the trailing chunk at argument 4, filtered to the `a` whose `b`
+    // has a successor `c`. All three are row-aligned, so output the (a, b, c)
+    // triple.
+    auto secondHop = builder.create<mlir::nl::GetOutEdges>(loc, bChunk, mlir::ValueRange {aChunk});
+    auto secondHopLoop = builder.create<mlir::nl::For>(loc, secondHop.getResult());
+    builder.setInsertionPointToStart(secondHopLoop.getBody());
+    const mlir::Value bFiltered = secondHopLoop.getBody()->getArgument(0);
+    const mlir::Value cChunk = secondHopLoop.getBody()->getArgument(3);
+    const mlir::Value filteredA = secondHopLoop.getBody()->getArgument(4);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk});
 }
 
 void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -12,7 +12,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 
 #include "DBOps.h"
-#include "NLDialect.h"
+#include "NLOps.h"
 #include "IRAssembler.h"
 #include "IRModuleInspector.h"
 
@@ -20,17 +20,27 @@ using namespace db;
 
 namespace {
 
-void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
-    std::cout << "hello from mlir" << '\n';
-
+// Appends an empty function to the module and moves the builder insertion
+// point inside its entry block
+void startFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module, const char* name) {
     mlir::MLIRContext* ctxt = builder.getContext();
     const mlir::Location loc = builder.getUnknownLoc();
 
+    builder.setInsertionPointToEnd(module.getBody());
+
     auto funcType = mlir::FunctionType::get(ctxt, {}, {});
-    auto func = builder.create<mlir::func::FuncOp>(loc, "main", funcType);
+    auto func = builder.create<mlir::func::FuncOp>(loc, name, funcType);
     auto& block = *func.addEntryBlock();
+
     builder.setInsertionPointToStart(&block);
-    module.push_back(func);
+}
+
+// The set-at-a-time form of the query: db dialect ops on whole columns
+void addDBFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
+    startFunction(builder, module, "db_ops");
+
+    mlir::MLIRContext* ctxt = builder.getContext();
+    const mlir::Location loc = builder.getUnknownLoc();
 
     // MATCH (a)->(b)->(c): scan `a`, then two get_out_edges hops. The second hop
     // carries the filtered `a` column so it ends up filtered to the `a` that reach a `c`.
@@ -58,6 +68,34 @@ void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     builder.create<mlir::db::GetOutEdges>(loc,
                                           mlir::TypeRange {colB2, colE1, colEt1, colC, colA2},
                                           mlir::ValueRange {hop1.getTgtids(), hop1.getSrcids()});
+
+    builder.create<mlir::func::ReturnOp>(loc);
+}
+
+// The imperative nested-loop form of the same query: nl dialect iterators
+// driven by chunked for loops. No type is ever spelled: the source ops infer
+// their iterator types and the nl.for builder looks up the loop variable
+// types on the iterator value
+void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
+    startFunction(builder, module, "nested_loop");
+
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    auto nodes = builder.create<mlir::nl::ScanNodes>(loc);
+    auto nodeLoop = builder.create<mlir::nl::For>(loc, nodes.getResult());
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    // Fill the node loop body: iterate the out-edges of each chunk of nodes
+    builder.setInsertionPointToStart(nodeLoop.getBody());
+    auto edges = builder.create<mlir::nl::GetOutEdges>(loc, nodeLoop.getBody()->getArgument(0));
+    builder.create<mlir::nl::For>(loc, edges.getResult());
+}
+
+void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
+    std::cout << "hello from mlir" << '\n';
+
+    addDBFunction(builder, module);
+    addNestedLoopFunction(builder, module);
 }
 
 void assembleFiles(mlir::MLIRContext& ctxt, mlir::ModuleOp& module, const std::vector<std::string>& files) {

--- a/samples/mlir/nested_loop.mlir
+++ b/samples/mlir/nested_loop.mlir
@@ -1,13 +1,14 @@
 // The nested-loop form of: db.scan_nodes -> db.get_out_edges / get_in_edges.
 // Each nl.for step pulls the next chunks from a database iterator, and
-// nl.output sends a chunk on as a column of the query result.
+// nl.output sends a chunk on as a column of the query result. The last block
+// shows a two-hop MATCH (a)->(b)->(c) using a get_out_edges carry set.
 module {
     func.func @nested_loop() {
         %nodes = nl.scan_nodes()
 
         nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
             // Forwards: emit each step's target (successor) node IDs
-            %out = nl.get_out_edges(%chunk)
+            %out = nl.get_out_edges(%chunk, {})
 
             nl.for %osrcs, %oeids, %oetypes, %otgts in %out : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
                 nl.output(%otgts) : !nl.chunk<!nl.node_id>
@@ -15,10 +16,29 @@ module {
             }
 
             // Backwards: same chunk shape, emit the source (predecessor) IDs
-            %in = nl.get_in_edges(%chunk)
+            %in = nl.get_in_edges(%chunk, {})
 
             nl.for %isrcs, %ieids, %ietypes, %itgts in %in : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
                 nl.output(%isrcs) : !nl.chunk<!nl.node_id>
+                nl.yield
+            }
+
+            // MATCH (a)->(b)->(c): two out-edge hops, the second carrying `a`.
+            // First hop a->b with an empty carry set; %hsrcs is `a`, %hb is `b`.
+            %h1 = nl.get_out_edges(%chunk, {})
+
+            nl.for %hsrcs, %he0, %het0, %hb in %h1 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+                // Second hop b->c carrying `a` (%hsrcs). Each second-hop edge
+                // binds its source(=b) %h2srcs and target(=c) %hc, and the
+                // carried `a` comes back filtered as %hafilt - all row-aligned,
+                // so we output the (a, b, c) triple.
+                %h2 = nl.get_out_edges(%hb, {%hsrcs}) : !nl.chunk<!nl.node_id>
+
+                nl.for %h2srcs, %he1, %het1, %hc, %hafilt in %h2 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
+                    nl.output(%hafilt, %h2srcs, %hc) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+                    nl.yield
+                }
+
                 nl.yield
             }
 

--- a/samples/mlir/nested_loop.mlir
+++ b/samples/mlir/nested_loop.mlir
@@ -2,10 +2,10 @@
 // Each nl.for step pulls the next chunks from a database iterator.
 module {
     func.func @nested_loop() {
-        %nodes = nl.scan_nodes() : !nl.iter<!nl.chunk<!nl.node_id>>
+        %nodes = nl.scan_nodes()
 
         nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
-            %edges = nl.get_out_edges(%chunk) : (!nl.chunk<!nl.node_id>) -> !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>>
+            %edges = nl.get_out_edges(%chunk)
 
             nl.for %srcs, %eids, %etypes, %tgts in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
                 nl.yield

--- a/samples/mlir/nested_loop.mlir
+++ b/samples/mlir/nested_loop.mlir
@@ -1,13 +1,24 @@
-// The nested-loop form of: db.scan_nodes -> db.get_out_edges.
-// Each nl.for step pulls the next chunks from a database iterator.
+// The nested-loop form of: db.scan_nodes -> db.get_out_edges / get_in_edges.
+// Each nl.for step pulls the next chunks from a database iterator, and
+// nl.output sends a chunk on as a column of the query result.
 module {
     func.func @nested_loop() {
         %nodes = nl.scan_nodes()
 
         nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
-            %edges = nl.get_out_edges(%chunk)
+            // Forwards: emit each step's target (successor) node IDs
+            %out = nl.get_out_edges(%chunk)
 
-            nl.for %srcs, %eids, %etypes, %tgts in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+            nl.for %osrcs, %oeids, %oetypes, %otgts in %out : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+                nl.output(%otgts) : !nl.chunk<!nl.node_id>
+                nl.yield
+            }
+
+            // Backwards: same chunk shape, emit the source (predecessor) IDs
+            %in = nl.get_in_edges(%chunk)
+
+            nl.for %isrcs, %ieids, %ietypes, %itgts in %in : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+                nl.output(%isrcs) : !nl.chunk<!nl.node_id>
                 nl.yield
             }
 

--- a/samples/mlir/nested_loop.mlir
+++ b/samples/mlir/nested_loop.mlir
@@ -1,0 +1,19 @@
+// The nested-loop form of: db.scan_nodes -> db.get_out_edges.
+// Each nl.for step pulls the next chunks from a database iterator.
+module {
+    func.func @nested_loop() {
+        %nodes = nl.scan_nodes() : !nl.iter<!nl.chunk<!nl.node_id>>
+
+        nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+            %edges = nl.get_out_edges(%chunk) : (!nl.chunk<!nl.node_id>) -> !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>>
+
+            nl.for %srcs, %eids, %etypes, %tgts in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+                nl.yield
+            }
+
+            nl.yield
+        }
+
+        return
+    }
+}


### PR DESCRIPTION
First version of the nested loop MLIR dialect corresponding to the db dialect. Heavily inspired by the dsa dialect of LingoDB.
We will use it to lower the db dialect that uses dataflow semantics to the nested loop dialect which is an actual imperative loop-based implementation.

```
MATCH (a)-->(b)-->(c) RETURN a,b,c
```

db dialect:
```
func.func @main() {
  // MATCH (a)->(b)->(c): scan `a`, then two get_out_edges hops.
  %a = db.scan_nodes() 

  // First hop a->b, nothing carried yet so the carry set is `{}`.
  %a1, %e0, %et0, %b = db.get_out_edges(%a, {})

  // Second hop b->c, carrying %a1 so it comes back as %a2 (the `a` that reach a `c`).
  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1})

  return
}
```

Nested loop implementation:
```
func.func @nested_loop() {
    %nodes = nl.scan_nodes()

    nl.for %chunk in %nodes {

        // MATCH (a)->(b)->(c)
        // First hop a->b with an empty carry set
        %h1 = nl.get_out_edges(%chunk, {})

       // %hsrcs = a, %hb = b
        nl.for %hsrcs, %he0, %het0, %hb in %h1 {
            // Second hop b->c
            %h2 = nl.get_out_edges(%hb, {%hsrcs})

            // %h2srcs = b, %hc = c, %hafilt = a
            nl.for %h2srcs, %he1, %het1, %hc, %hafilt in %h2 {
                nl.output(%hafilt, %h2srcs, %hc)
            }
        }
    }

    return
}
```

-> Nice assembly format for `nl.for` loops so that we can write `nl.for %chunk in %nodes`with a for..in syntax

## Types

* The db.dialect uses named db.column types such as in `%a = db.scan_nodes() : !db.column<"a">`
* For now, nl dialect uses parametric chunk types `nl.chunk<!nl.node_id>` 💀 maybe we should have the column names as well here