### PR TITLE
NL Subroutine Threaded interpreter

### DIFF
--- a/docs/subroutine_interpreter.md
+++ b/docs/subroutine_interpreter.md
@@ -142,7 +142,7 @@ New library `query/ir/interpreter/`, static target `turing_db_ir_interpreter_s`,
 linking the storage library, the nl dialect library and `turing_db_ir_common_s`.
 
 The hard boundary: **only `NLTranslator` includes MLIR headers.** `NLProgram`
-and `NLInterpreter` are pure runtime. After translation the MLIR module can be
+and `NLExecutor` are pure runtime. After translation the MLIR module can be
 destroyed; the descriptor program is self-contained, which also makes it the
 natural unit for a future plan cache.
 
@@ -153,7 +153,7 @@ natural unit for a future plan cache.
               v
           NLProgram          descriptors + preallocated chunk slots
               |
-              |  NLInterpreter::run(view, program, sink)   [no MLIR, per execution]
+              |  NLExecutor::run(view, program, sink)   [no MLIR, per execution]
               v
          NLOutputSink        receives output chunks, push-based
 ```
@@ -203,17 +203,17 @@ Known simplification for this milestone: the program owns its slot state, so
 one `NLProgram` instance supports one execution at a time. Splitting the
 immutable program from per-run state belongs with the plan cache work.
 
-## NLInterpreter — handlers and entry point
+## NLExecutor — handlers and entry point
 
 ```cpp
-class NLInterpreter {
+class NLExecutor {
 public:
     static void run(const GraphView& view, NLProgram& program, NLOutputSink& sink);
 };
 ```
 
 `NLExecutionContext` carries the `GraphView`, the sink pointer and the chunk
-size. Handlers are static member functions of `NLInterpreter`, one per
+size. Handlers are static member functions of `NLExecutor`, one per
 descriptor shape, exposed so the translator can bind them into descriptors.
 
 **Scan loop.** Constructs a `ScanNodesChunkWriter(view)` on the handler's own
@@ -326,7 +326,7 @@ name.
 
 # Testing
 
-`test/query/ir/NLInterpreterTest.cpp`, following the `ScanNodesIteratorTest`
+`test/query/ir/NLExecutorTest.cpp`, following the `ScanNodesIteratorTest`
 fixture pattern (`TuringTest` + `JobSystem`; `Graph::create()` →
 `newChange()` → datapart builder → `submit`). Programs are parsed from string
 with `mlir::parseSourceString<ModuleOp>` (the file-based `IRAssembler` stays
@@ -347,7 +347,7 @@ interpreter, dialect and storage libraries.
 # Implementation order
 
 1. `NLProgram.h/.cpp` — runtime structures, no MLIR.
-2. `NLInterpreter.h/.cpp` — handlers and entry point.
+2. `NLExecutor.h/.cpp` — handlers and entry point.
 3. `NLTranslator.h/.cpp` — the MLIR walk.
 4. CMake wiring for the library and tests.
 5. Tests, then one build and test run to verify the milestone.

--- a/docs/subroutine_interpreter.md
+++ b/docs/subroutine_interpreter.md
@@ -1,0 +1,368 @@
+# A subroutine-threaded interpreter for the nl dialect
+
+This document is the design and implementation plan for the runtime that executes
+`nl` (nested-loop) dialect programs. The `nl` dialect (`query/ir/dialect/nl`) is
+the imperative, chunk-at-a-time counterpart of the declarative `db` dialect: a
+query is a nest of `nl.for` loops driving database iterators, with `nl.output`
+as the sink. The interpreter described here runs such a program directly,
+without lowering to LLVM and without walking MLIR data structures at runtime.
+
+```mlir
+func.func @two_hop() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges
+        : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!nl.node_id>
+      nl.for %srcs2, %eids2, %etypes2, %c, %aFiltered in %hop
+          : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
+        nl.output(%aFiltered, %c) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+      }
+    }
+  }
+  func.return
+}
+```
+
+# Design space
+
+Four execution strategies were considered. The decisive context for all of them
+is that `nl` dispatch is **per chunk, not per row**: one `nl.for` step fills a
+chunk of up to `ChunkConfig::CHUNK_SIZE` IDs through a storage iterator, so the
+cost of one handler transition is amortized over thousands of rows of
+memory-bound graph traversal work. Interpretation overhead is a fraction of a
+percent of runtime before any dispatch optimization is applied.
+
+## Tree-walking the MLIR module — rejected
+
+Walking `mlir::Operation`s at runtime means dispatching on the dynamic op type
+at every step, chasing pointers through MLIR's allocation-heavy structures, and
+re-deriving types and operand bindings on every visit. It also keeps the MLIR
+module alive for the lifetime of the query. The deeper objection is the lost
+**translate-once** step: a separate translation pass is the natural place to
+assign storage to SSA values, preallocate chunk buffers and select kernels, so
+that none of it is redone per iteration.
+
+## Tail-call threading (musttail + preserve_none) — rejected
+
+First POC: https://godbolt.org/z/8MYY7o8ao. Handlers chained with
+`__attribute__((musttail))` calls under `[[clang::preserve_none]]`, an explicit
+frame of slot pointers in registers, loop control decomposed into
+loopInit/loopHead/loopBody handlers (the CPython 3.14 / wasm3 family).
+
+Its two virtues are translate-once (shared with the chosen design) and
+suspendability: with an explicit frame and pc and a flat C stack, execution can
+pause mid-loop. Its costs: `preserve_none` requires Clang 19+ (and gating with
+`__has_attribute`), throwing through musttail/preserve_none frames does not mix
+with the codebase's `TuringException`-based error model, and the flat stack
+makes perf/gdb attribution opaque. Per-instruction dispatch savings are what
+this technique buys, and at chunk granularity there is nothing to save.
+
+## Copy-and-patch JIT — rejected
+
+Build-time-compiled stencils memcpy'd into executable memory with operands and
+continuations patched in (the CPython 3.13 JIT technique). A stencil JIT is the
+subroutine-threaded interpreter with the indirect calls inlined and the
+descriptor data constant-folded into immediates — so its ceiling is exactly the
+glue fraction it removes, under 1% here. In exchange: a pinned-Clang stencil
+extraction toolchain (the Clang version gate returns through the back door,
+plus relocation parsing, per-architecture stencil sets), W^X executable memory
+in a long-running server, no exception unwinding through JIT frames, and
+anonymous code in profilers. I-cache behavior also inverts in the interpreter's
+favor: interpreter handlers are shared across all concurrent queries and stay
+hot, while per-query JIT code starts cold.
+
+If fused compilation is ever warranted (tight per-row expression work), the
+natural route is MLIR lowering (`nl` → `scf` → `llvm` + ORC) behind adaptive
+tiering — start interpreting, swap in compiled code when it pays — not a
+hand-rolled stencil system. The interpreter below is the tier 0 such a design
+requires, so the two are stages, not rivals.
+
+## Subroutine threading — chosen
+
+Second POC: https://godbolt.org/z/xaT9n4f4f. Handlers are ordinary functions
+composed by indirect calls through a descriptor table built at translation
+time. The key property: **loop control stays a native C++ loop inside the
+handler**, and the nesting structure of the nl program maps directly onto the C
+call stack. With `-O3` each loop compiles to real machine-code loop structure;
+the only per-iteration interpretation cost is one predicted indirect call.
+
+What this buys over the alternatives:
+
+- No toolchain gate: plain C++, any Clang or GCC.
+- Exceptions work: a `TuringException` thrown from the innermost handler
+  unwinds the loop nest correctly for free. Early termination (LIMIT) gets the
+  same channel.
+- The C stack mirrors the loop nest, so perf and gdb show `forLoop → forLoop →
+  output` with time attributable per nesting depth.
+- The handlers drive the **existing storage chunk writers**
+  (`ScanNodesChunkWriter`, `GetOutEdgesChunkWriter`, `GetInEdgesChunkWriter`)
+  unmodified — the interpreter reuses the native iteration machinery rather
+  than reimplementing it.
+
+The conscious trade-off: execution is **run-to-completion**. Iteration state
+lives on the C stack, so the interpreter cannot pause mid-loop and resume.
+Streaming results does not need suspension — `nl.output` pushes into a sink,
+and the sink can stream chunks out while the loops keep running. Suspension
+would only matter for cooperative time-slicing of queries on a shared thread;
+if that ever becomes a requirement, the escape hatches are a stackful fiber or
+moving loop state into the descriptor data.
+
+Recursion depth equals the query's pattern length (a handful of frames), so
+stack depth is a non-issue.
+
+# Generalizing the POC
+
+The POC indexes a flat descriptor array by loop depth (`_descrs[depth + 1]`),
+which only handles perfectly nested single-statement bodies. The real dialect
+needs three generalizations:
+
+1. **Bodies are sequences.** An `nl.for` body can contain an `nl.output` *and*
+   a nested loop, or several sibling loops. Each loop's descriptor data owns
+   its body as a vector of descriptors and the handler runs the whole sequence
+   per step. Once the data carries its own body, the `depth` parameter and the
+   global table disappear.
+
+2. **Iterator-producing ops are not descriptors.** `nl.scan_nodes`,
+   `nl.get_out_edges` and `nl.get_in_edges` do nothing per step — they
+   configure the iterator that the adjacent `nl.for` drives. Translation folds
+   them into the loop's descriptor data (iterator kind plus resolved slot
+   pointers). The descriptor program collapses to just loops and outputs.
+
+3. **Translation is where types die.** Every SSA chunk value gets a slot — a
+   preallocated `ColumnVector` of the right element type — assigned during
+   translation. Handlers receive typed pointers resolved once; the runtime
+   never consults a type again. The loop structure is static, so the full set
+   of live chunks is known up front and execution performs no allocation.
+
+# Architecture
+
+New library `query/ir/interpreter/`, static target `turing_db_ir_interpreter_s`,
+linking the storage library, the nl dialect library and `turing_db_ir_common_s`.
+
+The hard boundary: **only `NLTranslator` includes MLIR headers.** `NLProgram`
+and `NLInterpreter` are pure runtime. After translation the MLIR module can be
+destroyed; the descriptor program is self-contained, which also makes it the
+natural unit for a future plan cache.
+
+```
+        MLIR module (nl ops)
+              |
+              |  NLTranslator::translate(func::FuncOp)     [MLIR-facing, once]
+              v
+          NLProgram          descriptors + preallocated chunk slots
+              |
+              |  NLInterpreter::run(view, program, sink)   [no MLIR, per execution]
+              v
+         NLOutputSink        receives output chunks, push-based
+```
+
+## NLProgram — the descriptor program
+
+```cpp
+enum class NLChunkKind {
+    NodeID,
+    EdgeID,
+    EdgeTypeID,
+};
+
+struct NLFunctionData;
+
+using NLHandlerFunction = void (*)(NLExecutionContext&, NLFunctionData*);
+
+struct NLFunctionDescriptor {
+    NLHandlerFunction _function {nullptr};
+    NLFunctionData* _data {nullptr};
+};
+```
+
+`NLFunctionData` is the base of the per-descriptor payloads. Loop payloads come
+in two shapes, monomorphized at translation time so there is no runtime switch
+on iterator kind:
+
+- `NLScanLoopData`: the `ColumnNodeIDs*` slot of its single loop variable, and
+  the body descriptors.
+- `NLEdgeLoopData` (shared by the out- and in-edge loops; direction is encoded
+  by which handler the descriptor points at): the `const ColumnNodeIDs*` input
+  slot (a loop variable of the enclosing loop), typed slot pointers for the
+  four fixed chunks (sources, edge IDs, edge type IDs, targets), a scratch
+  `ColumnVector<size_t>` for the writer's indices column, a carry list of
+  `{const Column* in, Column* out, gather function}` entries with the gather
+  selected by `NLChunkKind` at translation time, and the body descriptors.
+
+`NLOutputData` holds the operand slots as `const Column*` plus their kinds.
+
+`NLProgram` owns all of it: the slot buffers (one `ColumnVector` per `nl.for`
+block argument, reserved to the chunk size up front), the `NLFunctionData`
+nodes, the top-level descriptor vector, and a configurable
+`size_t _chunkSize {ChunkConfig::CHUNK_SIZE}` so tests can force multi-step
+loops with tiny chunks.
+
+Known simplification for this milestone: the program owns its slot state, so
+one `NLProgram` instance supports one execution at a time. Splitting the
+immutable program from per-run state belongs with the plan cache work.
+
+## NLInterpreter — handlers and entry point
+
+```cpp
+class NLInterpreter {
+public:
+    static void run(const GraphView& view, NLProgram& program, NLOutputSink& sink);
+};
+```
+
+`NLExecutionContext` carries the `GraphView`, the sink pointer and the chunk
+size. Handlers are static member functions of `NLInterpreter`, one per
+descriptor shape, exposed so the translator can bind them into descriptors.
+
+**Scan loop.** Constructs a `ScanNodesChunkWriter(view)` on the handler's own
+stack — loop state on the native C stack is the point of the design — binds the
+loop-variable slot with `setNodeIDs`, then:
+
+```cpp
+while (writer.isValid()) {
+    writer.fill(context._chunkSize);
+    if (!nodeIDs->empty()) {
+        runBody(context, loopData->_body);
+    }
+}
+```
+
+(`fill` clears its bound columns before writing the next chunk, so handlers do
+not clear the writer-filled slots themselves.)
+
+**Edge loops.** One shared implementation templated over the writer type,
+instantiated as the out-edges and in-edges handlers. The writer is constructed
+fresh on each entry to the handler — each step of the *enclosing* loop re-enters
+it, so the iterator naturally re-initializes against the outer loop's current
+input chunk. Per step the writer fills its chunks plus the indices column,
+where `indices[i]` is the input-chunk row that produced output row `i`. That
+indices column carries the whole join-back semantics:
+
+- out-edges: the writer fills edge IDs, edge types and targets; the sources
+  chunk is gathered: `sources[i] = input[indices[i]]`.
+- in-edges: the writer fills sources directly (`setSrcIDs`); the targets chunk
+  is gathered from the input the same way.
+- carries (`columns_to_filter`): `carryOut[k][i] = carryIn[k][indices[i]]` via
+  the translation-time-selected gather. This one gather kernel implements the
+  dialect's carry-set filtering.
+
+Carry-in chunk lengths are `bioassert`ed against the input chunk length at
+loop entry.
+
+**Output.** Asserts all operand chunks have equal length and calls
+`sink.appendChunks(...)`.
+
+Errors throw `IRException`; because handlers are ordinary calls, a throw from
+any depth unwinds the entire nest correctly.
+
+## NLOutputSink — push-based output
+
+```cpp
+class NLOutputSink {
+public:
+    virtual ~NLOutputSink();
+
+    virtual void appendChunks(std::span<const Column* const> chunks) = 0;
+};
+```
+
+This is the run-to-completion contract: output is pushed chunk-wise as the
+loops run. Streaming to a client, if ever needed, plugs in here without
+touching the interpreter. Tests use a collecting sink that copies chunks into
+owned columns.
+
+## NLTranslator — MLIR to NLProgram, the only MLIR-facing file
+
+Constructor takes the `NLProgram&` to fill (caller-owns-output convention);
+`void translate(mlir::func::FuncOp function)` performs a single walk of the
+function body:
+
+- `nl.scan_nodes` / `nl.get_out_edges` / `nl.get_in_edges` emit no descriptor.
+  They record an iterator-config entry keyed by their result `Value`: the
+  iterator kind, the input chunk value and the carried chunk values.
+- `nl.for` looks up its operand's config, allocates one slot per body block
+  argument (block-argument order equals iterator chunk order, guaranteed by
+  `For::verify`), registers the arguments in the value-to-slot map, builds the
+  loop payload with resolved slot pointers, and recurses into the body.
+- `nl.output` resolves its operands through the value-to-slot map into an
+  `NLOutputData`.
+- `nl.yield` and `func.return` are structural; any other op is an
+  `IRException`.
+
+Chunk SSA values only exist as `nl.for` block arguments, so the value-to-slot
+map is complete by construction. An iterator operand not defined by one of the
+three source ops is a translation error. An iterator value consumed by two
+`nl.for` ops works for free: each loop instantiates its own writer from the
+shared config.
+
+Two same-loop checks close a gap the op verifiers leave open (they constrain
+only types): every `nl.output` operand must be a loop variable of the
+innermost enclosing `nl.for`, and a carry set must consist of loop variables
+of the same loop that binds `input_nodes`. Cross-loop chunks have no per-row
+correspondence to the current step, so such programs are rejected at
+translation with an `IRException` instead of misaligning rows or tripping the
+runtime length asserts.
+
+# Storage APIs the handlers drive
+
+All in `storage/iterators/`; exhaustion is `Iterator::isValid()` in all cases.
+
+| Writer | Construction | Per-step |
+|---|---|---|
+| `ScanNodesChunkWriter` | `(const GraphView&)` | `setNodeIDs(ColumnNodeIDs*)`, `fill(maxCount)` |
+| `GetOutEdgesChunkWriter` | `(const GraphView&, const ColumnNodeIDs* input)` | `setIndices`, `setEdgeIDs`, `setEdgeTypes`, `setTgtIDs`, `fill(maxCount)` |
+| `GetInEdgesChunkWriter` | `(const GraphView&, const ColumnNodeIDs* input)` | `setIndices`, `setEdgeIDs`, `setEdgeTypes`, `setSrcIDs`, `fill(maxCount)` |
+
+Chunks are `ColumnVector<T>` (`ColumnNodeIDs`, `ColumnEdgeIDs`,
+`ColumnEdgeTypes` from `storage/columns/ColumnIDs.h`). The writers handle
+tombstone filtering internally, including filtering the indices column, so the
+gather-by-indices step composes correctly with deletions.
+
+To verify while coding (not design risks): the exact append/overwrite behavior
+of `fill` (handlers clear slots per step regardless), and the in-edges setter
+name.
+
+# Testing
+
+`test/query/ir/NLInterpreterTest.cpp`, following the `ScanNodesIteratorTest`
+fixture pattern (`TuringTest` + `JobSystem`; `Graph::create()` →
+`newChange()` → datapart builder → `submit`). Programs are parsed from string
+with `mlir::parseSourceString<ModuleOp>` (the file-based `IRAssembler` stays
+out of unit tests), translated, and run with a collecting sink.
+
+1. scan → output: all node IDs; plus the empty-graph case.
+2. scan → out-edges → output `(%srcs, %b)`: 1-hop pairs, exercises the source
+   gather.
+3. Two-hop with carry, outputting `(%aFiltered, %c)`: exercises carry
+   filtering end-to-end against hand-computed paths.
+4. The in-edges variant of (2).
+5. (2) re-run with `_chunkSize = 2` on a graph large enough to force several
+   steps per loop: results must be identical regardless of chunking.
+
+CMake mirrors the `add_storage_tests` function pattern, linking the
+interpreter, dialect and storage libraries.
+
+# Implementation order
+
+1. `NLProgram.h/.cpp` — runtime structures, no MLIR.
+2. `NLInterpreter.h/.cpp` — handlers and entry point.
+3. `NLTranslator.h/.cpp` — the MLIR walk.
+4. CMake wiring for the library and tests.
+5. Tests, then one build and test run to verify the milestone.
+
+# Deferred work
+
+- db → nl lowering and wiring the interpreter into the query path.
+- Plan cache: split immutable `NLProgram` from per-run slot state, enabling
+  concurrent executions of one translated program.
+- LIMIT / early-termination channel (status return or exception).
+- Chunk-fullness invariant: ragged chunks (highly selective steps producing
+  near-empty chunks) erode the amortization argument; the fix belongs in the
+  iterator contract (keep filling across input rows), not the interpreter.
+- Fused superinstruction handlers for hot shapes (e.g. scan → expand → output):
+  drop-in descriptor replacements, no architectural change.
+- Per-element expression evaluation, when the dialect grows it: vectorized
+  expression kernels first; compilation only behind adaptive tiering via MLIR
+  lowering if profiles ever demand it.

--- a/query/ir/CMakeLists.txt
+++ b/query/ir/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(dialect)
 add_subdirectory(common)
 add_subdirectory(as)
+add_subdirectory(interpreter)

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(turing_db_ir_interpreter_s
     PUBLIC
         turing_db_ir_nldialect_s
         turing_db_storage_s
+        turing_db_memory_s
         turing_common_s
 
     PRIVATE

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -2,7 +2,8 @@ set(ir_interpreter_sources
     NLProgram.cpp
     NLOutputSink.cpp
     NLExecutor.cpp
-    NLTranslator.cpp)
+    NLTranslator.cpp
+    NLInterpreter.cpp)
 
 add_library(turing_db_ir_interpreter_s STATIC ${ir_interpreter_sources})
 

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(ir_interpreter_sources
     NLProgram.cpp
     NLOutputSink.cpp
-    NLInterpreter.cpp
+    NLExecutor.cpp
     NLTranslator.cpp)
 
 add_library(turing_db_ir_interpreter_s STATIC ${ir_interpreter_sources})

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(ir_interpreter_sources
+    NLProgram.cpp
+    NLOutputSink.cpp
+    NLInterpreter.cpp
+    NLTranslator.cpp)
+
+add_library(turing_db_ir_interpreter_s STATIC ${ir_interpreter_sources})
+
+target_link_libraries(turing_db_ir_interpreter_s
+    PUBLIC
+        turing_db_ir_nldialect_s
+        turing_db_storage_s
+        turing_common_s
+
+    PRIVATE
+        turing_db_ir_common_s)
+
+target_include_directories(turing_db_ir_interpreter_s PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR})

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1,4 +1,4 @@
-#include "NLInterpreter.h"
+#include "NLExecutor.h"
 
 #include <type_traits>
 
@@ -73,7 +73,7 @@ void runEdgeLoopSteps(NLExecutionContext* context,
 
 }
 
-NLInterpreter::NLInterpreter(const GraphView* view,
+NLExecutor::NLExecutor(const GraphView* view,
                              const NLProgram* prog,
                              NLOutputSink* sink)
     : _ctxt(view, sink, prog->getChunkSize()),
@@ -81,14 +81,14 @@ NLInterpreter::NLInterpreter(const GraphView* view,
 {
 }
 
-NLInterpreter::~NLInterpreter() {
+NLExecutor::~NLExecutor() {
 }
 
-void NLInterpreter::run() {
+void NLExecutor::run() {
     runBody(&_ctxt, _prog->getStmts());
 }
 
-void NLInterpreter::runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data) {
+void NLExecutor::runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data) {
     NLScanLoopData* loopData = static_cast<NLScanLoopData*>(data);
     const NLStmtContainer* loopBody = loopData->getStmts();
     ColumnNodeIDs* nodeIDs = loopData->getNodeIDs();
@@ -108,7 +108,7 @@ void NLInterpreter::runScanNodesLoop(NLExecutionContext* context, NLFunctionData
     }
 }
 
-void NLInterpreter::runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
+void NLExecutor::runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
     NLEdgeLoopData* loopData = static_cast<NLEdgeLoopData*>(data);
     const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
 
@@ -125,7 +125,7 @@ void NLInterpreter::runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionDa
     runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getSources());
 }
 
-void NLInterpreter::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
+void NLExecutor::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
     NLEdgeLoopData* loopData = static_cast<NLEdgeLoopData*>(data);
     const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
 
@@ -142,7 +142,7 @@ void NLInterpreter::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionDat
     runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getTargets());
 }
 
-void NLInterpreter::runOutput(NLExecutionContext* context, NLFunctionData* data) {
+void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     const NLOutputData* output = static_cast<NLOutputData*>(data);
     const auto& cols = output->outputs();
     bioassert(!cols.empty(), "nl.output requires at least one column");
@@ -151,7 +151,7 @@ void NLInterpreter::runOutput(NLExecutionContext* context, NLFunctionData* data)
     sink->appendChunks(cols);
 }
 
-NLGatherFunction NLInterpreter::selectGatherFunction(NLChunkKind kind) {
+NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
             return &gatherColumn<NodeID>;

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -31,12 +31,12 @@ private:
 };
 
 // Executes a translated NLProgram against a graph view
-class NLInterpreter {
+class NLExecutor {
 public:
-    NLInterpreter(const GraphView* view,
+    NLExecutor(const GraphView* view,
                   const NLProgram* prog,
                   NLOutputSink* sink);
-    ~NLInterpreter();
+    ~NLExecutor();
 
     void run();
 

--- a/query/ir/interpreter/NLInterpreter.cpp
+++ b/query/ir/interpreter/NLInterpreter.cpp
@@ -1,9 +1,12 @@
 #include "NLInterpreter.h"
 
+#include <type_traits>
+
 #include "iterators/GetInEdgesIterator.h"
 #include "iterators/GetOutEdgesIterator.h"
 #include "iterators/ScanNodesIterator.h"
 
+#include "NLProgram.h"
 #include "NLOutputSink.h"
 
 #include "BioAssert.h"
@@ -12,144 +15,140 @@ using namespace db;
 
 namespace {
 
-void runBody(NLExecutionContext& context, const std::vector<NLFunctionDescriptor>& body) {
-    for (const NLFunctionDescriptor& descriptor : body) {
-        descriptor._function(context, descriptor._data);
+// Execute a body of statements
+void runBody(NLExecutionContext* context, const NLStmtContainer* body) {
+    for (const NLFunctionDescriptor& descriptor : body->stmts()) {
+        const auto func = descriptor.getFunction();
+        NLFunctionData* funcData = descriptor.getData();
+        func(context, funcData);
     }
 }
 
-// The kernel behind NLCarriedColumn::_gather, instantiated per chunk element
-// type and selected at translation time. The casts are safe because slots are
-// allocated from the same NLChunkKind the gather is selected from.
+// Gather rows of a carried column by applying indices
 template <typename ElementType>
-void gatherColumn(const Column& input, const ColumnVector<size_t>& indices, Column& output) {
-    const auto& typedInput = static_cast<const ColumnVector<ElementType>&>(input);
-    auto& typedOutput = static_cast<ColumnVector<ElementType>&>(output);
+void gatherColumn(const Column* input,
+                  const ColumnVector<size_t>* indices,
+                  Column* output) {
+    const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
+    ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
 
-    typedOutput.clear();
-    for (const size_t index : indices.getRaw()) {
-        typedOutput.push_back(typedInput[index]);
+    typedOutput->clear();
+    typedOutput->reserve(indices->size());
+    const auto& indicesRaw = indices->getRaw();
+    auto& typedInputRaw = typedInput->getRaw();
+
+    for (const size_t index : indicesRaw) {
+        typedOutput->push_back(typedInputRaw[index]);
     }
 }
 
-void checkCarriedColumnSizes(const NLEdgeLoopData& loop) {
-    const size_t inputSize = loop._inputNodeIDs->size();
-    for (const NLCarriedColumn& carriedColumn : loop._carriedColumns) {
-        bioassert(carriedColumn._input->size() == inputSize,
-                  "Carried chunk must have one row per input node");
-    }
-}
+// Execute a get_out_edges/get_in_edges loop
+template <typename ChunkWriterType>
+void runEdgeLoopSteps(NLExecutionContext* context,
+                      NLEdgeLoopData* loopData,
+                      ChunkWriterType* chunkWriter,
+                      ColumnNodeIDs* gatheredNodeIDs) {
+    const NLStmtContainer* loopBody = loopData->getStmts();
 
-// The native chunk-stepping loop shared by the two edge-loop handlers. The
-// writer fills its bound chunks plus the indices column, where indices[i] is
-// the input-chunk row that produced output row i; that one map drives both
-// the reconstruction of the gathered side (sources for out-edges, targets for
-// in-edges) and the carry-set filtering.
-template <typename WriterType>
-void runEdgeLoopSteps(NLExecutionContext& context,
-                      NLEdgeLoopData& loop,
-                      WriterType& writer,
-                      ColumnNodeIDs& gatheredNodeIDs) {
-    while (writer.isValid()) {
-        // fill clears the bound columns before writing the next chunk
-        writer.fill(context._chunkSize);
+    while (chunkWriter->isValid()) {
+        chunkWriter->fill(context->getChunkSize());
 
-        // Every row of this step may have been tombstone-filtered away
-        if (loop._indices.empty()) {
+        const ColumnVector<size_t>* indices = loopData->getIndices();
+        if (indices->empty()) {
             continue;
         }
 
-        gatherColumn<NodeID>(*loop._inputNodeIDs, loop._indices, gatheredNodeIDs);
+        // Gather either source or target if we are get_out or get_in (the source side)
+        gatherColumn<NodeID>(loopData->getInput(), indices, gatheredNodeIDs);
 
-        for (const NLCarriedColumn& carriedColumn : loop._carriedColumns) {
-            carriedColumn._gather(*carriedColumn._input, loop._indices, *carriedColumn._output);
+        // Transform all the columns in the carried set according to indices
+        for (const NLCarriedColumn& carriedColumn : loopData->carriedColumns()) {
+            const auto gatherFunc = carriedColumn.getGatherFunc();
+            gatherFunc(carriedColumn.getInput(), indices, carriedColumn.getOutput());
         }
 
-        runBody(context, loop._body);
+        runBody(context, loopBody);
     }
 }
 
 }
 
-void NLInterpreter::run(const GraphView& view, NLProgram& program, NLOutputSink& sink) {
-    NLExecutionContext context {view, &sink, program.getChunkSize()};
-    runBody(context, program.getTopLevel());
+NLInterpreter::NLInterpreter(const GraphView* view,
+                             const NLProgram* prog,
+                             NLOutputSink* sink)
+    : _ctxt(view, sink, prog->getChunkSize()),
+    _prog(prog)
+{
 }
 
-void NLInterpreter::runScanNodesLoop(NLExecutionContext& context, NLFunctionData* data) {
-    auto* loop = static_cast<NLScanLoopData*>(data);
-    ColumnNodeIDs* nodeIDs = loop->_nodeIDs;
+NLInterpreter::~NLInterpreter() {
+}
 
-    // The writer lives on the handler's own stack: loop state on the native C
-    // stack is the point of the subroutine-threaded design
-    ScanNodesChunkWriter writer(context._view);
-    writer.setNodeIDs(nodeIDs);
+void NLInterpreter::run() {
+    runBody(&_ctxt, _prog->getStmts());
+}
 
-    while (writer.isValid()) {
-        writer.fill(context._chunkSize);
+void NLInterpreter::runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLScanLoopData* loopData = static_cast<NLScanLoopData*>(data);
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    ColumnNodeIDs* nodeIDs = loopData->getNodeIDs();
+    const size_t chunkSize = context->getChunkSize();
+
+    ScanNodesChunkWriter chunkWriter(*context->getView());
+    chunkWriter.setNodeIDs(nodeIDs);
+
+    while (chunkWriter.isValid()) {
+        chunkWriter.fill(chunkSize);
 
         if (nodeIDs->empty()) {
             continue;
         }
 
-        runBody(context, loop->_body);
+        runBody(context, loopBody);
     }
 }
 
-void NLInterpreter::runGetOutEdgesLoop(NLExecutionContext& context, NLFunctionData* data) {
-    auto* loop = static_cast<NLEdgeLoopData*>(data);
-    const ColumnNodeIDs* inputNodeIDs = loop->_inputNodeIDs;
+void NLInterpreter::runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLEdgeLoopData* loopData = static_cast<NLEdgeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
 
     if (inputNodeIDs->empty()) {
         return;
     }
 
-    checkCarriedColumnSizes(*loop);
+    GetOutEdgesChunkWriter chunkWriter(*context->getView(), inputNodeIDs);
+    chunkWriter.setIndices(loopData->getIndices());
+    chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
+    chunkWriter.setEdgeTypes(loopData->getEdgeTypes());
+    chunkWriter.setTgtIDs(loopData->getTargets());
 
-    // Constructed at handler entry, after the enclosing loop filled the input
-    // slot: the writer captures the input column's iterators on construction
-    GetOutEdgesChunkWriter writer(context._view, inputNodeIDs);
-    writer.setIndices(&loop->_indices);
-    writer.setEdgeIDs(loop->_edgeIDs);
-    writer.setEdgeTypes(loop->_edgeTypes);
-    writer.setTgtIDs(loop->_targets);
-
-    // Out-edges walk the successors of the input nodes: the writer fills the
-    // target side and the source side is gathered from the input
-    runEdgeLoopSteps(context, *loop, writer, *loop->_sources);
+    runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getSources());
 }
 
-void NLInterpreter::runGetInEdgesLoop(NLExecutionContext& context, NLFunctionData* data) {
-    auto* loop = static_cast<NLEdgeLoopData*>(data);
-    const ColumnNodeIDs* inputNodeIDs = loop->_inputNodeIDs;
+void NLInterpreter::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLEdgeLoopData* loopData = static_cast<NLEdgeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
 
     if (inputNodeIDs->empty()) {
         return;
     }
 
-    checkCarriedColumnSizes(*loop);
+    GetInEdgesChunkWriter chunkWriter(*context->getView(), inputNodeIDs);
+    chunkWriter.setIndices(loopData->getIndices());
+    chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
+    chunkWriter.setEdgeTypes(loopData->getEdgeTypes());
+    chunkWriter.setSrcIDs(loopData->getSources());
 
-    GetInEdgesChunkWriter writer(context._view, inputNodeIDs);
-    writer.setIndices(&loop->_indices);
-    writer.setEdgeIDs(loop->_edgeIDs);
-    writer.setEdgeTypes(loop->_edgeTypes);
-    writer.setSrcIDs(loop->_sources);
-
-    // In-edges walk the predecessors of the input nodes: the writer fills the
-    // source side and the target side is gathered from the input
-    runEdgeLoopSteps(context, *loop, writer, *loop->_targets);
+    runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getTargets());
 }
 
-void NLInterpreter::runOutput(NLExecutionContext& context, NLFunctionData* data) {
-    const auto* output = static_cast<NLOutputData*>(data);
-    bioassert(!output->_columns.empty(), "nl.output requires at least one column");
+void NLInterpreter::runOutput(NLExecutionContext* context, NLFunctionData* data) {
+    const NLOutputData* output = static_cast<NLOutputData*>(data);
+    const auto& cols = output->outputs();
+    bioassert(!cols.empty(), "nl.output requires at least one column");
 
-    const size_t rowCount = output->_columns.front()->size();
-    for (const Column* column : output->_columns) {
-        bioassert(column->size() == rowCount, "nl.output columns must have the same length");
-    }
-
-    context._sink->appendChunks(output->_columns);
+    NLOutputSink* sink = context->getSink();
+    sink->appendChunks(cols);
 }
 
 NLGatherFunction NLInterpreter::selectGatherFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLInterpreter.cpp
+++ b/query/ir/interpreter/NLInterpreter.cpp
@@ -14,10 +14,12 @@ using namespace db;
 NLInterpreter::NLInterpreter(const mlir::ModuleOp& module,
                              const GraphView* view,
                              NLOutputSink* sink,
+                             LocalMemory* memory,
                              size_t chunkSize)
     : _module(module),
     _view(view),
     _sink(sink),
+    _memory(memory),
     _chunkSize(chunkSize)
 {
 }
@@ -36,7 +38,7 @@ void NLInterpreter::run() {
     NLProgram program;
     program.setChunkSize(_chunkSize);
 
-    NLTranslator translator(&program);
+    NLTranslator translator(&program, _memory);
     translator.translate(function);
 
     NLExecutor executor(_view, &program, _sink);

--- a/query/ir/interpreter/NLInterpreter.cpp
+++ b/query/ir/interpreter/NLInterpreter.cpp
@@ -1,5 +1,7 @@
 #include "NLInterpreter.h"
 
+#include <iostream>
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/SymbolTable.h"
 
@@ -8,6 +10,7 @@
 #include "NLExecutor.h"
 
 #include "IRException.h"
+#include "TuringTime.h"
 
 using namespace db;
 
@@ -38,9 +41,25 @@ void NLInterpreter::run() {
     NLProgram program;
     program.setChunkSize(_chunkSize);
 
-    NLTranslator translator(&program, _memory);
-    translator.translate(function);
+    float translateMilliseconds {0.0f};
+    float executeMilliseconds {0.0f};
 
-    NLExecutor executor(_view, &program, _sink);
-    executor.run();
+    {
+        const TimePoint start = Clock::now();
+        NLTranslator translator(&program, _memory);
+        translator.translate(function);
+        const TimePoint end = Clock::now();
+        translateMilliseconds = duration<Milliseconds>(start, end);
+    }
+
+    {
+        const TimePoint start = Clock::now();
+        NLExecutor executor(_view, &program, _sink);
+        executor.run();
+        const TimePoint end = Clock::now();
+        executeMilliseconds = duration<Milliseconds>(start, end);
+    }
+
+    std::cout << "[NLInterpreter] translation: " << translateMilliseconds << " ms, "
+              << "execution: " << executeMilliseconds << " ms\n";
 }

--- a/query/ir/interpreter/NLInterpreter.cpp
+++ b/query/ir/interpreter/NLInterpreter.cpp
@@ -1,0 +1,172 @@
+#include "NLInterpreter.h"
+
+#include "iterators/GetInEdgesIterator.h"
+#include "iterators/GetOutEdgesIterator.h"
+#include "iterators/ScanNodesIterator.h"
+
+#include "NLOutputSink.h"
+
+#include "BioAssert.h"
+
+using namespace db;
+
+namespace {
+
+void runBody(NLExecutionContext& context, const std::vector<NLFunctionDescriptor>& body) {
+    for (const NLFunctionDescriptor& descriptor : body) {
+        descriptor._function(context, descriptor._data);
+    }
+}
+
+// The kernel behind NLCarriedColumn::_gather, instantiated per chunk element
+// type and selected at translation time. The casts are safe because slots are
+// allocated from the same NLChunkKind the gather is selected from.
+template <typename ElementType>
+void gatherColumn(const Column& input, const ColumnVector<size_t>& indices, Column& output) {
+    const auto& typedInput = static_cast<const ColumnVector<ElementType>&>(input);
+    auto& typedOutput = static_cast<ColumnVector<ElementType>&>(output);
+
+    typedOutput.clear();
+    for (const size_t index : indices.getRaw()) {
+        typedOutput.push_back(typedInput[index]);
+    }
+}
+
+void checkCarriedColumnSizes(const NLEdgeLoopData& loop) {
+    const size_t inputSize = loop._inputNodeIDs->size();
+    for (const NLCarriedColumn& carriedColumn : loop._carriedColumns) {
+        bioassert(carriedColumn._input->size() == inputSize,
+                  "Carried chunk must have one row per input node");
+    }
+}
+
+// The native chunk-stepping loop shared by the two edge-loop handlers. The
+// writer fills its bound chunks plus the indices column, where indices[i] is
+// the input-chunk row that produced output row i; that one map drives both
+// the reconstruction of the gathered side (sources for out-edges, targets for
+// in-edges) and the carry-set filtering.
+template <typename WriterType>
+void runEdgeLoopSteps(NLExecutionContext& context,
+                      NLEdgeLoopData& loop,
+                      WriterType& writer,
+                      ColumnNodeIDs& gatheredNodeIDs) {
+    while (writer.isValid()) {
+        // fill clears the bound columns before writing the next chunk
+        writer.fill(context._chunkSize);
+
+        // Every row of this step may have been tombstone-filtered away
+        if (loop._indices.empty()) {
+            continue;
+        }
+
+        gatherColumn<NodeID>(*loop._inputNodeIDs, loop._indices, gatheredNodeIDs);
+
+        for (const NLCarriedColumn& carriedColumn : loop._carriedColumns) {
+            carriedColumn._gather(*carriedColumn._input, loop._indices, *carriedColumn._output);
+        }
+
+        runBody(context, loop._body);
+    }
+}
+
+}
+
+void NLInterpreter::run(const GraphView& view, NLProgram& program, NLOutputSink& sink) {
+    NLExecutionContext context {view, &sink, program.getChunkSize()};
+    runBody(context, program.getTopLevel());
+}
+
+void NLInterpreter::runScanNodesLoop(NLExecutionContext& context, NLFunctionData* data) {
+    auto* loop = static_cast<NLScanLoopData*>(data);
+    ColumnNodeIDs* nodeIDs = loop->_nodeIDs;
+
+    // The writer lives on the handler's own stack: loop state on the native C
+    // stack is the point of the subroutine-threaded design
+    ScanNodesChunkWriter writer(context._view);
+    writer.setNodeIDs(nodeIDs);
+
+    while (writer.isValid()) {
+        writer.fill(context._chunkSize);
+
+        if (nodeIDs->empty()) {
+            continue;
+        }
+
+        runBody(context, loop->_body);
+    }
+}
+
+void NLInterpreter::runGetOutEdgesLoop(NLExecutionContext& context, NLFunctionData* data) {
+    auto* loop = static_cast<NLEdgeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loop->_inputNodeIDs;
+
+    if (inputNodeIDs->empty()) {
+        return;
+    }
+
+    checkCarriedColumnSizes(*loop);
+
+    // Constructed at handler entry, after the enclosing loop filled the input
+    // slot: the writer captures the input column's iterators on construction
+    GetOutEdgesChunkWriter writer(context._view, inputNodeIDs);
+    writer.setIndices(&loop->_indices);
+    writer.setEdgeIDs(loop->_edgeIDs);
+    writer.setEdgeTypes(loop->_edgeTypes);
+    writer.setTgtIDs(loop->_targets);
+
+    // Out-edges walk the successors of the input nodes: the writer fills the
+    // target side and the source side is gathered from the input
+    runEdgeLoopSteps(context, *loop, writer, *loop->_sources);
+}
+
+void NLInterpreter::runGetInEdgesLoop(NLExecutionContext& context, NLFunctionData* data) {
+    auto* loop = static_cast<NLEdgeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loop->_inputNodeIDs;
+
+    if (inputNodeIDs->empty()) {
+        return;
+    }
+
+    checkCarriedColumnSizes(*loop);
+
+    GetInEdgesChunkWriter writer(context._view, inputNodeIDs);
+    writer.setIndices(&loop->_indices);
+    writer.setEdgeIDs(loop->_edgeIDs);
+    writer.setEdgeTypes(loop->_edgeTypes);
+    writer.setSrcIDs(loop->_sources);
+
+    // In-edges walk the predecessors of the input nodes: the writer fills the
+    // source side and the target side is gathered from the input
+    runEdgeLoopSteps(context, *loop, writer, *loop->_targets);
+}
+
+void NLInterpreter::runOutput(NLExecutionContext& context, NLFunctionData* data) {
+    const auto* output = static_cast<NLOutputData*>(data);
+    bioassert(!output->_columns.empty(), "nl.output requires at least one column");
+
+    const size_t rowCount = output->_columns.front()->size();
+    for (const Column* column : output->_columns) {
+        bioassert(column->size() == rowCount, "nl.output columns must have the same length");
+    }
+
+    context._sink->appendChunks(output->_columns);
+}
+
+NLGatherFunction NLInterpreter::selectGatherFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &gatherColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &gatherColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &gatherColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}

--- a/query/ir/interpreter/NLInterpreter.cpp
+++ b/query/ir/interpreter/NLInterpreter.cpp
@@ -1,0 +1,44 @@
+#include "NLInterpreter.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/SymbolTable.h"
+
+#include "NLProgram.h"
+#include "NLTranslator.h"
+#include "NLExecutor.h"
+
+#include "IRException.h"
+
+using namespace db;
+
+NLInterpreter::NLInterpreter(const mlir::ModuleOp& module,
+                             const GraphView* view,
+                             NLOutputSink* sink,
+                             size_t chunkSize)
+    : _module(module),
+    _view(view),
+    _sink(sink),
+    _chunkSize(chunkSize)
+{
+}
+
+NLInterpreter::~NLInterpreter() {
+}
+
+void NLInterpreter::run() {
+    // The module holds the nl program as its "main" func.func; the translator
+    // lowers that function's body into the NLProgram's statement tree
+    const mlir::func::FuncOp function = _module.lookupSymbol<mlir::func::FuncOp>("main");
+    if (!function) {
+        throw IRException("nl module has no 'main' function to interpret");
+    }
+
+    NLProgram program;
+    program.setChunkSize(_chunkSize);
+
+    NLTranslator translator(&program);
+    translator.translate(function);
+
+    NLExecutor executor(_view, &program, _sink);
+    executor.run();
+}

--- a/query/ir/interpreter/NLInterpreter.h
+++ b/query/ir/interpreter/NLInterpreter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "mlir/IR/BuiltinOps.h"
+
+#include "iterators/ChunkConfig.h"
+
+namespace db {
+
+class GraphView;
+class NLOutputSink;
+
+// Translates an nl-dialect MLIR module into an NLProgram and executes it
+// against a graph view, pushing output chunk-wise into the sink. Wraps the
+// NLTranslator and NLExecutor steps behind a single run() call.
+class NLInterpreter {
+public:
+    NLInterpreter(const mlir::ModuleOp& module,
+                  const GraphView* view,
+                  NLOutputSink* sink,
+                  size_t chunkSize = ChunkConfig::CHUNK_SIZE);
+    ~NLInterpreter();
+
+    void run();
+
+private:
+    mlir::ModuleOp _module;
+    const GraphView* _view {nullptr};
+    NLOutputSink* _sink {nullptr};
+    size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
+};
+
+}

--- a/query/ir/interpreter/NLInterpreter.h
+++ b/query/ir/interpreter/NLInterpreter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "views/GraphView.h"
+
+#include "NLProgram.h"
+
+namespace db {
+
+class NLOutputSink;
+
+// Everything a handler needs besides its own payload, passed down the call
+// chain by reference.
+struct NLExecutionContext {
+    GraphView _view;
+    NLOutputSink* _sink {nullptr};
+    size_t _chunkSize {0};
+};
+
+// Executes a translated NLProgram against a graph view. Handlers are exposed
+// as statics so NLTranslator can bind them into descriptors; they are not
+// meant to be called directly.
+class NLInterpreter {
+public:
+    static void run(const GraphView& view, NLProgram& program, NLOutputSink& sink);
+
+    static void runScanNodesLoop(NLExecutionContext& context, NLFunctionData* data);
+    static void runGetOutEdgesLoop(NLExecutionContext& context, NLFunctionData* data);
+    static void runGetInEdgesLoop(NLExecutionContext& context, NLFunctionData* data);
+    static void runOutput(NLExecutionContext& context, NLFunctionData* data);
+
+    static NLGatherFunction selectGatherFunction(NLChunkKind kind);
+};
+
+}

--- a/query/ir/interpreter/NLInterpreter.h
+++ b/query/ir/interpreter/NLInterpreter.h
@@ -2,35 +2,53 @@
 
 #include <stddef.h>
 
-#include "views/GraphView.h"
-
 #include "NLProgram.h"
 
 namespace db {
 
+class GraphView;
 class NLOutputSink;
 
-// Everything a handler needs besides its own payload, passed down the call
-// chain by reference.
-struct NLExecutionContext {
-    GraphView _view;
+class NLExecutionContext {
+public:
+    NLExecutionContext(const GraphView* view,
+                       NLOutputSink* sink,
+                       size_t chunkSize)
+        : _view(view),
+        _sink(sink),
+        _chunkSize(chunkSize)
+    {
+    }
+
+    const GraphView* getView() const { return _view; }
+    NLOutputSink* getSink() const { return _sink; }
+    size_t getChunkSize() const { return _chunkSize; }
+
+private:
+    const GraphView* _view {nullptr};
     NLOutputSink* _sink {nullptr};
     size_t _chunkSize {0};
 };
 
-// Executes a translated NLProgram against a graph view. Handlers are exposed
-// as statics so NLTranslator can bind them into descriptors; they are not
-// meant to be called directly.
+// Executes a translated NLProgram against a graph view
 class NLInterpreter {
 public:
-    static void run(const GraphView& view, NLProgram& program, NLOutputSink& sink);
+    NLInterpreter(const GraphView* view,
+                  const NLProgram* prog,
+                  NLOutputSink* sink);
+    ~NLInterpreter();
 
-    static void runScanNodesLoop(NLExecutionContext& context, NLFunctionData* data);
-    static void runGetOutEdgesLoop(NLExecutionContext& context, NLFunctionData* data);
-    static void runGetInEdgesLoop(NLExecutionContext& context, NLFunctionData* data);
-    static void runOutput(NLExecutionContext& context, NLFunctionData* data);
+    void run();
 
+    static void runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
+
+private:
+    NLExecutionContext _ctxt;
+    const NLProgram* _prog {nullptr};
 };
 
 }

--- a/query/ir/interpreter/NLInterpreter.h
+++ b/query/ir/interpreter/NLInterpreter.h
@@ -10,6 +10,7 @@ namespace db {
 
 class GraphView;
 class NLOutputSink;
+class LocalMemory;
 
 // Translates an nl-dialect MLIR module into an NLProgram and executes it
 // against a graph view, pushing output chunk-wise into the sink. Wraps the
@@ -19,6 +20,7 @@ public:
     NLInterpreter(const mlir::ModuleOp& module,
                   const GraphView* view,
                   NLOutputSink* sink,
+                  LocalMemory* memory,
                   size_t chunkSize = ChunkConfig::CHUNK_SIZE);
     ~NLInterpreter();
 
@@ -28,6 +30,7 @@ private:
     mlir::ModuleOp _module;
     const GraphView* _view {nullptr};
     NLOutputSink* _sink {nullptr};
+    LocalMemory* _memory {nullptr};
     size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
 };
 

--- a/query/ir/interpreter/NLOutputSink.cpp
+++ b/query/ir/interpreter/NLOutputSink.cpp
@@ -1,0 +1,6 @@
+#include "NLOutputSink.h"
+
+using namespace db;
+
+NLOutputSink::~NLOutputSink() {
+}

--- a/query/ir/interpreter/NLOutputSink.h
+++ b/query/ir/interpreter/NLOutputSink.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <span>
+
+namespace db {
+
+class Column;
+
+// Where nl.output rows land. The interpreter is run-to-completion, pushing
+// output chunk-wise as the loops run; a streaming consumer plugs in here.
+class NLOutputSink {
+public:
+    virtual ~NLOutputSink();
+
+    // One call per nl.output execution: one chunk per output column, all of
+    // the same length. The chunks are the program's slot buffers; copy what
+    // must outlive the call.
+    virtual void appendChunks(std::span<const Column* const> chunks) = 0;
+};
+
+}

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -4,35 +4,32 @@
 
 using namespace db;
 
-NLFunctionData::~NLFunctionData() {
-}
-
 NLProgram::NLProgram() {
 }
 
 NLProgram::~NLProgram() {
 }
 
-Column* NLProgram::addChunkSlot(NLChunkKind kind) {
+Column* NLProgram::allocColumn(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID: {
             auto column = std::make_unique<ColumnNodeIDs>();
             column->reserve(_chunkSize);
-            return _chunkSlots.emplace_back(std::move(column)).get();
+            return _columns.emplace_back(std::move(column)).get();
         }
         break;
 
         case NLChunkKind::EdgeID: {
             auto column = std::make_unique<ColumnEdgeIDs>();
             column->reserve(_chunkSize);
-            return _chunkSlots.emplace_back(std::move(column)).get();
+            return _columns.emplace_back(std::move(column)).get();
         }
         break;
 
         case NLChunkKind::EdgeTypeID: {
             auto column = std::make_unique<ColumnEdgeTypes>();
             column->reserve(_chunkSize);
-            return _chunkSlots.emplace_back(std::move(column)).get();
+            return _columns.emplace_back(std::move(column)).get();
         }
         break;
     }

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -1,39 +1,9 @@
 #include "NLProgram.h"
 
-#include "BioAssert.h"
-
 using namespace db;
 
 NLProgram::NLProgram() {
 }
 
 NLProgram::~NLProgram() {
-}
-
-Column* NLProgram::allocColumn(NLChunkKind kind) {
-    switch (kind) {
-        case NLChunkKind::NodeID: {
-            auto column = std::make_unique<ColumnNodeIDs>();
-            column->reserve(_chunkSize);
-            return _columns.emplace_back(std::move(column)).get();
-        }
-        break;
-
-        case NLChunkKind::EdgeID: {
-            auto column = std::make_unique<ColumnEdgeIDs>();
-            column->reserve(_chunkSize);
-            return _columns.emplace_back(std::move(column)).get();
-        }
-        break;
-
-        case NLChunkKind::EdgeTypeID: {
-            auto column = std::make_unique<ColumnEdgeTypes>();
-            column->reserve(_chunkSize);
-            return _columns.emplace_back(std::move(column)).get();
-        }
-        break;
-    }
-
-    bioassert(false, "Unknown NLChunkKind");
-    return nullptr;
 }

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -1,0 +1,42 @@
+#include "NLProgram.h"
+
+#include "BioAssert.h"
+
+using namespace db;
+
+NLFunctionData::~NLFunctionData() {
+}
+
+NLProgram::NLProgram() {
+}
+
+NLProgram::~NLProgram() {
+}
+
+Column* NLProgram::addChunkSlot(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID: {
+            auto column = std::make_unique<ColumnNodeIDs>();
+            column->reserve(_chunkSize);
+            return _chunkSlots.emplace_back(std::move(column)).get();
+        }
+        break;
+
+        case NLChunkKind::EdgeID: {
+            auto column = std::make_unique<ColumnEdgeIDs>();
+            column->reserve(_chunkSize);
+            return _chunkSlots.emplace_back(std::move(column)).get();
+        }
+        break;
+
+        case NLChunkKind::EdgeTypeID: {
+            auto column = std::make_unique<ColumnEdgeTypes>();
+            column->reserve(_chunkSize);
+            return _chunkSlots.emplace_back(std::move(column)).get();
+        }
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <stddef.h>
+#include <memory>
+#include <vector>
+
+#include "columns/ColumnEdgeTypes.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+
+namespace db {
+
+struct NLExecutionContext;
+struct NLFunctionData;
+
+// The element type of a chunk slot, mirroring the !nl.chunk element types of
+// the nl dialect. Translation resolves every chunk SSA value to a concrete
+// ColumnVector through this kind; the interpreter never consults a type again.
+enum class NLChunkKind {
+    NodeID,
+    EdgeID,
+    EdgeTypeID,
+};
+
+// A handler is an ordinary function composed by plain indirect calls: the
+// interpreter is subroutine-threaded, so loop control stays a native C++ loop
+// inside the handler and nesting maps onto the C call stack
+// (see docs/subroutine_interpreter.md).
+using NLHandlerFunction = void (*)(NLExecutionContext& context, NLFunctionData* data);
+
+// One translated statement: the handler to call and the payload it runs on.
+struct NLFunctionDescriptor {
+    NLHandlerFunction _function {nullptr};
+    NLFunctionData* _data {nullptr};
+};
+
+// Base of the per-descriptor payloads, owned by the NLProgram. Handlers know
+// the concrete payload type of their descriptor and static_cast to it.
+struct NLFunctionData {
+    virtual ~NLFunctionData();
+};
+
+// Copies the input rows selected by the writer's indices column into the
+// output chunk. Selected per NLChunkKind at translation time.
+using NLGatherFunction = void (*)(const Column& input,
+                                  const ColumnVector<size_t>& indices,
+                                  Column& output);
+
+// One columns_to_filter entry of an edge fetch: the chunk of the enclosing
+// loop to filter down to the rows surviving the traversal, and the loop
+// variable slot the filtered chunk lands in.
+struct NLCarriedColumn {
+    const Column* _input {nullptr};
+    Column* _output {nullptr};
+    NLGatherFunction _gather {nullptr};
+};
+
+// nl.for over an nl.scan_nodes iterator.
+struct NLScanLoopData : public NLFunctionData {
+    ColumnNodeIDs* _nodeIDs {nullptr};
+    std::vector<NLFunctionDescriptor> _body;
+};
+
+// nl.for over an nl.get_out_edges or nl.get_in_edges iterator. The source op
+// emits no descriptor of its own: its configuration is folded in here, so the
+// handler drives the storage chunk writer directly.
+struct NLEdgeLoopData : public NLFunctionData {
+    const ColumnNodeIDs* _inputNodeIDs {nullptr};
+
+    // The four fixed chunks of an edge iterator step, in loop-variable order
+    ColumnNodeIDs* _sources {nullptr};
+    ColumnEdgeIDs* _edgeIDs {nullptr};
+    ColumnEdgeTypes* _edgeTypes {nullptr};
+    ColumnNodeIDs* _targets {nullptr};
+
+    std::vector<NLCarriedColumn> _carriedColumns;
+    std::vector<NLFunctionDescriptor> _body;
+
+    // Scratch for the writer's row-to-input-row map, which drives the gathers
+    ColumnVector<size_t> _indices;
+};
+
+// nl.output: hand the current chunks to the sink, one output column per chunk.
+struct NLOutputData : public NLFunctionData {
+    std::vector<const Column*> _columns;
+};
+
+// A translated nl program: the descriptor tree plus all the state it points
+// into. Slots are preallocated at translation time, so execution performs no
+// allocation. The program owns its slot state, which means one NLProgram
+// instance supports one execution at a time.
+class NLProgram {
+public:
+    NLProgram();
+    ~NLProgram();
+
+    NLProgram(const NLProgram&) = delete;
+    NLProgram& operator=(const NLProgram&) = delete;
+
+    // Allocates the backing column of one chunk SSA value, reserved to the
+    // chunk size. Set the chunk size before translating.
+    Column* addChunkSlot(NLChunkKind kind);
+
+    template <typename DataType>
+    DataType* addFunctionData() {
+        auto data = std::make_unique<DataType>();
+        DataType* dataPointer = data.get();
+        _functionData.push_back(std::move(data));
+        return dataPointer;
+    }
+
+    std::vector<NLFunctionDescriptor>& getTopLevel() { return _topLevel; }
+    const std::vector<NLFunctionDescriptor>& getTopLevel() const { return _topLevel; }
+
+    size_t getChunkSize() const { return _chunkSize; }
+    void setChunkSize(size_t chunkSize) { _chunkSize = chunkSize; }
+
+private:
+    std::vector<std::unique_ptr<Column>> _chunkSlots;
+    std::vector<std::unique_ptr<NLFunctionData>> _functionData;
+    std::vector<NLFunctionDescriptor> _topLevel;
+    size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
+};
+
+}

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -11,61 +11,149 @@
 
 namespace db {
 
-struct NLExecutionContext;
-struct NLFunctionData;
+class NLExecutionContext;
+class NLFunctionData;
 
-// The element type of a chunk slot, mirroring the !nl.chunk element types of
-// the nl dialect. Translation resolves every chunk SSA value to a concrete
-// ColumnVector through this kind; the interpreter never consults a type again.
+// Translation resolves every chunk SSA value 
+// to a concrete ColumnVector type through this kind
 enum class NLChunkKind {
     NodeID,
     EdgeID,
     EdgeTypeID,
 };
 
-// A handler is an ordinary function composed by plain indirect calls: the
-// interpreter is subroutine-threaded, so loop control stays a native C++ loop
-// inside the handler and nesting maps onto the C call stack
-// (see docs/subroutine_interpreter.md).
-using NLHandlerFunction = void (*)(NLExecutionContext& context, NLFunctionData* data);
+// Type of function pointers implementing operations
+using NLHandlerFunction = void (*)(NLExecutionContext* context, NLFunctionData* data);
 
-// One translated statement: the handler to call and the payload it runs on.
-struct NLFunctionDescriptor {
+// Function descriptor representing translated statements
+// It consists of a function pointer and function-specific data
+class NLFunctionDescriptor {
+public:
+    NLFunctionDescriptor(NLHandlerFunction function,
+                         NLFunctionData* data)
+        : _function(function),
+        _data(data)
+    {
+    }
+
+    NLHandlerFunction getFunction() const { return _function; }
+    NLFunctionData* getData() const { return _data; }
+
+private:
     NLHandlerFunction _function {nullptr};
     NLFunctionData* _data {nullptr};
 };
 
-// Base of the per-descriptor payloads, owned by the NLProgram. Handlers know
-// the concrete payload type of their descriptor and static_cast to it.
-struct NLFunctionData {
-    virtual ~NLFunctionData();
+// Base class of function-specific data
+class NLFunctionData {
+public:
+    virtual ~NLFunctionData() = default;
 };
 
-// Copies the input rows selected by the writer's indices column into the
-// output chunk. Selected per NLChunkKind at translation time.
-using NLGatherFunction = void (*)(const Column& input,
-                                  const ColumnVector<size_t>& indices,
-                                  Column& output);
+// Holds the translated statements of a program or loop body
+class NLStmtContainer {
+public:
+    using Stmts = std::vector<NLFunctionDescriptor>;
 
-// One columns_to_filter entry of an edge fetch: the chunk of the enclosing
-// loop to filter down to the rows surviving the traversal, and the loop
-// variable slot the filtered chunk lands in.
-struct NLCarriedColumn {
+    const Stmts& stmts() const { return _stmts; }
+
+    void addStmt(const NLFunctionDescriptor& stmt) {
+        _stmts.push_back(stmt);
+    }
+
+private:
+    Stmts _stmts;
+};
+
+// Type of handles per column type that writes the input rows selected 
+// by the indices column into output
+using NLGatherFunction = void (*)(const Column* input,
+                                  const ColumnVector<size_t>* indices,
+                                  Column* output);
+
+// Wraps a "carried" column from previous operations
+class NLCarriedColumn {
+public:
+    NLCarriedColumn(const Column* input,
+                    Column* output,
+                    NLGatherFunction gather)
+        : _input(input),
+        _output(output),
+        _gather(gather)
+    {
+    }
+
+    const Column* getInput() const { return _input; }
+    Column* getOutput() const { return _output; }
+    NLGatherFunction getGatherFunc() const { return _gather; }
+
+private:
+    // Carried column pre-filtering
     const Column* _input {nullptr};
+
+    // Output column after filtering
     Column* _output {nullptr};
+
+    // Gather function to be used to process indices
     NLGatherFunction _gather {nullptr};
 };
 
-// nl.for over an nl.scan_nodes iterator.
-struct NLScanLoopData : public NLFunctionData {
+// nl.scan_nodes loop data
+class NLScanLoopData : public NLFunctionData {
+public:
+    NLScanLoopData(ColumnNodeIDs* nodeIDs)
+        : _nodeIDs(nodeIDs)
+    {
+    }
+
+    ColumnNodeIDs* getNodeIDs() const { return _nodeIDs; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
     ColumnNodeIDs* _nodeIDs {nullptr};
-    std::vector<NLFunctionDescriptor> _body;
+    NLStmtContainer _stmts;
 };
 
-// nl.for over an nl.get_out_edges or nl.get_in_edges iterator. The source op
-// emits no descriptor of its own: its configuration is folded in here, so the
-// handler drives the storage chunk writer directly.
-struct NLEdgeLoopData : public NLFunctionData {
+// nl.get_out_edges and nl.get_in_edges loop data
+// The state is the same for get_out_edges/get_in_edges
+class NLEdgeLoopData : public NLFunctionData {
+public:
+    using CarriedColumns = std::vector<NLCarriedColumn>;
+
+    NLEdgeLoopData(const ColumnNodeIDs* input,
+                   ColumnNodeIDs* sources,
+                   ColumnEdgeIDs* edgeIDs,
+                   ColumnEdgeTypes* edgeTypes,
+                   ColumnNodeIDs* targets)
+        : _inputNodeIDs(input),
+        _sources(sources),
+        _edgeIDs(edgeIDs),
+        _edgeTypes(edgeTypes),
+        _targets(targets)
+    {
+    }
+
+    const ColumnNodeIDs* getInput() const { return _inputNodeIDs; }
+
+    ColumnNodeIDs* getSources() const { return _sources; }
+    ColumnEdgeIDs* getEdgeIDs() const { return _edgeIDs; }
+    ColumnEdgeTypes* getEdgeTypes() const { return _edgeTypes; }
+    ColumnNodeIDs* getTargets() const { return _targets; }
+
+    ColumnVector<size_t>* getIndices() { return &_indices; }
+
+    const CarriedColumns& carriedColumns() const { return _carriedColumns; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+    void addCarriedColumn(const NLCarriedColumn& carried) {
+        _carriedColumns.push_back(carried);
+    }
+
+private:
     const ColumnNodeIDs* _inputNodeIDs {nullptr};
 
     // The four fixed chunks of an edge iterator step, in loop-variable order
@@ -74,22 +162,28 @@ struct NLEdgeLoopData : public NLFunctionData {
     ColumnEdgeTypes* _edgeTypes {nullptr};
     ColumnNodeIDs* _targets {nullptr};
 
-    std::vector<NLCarriedColumn> _carriedColumns;
-    std::vector<NLFunctionDescriptor> _body;
+    CarriedColumns _carriedColumns;
+    NLStmtContainer _stmts;
 
     // Scratch for the writer's row-to-input-row map, which drives the gathers
     ColumnVector<size_t> _indices;
 };
 
-// nl.output: hand the current chunks to the sink, one output column per chunk.
-struct NLOutputData : public NLFunctionData {
+// nl.output data
+class NLOutputData : public NLFunctionData {
+public:
+    using OutputColumns = std::vector<const Column*>;
+
+    const OutputColumns& outputs() const { return _columns; }
+
+    void addOutputColumn(const Column* col) {
+        _columns.push_back(col);
+    }
+
+private:
     std::vector<const Column*> _columns;
 };
 
-// A translated nl program: the descriptor tree plus all the state it points
-// into. Slots are preallocated at translation time, so execution performs no
-// allocation. The program owns its slot state, which means one NLProgram
-// instance supports one execution at a time.
 class NLProgram {
 public:
     NLProgram();
@@ -98,29 +192,28 @@ public:
     NLProgram(const NLProgram&) = delete;
     NLProgram& operator=(const NLProgram&) = delete;
 
-    // Allocates the backing column of one chunk SSA value, reserved to the
-    // chunk size. Set the chunk size before translating.
-    Column* addChunkSlot(NLChunkKind kind);
+    // Allocate a concrete column given an NLChunkKind
+    Column* allocColumn(NLChunkKind kind);
 
-    template <typename DataType>
-    DataType* addFunctionData() {
-        auto data = std::make_unique<DataType>();
-        DataType* dataPointer = data.get();
+    template <typename DataType, typename... Args>
+    DataType* allocFunctionData(Args... args) {
+        auto data = std::make_unique<DataType>(args...);
+        DataType* dataPtr = data.get();
         _functionData.push_back(std::move(data));
-        return dataPointer;
+        return dataPtr;
     }
 
-    std::vector<NLFunctionDescriptor>& getTopLevel() { return _topLevel; }
-    const std::vector<NLFunctionDescriptor>& getTopLevel() const { return _topLevel; }
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
 
     size_t getChunkSize() const { return _chunkSize; }
     void setChunkSize(size_t chunkSize) { _chunkSize = chunkSize; }
 
 private:
-    std::vector<std::unique_ptr<Column>> _chunkSlots;
-    std::vector<std::unique_ptr<NLFunctionData>> _functionData;
-    std::vector<NLFunctionDescriptor> _topLevel;
     size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
+    std::vector<std::unique_ptr<Column>> _columns;
+    std::vector<std::unique_ptr<NLFunctionData>> _functionData;
+    NLStmtContainer _stmts;
 };
 
 }

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -192,9 +192,6 @@ public:
     NLProgram(const NLProgram&) = delete;
     NLProgram& operator=(const NLProgram&) = delete;
 
-    // Allocate a concrete column given an NLChunkKind
-    Column* allocColumn(NLChunkKind kind);
-
     template <typename DataType, typename... Args>
     DataType* allocFunctionData(Args... args) {
         auto data = std::make_unique<DataType>(args...);
@@ -211,7 +208,6 @@ public:
 
 private:
     size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
-    std::vector<std::unique_ptr<Column>> _columns;
     std::vector<std::unique_ptr<NLFunctionData>> _functionData;
     NLStmtContainer _stmts;
 };

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -7,14 +7,17 @@
 
 #include "NLExecutor.h"
 
+#include "LocalMemory.h"
 #include "IRException.h"
+#include "BioAssert.h"
 
 using namespace db;
 
 namespace nl = mlir::nl;
 
-NLTranslator::NLTranslator(NLProgram* program)
-    : _program(program)
+NLTranslator::NLTranslator(NLProgram* program, LocalMemory* memory)
+    : _program(program),
+    _memory(memory)
 {
 }
 
@@ -193,9 +196,41 @@ void NLTranslator::translateOutput(const nl::Output& output, NLStmtContainer* bo
 Column* NLTranslator::allocColumn(mlir::Value chunkValue) {
     const NLChunkKind kind = getChunkKind(chunkValue.getType());
 
-    Column* column = _program->allocColumn(kind);
+    Column* column = allocColumnForKind(kind);
     _valueSlots[chunkValue] = column;
     return column;
+}
+
+// Pool-allocate a chunk column of the right concrete type from the external
+// arena, reserving a full chunk so execution stays allocation-free
+Column* NLTranslator::allocColumnForKind(NLChunkKind kind) {
+    const size_t chunkSize = _program->getChunkSize();
+
+    switch (kind) {
+        case NLChunkKind::NodeID: {
+            ColumnNodeIDs* column = _memory->alloc<ColumnNodeIDs>();
+            column->reserve(chunkSize);
+            return column;
+        }
+        break;
+
+        case NLChunkKind::EdgeID: {
+            ColumnEdgeIDs* column = _memory->alloc<ColumnEdgeIDs>();
+            column->reserve(chunkSize);
+            return column;
+        }
+        break;
+
+        case NLChunkKind::EdgeTypeID: {
+            ColumnEdgeTypes* column = _memory->alloc<ColumnEdgeTypes>();
+            column->reserve(chunkSize);
+            return column;
+        }
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
 }
 
 Column* NLTranslator::getColumn(mlir::Value chunkValue) const {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -5,7 +5,7 @@
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Verifier.h"
 
-#include "NLInterpreter.h"
+#include "NLExecutor.h"
 
 #include "IRException.h"
 
@@ -92,7 +92,7 @@ void NLTranslator::translateScanLoop(mlir::Block& loopBody, NLStmtContainer* bod
 
     NLScanLoopData* loopData = _program->allocFunctionData<NLScanLoopData>(nodeIDs);
 
-    body->addStmt(NLFunctionDescriptor {&NLInterpreter::runScanNodesLoop, loopData});
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runScanNodesLoop, loopData});
 
     translateBlock(loopBody, loopData->getStmts());
 }
@@ -144,13 +144,13 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
 
         const NLCarriedColumn carriedColumn(getColumn(carriedValue),
                                             carriedOutput,
-                                            NLInterpreter::selectGatherFunction(kind));
+                                            NLExecutor::selectGatherFunction(kind));
         loopData->addCarriedColumn(carriedColumn);
     }
 
     const bool isOutEdges = config._kind == IteratorKind::GetOutEdges;
-    const NLHandlerFunction handler = isOutEdges ? &NLInterpreter::runGetOutEdgesLoop
-                                                 : &NLInterpreter::runGetInEdgesLoop;
+    const NLHandlerFunction handler = isOutEdges ? &NLExecutor::runGetOutEdgesLoop
+                                                 : &NLExecutor::runGetInEdgesLoop;
     body->addStmt(NLFunctionDescriptor {handler, loopData});
 
     translateBlock(loopBody, loopData->getStmts());
@@ -187,7 +187,7 @@ void NLTranslator::translateOutput(const nl::Output& output, NLStmtContainer* bo
         outputData->addOutputColumn(getColumn(column));
     }
 
-    body->addStmt(NLFunctionDescriptor {&NLInterpreter::runOutput, outputData});
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runOutput, outputData});
 }
 
 Column* NLTranslator::allocColumn(mlir::Value chunkValue) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -13,7 +13,7 @@ using namespace db;
 
 namespace nl = mlir::nl;
 
-NLTranslator::NLTranslator(NLProgram& program)
+NLTranslator::NLTranslator(NLProgram* program)
     : _program(program)
 {
 }
@@ -21,21 +21,26 @@ NLTranslator::NLTranslator(NLProgram& program)
 NLTranslator::~NLTranslator() {
 }
 
-void NLTranslator::translate(mlir::func::FuncOp function) {
-    // The op verifiers carry the type guarantees the slot casts below rely on
-    if (mlir::failed(mlir::verify(function.getOperation()))) {
+void NLTranslator::translate(const mlir::func::FuncOp& function) {
+    // The op verifiers carry the type guarantees the column casts below rely
+    // on. The const handle converts to Operation* through its const
+    // conversion operator.
+    if (mlir::failed(mlir::verify(function))) {
         throw IRException("nl function failed MLIR verification");
     }
 
-    mlir::Region& bodyRegion = function.getBody();
+    // The generated accessors are non-const, so the const handle is read
+    // through its const operator-> into the generic Operation API: region 0
+    // of a func.func is its body
+    mlir::Region& bodyRegion = function->getRegion(0);
     if (!bodyRegion.hasOneBlock()) {
         throw IRException("NLTranslator expects a function with a single block");
     }
 
-    translateBlock(bodyRegion.front(), _program.getTopLevel());
+    translateBlock(bodyRegion.front(), _program->getStmts());
 }
 
-void NLTranslator::translateBlock(mlir::Block& block, std::vector<NLFunctionDescriptor>& body) {
+void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
     for (mlir::Operation& operation : block) {
         if (auto scanNodes = mlir::dyn_cast<nl::ScanNodes>(operation)) {
             _iteratorConfigs[scanNodes.getResult()] = IteratorConfig {IteratorKind::ScanNodes, {}, {}};
@@ -62,14 +67,16 @@ void NLTranslator::translateBlock(mlir::Block& block, std::vector<NLFunctionDesc
     }
 }
 
-void NLTranslator::translateFor(nl::For forLoop, std::vector<NLFunctionDescriptor>& body) {
-    const auto configIt = _iteratorConfigs.find(forLoop.getIterator());
+void NLTranslator::translateFor(const nl::For& forLoop, NLStmtContainer* body) {
+    // The iterator is the only operand of nl.for and the loop body is the
+    // single block of its only region, both read through the const operator->
+    const auto configIt = _iteratorConfigs.find(forLoop->getOperand(0));
     if (configIt == _iteratorConfigs.end()) {
         throw IRException("nl.for iterator must be produced by an nl source operation");
     }
 
     const IteratorConfig& config = configIt->second;
-    mlir::Block* loopBody = forLoop.getBody();
+    mlir::Block& loopBody = forLoop->getRegion(0).front();
 
     if (config._kind == IteratorKind::ScanNodes) {
         translateScanLoop(loopBody, body);
@@ -78,47 +85,40 @@ void NLTranslator::translateFor(nl::For forLoop, std::vector<NLFunctionDescripto
     }
 }
 
-void NLTranslator::translateScanLoop(mlir::Block* loopBody, std::vector<NLFunctionDescriptor>& body) {
+void NLTranslator::translateScanLoop(mlir::Block& loopBody, NLStmtContainer* body) {
     // For::verify guarantees one block argument per iterator chunk, and a
     // node scan iterator has exactly one chunk of node IDs
-    Column* nodeIDsSlot = _program.addChunkSlot(NLChunkKind::NodeID);
-    _valueSlots[loopBody->getArgument(0)] = nodeIDsSlot;
+    ColumnNodeIDs* nodeIDs = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(0)));
 
-    NLScanLoopData* loopData = _program.addFunctionData<NLScanLoopData>();
-    loopData->_nodeIDs = static_cast<ColumnNodeIDs*>(nodeIDsSlot);
+    NLScanLoopData* loopData = _program->allocFunctionData<NLScanLoopData>(nodeIDs);
 
-    body.push_back(NLFunctionDescriptor {&NLInterpreter::runScanNodesLoop, loopData});
+    body->addStmt(NLFunctionDescriptor {&NLInterpreter::runScanNodesLoop, loopData});
 
-    translateBlock(*loopBody, loopData->_body);
+    translateBlock(loopBody, loopData->getStmts());
 }
 
 void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
-                                     mlir::Block* loopBody,
-                                     std::vector<NLFunctionDescriptor>& body) {
-    NLEdgeLoopData* loopData = _program.addFunctionData<NLEdgeLoopData>();
-    loopData->_inputNodeIDs = static_cast<const ColumnNodeIDs*>(resolveChunkSlot(config._inputNodes));
-
-    // The scratch indices column gets the same up-front reservation as the
-    // slots, keeping execution allocation-free
-    loopData->_indices.reserve(_program.getChunkSize());
-
+                                     mlir::Block& loopBody,
+                                     NLStmtContainer* body) {
     // The four fixed chunks of an edge iterator step, in the block-argument
     // order established by getEdgeIteratorType: sources, edge IDs, edge type
     // IDs, targets
-    Column* sourcesSlot = _program.addChunkSlot(NLChunkKind::NodeID);
-    Column* edgeIDsSlot = _program.addChunkSlot(NLChunkKind::EdgeID);
-    Column* edgeTypesSlot = _program.addChunkSlot(NLChunkKind::EdgeTypeID);
-    Column* targetsSlot = _program.addChunkSlot(NLChunkKind::NodeID);
+    ColumnNodeIDs* sources = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(0)));
+    ColumnEdgeIDs* edgeIDs = static_cast<ColumnEdgeIDs*>(allocColumn(loopBody.getArgument(1)));
+    ColumnEdgeTypes* edgeTypes = static_cast<ColumnEdgeTypes*>(allocColumn(loopBody.getArgument(2)));
+    ColumnNodeIDs* targets = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(3)));
 
-    loopData->_sources = static_cast<ColumnNodeIDs*>(sourcesSlot);
-    loopData->_edgeIDs = static_cast<ColumnEdgeIDs*>(edgeIDsSlot);
-    loopData->_edgeTypes = static_cast<ColumnEdgeTypes*>(edgeTypesSlot);
-    loopData->_targets = static_cast<ColumnNodeIDs*>(targetsSlot);
+    const ColumnNodeIDs* inputNodeIDs = static_cast<const ColumnNodeIDs*>(getColumn(config._inputNodes));
 
-    _valueSlots[loopBody->getArgument(0)] = sourcesSlot;
-    _valueSlots[loopBody->getArgument(1)] = edgeIDsSlot;
-    _valueSlots[loopBody->getArgument(2)] = edgeTypesSlot;
-    _valueSlots[loopBody->getArgument(3)] = targetsSlot;
+    NLEdgeLoopData* loopData = _program->allocFunctionData<NLEdgeLoopData>(inputNodeIDs,
+                                                                           sources,
+                                                                           edgeIDs,
+                                                                           edgeTypes,
+                                                                           targets);
+
+    // The scratch indices column gets the same up-front reservation as the
+    // other columns, keeping execution allocation-free
+    loopData->getIndices()->reserve(_program->getChunkSize());
 
     // One carried chunk per columns_to_filter entry, bound as trailing loop
     // variables after the four fixed chunks
@@ -139,28 +139,27 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
             throw IRException("Carried columns must be loop variables of the same nl.for as the input chunk");
         }
 
-        const NLChunkKind kind = chunkKindOf(carriedValue.getType());
+        const NLChunkKind kind = getChunkKind(carriedValue.getType());
+        Column* carriedOutput = allocColumn(loopBody.getArgument(static_cast<unsigned>(4 + carriedIndex)));
 
-        Column* carriedOutSlot = _program.addChunkSlot(kind);
-        _valueSlots[loopBody->getArgument(static_cast<unsigned>(4 + carriedIndex))] = carriedOutSlot;
-
-        NLCarriedColumn carriedColumn;
-        carriedColumn._input = resolveChunkSlot(carriedValue);
-        carriedColumn._output = carriedOutSlot;
-        carriedColumn._gather = NLInterpreter::selectGatherFunction(kind);
-        loopData->_carriedColumns.push_back(carriedColumn);
+        const NLCarriedColumn carriedColumn(getColumn(carriedValue),
+                                            carriedOutput,
+                                            NLInterpreter::selectGatherFunction(kind));
+        loopData->addCarriedColumn(carriedColumn);
     }
 
     const bool isOutEdges = config._kind == IteratorKind::GetOutEdges;
     const NLHandlerFunction handler = isOutEdges ? &NLInterpreter::runGetOutEdgesLoop
                                                  : &NLInterpreter::runGetInEdgesLoop;
-    body.push_back(NLFunctionDescriptor {handler, loopData});
+    body->addStmt(NLFunctionDescriptor {handler, loopData});
 
-    translateBlock(*loopBody, loopData->_body);
+    translateBlock(loopBody, loopData->getStmts());
 }
 
-void NLTranslator::translateOutput(nl::Output output, std::vector<NLFunctionDescriptor>& body) {
-    const mlir::OperandRange columns = output.getColumns();
+void NLTranslator::translateOutput(const nl::Output& output, NLStmtContainer* body) {
+    // The columns are the only operands of nl.output, read through the const
+    // operator-> since the generated accessors are non-const
+    const mlir::OperandRange columns = output->getOperands();
     if (columns.empty()) {
         throw IRException("nl.output requires at least one column");
     }
@@ -177,7 +176,7 @@ void NLTranslator::translateOutput(nl::Output output, std::vector<NLFunctionDesc
     // verification and has to be rejected here.
     mlir::Block* outputBlock = output->getBlock();
 
-    NLOutputData* outputData = _program.addFunctionData<NLOutputData>();
+    NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
     for (const mlir::Value column : columns) {
         const auto columnArgument = mlir::dyn_cast<mlir::BlockArgument>(column);
         const bool isInnermostLoopVariable = columnArgument && columnArgument.getOwner() == outputBlock;
@@ -185,13 +184,21 @@ void NLTranslator::translateOutput(nl::Output output, std::vector<NLFunctionDesc
             throw IRException("nl.output columns must be loop variables of the innermost enclosing nl.for");
         }
 
-        outputData->_columns.push_back(resolveChunkSlot(column));
+        outputData->addOutputColumn(getColumn(column));
     }
 
-    body.push_back(NLFunctionDescriptor {&NLInterpreter::runOutput, outputData});
+    body->addStmt(NLFunctionDescriptor {&NLInterpreter::runOutput, outputData});
 }
 
-Column* NLTranslator::resolveChunkSlot(mlir::Value chunkValue) {
+Column* NLTranslator::allocColumn(mlir::Value chunkValue) {
+    const NLChunkKind kind = getChunkKind(chunkValue.getType());
+
+    Column* column = _program->allocColumn(kind);
+    _valueSlots[chunkValue] = column;
+    return column;
+}
+
+Column* NLTranslator::getColumn(mlir::Value chunkValue) const {
     // Chunk SSA values only exist as nl.for block arguments, each of which
     // was registered when its loop was translated
     const auto slotIt = _valueSlots.find(chunkValue);
@@ -202,7 +209,7 @@ Column* NLTranslator::resolveChunkSlot(mlir::Value chunkValue) {
     return slotIt->second;
 }
 
-NLChunkKind NLTranslator::chunkKindOf(mlir::Type chunkType) {
+NLChunkKind NLTranslator::getChunkKind(mlir::Type chunkType) {
     const auto chunk = mlir::dyn_cast<nl::ChunkType>(chunkType);
     if (!chunk) {
         throw IRException("Expected an !nl.chunk type");

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1,0 +1,221 @@
+#include "NLTranslator.h"
+
+#include <spdlog/fmt/bundled/format.h>
+
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Verifier.h"
+
+#include "NLInterpreter.h"
+
+#include "IRException.h"
+
+using namespace db;
+
+namespace nl = mlir::nl;
+
+NLTranslator::NLTranslator(NLProgram& program)
+    : _program(program)
+{
+}
+
+NLTranslator::~NLTranslator() {
+}
+
+void NLTranslator::translate(mlir::func::FuncOp function) {
+    // The op verifiers carry the type guarantees the slot casts below rely on
+    if (mlir::failed(mlir::verify(function.getOperation()))) {
+        throw IRException("nl function failed MLIR verification");
+    }
+
+    mlir::Region& bodyRegion = function.getBody();
+    if (!bodyRegion.hasOneBlock()) {
+        throw IRException("NLTranslator expects a function with a single block");
+    }
+
+    translateBlock(bodyRegion.front(), _program.getTopLevel());
+}
+
+void NLTranslator::translateBlock(mlir::Block& block, std::vector<NLFunctionDescriptor>& body) {
+    for (mlir::Operation& operation : block) {
+        if (auto scanNodes = mlir::dyn_cast<nl::ScanNodes>(operation)) {
+            _iteratorConfigs[scanNodes.getResult()] = IteratorConfig {IteratorKind::ScanNodes, {}, {}};
+        } else if (auto getOutEdges = mlir::dyn_cast<nl::GetOutEdges>(operation)) {
+            IteratorConfig config {IteratorKind::GetOutEdges, getOutEdges.getInputNodes(), {}};
+            const mlir::OperandRange carriedColumns = getOutEdges.getColumnsToFilter();
+            config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
+            _iteratorConfigs[getOutEdges.getResult()] = config;
+        } else if (auto getInEdges = mlir::dyn_cast<nl::GetInEdges>(operation)) {
+            IteratorConfig config {IteratorKind::GetInEdges, getInEdges.getInputNodes(), {}};
+            const mlir::OperandRange carriedColumns = getInEdges.getColumnsToFilter();
+            config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
+            _iteratorConfigs[getInEdges.getResult()] = config;
+        } else if (auto forLoop = mlir::dyn_cast<nl::For>(operation)) {
+            translateFor(forLoop, body);
+        } else if (auto output = mlir::dyn_cast<nl::Output>(operation)) {
+            translateOutput(output, body);
+        } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
+            // Structural terminators carry no behavior
+        } else {
+            throw IRException(fmt::format("NLTranslator cannot translate operation '{}'",
+                                          operation.getName().getStringRef().str()));
+        }
+    }
+}
+
+void NLTranslator::translateFor(nl::For forLoop, std::vector<NLFunctionDescriptor>& body) {
+    const auto configIt = _iteratorConfigs.find(forLoop.getIterator());
+    if (configIt == _iteratorConfigs.end()) {
+        throw IRException("nl.for iterator must be produced by an nl source operation");
+    }
+
+    const IteratorConfig& config = configIt->second;
+    mlir::Block* loopBody = forLoop.getBody();
+
+    if (config._kind == IteratorKind::ScanNodes) {
+        translateScanLoop(loopBody, body);
+    } else {
+        translateEdgeLoop(config, loopBody, body);
+    }
+}
+
+void NLTranslator::translateScanLoop(mlir::Block* loopBody, std::vector<NLFunctionDescriptor>& body) {
+    // For::verify guarantees one block argument per iterator chunk, and a
+    // node scan iterator has exactly one chunk of node IDs
+    Column* nodeIDsSlot = _program.addChunkSlot(NLChunkKind::NodeID);
+    _valueSlots[loopBody->getArgument(0)] = nodeIDsSlot;
+
+    NLScanLoopData* loopData = _program.addFunctionData<NLScanLoopData>();
+    loopData->_nodeIDs = static_cast<ColumnNodeIDs*>(nodeIDsSlot);
+
+    body.push_back(NLFunctionDescriptor {&NLInterpreter::runScanNodesLoop, loopData});
+
+    translateBlock(*loopBody, loopData->_body);
+}
+
+void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
+                                     mlir::Block* loopBody,
+                                     std::vector<NLFunctionDescriptor>& body) {
+    NLEdgeLoopData* loopData = _program.addFunctionData<NLEdgeLoopData>();
+    loopData->_inputNodeIDs = static_cast<const ColumnNodeIDs*>(resolveChunkSlot(config._inputNodes));
+
+    // The scratch indices column gets the same up-front reservation as the
+    // slots, keeping execution allocation-free
+    loopData->_indices.reserve(_program.getChunkSize());
+
+    // The four fixed chunks of an edge iterator step, in the block-argument
+    // order established by getEdgeIteratorType: sources, edge IDs, edge type
+    // IDs, targets
+    Column* sourcesSlot = _program.addChunkSlot(NLChunkKind::NodeID);
+    Column* edgeIDsSlot = _program.addChunkSlot(NLChunkKind::EdgeID);
+    Column* edgeTypesSlot = _program.addChunkSlot(NLChunkKind::EdgeTypeID);
+    Column* targetsSlot = _program.addChunkSlot(NLChunkKind::NodeID);
+
+    loopData->_sources = static_cast<ColumnNodeIDs*>(sourcesSlot);
+    loopData->_edgeIDs = static_cast<ColumnEdgeIDs*>(edgeIDsSlot);
+    loopData->_edgeTypes = static_cast<ColumnEdgeTypes*>(edgeTypesSlot);
+    loopData->_targets = static_cast<ColumnNodeIDs*>(targetsSlot);
+
+    _valueSlots[loopBody->getArgument(0)] = sourcesSlot;
+    _valueSlots[loopBody->getArgument(1)] = edgeIDsSlot;
+    _valueSlots[loopBody->getArgument(2)] = edgeTypesSlot;
+    _valueSlots[loopBody->getArgument(3)] = targetsSlot;
+
+    // One carried chunk per columns_to_filter entry, bound as trailing loop
+    // variables after the four fixed chunks
+    const auto inputArgument = mlir::dyn_cast<mlir::BlockArgument>(config._inputNodes);
+    const size_t carriedCount = config._carriedColumns.size();
+    for (size_t carriedIndex = 0; carriedIndex < carriedCount; carriedIndex++) {
+        const mlir::Value carriedValue = config._carriedColumns[carriedIndex];
+
+        // A carried chunk is filtered through the same indices as the input,
+        // so its rows must belong to the same loop step: it must be a loop
+        // variable of the nl.for that binds input_nodes. The ops constrain
+        // only types, so a cross-loop carry passes MLIR verification and has
+        // to be rejected here, before it can misalign the gathers at runtime.
+        const auto carriedArgument = mlir::dyn_cast<mlir::BlockArgument>(carriedValue);
+        const bool boundBySameLoop = inputArgument && carriedArgument
+                                     && carriedArgument.getOwner() == inputArgument.getOwner();
+        if (!boundBySameLoop) {
+            throw IRException("Carried columns must be loop variables of the same nl.for as the input chunk");
+        }
+
+        const NLChunkKind kind = chunkKindOf(carriedValue.getType());
+
+        Column* carriedOutSlot = _program.addChunkSlot(kind);
+        _valueSlots[loopBody->getArgument(static_cast<unsigned>(4 + carriedIndex))] = carriedOutSlot;
+
+        NLCarriedColumn carriedColumn;
+        carriedColumn._input = resolveChunkSlot(carriedValue);
+        carriedColumn._output = carriedOutSlot;
+        carriedColumn._gather = NLInterpreter::selectGatherFunction(kind);
+        loopData->_carriedColumns.push_back(carriedColumn);
+    }
+
+    const bool isOutEdges = config._kind == IteratorKind::GetOutEdges;
+    const NLHandlerFunction handler = isOutEdges ? &NLInterpreter::runGetOutEdgesLoop
+                                                 : &NLInterpreter::runGetInEdgesLoop;
+    body.push_back(NLFunctionDescriptor {handler, loopData});
+
+    translateBlock(*loopBody, loopData->_body);
+}
+
+void NLTranslator::translateOutput(nl::Output output, std::vector<NLFunctionDescriptor>& body) {
+    const mlir::OperandRange columns = output.getColumns();
+    if (columns.empty()) {
+        throw IRException("nl.output requires at least one column");
+    }
+
+    if (!mlir::isa<nl::For>(output->getParentOp())) {
+        throw IRException("nl.output must appear inside an nl.for body");
+    }
+
+    // The output chunks are zipped into rows, so they must all describe the
+    // same loop step: block arguments of the innermost enclosing nl.for. An
+    // outer loop variable has no per-row correspondence to the current step -
+    // it must be carried through columns_to_filter to reach this depth. The
+    // op constrains only types, so a cross-loop operand passes MLIR
+    // verification and has to be rejected here.
+    mlir::Block* outputBlock = output->getBlock();
+
+    NLOutputData* outputData = _program.addFunctionData<NLOutputData>();
+    for (const mlir::Value column : columns) {
+        const auto columnArgument = mlir::dyn_cast<mlir::BlockArgument>(column);
+        const bool isInnermostLoopVariable = columnArgument && columnArgument.getOwner() == outputBlock;
+        if (!isInnermostLoopVariable) {
+            throw IRException("nl.output columns must be loop variables of the innermost enclosing nl.for");
+        }
+
+        outputData->_columns.push_back(resolveChunkSlot(column));
+    }
+
+    body.push_back(NLFunctionDescriptor {&NLInterpreter::runOutput, outputData});
+}
+
+Column* NLTranslator::resolveChunkSlot(mlir::Value chunkValue) {
+    // Chunk SSA values only exist as nl.for block arguments, each of which
+    // was registered when its loop was translated
+    const auto slotIt = _valueSlots.find(chunkValue);
+    if (slotIt == _valueSlots.end()) {
+        throw IRException("Chunk value must be a loop variable of an enclosing nl.for");
+    }
+
+    return slotIt->second;
+}
+
+NLChunkKind NLTranslator::chunkKindOf(mlir::Type chunkType) {
+    const auto chunk = mlir::dyn_cast<nl::ChunkType>(chunkType);
+    if (!chunk) {
+        throw IRException("Expected an !nl.chunk type");
+    }
+
+    const mlir::Type elementType = chunk.getElementType();
+    if (mlir::isa<nl::NodeIDType>(elementType)) {
+        return NLChunkKind::NodeID;
+    } else if (mlir::isa<nl::EdgeIDType>(elementType)) {
+        return NLChunkKind::EdgeID;
+    } else if (mlir::isa<nl::EdgeTypeIDType>(elementType)) {
+        return NLChunkKind::EdgeTypeID;
+    }
+
+    throw IRException("Unsupported chunk element type");
+}

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -45,21 +45,21 @@ void NLTranslator::translate(const mlir::func::FuncOp& function) {
 
 void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
     for (mlir::Operation& operation : block) {
-        if (auto scanNodes = mlir::dyn_cast<nl::ScanNodes>(operation)) {
+        if (nl::ScanNodes scanNodes = mlir::dyn_cast<nl::ScanNodes>(operation)) {
             _iteratorConfigs[scanNodes.getResult()] = IteratorConfig {IteratorKind::ScanNodes, {}, {}};
-        } else if (auto getOutEdges = mlir::dyn_cast<nl::GetOutEdges>(operation)) {
+        } else if (nl::GetOutEdges getOutEdges = mlir::dyn_cast<nl::GetOutEdges>(operation)) {
             IteratorConfig config {IteratorKind::GetOutEdges, getOutEdges.getInputNodes(), {}};
             const mlir::OperandRange carriedColumns = getOutEdges.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
             _iteratorConfigs[getOutEdges.getResult()] = config;
-        } else if (auto getInEdges = mlir::dyn_cast<nl::GetInEdges>(operation)) {
+        } else if (nl::GetInEdges getInEdges = mlir::dyn_cast<nl::GetInEdges>(operation)) {
             IteratorConfig config {IteratorKind::GetInEdges, getInEdges.getInputNodes(), {}};
             const mlir::OperandRange carriedColumns = getInEdges.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
             _iteratorConfigs[getInEdges.getResult()] = config;
-        } else if (auto forLoop = mlir::dyn_cast<nl::For>(operation)) {
+        } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
-        } else if (auto output = mlir::dyn_cast<nl::Output>(operation)) {
+        } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
             // Structural terminators carry no behavior

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -10,10 +10,12 @@
 
 namespace db {
 
+class LocalMemory;
+
 // Translates an MLIR func.func in the nl dialect into an NLProgram
 class NLTranslator {
 public:
-    explicit NLTranslator(NLProgram* program);
+    NLTranslator(NLProgram* program, LocalMemory* memory);
     ~NLTranslator();
 
     void translate(const mlir::func::FuncOp& function);
@@ -32,6 +34,7 @@ private:
     };
 
     NLProgram* _program {nullptr};
+    LocalMemory* _memory {nullptr};
     llvm::DenseMap<mlir::Value, Column*> _valueSlots;
     llvm::DenseMap<mlir::Value, IteratorConfig> _iteratorConfigs;
 
@@ -44,6 +47,7 @@ private:
     void translateOutput(const mlir::nl::Output& output, NLStmtContainer* body);
 
     Column* allocColumn(mlir::Value chunkValue);
+    Column* allocColumnForKind(NLChunkKind kind);
     Column* getColumn(mlir::Value chunkValue) const;
     static NLChunkKind getChunkKind(mlir::Type chunkType);
 };

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "NLOps.h"
+
+#include "NLProgram.h"
+
+namespace db {
+
+// Translates one func.func of nl ops into an NLProgram, once. This is the
+// only MLIR-facing file of the interpreter: translation is where SSA chunk
+// values become preallocated slots and handlers are selected, so the runtime
+// never touches MLIR and the module can be destroyed after translating.
+class NLTranslator {
+public:
+    explicit NLTranslator(NLProgram& program);
+    ~NLTranslator();
+
+    void translate(mlir::func::FuncOp function);
+
+private:
+    // The source ops (nl.scan_nodes, nl.get_out_edges, nl.get_in_edges) emit
+    // no descriptor: they only configure the iterator that a consuming nl.for
+    // drives, so translation records one config per iterator value and folds
+    // it into the loop that uses it.
+    enum class IteratorKind {
+        ScanNodes,
+        GetOutEdges,
+        GetInEdges,
+    };
+
+    struct IteratorConfig {
+        IteratorKind _kind {IteratorKind::ScanNodes};
+        mlir::Value _inputNodes;
+        llvm::SmallVector<mlir::Value, 4> _carriedColumns;
+    };
+
+    NLProgram& _program;
+    llvm::DenseMap<mlir::Value, Column*> _valueSlots;
+    llvm::DenseMap<mlir::Value, IteratorConfig> _iteratorConfigs;
+
+    void translateBlock(mlir::Block& block, std::vector<NLFunctionDescriptor>& body);
+    void translateFor(mlir::nl::For forLoop, std::vector<NLFunctionDescriptor>& body);
+    void translateScanLoop(mlir::Block* loopBody, std::vector<NLFunctionDescriptor>& body);
+    void translateEdgeLoop(const IteratorConfig& config,
+                           mlir::Block* loopBody,
+                           std::vector<NLFunctionDescriptor>& body);
+    void translateOutput(mlir::nl::Output output, std::vector<NLFunctionDescriptor>& body);
+
+    Column* resolveChunkSlot(mlir::Value chunkValue);
+    static NLChunkKind chunkKindOf(mlir::Type chunkType);
+};
+
+}

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -10,22 +10,15 @@
 
 namespace db {
 
-// Translates one func.func of nl ops into an NLProgram, once. This is the
-// only MLIR-facing file of the interpreter: translation is where SSA chunk
-// values become preallocated slots and handlers are selected, so the runtime
-// never touches MLIR and the module can be destroyed after translating.
+// Translates an MLIR func.func in the nl dialect into an NLProgram
 class NLTranslator {
 public:
-    explicit NLTranslator(NLProgram& program);
+    explicit NLTranslator(NLProgram* program);
     ~NLTranslator();
 
-    void translate(mlir::func::FuncOp function);
+    void translate(const mlir::func::FuncOp& function);
 
 private:
-    // The source ops (nl.scan_nodes, nl.get_out_edges, nl.get_in_edges) emit
-    // no descriptor: they only configure the iterator that a consuming nl.for
-    // drives, so translation records one config per iterator value and folds
-    // it into the loop that uses it.
     enum class IteratorKind {
         ScanNodes,
         GetOutEdges,
@@ -38,20 +31,21 @@ private:
         llvm::SmallVector<mlir::Value, 4> _carriedColumns;
     };
 
-    NLProgram& _program;
+    NLProgram* _program {nullptr};
     llvm::DenseMap<mlir::Value, Column*> _valueSlots;
     llvm::DenseMap<mlir::Value, IteratorConfig> _iteratorConfigs;
 
-    void translateBlock(mlir::Block& block, std::vector<NLFunctionDescriptor>& body);
-    void translateFor(mlir::nl::For forLoop, std::vector<NLFunctionDescriptor>& body);
-    void translateScanLoop(mlir::Block* loopBody, std::vector<NLFunctionDescriptor>& body);
+    void translateBlock(mlir::Block& block, NLStmtContainer* body);
+    void translateFor(const mlir::nl::For& forLoop, NLStmtContainer* body);
+    void translateScanLoop(mlir::Block& loopBody, NLStmtContainer* body);
     void translateEdgeLoop(const IteratorConfig& config,
-                           mlir::Block* loopBody,
-                           std::vector<NLFunctionDescriptor>& body);
-    void translateOutput(mlir::nl::Output output, std::vector<NLFunctionDescriptor>& body);
+                           mlir::Block& loopBody,
+                           NLStmtContainer* body);
+    void translateOutput(const mlir::nl::Output& output, NLStmtContainer* body);
 
-    Column* resolveChunkSlot(mlir::Value chunkValue);
-    static NLChunkKind chunkKindOf(mlir::Type chunkType);
+    Column* allocColumn(mlir::Value chunkValue);
+    Column* getColumn(mlir::Value chunkValue) const;
+    static NLChunkKind getChunkKind(mlir::Type chunkType);
 };
 
 }

--- a/samples/mlir/CMakeLists.txt
+++ b/samples/mlir/CMakeLists.txt
@@ -11,6 +11,8 @@ target_link_libraries(${SAMPLE_NAME}
     turing_db_ir_common_s
     turing_db_ir_dbdialect_s
     turing_db_ir_nldialect_s
+    turing_db_ir_interpreter_s
+    turing_db_storage_s
     turing_db_io_fs_s
     turing_common_s
     argparse

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -26,6 +26,8 @@
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnEdgeTypes.h"
 
+#include "LocalMemory.h"
+
 using namespace db;
 
 namespace {
@@ -223,8 +225,9 @@ void executeModule(mlir::ModuleOp& module, const std::string& graphDir) {
     const GraphReader reader = transaction.readGraph();
     const GraphView& view = reader.getView();
 
+    LocalMemory memory;
     PrintingSink sink;
-    NLInterpreter interpreter(module, &view, &sink);
+    NLInterpreter interpreter(module, &view, &sink, &memory);
     interpreter.run();
 
     std::cout << sink.getRowCount() << " rows\n";

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <iostream>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -13,8 +14,17 @@
 
 #include "DBOps.h"
 #include "NLOps.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
 #include "IRAssembler.h"
 #include "IRModuleInspector.h"
+
+#include "Graph.h"
+#include "dump/GraphLoader.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnEdgeTypes.h"
 
 using namespace db;
 
@@ -153,6 +163,73 @@ void assembleFiles(mlir::MLIRContext& ctxt, mlir::ModuleOp& module, const std::v
     assembler.assemble();
 }
 
+// Prints each nl.output chunk set as one row per index, zipping the columns.
+// The interpreter pushes one chunk per output column, all of the same length.
+class PrintingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks) override {
+        if (chunks.empty()) {
+            return;
+        }
+
+        const size_t rowCount = chunks.front()->size();
+        for (size_t row = 0; row < rowCount; row++) {
+            std::cout << "(";
+            for (size_t column = 0; column < chunks.size(); column++) {
+                if (column > 0) {
+                    std::cout << ", ";
+                }
+
+                printCell(chunks[column], row);
+            }
+
+            std::cout << ")\n";
+            _rowCount++;
+        }
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    // The translator only ever emits node ID, edge ID and edge type ID chunks
+    static void printCell(const Column* column, size_t row) {
+        if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
+            std::cout << (*nodeIDs)[row].getValue();
+        } else if (const auto* edgeIDs = dynamic_cast<const ColumnEdgeIDs*>(column)) {
+            std::cout << (*edgeIDs)[row].getValue();
+        } else if (const auto* edgeTypes = dynamic_cast<const ColumnEdgeTypes*>(column)) {
+            std::cout << (*edgeTypes)[row].getValue();
+        } else {
+            std::cout << "?";
+        }
+    }
+
+    size_t _rowCount {0};
+};
+
+// Loads the graph at graphDir and runs the module's main function against it
+void executeModule(mlir::ModuleOp& module, const std::string& graphDir) {
+    if (graphDir.empty()) {
+        throw std::runtime_error("-exec requires a graph directory given with -graph");
+    }
+
+    auto graph = Graph::create();
+    const auto loadResult = GraphLoader::load(graph.get(), fs::Path(graphDir));
+    if (!loadResult) {
+        throw std::runtime_error(loadResult.error().fmtMessage());
+    }
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView& view = reader.getView();
+
+    PrintingSink sink;
+    NLInterpreter interpreter(module, &view, &sink);
+    interpreter.run();
+
+    std::cout << sink.getRowCount() << " rows\n";
+}
+
 }
 
 int main(int argc, char** argv) {
@@ -161,6 +238,8 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> files;
     bool dumpCode = false;
+    bool execute = false;
+    std::string graphDir;
 
     parser.add_argument("files")
         .metavar("mlir.txt")
@@ -171,6 +250,15 @@ int main(int argc, char** argv) {
     parser.add_argument("-d", "--dump")
         .store_into(dumpCode)
         .help("Dump the full MLIR code of every function in the module");
+
+    parser.add_argument("-exec")
+        .store_into(execute)
+        .help("Execute the module's main function with the NLInterpreter");
+
+    parser.add_argument("-graph")
+        .metavar("path")
+        .store_into(graphDir)
+        .help("Graph directory to load and execute against (requires -exec)");
 
     try {
         parser.parse_args(argc, argv);
@@ -200,6 +288,10 @@ int main(int argc, char** argv) {
             inspector.dumpFunctions(std::cout);
         } else {
             inspector.dumpFunctionTypes(std::cout);
+        }
+
+        if (execute) {
+            executeModule(mainMod, graphDir);
         }
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";

--- a/samples/mlir/nested_loop.mlir
+++ b/samples/mlir/nested_loop.mlir
@@ -3,7 +3,7 @@
 // nl.output sends a chunk on as a column of the query result. The last block
 // shows a two-hop MATCH (a)->(b)->(c) using a get_out_edges carry set.
 module {
-    func.func @nested_loop() {
+    func.func @main() {
         %nodes = nl.scan_nodes()
 
         nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {

--- a/test/query/CMakeLists.txt
+++ b/test/query/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(analyzer)
+add_subdirectory(ir)
 add_subdirectory(pipeline)
 add_subdirectory(queries)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -9,4 +9,4 @@ function(add_ir_tests exe_name cpp_file)
             MLIRParser)
 endfunction()
 
-add_ir_tests(test_query_ir_nlinterpreter NLInterpreterTest.cpp)
+add_ir_tests(test_query_ir_nlexecutor NLExecutorTest.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1,0 +1,12 @@
+function(add_ir_tests exe_name cpp_file)
+    add_turing_test(${exe_name} ${cpp_file})
+    target_link_libraries(${exe_name} PRIVATE
+            turing_common_s
+            turing_db_storage_s
+            turing_db_jobs_s
+            turing_db_ir_interpreter_s
+            turing_db_ir_common_s
+            MLIRParser)
+endfunction()
+
+add_ir_tests(test_query_ir_nlinterpreter NLInterpreterTest.cpp)

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -23,6 +23,7 @@
 #include "writers/MetadataBuilder.h"
 
 #include "IRException.h"
+#include "LocalMemory.h"
 #include "NLDialect.h"
 #include "NLInterpreter.h"
 #include "NLOutputSink.h"
@@ -240,7 +241,8 @@ protected:
         mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
         ASSERT_TRUE(module);
 
-        NLInterpreter interpreter(*module, &view, &sink, chunkSize);
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, &view, &sink, &memory, chunkSize);
         interpreter.run();
     }
 
@@ -256,7 +258,8 @@ protected:
 
         // run() reaches the translator before touching the graph view or sink,
         // so a rejected program surfaces its IRException with neither supplied
-        NLInterpreter interpreter(*module, nullptr, nullptr);
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, nullptr, nullptr, &memory);
         EXPECT_THROW(interpreter.run(), IRException);
     }
 

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -24,10 +24,8 @@
 
 #include "IRException.h"
 #include "NLDialect.h"
-#include "NLExecutor.h"
+#include "NLInterpreter.h"
 #include "NLOutputSink.h"
-#include "NLProgram.h"
-#include "NLTranslator.h"
 
 #include "TuringTest.h"
 
@@ -82,7 +80,7 @@ private:
 
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
-func.func @scan() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     nl.output(%a) : !nl.chunk<!nl.node_id>
@@ -94,7 +92,7 @@ func.func @scan() {
 // One hop along out-edges, outputting (source, target) pairs. The source
 // column exercises the gather-by-indices reconstruction.
 constexpr const char* oneHopOutProgram = R"mlir(
-func.func @one_hop_out() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     %edges = nl.get_out_edges(%a, {})
@@ -109,7 +107,7 @@ func.func @one_hop_out() {
 // One hop along in-edges: the writer fills the source side and the target
 // side is gathered from the input, so the output pairs are the same edge set
 constexpr const char* oneHopInProgram = R"mlir(
-func.func @one_hop_in() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     %edges = nl.get_in_edges(%a, {})
@@ -123,7 +121,7 @@ func.func @one_hop_in() {
 
 // Two hops a->b->c carrying a through the second hop, outputting (a, c) pairs
 constexpr const char* twoHopProgram = R"mlir(
-func.func @two_hop() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     %edges = nl.get_out_edges(%a, {})
@@ -141,7 +139,7 @@ func.func @two_hop() {
 // Verifier-legal but rejected by the translator: outputs an outer loop
 // variable from the inner loop instead of carrying it through the carry set
 constexpr const char* crossLoopOutputProgram = R"mlir(
-func.func @cross_loop_output() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     %edges = nl.get_out_edges(%a, {})
@@ -156,7 +154,7 @@ func.func @cross_loop_output() {
 // Verifier-legal but rejected by the translator: carries a chunk bound by a
 // different loop than the one binding the input chunk
 constexpr const char* crossLoopCarryProgram = R"mlir(
-func.func @cross_loop_carry() {
+func.func @main() {
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
     %edges = nl.get_out_edges(%a, {})
@@ -242,17 +240,8 @@ protected:
         mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
         ASSERT_TRUE(module);
 
-        auto functions = module->getOps<mlir::func::FuncOp>();
-        ASSERT_TRUE(functions.begin() != functions.end());
-
-        NLProgram program;
-        program.setChunkSize(chunkSize);
-
-        NLTranslator translator(&program);
-        translator.translate(*functions.begin());
-
-        NLExecutor executor(&view, &program, &sink);
-        executor.run();
+        NLInterpreter interpreter(*module, &view, &sink, chunkSize);
+        interpreter.run();
     }
 
     // Parses a program that MLIR accepts but the translator must reject
@@ -265,12 +254,10 @@ protected:
         mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
         ASSERT_TRUE(module);
 
-        auto functions = module->getOps<mlir::func::FuncOp>();
-        ASSERT_TRUE(functions.begin() != functions.end());
-
-        NLProgram program;
-        NLTranslator translator(&program);
-        EXPECT_THROW(translator.translate(*functions.begin()), IRException);
+        // run() reaches the translator before touching the graph view or sink,
+        // so a rejected program surfaces its IRException with neither supplied
+        NLInterpreter interpreter(*module, nullptr, nullptr);
+        EXPECT_THROW(interpreter.run(), IRException);
     }
 
     std::unique_ptr<JobSystem> _jobSystem;

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -24,7 +24,7 @@
 
 #include "IRException.h"
 #include "NLDialect.h"
-#include "NLInterpreter.h"
+#include "NLExecutor.h"
 #include "NLOutputSink.h"
 #include "NLProgram.h"
 #include "NLTranslator.h"
@@ -173,7 +173,7 @@ func.func @cross_loop_carry() {
 
 }
 
-class NLInterpreterTest : public TuringTest {
+class NLExecutorTest : public TuringTest {
 protected:
     void initialize() override {
         _jobSystem = std::make_unique<JobSystem>();
@@ -251,8 +251,8 @@ protected:
         NLTranslator translator(&program);
         translator.translate(*functions.begin());
 
-        NLInterpreter interpreter(&view, &program, &sink);
-        interpreter.run();
+        NLExecutor executor(&view, &program, &sink);
+        executor.run();
     }
 
     // Parses a program that MLIR accepts but the translator must reject
@@ -276,7 +276,7 @@ protected:
     std::unique_ptr<JobSystem> _jobSystem;
 };
 
-TEST_F(NLInterpreterTest, emptyGraphProducesNoOutput) {
+TEST_F(NLExecutorTest, emptyGraphProducesNoOutput) {
     auto graph = Graph::create();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -287,7 +287,7 @@ TEST_F(NLInterpreterTest, emptyGraphProducesNoOutput) {
     EXPECT_TRUE(sink.getColumns().empty());
 }
 
-TEST_F(NLInterpreterTest, scanNodesOutput) {
+TEST_F(NLExecutorTest, scanNodesOutput) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -301,7 +301,7 @@ TEST_F(NLInterpreterTest, scanNodesOutput) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(NLInterpreterTest, oneHopOutEdges) {
+TEST_F(NLExecutorTest, oneHopOutEdges) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -315,7 +315,7 @@ TEST_F(NLInterpreterTest, oneHopOutEdges) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(NLInterpreterTest, oneHopInEdges) {
+TEST_F(NLExecutorTest, oneHopInEdges) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -329,7 +329,7 @@ TEST_F(NLInterpreterTest, oneHopInEdges) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(NLInterpreterTest, twoHopWithCarriedColumn) {
+TEST_F(NLExecutorTest, twoHopWithCarriedColumn) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -344,7 +344,7 @@ TEST_F(NLInterpreterTest, twoHopWithCarriedColumn) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(NLInterpreterTest, oneHopSmallChunksTwoParts) {
+TEST_F(NLExecutorTest, oneHopSmallChunksTwoParts) {
     auto graph = buildDiamondGraph();
     addSecondPart(*graph);
 
@@ -362,11 +362,11 @@ TEST_F(NLInterpreterTest, oneHopSmallChunksTwoParts) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(NLInterpreterTest, rejectsCrossLoopOutputColumns) {
+TEST_F(NLExecutorTest, rejectsCrossLoopOutputColumns) {
     expectTranslationFailure(crossLoopOutputProgram);
 }
 
-TEST_F(NLInterpreterTest, rejectsCrossLoopCarriedColumns) {
+TEST_F(NLExecutorTest, rejectsCrossLoopCarriedColumns) {
     expectTranslationFailure(crossLoopCarryProgram);
 }
 

--- a/test/query/ir/NLInterpreterTest.cpp
+++ b/test/query/ir/NLInterpreterTest.cpp
@@ -1,0 +1,374 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "columns/ColumnIDs.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "IRException.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "NLProgram.h"
+#include "NLTranslator.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Collects every output chunk into one accumulated value vector per column.
+// All test programs output node ID chunks only.
+class CollectingNodeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks) override {
+        if (_columns.empty()) {
+            _columns.resize(chunks.size());
+        }
+
+        ASSERT_EQ(chunks.size(), _columns.size());
+
+        for (size_t columnIndex = 0; columnIndex < chunks.size(); columnIndex++) {
+            const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[columnIndex]);
+            ASSERT_NE(nodeIDs, nullptr);
+
+            for (const NodeID nodeID : *nodeIDs) {
+                _columns[columnIndex].push_back(nodeID.getValue());
+            }
+        }
+    }
+
+    const std::vector<std::vector<uint64_t>>& getColumns() const { return _columns; }
+
+    // Fills rows zipped from the columns and sorted: chunk order depends on
+    // datapart-major iteration, so tests compare order-independently
+    void sortedRows(std::vector<std::vector<uint64_t>>& rows) const {
+        rows.clear();
+        const size_t rowCount = _columns.empty() ? 0 : _columns.front().size();
+
+        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            std::vector<uint64_t> row;
+            for (const std::vector<uint64_t>& column : _columns) {
+                row.push_back(column[rowIndex]);
+            }
+            rows.push_back(row);
+        }
+
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<std::vector<uint64_t>> _columns;
+};
+
+// Scan all nodes and output them
+constexpr const char* scanProgram = R"mlir(
+func.func @scan() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    nl.output(%a) : !nl.chunk<!nl.node_id>
+  }
+  func.return
+}
+)mlir";
+
+// One hop along out-edges, outputting (source, target) pairs. The source
+// column exercises the gather-by-indices reconstruction.
+constexpr const char* oneHopOutProgram = R"mlir(
+func.func @one_hop_out() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      nl.output(%srcs, %b) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+    }
+  }
+  func.return
+}
+)mlir";
+
+// One hop along in-edges: the writer fills the source side and the target
+// side is gathered from the input, so the output pairs are the same edge set
+constexpr const char* oneHopInProgram = R"mlir(
+func.func @one_hop_in() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_in_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      nl.output(%srcs, %b) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+    }
+  }
+  func.return
+}
+)mlir";
+
+// Two hops a->b->c carrying a through the second hop, outputting (a, c) pairs
+constexpr const char* twoHopProgram = R"mlir(
+func.func @two_hop() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!nl.node_id>
+      nl.for %srcs2, %eids2, %etypes2, %c, %aCarried in %hop : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
+        nl.output(%aCarried, %c) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+      }
+    }
+  }
+  func.return
+}
+)mlir";
+
+// Verifier-legal but rejected by the translator: outputs an outer loop
+// variable from the inner loop instead of carrying it through the carry set
+constexpr const char* crossLoopOutputProgram = R"mlir(
+func.func @cross_loop_output() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      nl.output(%a, %b) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+    }
+  }
+  func.return
+}
+)mlir";
+
+// Verifier-legal but rejected by the translator: carries a chunk bound by a
+// different loop than the one binding the input chunk
+constexpr const char* crossLoopCarryProgram = R"mlir(
+func.func @cross_loop_carry() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
+      %hop = nl.get_out_edges(%b, {%a}) : !nl.chunk<!nl.node_id>
+      nl.for %srcs2, %eids2, %etypes2, %c, %aCarried in %hop : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
+        nl.output(%aCarried, %c) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+      }
+    }
+  }
+  func.return
+}
+)mlir";
+
+}
+
+class NLInterpreterTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // A diamond: 0 -> {1, 2} -> 3, so the two-hop pair (0, 3) exists twice
+    std::unique_ptr<Graph> buildDiamondGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        metadata.getOrCreateLabel("0");
+        metadata.getOrCreateEdgeType("0");
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const NodeID nodeA = builder.addNode(labelset);
+        const NodeID nodeB = builder.addNode(labelset);
+        const NodeID nodeC = builder.addNode(labelset);
+        const NodeID nodeD = builder.addNode(labelset);
+
+        builder.addEdge(0, nodeA, nodeB);
+        builder.addEdge(0, nodeA, nodeC);
+        builder.addEdge(0, nodeB, nodeD);
+        builder.addEdge(0, nodeC, nodeD);
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
+    // A second datapart with nodes 4, 5 and the edge 4 -> 5, exercising the
+    // datapart-major iteration of the writers
+    void addSecondPart(Graph& graph) {
+        auto change = graph.newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const NodeID nodeE = builder.addNode(labelset);
+        const NodeID nodeF = builder.addNode(labelset);
+
+        builder.addEdge(0, nodeE, nodeF);
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+    }
+
+    void runProgram(const char* programText,
+                    const GraphView& view,
+                    size_t chunkSize,
+                    CollectingNodeSink& sink) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        auto functions = module->getOps<mlir::func::FuncOp>();
+        ASSERT_TRUE(functions.begin() != functions.end());
+
+        NLProgram program;
+        program.setChunkSize(chunkSize);
+
+        NLTranslator translator(program);
+        translator.translate(*functions.begin());
+
+        NLInterpreter::run(view, program, sink);
+    }
+
+    // Parses a program that MLIR accepts but the translator must reject
+    void expectTranslationFailure(const char* programText) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        auto functions = module->getOps<mlir::func::FuncOp>();
+        ASSERT_TRUE(functions.begin() != functions.end());
+
+        NLProgram program;
+        NLTranslator translator(program);
+        EXPECT_THROW(translator.translate(*functions.begin()), IRException);
+    }
+
+    std::unique_ptr<JobSystem> _jobSystem;
+};
+
+TEST_F(NLInterpreterTest, emptyGraphProducesNoOutput) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(scanProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    EXPECT_TRUE(sink.getColumns().empty());
+}
+
+TEST_F(NLInterpreterTest, scanNodesOutput) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(scanProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0}, {1}, {2}, {3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLInterpreterTest, oneHopOutEdges) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(oneHopOutProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLInterpreterTest, oneHopInEdges) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(oneHopInProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLInterpreterTest, twoHopWithCarriedColumn) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(twoHopProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // Both two-hop paths go from 0 to 3, one through 1 and one through 2
+    const std::vector<std::vector<uint64_t>> expected {{0, 3}, {0, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLInterpreterTest, oneHopSmallChunksTwoParts) {
+    auto graph = buildDiamondGraph();
+    addSecondPart(*graph);
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A chunk size smaller than the node count forces several steps per loop;
+    // the result must not depend on the chunking
+    CollectingNodeSink sink;
+    runProgram(oneHopOutProgram, reader.getView(), 2, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}, {4, 5}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLInterpreterTest, rejectsCrossLoopOutputColumns) {
+    expectTranslationFailure(crossLoopOutputProgram);
+}
+
+TEST_F(NLInterpreterTest, rejectsCrossLoopCarriedColumns) {
+    expectTranslationFailure(crossLoopCarryProgram);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/NLInterpreterTest.cpp
+++ b/test/query/ir/NLInterpreterTest.cpp
@@ -248,10 +248,11 @@ protected:
         NLProgram program;
         program.setChunkSize(chunkSize);
 
-        NLTranslator translator(program);
+        NLTranslator translator(&program);
         translator.translate(*functions.begin());
 
-        NLInterpreter::run(view, program, sink);
+        NLInterpreter interpreter(&view, &program, &sink);
+        interpreter.run();
     }
 
     // Parses a program that MLIR accepts but the translator must reject
@@ -268,7 +269,7 @@ protected:
         ASSERT_TRUE(functions.begin() != functions.end());
 
         NLProgram program;
-        NLTranslator translator(program);
+        NLTranslator translator(&program);
         EXPECT_THROW(translator.translate(*functions.begin()), IRException);
     }
 


### PR DESCRIPTION
* NLTranslator: translated MLIR nl dialect modules into an NLProgram that contains loops of function pointers. This is to avoid doing dynamic dispatch of the MLIR operations at each iteration.
* NLExecutor: executes NLProgram using function pointers
* NLInterpreter: takes an MLIR module in nl dialect and wraps NLTranslator + NLExecutor

MLIR sample:
We can specify -exec and -graph to the mlir sample to execute an mlir program now on a graph:
```
./mlir -exec -graph $HOME/.turing/graphs/simpledb/ ~/turingdb4/samples/mlir/nested_loop.mlir
``` 