### PR TITLE
Pin regress uv venvs to the wheel's Python version

### DIFF
--- a/regress/call_metadata/run.sh
+++ b/regress/call_metadata/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/change_10/run.sh
+++ b/regress/change_10/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/change_submit_alice/run.sh
+++ b/regress/change_submit_alice/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/complex_rebases/run.sh
+++ b/regress/complex_rebases/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/count_alias_simpledb/run.sh
+++ b/regress/count_alias_simpledb/run.sh
@@ -21,6 +21,14 @@ cp -r $SCRIPT_DIR/simpledb.out/simpledb $SCRIPT_DIR/.turing/graphs/simpledb
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/count_simpledb/run.sh
+++ b/regress/count_simpledb/run.sh
@@ -21,6 +21,14 @@ cp -r $SCRIPT_DIR/simpledb.out/simpledb $SCRIPT_DIR/.turing/graphs/simpledb
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/create_edges_inject/run.sh
+++ b/regress/create_edges_inject/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/create_turingdb_object/run.sh
+++ b/regress/create_turingdb_object/run.sh
@@ -15,6 +15,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/delete_tests/run.sh
+++ b/regress/delete_tests/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/embedding_properties/run.sh
+++ b/regress/embedding_properties/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/get_nodes_invalid_id/run.sh
+++ b/regress/get_nodes_invalid_id/run.sh
@@ -21,6 +21,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/history_on_change/run.sh
+++ b/regress/history_on_change/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/in_process_count_simpledb/run.sh
+++ b/regress/in_process_count_simpledb/run.sh
@@ -19,6 +19,14 @@ rm -rf $SCRIPT_DIR/.turing/graphs/simpledb
 cp -r $SCRIPT_DIR/simpledb.out/simpledb $SCRIPT_DIR/.turing/graphs/simpledb
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/json_error_msg/run.sh
+++ b/regress/json_error_msg/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/json_escape_properties/run.sh
+++ b/regress/json_escape_properties/run.sh
@@ -23,6 +23,14 @@ turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null && break; sleep 0.1; done
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 uv add httpx

--- a/regress/list_graphs/run.sh
+++ b/regress/list_graphs/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/load_csv/run.sh
+++ b/regress/load_csv/run.sh
@@ -35,6 +35,14 @@ for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null && break; sleep 0.1; 
 
 # Setup Python environment
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 
 # Set PYTURINGDB if not already set (for running outside CMake)

--- a/regress/load_csv_stations/run.sh
+++ b/regress/load_csv_stations/run.sh
@@ -34,6 +34,14 @@ for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null && break; sleep 0.1; 
 
 # Setup Python environment
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 
 # Set PYTURINGDB if not already set (for running outside CMake)

--- a/regress/load_embedding/run.sh
+++ b/regress/load_embedding/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 # pyarrow/numpy only build the test Parquet fixture; install them straight into

--- a/regress/load_jsonl_property_types/run.sh
+++ b/regress/load_jsonl_property_types/run.sh
@@ -18,6 +18,14 @@ cp $SCRIPT_DIR/type_coverage.jsonl $SCRIPT_DIR/.turing/data/
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/load_jsonl_reactome/run.sh
+++ b/regress/load_jsonl_reactome/run.sh
@@ -19,6 +19,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 uv add boto3

--- a/regress/multi_type_properties/run.sh
+++ b/regress/multi_type_properties/run.sh
@@ -21,6 +21,14 @@ cp -r $SCRIPT_DIR/simpledb.out/simpledb $SCRIPT_DIR/.turing/graphs/simpledb
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/read_script/run.sh
+++ b/regress/read_script/run.sh
@@ -36,6 +36,14 @@ fi
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/reload_submit_edge/run.sh
+++ b/regress/reload_submit_edge/run.sh
@@ -11,6 +11,14 @@ rm -rf "$SCRIPT_DIR/.turing"
 turingdb -demon -turing-dir "$SCRIPT_DIR/.turing"
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add "$PYTURINGDB"
 

--- a/regress/reset_default/run.sh
+++ b/regress/reset_default/run.sh
@@ -5,6 +5,14 @@ cd "$SCRIPT_DIR"
 SCRIPT_GRAPHS_DIR="$SCRIPT_DIR/.turing/graphs"
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/serialization/run.sh
+++ b/regress/serialization/run.sh
@@ -12,6 +12,14 @@ for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null || break; sleep 0.1; 
 rm -rf $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/snapshot_isolation/run.sh
+++ b/regress/snapshot_isolation/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/start-stop/run.sh
+++ b/regress/start-stop/run.sh
@@ -12,6 +12,14 @@ for i in $(seq 1 100); do nc -z localhost 6666 2>/dev/null || break; sleep 0.1; 
 rm -rf $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/submit_empty_change/run.sh
+++ b/regress/submit_empty_change/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/test_suite_queries/run.sh
+++ b/regress/test_suite_queries/run.sh
@@ -22,6 +22,14 @@ cp -r $SCRIPT_DIR/simpledb.out/simpledb $SCRIPT_DIR/.turing/graphs/simpledb
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 

--- a/regress/vector_serialization/run.sh
+++ b/regress/vector_serialization/run.sh
@@ -12,6 +12,14 @@ mkdir -p $SCRATCH_DIR
 cd $SCRATCH_DIR
 
 # Initialize uv repo
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init --bare
 uv add $PYTURINGDB
 

--- a/regress/wine_ontology/run.sh
+++ b/regress/wine_ontology/run.sh
@@ -13,6 +13,14 @@ rm -rf $SCRIPT_DIR/.turing
 turingdb -demon -turing-dir $SCRIPT_DIR/.turing
 
 rm -f pyproject.toml
+# Pin uv to the Python version the wheel was built for (encoded in the wheel
+# filename, e.g. cp310); otherwise uv creates the venv with the newest
+# interpreter available (e.g. 3.14), which has no ABI for a cp310 wheel.
+wheel_base=$(basename "$PYTURINGDB")
+if [[ "$wheel_base" =~ -cp([0-9])([0-9]+)- ]]; then
+    export UV_PYTHON="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
 uv init
 uv add $PYTURINGDB
 


### PR DESCRIPTION
Pins each regress test's uv venv to the Python version encoded in the wheel filename so the cp3XX wheel installs instead of uv picking a newer interpreter (e.g. 3.14) on the shared CI runner.