### PR TITLE
ci: rewrite baked dependency paths to the canonical cache location

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -129,7 +129,7 @@ jobs:
         python3 scripts/with_host_lock.py /tmp/turingdb-depcache.lock \
           bash scripts/dep_cache.sh restore \
           /Users/m1/actions-local-cache \
-          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh') }}"
+          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh', 'scripts/dep_cache.sh') }}"
 
     - name: Install build tools
       run: ./install_build_tools.sh
@@ -145,7 +145,7 @@ jobs:
         python3 scripts/with_host_lock.py /tmp/turingdb-depcache.lock \
           bash scripts/dep_cache.sh publish \
           /Users/m1/actions-local-cache \
-          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh') }}"
+          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh', 'scripts/dep_cache.sh') }}"
 
     - name: Setup Python
       run: uv python install ${{ matrix.python_version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,12 @@ Key points:
 - **Partitioning** is on the near-term roadmap (as of 2026-05-04). Some customers have specifically asked for **METIS-style structural partitioning** (edge-cut minimization), not hash partitioning. Treat partitioning as a near-term constraint when discussing scale-out, not a future-optional.
 - The **replication / distribution** initiative is motivated by *both* (a) scaling beyond single-node memory (which forces partitioning) and (b) write availability across network partitions / regions (which motivates CRDT-style merge). The realistic landing point is a layered hybrid; evaluate any proposal against both goals.
 
+## CI / self-hosted runners
+
+- macOS CI runs on a few **self-hosted minis that share one filesystem** (`/Users/m1`) across several runner instances (`actions-runner`, `actions-runner-2`, ...), with **no isolation** beyond each instance's own `_work` checkout. Linux self-hosted runners are containerized.
+- The `external/dependencies` build is cached on local disk and **shared across those instances** (`scripts/dep_cache.sh`, base `/Users/m1/actions-local-cache`). The dependency build bakes **absolute paths into the installed CMake/pkg-config files** (e.g. faiss's `BLAS_LIBRARIES=…/external/dependencies/lib/libopenblas.a`, LLVM/MLIR configs) pointing into the *building* instance's checkout. Each instance `git clean -ffdx`s its own checkout between jobs, so a consumer on a *different* instance imports a path that a concurrent checkout deletes mid-build — surfacing as `make: No rule to make target '…/libopenblas.a'`, and downstream as a misleading `delocate … FileNotFoundError: dist/turingdb-*.whl`. `scripts/dep_cache.sh publish` rewrites those baked paths to the canonical, never-git-cleaned cache location. The bug is non-deterministic (depends on whether a concurrent job on the publishing instance cleans during your build window), so reproductions need overlapping runs. Bump the macOS dependency cache key when changing how deps are built/cached, or stale poisoned entries persist.
+- Per-host serialization (port 6666, host-wide `pkill turingdb`, the shared dep cache) uses a kernel `flock` via `scripts/with_host_lock.py`, which the OS releases on process exit.
+
 ## Commit style
 
 Do not include Claude as a co-author in the commits.

--- a/scripts/dep_cache.sh
+++ b/scripts/dep_cache.sh
@@ -16,6 +16,14 @@
 # publish can never leave a partial cache entry that a later restore mistakes
 # for a complete one.
 #
+# Publishing additionally rewrites the absolute paths the dependency build bakes
+# into its installed CMake/pkg-config files (e.g. faiss's BLAS_LIBRARIES, the
+# LLVM/MLIR configs). Those paths point into the building instance's own checkout
+# -- a transient path that other instances git-clean between jobs -- so a consumer
+# on a different instance would link against e.g. a libopenblas.a that a concurrent
+# checkout deletes mid-build. We rewrite them to the canonical, never-cleaned cache
+# location so any instance can consume the entry.
+#
 # Usage: dep_cache.sh restore|publish BASE KEY
 set -euo pipefail
 
@@ -53,6 +61,12 @@ publish)
         exit 0
     fi
 
+    # The build baked this checkout's external/dependencies path into the
+    # installed configs. Capture both its logical and physical forms (macOS
+    # firmlinks /Users) before the move so we can rewrite every baked occurrence.
+    built_logical="$(pwd)/external/dependencies"
+    built_physical="$(cd external/dependencies && pwd -P)"
+
     mkdir -p "$base/$key"
 
     # Move the built tree next to its final location, then reveal it with a
@@ -61,6 +75,28 @@ publish)
     rm -rf "$staging"
     mv external/dependencies "$staging"
     mv "$staging" "$entry"
+
+    # Rewrite the baked per-checkout paths to the canonical cache path in the
+    # CMake/pkg-config files a consumer's find_package() reads. Binaries are
+    # skipped (grep -I); static archives carry no such dependency. The scan is
+    # scoped to config locations so it stays fast on the large dependency tree.
+    scan_roots=()
+    for dir in "$entry/lib" "$entry/share" "$entry/build/llvm-project/lib/cmake"; do
+        if [ -d "$dir" ]; then
+            scan_roots+=("$dir")
+        fi
+    done
+
+    if [ "${#scan_roots[@]}" -gt 0 ]; then
+        for old in "$built_logical" "$built_physical"; do
+            if [ "$old" = "$entry" ]; then
+                continue
+            fi
+            while IFS= read -r config; do
+                LC_ALL=C sed -i '' "s|$old|$entry|g" "$config"
+            done < <(grep -rIlF -- "$old" "${scan_roots[@]}" 2>/dev/null || true)
+        done
+    fi
 
     # Re-link so the steps after publish keep reading external/dependencies.
     ln -s "$entry" external/dependencies


### PR DESCRIPTION
Fixes the intermittent macOS `libopenblas.a` build failure by rewriting the checkout-specific absolute paths the dependency build bakes into its CMake/pkg-config files to the shared cache's canonical, never-git-cleaned location at publish time.