### PR TITLE
Neighborhood index page-directory-style simulator

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -51,6 +51,7 @@ add_subdirectory(gnn)
 add_subdirectory(list-buffer)
 add_subdirectory(mlir)
 add_subdirectory(vardeps)
+add_subdirectory(commit-index-sim)
 
 set (SCRIPT_LIST_CONTENT "")
 list (LENGTH SAMPLE_LIST SAMPLE_COUNT)

--- a/samples/commit-index-sim/CMakeLists.txt
+++ b/samples/commit-index-sim/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(SAMPLE_NAME commit-index-sim)
+
+set(SOURCES
+    main.cpp
+    Simulator.cpp
+)
+
+turing_sample(${SAMPLE_NAME} ${SOURCES})
+
+target_link_libraries(${SAMPLE_NAME}
+    argparse
+)

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -12,38 +12,29 @@ We want to evaluate an idea: keep a per-commit **page-table directory** (a radix
 flowchart TD
     classDef shared fill:#eaf2ff,stroke:#4a7fe0,color:#10243e
     classDef new fill:#ffefe0,stroke:#e07b2a,color:#4a2606
-    classDef bits fill:#f3f0ff,stroke:#8a6fd4,color:#2c1f54
-
-    subgraph nid["NodeID (high bits to low bits)"]
-      direction LR
-      hi["level-1 bits"]:::bits --- mid["page bits"]:::bits --- lo["page bits"]:::bits
-    end
 
     rN["root (commit N)"]:::shared
     rN1["root (commit N+1)"]:::new
+
     A["inner page A"]:::shared
     B["inner page B"]:::shared
     Bn["inner page B (copy)"]:::new
+
     la["leaf"]:::shared
     lb["leaf"]:::shared
-    lc["leaf (old)"]:::shared
-    lcn["leaf (new)"]:::new
-    nbr["changed node's neighborhood"]:::new
+    lc["leaf: changed node (old)"]:::shared
+    lcn["leaf: changed node (new)"]:::new
 
     rN --> A
     rN --> B
     A --> la
     B --> lb
     B --> lc
+
     rN1 --> A
     rN1 --> Bn
     Bn --> lb
     Bn --> lcn
-    lcn --> nbr
-
-    hi -. "picks inner page" .-> Bn
-    mid -. "picks leaf" .-> lcn
-    lo -. "picks neighborhood" .-> nbr
 ```
 
 The tree is shared across commits. A new commit only rewrites the pages on the path from each changed node up to a fresh root. We want to know what gain it gives us on reads and what it costs on writes.

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -21,16 +21,17 @@ It then reports read and write cost for the current design and for two flavors o
 
 ## Results 
 
-Default run: 1M nodes, 2000 mutation commits:
+Default run: 1M nodes, 2000 mutation commits. Memory is the index-structure overhead (the raw edges, ~288 MB, are identical for all three): per commit, and the total once the full 2000-commit history is retained.
 
-| Design | Neighborhood read | Commit write | The catch |
-|---|---|---|---|
-| Current (probe every datapart) | ~190 µs | ~72 µs | read cost scales with commit-history depth |
-| Page-table — delta leaves | ~300–360 ns | ~158 µs (2.2×) | cheap reads, modest write overhead |
-| Page-table — consolidated leaves | ~210–220 ns | ~218 µs (3.0×) | fastest reads, but re-copies hub adjacency every touch |
+| Design | Neighborhood read | Commit write | Index mem/commit | Index mem total | The catch |
+|---|---|---|---|---|---|
+| Current (probe every datapart) | ~190 µs | ~72 µs | ~39 KB | ~107 MB | read cost scales with commit-history depth |
+| Page-table — delta leaves | ~300–360 ns (~530–640×) | ~158 µs (2.2×) | ~1.5 MB | ~3.0 GB | cheap reads, modest write overhead |
+| Page-table — consolidated leaves | ~210–220 ns (~860–915×) | ~218 µs (3.0×) | ~1.7 MB | ~3.4 GB | fastest reads, but re-copies hub adjacency every touch |
 
 ## Conclusion
 
 Reads get ~500–900× faster with 2000 commits, because the walk cost is fixed while today's probe cost grows with every commit. 
 Writes get 2–3× more expensive from path-copying, mostly the root rewrite, which shrinks fast with a narrower root (`--level1-bits 10` drops delta to ~1.1×). 
+The real price is memory: retaining a copied page tree per commit costs ~30× the current index (narrower pages and merge/compaction both bring it down). 
 The delta variant is the sweet spot. The read win is largest on deep, rarely-merged histories and narrows once compaction keeps the datapart count low.

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -1,0 +1,36 @@
+# Page-table neighborhood index — is it worth it?
+
+## Overview
+
+Currently, reading the neighborhood of node means visiting *every* reachable datapart in the commit history and doing a hash probe in each to see whether edges have been added to that node. 
+
+After a bulk load and a long tail of small commits, that's a lot of hash probes and almost all of them miss. 
+
+We want to evaluate an idea: keep a per-commit **page-table directory** (a radix tree with NodeID bits as keys) that points to each node's neighborhood, so a read is a very short constant-depth tree walk (1-2 levels) instead of N hash probes. 
+
+The tree is shared across commits. A new commit only rewrites the pages on the path from each changed node up to a fresh root. We want to know what gain it gives us on reads and what it costs on writes.
+
+## How the simulator works
+
+We implement a quick and dirty simulator as a sample tool that doesn't touch the engine. It replays a synthetic workload:
+* bulk-load 1M nodes
+* 2000 small commits that add edges to existing nodes, with hub skew so old nodes keep growing
+
+It adds up approximate latencies per operation: cache/DRAM hits, hash probes, sequential edge scans, and page-copy bandwidth. 
+It then reports read and write cost for the current design and for two flavors of the page-table: **delta** leaves (store just this commit's new edges) and **consolidated** leaves (store the node's fully merged neighborhood).
+
+## Results 
+
+Default run: 1M nodes, 2000 mutation commits:
+
+| Design | Neighborhood read | Commit write | The catch |
+|---|---|---|---|
+| Current (probe every datapart) | ~190 µs | ~72 µs | read cost scales with commit-history depth |
+| Page-table — delta leaves | ~300–360 ns | ~158 µs (2.2×) | cheap reads, modest write overhead |
+| Page-table — consolidated leaves | ~210–220 ns | ~218 µs (3.0×) | fastest reads, but re-copies hub adjacency every touch |
+
+## Conclusion
+
+Reads get ~500–900× faster with 2000 commits, because the walk cost is fixed while today's probe cost grows with every commit. 
+Writes get 2–3× more expensive from path-copying, mostly the root rewrite, which shrinks fast with a narrower root (`--level1-bits 10` drops delta to ~1.1×). 
+The delta variant is the sweet spot. The read win is largest on deep, rarely-merged histories and narrows once compaction keeps the datapart count low.

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -78,6 +78,33 @@ Write cost doesn't move with depth: current ~72 µs, delta ~158 µs (2.2×), con
 
 Memory is also far gentler when histories stay shallow: ~5–11× the current index at 50–200 commits, versus ~30× at 2000.
 
+## Append-heavy histories (patch fraction)
+
+So far every commit patches an existing node. Realistically, most commits in an append-heavy history only add new nodes — attached to a handful of hub, category, and constant nodes — and patch nothing else.
+
+Those append-only commits hold an empty patch map, so a read of an existing node skips them in a few ns instead of paying a ~95 ns probe. `--patch-fraction` sets how many commits patch existing nodes.
+
+At 2000 commits:
+
+| Patch fraction | Patching commits | Current read | Read speedup |
+|---|---|---|---|
+| 1.0 | 2000 | ~190 µs | ~530× |
+| 0.2 | 400 | ~45 µs | ~180× |
+| 0.1 | 200 | ~26 µs | ~114× |
+| 0.05 | 100 | ~17 µs | ~77× |
+
+The same realistic patch fraction of 0.1, across the shallower histories a compacting engine actually keeps:
+
+| Commits | Patching commits | Current read | Read speedup |
+|---|---|---|---|
+| 50 | 5 | ~0.9 µs | ~4× |
+| 100 | 10 | ~1.5 µs | ~7× |
+| 200 | 20 | ~2.8 µs | ~13× |
+
+The page-table read stays flat at ~210 ns throughout, and its write and memory overhead scale down with the patch fraction too (fewer patching commits, fewer path-copies).
+
+But even at a patch fraction of zero the current read still floors at ~8 µs at 2000 commits (2000 dataparts × ~4 ns), because it walks the whole history regardless. The page-table's real win is never visiting it — so the gap shrinks with fewer patches but never closes at depth.
+
 ## Conclusion
 
 Reads get ~500–900× faster with 2000 commits, because the walk cost is fixed while today's probe cost grows with every commit. 

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -92,6 +92,7 @@ At 2000 commits:
 | 0.2 | 400 | ~45 µs | ~180× |
 | 0.1 | 200 | ~26 µs | ~114× |
 | 0.05 | 100 | ~17 µs | ~77× |
+| 0 | 0 | ~8 µs | ~38× |
 
 The same realistic patch fraction of 0.1, across the shallower histories a compacting engine actually keeps:
 

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -66,6 +66,9 @@ Page-table figures below are the delta variant; consolidated is marginally faste
 
 | Commits | Current read | Page-table read | Read speedup | Total index mem (current → delta) |
 |---|---|---|---|---|
+| 1 | ~308 ns | ~217 ns | ~1.4× | 31 MB → 124 MB |
+| 2 | ~403 ns | ~217 ns | ~1.9× | 31 MB → 126 MB |
+| 4 | ~593 ns | ~217 ns | ~2.7× | 31 MB → 129 MB |
 | 50 | ~5.0 µs | ~221 ns | ~23× | 32 MB → 196 MB |
 | 100 | ~9.7 µs | ~224 ns | ~43× | 34 MB → 270 MB |
 | 200 | ~19 µs | ~232 ns | ~83× | 38 MB → 417 MB |

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -12,29 +12,38 @@ We want to evaluate an idea: keep a per-commit **page-table directory** (a radix
 flowchart TD
     classDef shared fill:#eaf2ff,stroke:#4a7fe0,color:#10243e
     classDef new fill:#ffefe0,stroke:#e07b2a,color:#4a2606
+    classDef bits fill:#f3f0ff,stroke:#8a6fd4,color:#2c1f54
+
+    subgraph nid["NodeID (high bits to low bits)"]
+      direction LR
+      hi["level-1 bits"]:::bits --- mid["page bits"]:::bits --- lo["page bits"]:::bits
+    end
 
     rN["root (commit N)"]:::shared
     rN1["root (commit N+1)"]:::new
-
     A["inner page A"]:::shared
     B["inner page B"]:::shared
     Bn["inner page B (copy)"]:::new
-
     la["leaf"]:::shared
     lb["leaf"]:::shared
-    lc["leaf: changed node (old)"]:::shared
-    lcn["leaf: changed node (new)"]:::new
+    lc["leaf (old)"]:::shared
+    lcn["leaf (new)"]:::new
+    nbr["changed node's neighborhood"]:::new
 
     rN --> A
     rN --> B
     A --> la
     B --> lb
     B --> lc
-
     rN1 --> A
     rN1 --> Bn
     Bn --> lb
     Bn --> lcn
+    lcn --> nbr
+
+    hi -. "picks inner page" .-> Bn
+    mid -. "picks leaf" .-> lcn
+    lo -. "picks neighborhood" .-> nbr
 ```
 
 The tree is shared across commits. A new commit only rewrites the pages on the path from each changed node up to a fresh root. We want to know what gain it gives us on reads and what it costs on writes.

--- a/samples/commit-index-sim/COMPARISON.md
+++ b/samples/commit-index-sim/COMPARISON.md
@@ -2,11 +2,40 @@
 
 ## Overview
 
-Currently, reading the neighborhood of node means visiting *every* reachable datapart in the commit history and doing a hash probe in each to see whether edges have been added to that node. 
+Currently, reading the neighborhood of a node means visiting *every* reachable datapart in the commit history and doing a hash probe in each to see whether edges have been added to that node. 
 
 After a bulk load and a long tail of small commits, that's a lot of hash probes and almost all of them miss. 
 
 We want to evaluate an idea: keep a per-commit **page-table directory** (a radix tree with NodeID bits as keys) that points to each node's neighborhood, so a read is a very short constant-depth tree walk (1-2 levels) instead of N hash probes. 
+
+```mermaid
+flowchart TD
+    classDef shared fill:#eaf2ff,stroke:#4a7fe0,color:#10243e
+    classDef new fill:#ffefe0,stroke:#e07b2a,color:#4a2606
+
+    rN["root (commit N)"]:::shared
+    rN1["root (commit N+1)"]:::new
+
+    A["inner page A"]:::shared
+    B["inner page B"]:::shared
+    Bn["inner page B (copy)"]:::new
+
+    la["leaf"]:::shared
+    lb["leaf"]:::shared
+    lc["leaf: changed node (old)"]:::shared
+    lcn["leaf: changed node (new)"]:::new
+
+    rN --> A
+    rN --> B
+    A --> la
+    B --> lb
+    B --> lc
+
+    rN1 --> A
+    rN1 --> Bn
+    Bn --> lb
+    Bn --> lcn
+```
 
 The tree is shared across commits. A new commit only rewrites the pages on the path from each changed node up to a fresh root. We want to know what gain it gives us on reads and what it costs on writes.
 
@@ -28,6 +57,23 @@ Default run: 1M nodes, 2000 mutation commits. Memory is the index-structure over
 | Current (probe every datapart) | ~190 µs | ~72 µs | ~39 KB | ~107 MB | read cost scales with commit-history depth |
 | Page-table — delta leaves | ~300–360 ns (~530–640×) | ~158 µs (2.2×) | ~1.5 MB | ~3.0 GB | cheap reads, modest write overhead |
 | Page-table — consolidated leaves | ~210–220 ns (~860–915×) | ~218 µs (3.0×) | ~1.7 MB | ~3.4 GB | fastest reads, but re-copies hub adjacency every touch |
+
+## How it scales with commit depth
+
+The 2000-commit run above is the extreme case. The read win is really just the datapart count: today's cost is ~95 ns per probe × commits, while the page-table walk stays flat, so the speedup is roughly commits / 2.
+
+Page-table figures below are the delta variant; consolidated is marginally faster on reads.
+
+| Commits | Current read | Page-table read | Read speedup | Total index mem (current → delta) |
+|---|---|---|---|---|
+| 50 | ~5.0 µs | ~221 ns | ~23× | 32 MB → 196 MB |
+| 100 | ~9.7 µs | ~224 ns | ~43× | 34 MB → 270 MB |
+| 200 | ~19 µs | ~232 ns | ~83× | 38 MB → 417 MB |
+| 2000 | ~190 µs | ~360 ns | ~530× | 107 MB → 3.0 GB |
+
+Write cost doesn't move with depth: current ~72 µs, delta ~158 µs (2.2×), consolidated ~218 µs (3.0×) at every row.
+
+Memory is also far gentler when histories stay shallow: ~5–11× the current index at 50–200 commits, versus ~30× at 2000.
 
 ## Conclusion
 

--- a/samples/commit-index-sim/README.md
+++ b/samples/commit-index-sim/README.md
@@ -80,6 +80,10 @@ Useful experiments:
 
 # Heavier hub skew and bigger commits
 ./commit-index-sim --skew 2.2 --edges-per-commit 5000
+
+# Realistic append-heavy history: only a small fraction of commits patch
+# existing nodes; the rest add new nodes and are skipped cheaply on reads
+./commit-index-sim --patch-fraction 0.1
 ```
 
 ## Caveats
@@ -88,5 +92,10 @@ The latencies are coarse, order-of-magnitude constants (overridable via
 `--dram-ns`, `--hash-hit-ns`, `--hash-miss-ns`, `--bandwidth`); the value is in
 the *relative* comparison and the *scaling*, not absolute predictions. The
 current-design read cost assumes no datapart merging — set `--commits` to the
-expected post-compaction reachable-datapart count to model a merged history. The
-model counts out-edges only; in-edges are structurally symmetric.
+expected post-compaction reachable-datapart count to model a merged history.
+`--patch-fraction` models append-heavy histories: append-only commits hold an
+empty patch map, so reading an existing node skips them at ~`_emptyHashProbeNs`
+each — near-free per datapart, but still an O(D) walk over the whole history,
+which is why the page-table keeps a large edge even as the fraction drops. Write
+and memory figures are reported per *patching* commit. The model counts
+out-edges only; in-edges are structurally symmetric.

--- a/samples/commit-index-sim/README.md
+++ b/samples/commit-index-sim/README.md
@@ -1,0 +1,92 @@
+# commit-index-sim
+
+A standalone cost simulator that evaluates an alternative neighborhood index for
+TuringDB's versioned storage: a **per-commit, page-table-style directory of node
+neighborhoods**, compared against the current design.
+
+It does not touch the storage engine and links nothing but `argparse`. It does
+not implement the index — it estimates the per-operation cost of each design
+under a synthetic commit workload, using approximate latencies, so the idea can
+be judged before any engine work.
+
+## The two designs
+
+**Current ("probe every reachable datapart").** A commit's reachable history is
+an ordered list of immutable dataparts. To read a node's neighborhood, the
+engine visits *every* reachable datapart and asks its `EdgeIndexer` for that
+node's edges (`storage/iterators/GetInEdgesIterator.cpp`,
+`storage/indexers/EdgeIndexer.cpp`):
+
+- the datapart that *created* the node answers by direct array index;
+- every *newer* datapart is consulted via an `unordered_map<NodeID, size_t>`
+  patch-node probe — a hit if that commit added edges to the node, a miss
+  otherwise.
+
+So a neighborhood read costs one probe per reachable datapart. After a bulk load
+plus *D* small mutation commits, every read of an original node pays ~*D* patch
+probes — **most of them misses** — regardless of the node's degree. Writes, on
+the other hand, are cheap: a commit just builds and appends its own datapart and
+never touches existing ones.
+
+**Page-table directory.** A sparse radix tree keyed by `NodeID`: the top
+`--level1-bits` index a root page directory, each deeper level consumes
+`--page-bits` more bits, and the leaf points at the node's neighborhood. The
+tree is persistent — commits share substructure, and a new commit path-copies
+only the pages from each modified leaf up to a fresh root. A read is a fixed
+depth-*L* walk straight to the node's entry, with **no per-datapart probing**.
+
+Two leaf variants are modeled:
+
+- **consolidated** — the leaf holds the node's full merged neighborhood, so a
+  read yields a single span. Best reads, but a write must re-copy a touched
+  node's existing adjacency before appending (write amplification on hubs).
+- **delta** — the leaf chains a small per-commit neighborhood delta. Writes stay
+  cheap; a read still gathers one span per commit that touched the node, but
+  pays none of the miss probes the current design does.
+
+## Workload model
+
+An initial bulk load creates every node and its initial edges, followed by a
+long tail of small mutation commits, each adding edges to already-existing nodes
+(the patch-edge case). Edge endpoints are drawn with a tunable skew (`--skew`,
+>1 concentrates on low-id "hub" nodes, modelling preferential attachment), so
+old hubs keep accreting edges across many commits — the worst case for the
+current design. The run is fully deterministic for a given `--seed`.
+
+## What it measures
+
+- **Reads:** mean / median / p99 latency per neighborhood lookup for each
+  design, under a hub-weighted ("hot") and a uniform read mix, plus speedups.
+- **Writes:** mean / max latency to commit one mutation commit, pages rewritten
+  per commit, and the persistent index bytes each commit adds.
+- **Index space:** one-time directory size and projected growth over the run.
+
+## Build & run
+
+```bash
+cd build && make commit-index-sim
+./samples/commit-index-sim/commit-index-sim            # defaults
+./samples/commit-index-sim/commit-index-sim --help     # all knobs
+```
+
+Useful experiments:
+
+```bash
+# Cheaper path-copy writes via a narrower root (deeper walk, still ~200 ns reads)
+./commit-index-sim --level1-bits 10 --page-bits 6
+
+# Post-compaction: only 50 reachable dataparts -> current reads recover
+./commit-index-sim --commits 50
+
+# Heavier hub skew and bigger commits
+./commit-index-sim --skew 2.2 --edges-per-commit 5000
+```
+
+## Caveats
+
+The latencies are coarse, order-of-magnitude constants (overridable via
+`--dram-ns`, `--hash-hit-ns`, `--hash-miss-ns`, `--bandwidth`); the value is in
+the *relative* comparison and the *scaling*, not absolute predictions. The
+current-design read cost assumes no datapart merging — set `--commits` to the
+expected post-compaction reachable-datapart count to model a merged history. The
+model counts out-edges only; in-edges are structurally symmetric.

--- a/samples/commit-index-sim/Simulator.cpp
+++ b/samples/commit-index-sim/Simulator.cpp
@@ -180,12 +180,26 @@ void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
     double sumDeltaBytes = 0.0;
     double sumConsolidatedBytes = 0.0;
     double sumCurrentIndexBytes = 0.0;
+    size_t patchingCommitCount = 0;
 
     const double logEdges = log2((double)(edgesPerCommit < 2 ? 2 : edgesPerCommit));
     const double buildNs = (double)edgesPerCommit * _model._edgePlaceNs
                          + (double)edgesPerCommit * logEdges * _model._compareNs;
 
     for (size_t commit = 0; commit < mutationCommits; commit++) {
+        // Spread the patching commits evenly across the history. The rest are
+        // append-only: they add new nodes but patch no existing node, so their
+        // patch map is empty and a read of an existing node skips them cheaply
+        // (modelled in currentReadNs). New dense nodes are not materialised here.
+        const size_t patchedBefore = (size_t)((double)commit * _workload._patchFraction);
+        const size_t patchedAfter = (size_t)((double)(commit + 1) * _workload._patchFraction);
+        const bool isPatchingCommit = patchedAfter > patchedBefore;
+        if (!isPatchingCommit) {
+            continue;
+        }
+
+        patchingCommitCount += 1;
+
         touchedNodes.clear();
         touchedPreDegree.clear();
         for (size_t depth = 0; depth < levels; depth++) {
@@ -268,9 +282,12 @@ void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
             (double)distinctNodes * (double)(_model._hashEntryBytes + _model._nodeEdgeDataBytes);
     }
 
-    _results._totalEdges += mutationCommits * edgesPerCommit;
+    _results._totalEdges += patchingCommitCount * edgesPerCommit;
+    _results._patchingCommits = patchingCommitCount;
 
-    const double commits = mutationCommits == 0 ? 1.0 : (double)mutationCommits;
+    // Write and memory figures are per patching commit; append-only commits add
+    // cheap dense nodes and are near design-neutral, so they are excluded here.
+    const double commits = patchingCommitCount == 0 ? 1.0 : (double)patchingCommitCount;
 
     _results._currentWrite._meanNsPerCommit = sumCurrentNs / commits;
     _results._currentWrite._maxNsPerCommit = maxCurrentNs;
@@ -374,8 +391,10 @@ void CommitIndexSimulator::computeIndexSpace() {
 
 double CommitIndexSimulator::currentReadNs(size_t touchCount, size_t degree, bool hasCoreEdges) const {
     const size_t mutations = _workload._mutationCommits;
-    const size_t hits = touchCount > mutations ? mutations : touchCount;
-    const size_t misses = mutations - hits;
+    const size_t patchingParts = _results._patchingCommits;
+    const size_t appendOnlyParts = mutations - patchingParts;
+    const size_t hits = touchCount > patchingParts ? patchingParts : touchCount;
+    const size_t misses = patchingParts - hits;
 
     // The owning load datapart resolves the node by direct array index (one
     // NodeEdgeData read); any other load dataparts are cheap out-of-range checks.
@@ -384,7 +403,9 @@ double CommitIndexSimulator::currentReadNs(size_t touchCount, size_t degree, boo
         ns += (double)(_workload._loadDataparts - 1) * _model._boundsCheckNs;
     }
 
-    // Every mutation datapart is probed once, whether or not it holds a patch.
+    // Every mutation datapart is still visited. Append-only ones hold an empty
+    // patch map (near-free probe); patching ones cost a hit or a populated miss.
+    ns += (double)appendOnlyParts * _model._emptyHashProbeNs;
     ns += (double)hits * _model._hashProbeHitNs;
     ns += (double)misses * _model._hashProbeMissNs;
 
@@ -409,8 +430,8 @@ double CommitIndexSimulator::pageTableReadNs(bool consolidated,
                                              size_t touchCount,
                                              size_t degree,
                                              bool hasCoreEdges) const {
-    const size_t mutations = _workload._mutationCommits;
-    const size_t hits = touchCount > mutations ? mutations : touchCount;
+    const size_t patchingParts = _results._patchingCommits;
+    const size_t hits = touchCount > patchingParts ? patchingParts : touchCount;
 
     double ns = pageTableWalkNs();
 

--- a/samples/commit-index-sim/Simulator.cpp
+++ b/samples/commit-index-sim/Simulator.cpp
@@ -1,0 +1,414 @@
+#include "Simulator.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <algorithm>
+#include <unordered_set>
+#include <vector>
+
+using namespace db;
+
+namespace {
+
+// Deterministic splitmix64: cheap, seedable, no global state. Reproducible runs
+// matter more here than statistical perfection.
+uint64_t nextRandom(uint64_t& state) {
+    state += 0x9E3779B97F4A7C15ull;
+    uint64_t z = state;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+    return z ^ (z >> 31);
+}
+
+double nextUniform(uint64_t& state) {
+    return (double)(nextRandom(state) >> 11) * (1.0 / 9007199254740992.0);
+}
+
+// Draws a NodeID with a power-law-ish bias toward low ids. `skew` == 1 is
+// uniform; `skew` > 1 concentrates draws on the first (hub) nodes, modelling
+// preferential attachment where old nodes keep accruing edges.
+size_t sampleNode(uint64_t& state, size_t numNodes, double skew) {
+    const double uniform = nextUniform(state);
+    const double biased = skew == 1.0 ? uniform : pow(uniform, skew);
+    size_t node = (size_t)(biased * (double)numNodes);
+    if (node >= numNodes) {
+        node = numNodes - 1;
+    }
+    return node;
+}
+
+void computeReadStats(std::vector<double>& samples, ReadStats& out) {
+    if (samples.empty()) {
+        return;
+    }
+
+    std::sort(samples.begin(), samples.end());
+
+    double sum = 0.0;
+    for (const double value : samples) {
+        sum += value;
+    }
+
+    const size_t count = samples.size();
+    const size_t medianIndex = count / 2;
+    const size_t p99Index = (count * 99) / 100 >= count ? count - 1 : (count * 99) / 100;
+
+    out._meanNs = sum / (double)count;
+    out._medianNs = samples[medianIndex];
+    out._p99Ns = samples[p99Index];
+}
+
+}
+
+double LatencyModel::cacheLatencyForBytes(size_t bytes) const {
+    if (bytes <= _l1Bytes) {
+        return _l1Ns;
+    } else if (bytes <= _l2Bytes) {
+        return _l2Ns;
+    } else if (bytes <= _l3Bytes) {
+        return _l3Ns;
+    } else {
+        return _dramNs;
+    }
+}
+
+void PageTableConfig::compute(size_t numNodes, const LatencyModel& model) {
+    // Bits required to address the populated id space.
+    size_t bits = 1;
+    while ((size_t(1) << bits) < numNodes && bits < 63) {
+        bits++;
+    }
+    _effectiveBits = bits;
+
+    // The root cannot resolve more bits than the id space has.
+    size_t level1 = _level1Bits;
+    if (level1 > _effectiveBits) {
+        level1 = _effectiveBits;
+    }
+
+    const size_t remaining = _effectiveBits - level1;
+    size_t lowerLevels = 0;
+    if (remaining > 0) {
+        lowerLevels = (remaining + _pageBits - 1) / _pageBits;
+    }
+    _levels = 1 + lowerLevels;
+
+    // _pagePrefixShift[d]: shift applied to a NodeID to identify which page is
+    // visited at depth d. Depth 0 is the single root directory, so its shift is
+    // the full width and every node maps to selector 0.
+    _pagePrefixShift.clear();
+    _pagePrefixShift.reserve(_levels);
+
+    size_t consumed = 0;  // index bits resolved by the depths above this one
+    for (size_t depth = 0; depth < _levels; depth++) {
+        _pagePrefixShift.push_back(_effectiveBits - consumed);
+
+        if (depth == 0) {
+            consumed += level1;
+        } else {
+            consumed += _pageBits;
+        }
+
+        if (consumed > _effectiveBits) {
+            consumed = _effectiveBits;
+        }
+    }
+
+    _rootBytes = (size_t(1) << level1) * model._pointerBytes;
+    _innerPageBytes = (size_t(1) << _pageBits) * model._pointerBytes;
+}
+
+CommitIndexSimulator::CommitIndexSimulator(const LatencyModel& model,
+                                           const Workload& workload,
+                                           const PageTableConfig& pageTable)
+    : _model(model)
+    , _workload(workload)
+    , _pageTable(pageTable)
+{
+}
+
+CommitIndexSimulator::~CommitIndexSimulator() {
+}
+
+void CommitIndexSimulator::run() {
+    const size_t numNodes = _workload._numNodes;
+
+    _coreDegree.assign(numNodes, 0);
+    _patchDegree.assign(numNodes, 0);
+    _touchCount.assign(numNodes, 0);
+    _lastTouchCommit.assign(numNodes, UINT32_MAX);
+
+    uint64_t rngState = _workload._seed;
+
+    bulkLoad(rngState);
+    simulateMutations(rngState);
+    computeGraphStats();
+    measureReads(rngState);
+    computeIndexSpace();
+}
+
+void CommitIndexSimulator::bulkLoad(uint64_t& rngState) {
+    const size_t numNodes = _workload._numNodes;
+    const size_t loadEdges = numNodes * _workload._avgInitialDegree;
+
+    for (size_t edge = 0; edge < loadEdges; edge++) {
+        const size_t source = sampleNode(rngState, numNodes, _workload._skew);
+        _coreDegree[source] += 1;
+    }
+
+    _results._totalEdges += loadEdges;
+}
+
+void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
+    const size_t numNodes = _workload._numNodes;
+    const size_t mutationCommits = _workload._mutationCommits;
+    const size_t edgesPerCommit = _workload._avgEdgesPerCommit;
+    const size_t levels = _pageTable._levels;
+
+    // Per-commit scratch, cleared and reused each iteration.
+    std::vector<size_t> touchedNodes;
+    std::vector<size_t> touchedPreDegree;
+    std::vector<std::unordered_set<uint64_t>> pageSets(levels);
+
+    double sumCurrentNs = 0.0;
+    double maxCurrentNs = 0.0;
+    double sumDeltaNs = 0.0;
+    double maxDeltaNs = 0.0;
+    double sumConsolidatedNs = 0.0;
+    double maxConsolidatedNs = 0.0;
+    double sumRewrittenPages = 0.0;
+    double sumDeltaBytes = 0.0;
+    double sumConsolidatedBytes = 0.0;
+
+    const double logEdges = log2((double)(edgesPerCommit < 2 ? 2 : edgesPerCommit));
+    const double buildNs = (double)edgesPerCommit * _model._edgePlaceNs
+                         + (double)edgesPerCommit * logEdges * _model._compareNs;
+
+    for (size_t commit = 0; commit < mutationCommits; commit++) {
+        touchedNodes.clear();
+        touchedPreDegree.clear();
+        for (size_t depth = 0; depth < levels; depth++) {
+            pageSets[depth].clear();
+        }
+
+        for (size_t edge = 0; edge < edgesPerCommit; edge++) {
+            const size_t source = sampleNode(rngState, numNodes, _workload._skew);
+
+            const bool firstTouchThisCommit = _lastTouchCommit[source] != (uint32_t)commit;
+            if (firstTouchThisCommit) {
+                _lastTouchCommit[source] = (uint32_t)commit;
+                _touchCount[source] += 1;
+
+                const size_t preDegree = _coreDegree[source] + _patchDegree[source];
+                touchedNodes.push_back(source);
+                touchedPreDegree.push_back(preDegree);
+
+                for (size_t depth = 0; depth < levels; depth++) {
+                    const size_t shift = _pageTable._pagePrefixShift[depth];
+                    const uint64_t selector = shift >= 64 ? 0 : ((uint64_t)source >> shift);
+                    pageSets[depth].insert(selector);
+                }
+            }
+
+            _patchDegree[source] += 1;
+        }
+
+        const size_t distinctNodes = touchedNodes.size();
+
+        // Current design: build the new datapart and its patch-node hash map.
+        // No existing datapart is touched.
+        const double currentNs = buildNs + (double)distinctNodes * _model._hashInsertNs;
+
+        // Path copying rewrites every dirty page from each touched leaf up to the
+        // shared root. Distinct pages per depth = distinct NodeID prefixes.
+        size_t rewrittenPages = 0;
+        double directoryBytes = 0.0;
+        for (size_t depth = 0; depth < levels; depth++) {
+            const size_t pages = pageSets[depth].size();
+            rewrittenPages += pages;
+
+            const size_t pageBytes = depth == 0 ? _pageTable._rootBytes : _pageTable._innerPageBytes;
+            directoryBytes += (double)pages * (double)pageBytes;
+        }
+
+        const double pageCopyNs = directoryBytes / _model._bandwidthBytesPerNs
+                                + (double)rewrittenPages * _model._allocNs;
+
+        // Delta variant: append a small per-commit neighborhood delta and rewrite
+        // only the directory pages on the path to the new root.
+        const double deltaNs = buildNs + pageCopyNs + (double)distinctNodes * _model._edgePlaceNs;
+
+        // Consolidated variant: each touched leaf must hold the full, merged
+        // neighborhood, so the node's existing adjacency is re-copied before the
+        // new edges are appended. That re-copy is the write amplification.
+        double recopyEdges = 0.0;
+        for (const size_t preDegree : touchedPreDegree) {
+            recopyEdges += (double)preDegree;
+        }
+
+        const double recopyNs = recopyEdges * (double)_model._edgeRecordBytes / _model._bandwidthBytesPerNs
+                              + (double)distinctNodes * _model._dramNs;
+        const double consolidatedNs = buildNs + pageCopyNs + recopyNs;
+
+        sumCurrentNs += currentNs;
+        sumDeltaNs += deltaNs;
+        sumConsolidatedNs += consolidatedNs;
+        maxCurrentNs = std::max(maxCurrentNs, currentNs);
+        maxDeltaNs = std::max(maxDeltaNs, deltaNs);
+        maxConsolidatedNs = std::max(maxConsolidatedNs, consolidatedNs);
+
+        sumRewrittenPages += (double)rewrittenPages;
+        sumDeltaBytes += directoryBytes;
+        sumConsolidatedBytes += directoryBytes + recopyEdges * (double)_model._edgeRecordBytes;
+    }
+
+    _results._totalEdges += mutationCommits * edgesPerCommit;
+
+    const double commits = mutationCommits == 0 ? 1.0 : (double)mutationCommits;
+
+    _results._currentWrite._meanNsPerCommit = sumCurrentNs / commits;
+    _results._currentWrite._maxNsPerCommit = maxCurrentNs;
+
+    _results._pageTableDeltaWrite._meanNsPerCommit = sumDeltaNs / commits;
+    _results._pageTableDeltaWrite._maxNsPerCommit = maxDeltaNs;
+    _results._pageTableDeltaWrite._meanRewrittenPages = sumRewrittenPages / commits;
+    _results._pageTableDeltaWrite._meanBytesPerCommit = sumDeltaBytes / commits;
+
+    _results._pageTableConsolidatedWrite._meanNsPerCommit = sumConsolidatedNs / commits;
+    _results._pageTableConsolidatedWrite._maxNsPerCommit = maxConsolidatedNs;
+    _results._pageTableConsolidatedWrite._meanRewrittenPages = sumRewrittenPages / commits;
+    _results._pageTableConsolidatedWrite._meanBytesPerCommit = sumConsolidatedBytes / commits;
+}
+
+void CommitIndexSimulator::computeGraphStats() {
+    const size_t numNodes = _workload._numNodes;
+
+    size_t maxDegree = 0;
+    size_t maxTouchCount = 0;
+    double sumDegree = 0.0;
+    double sumTouchCount = 0.0;
+
+    for (size_t node = 0; node < numNodes; node++) {
+        const size_t degree = _coreDegree[node] + _patchDegree[node];
+        sumDegree += (double)degree;
+        maxDegree = std::max(maxDegree, degree);
+
+        const size_t touches = _touchCount[node];
+        sumTouchCount += (double)touches;
+        maxTouchCount = std::max(maxTouchCount, touches);
+    }
+
+    _results._maxDegree = maxDegree;
+    _results._avgDegree = sumDegree / (double)numNodes;
+    _results._maxTouchCount = maxTouchCount;
+    _results._avgTouchCount = sumTouchCount / (double)numNodes;
+}
+
+void CommitIndexSimulator::measureReads(uint64_t& rngState) {
+    const size_t numNodes = _workload._numNodes;
+    const size_t samples = _workload._readSamples;
+
+    for (size_t mixIndex = 0; mixIndex < 2; mixIndex++) {
+        const double skew = mixIndex == (size_t)ReadMix::Hot ? _workload._skew : 1.0;
+
+        std::vector<double> currentSamples;
+        std::vector<double> consolidatedSamples;
+        std::vector<double> deltaSamples;
+        currentSamples.reserve(samples);
+        consolidatedSamples.reserve(samples);
+        deltaSamples.reserve(samples);
+
+        for (size_t sample = 0; sample < samples; sample++) {
+            const size_t node = sampleNode(rngState, numNodes, skew);
+            const size_t touches = _touchCount[node];
+            const size_t degree = _coreDegree[node] + _patchDegree[node];
+            const bool hasCoreEdges = _coreDegree[node] > 0;
+
+            currentSamples.push_back(currentReadNs(touches, degree, hasCoreEdges));
+            consolidatedSamples.push_back(pageTableReadNs(true, touches, degree, hasCoreEdges));
+            deltaSamples.push_back(pageTableReadNs(false, touches, degree, hasCoreEdges));
+        }
+
+        computeReadStats(currentSamples, _results._currentRead[mixIndex]);
+        computeReadStats(consolidatedSamples, _results._pageTableConsolidatedRead[mixIndex]);
+        computeReadStats(deltaSamples, _results._pageTableDeltaRead[mixIndex]);
+    }
+}
+
+void CommitIndexSimulator::computeIndexSpace() {
+    const size_t numNodes = _workload._numNodes;
+    const size_t levels = _pageTable._levels;
+
+    double initialBytes = 0.0;
+    for (size_t depth = 0; depth < levels; depth++) {
+        const size_t shift = _pageTable._pagePrefixShift[depth];
+        const size_t pages = shift >= 64 ? 1 : (((numNodes - 1) >> shift) + 1);
+        const size_t pageBytes = depth == 0 ? _pageTable._rootBytes : _pageTable._innerPageBytes;
+        initialBytes += (double)pages * (double)pageBytes;
+    }
+
+    _results._initialIndexBytes = initialBytes;
+    _results._projectedDeltaGrowthBytes =
+        _results._pageTableDeltaWrite._meanBytesPerCommit * (double)_workload._mutationCommits;
+}
+
+double CommitIndexSimulator::currentReadNs(size_t touchCount, size_t degree, bool hasCoreEdges) const {
+    const size_t mutations = _workload._mutationCommits;
+    const size_t hits = touchCount > mutations ? mutations : touchCount;
+    const size_t misses = mutations - hits;
+
+    // The owning load datapart resolves the node by direct array index (one
+    // NodeEdgeData read); any other load dataparts are cheap out-of-range checks.
+    double ns = _model._dramNs;
+    if (_workload._loadDataparts > 1) {
+        ns += (double)(_workload._loadDataparts - 1) * _model._boundsCheckNs;
+    }
+
+    // Every mutation datapart is probed once, whether or not it holds a patch.
+    ns += (double)hits * _model._hashProbeHitNs;
+    ns += (double)misses * _model._hashProbeMissNs;
+
+    // Gather the edges: one disjoint span per source (load core + each patching
+    // commit), each starting with a first-touch miss, then sequential bandwidth.
+    const size_t spans = (hasCoreEdges ? 1 : 0) + hits;
+    ns += (double)spans * _model._dramNs;
+    ns += (double)(degree * _model._edgeRecordBytes) / _model._bandwidthBytesPerNs;
+
+    return ns;
+}
+
+double CommitIndexSimulator::pageTableWalkNs() const {
+    double ns = _model.cacheLatencyForBytes(_pageTable._rootBytes);
+    if (_pageTable._levels > 1) {
+        ns += (double)(_pageTable._levels - 1) * _model._dramNs;
+    }
+    return ns;
+}
+
+double CommitIndexSimulator::pageTableReadNs(bool consolidated,
+                                             size_t touchCount,
+                                             size_t degree,
+                                             bool hasCoreEdges) const {
+    const size_t mutations = _workload._mutationCommits;
+    const size_t hits = touchCount > mutations ? mutations : touchCount;
+
+    double ns = pageTableWalkNs();
+
+    // The walk lands directly on the node's entry: no per-datapart probing. The
+    // consolidated leaf yields a single neighborhood span; the delta leaf still
+    // chains one span per patching commit, but pays no miss probes.
+    size_t spans = 0;
+    if (consolidated) {
+        spans = 1;
+    } else {
+        spans = (hasCoreEdges ? 1 : 0) + hits;
+        if (spans == 0) {
+            spans = 1;
+        }
+    }
+
+    ns += (double)spans * _model._dramNs;
+    ns += (double)(degree * _model._edgeRecordBytes) / _model._bandwidthBytesPerNs;
+
+    return ns;
+}

--- a/samples/commit-index-sim/Simulator.cpp
+++ b/samples/commit-index-sim/Simulator.cpp
@@ -179,6 +179,7 @@ void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
     double sumRewrittenPages = 0.0;
     double sumDeltaBytes = 0.0;
     double sumConsolidatedBytes = 0.0;
+    double sumCurrentIndexBytes = 0.0;
 
     const double logEdges = log2((double)(edgesPerCommit < 2 ? 2 : edgesPerCommit));
     const double buildNs = (double)edgesPerCommit * _model._edgePlaceNs
@@ -260,6 +261,11 @@ void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
         sumRewrittenPages += (double)rewrittenPages;
         sumDeltaBytes += directoryBytes;
         sumConsolidatedBytes += directoryBytes + recopyEdges * (double)_model._edgeRecordBytes;
+
+        // Current design retains, per mutation datapart, a patch-node hash map
+        // plus a NodeEdgeData entry for each patched node.
+        sumCurrentIndexBytes +=
+            (double)distinctNodes * (double)(_model._hashEntryBytes + _model._nodeEdgeDataBytes);
     }
 
     _results._totalEdges += mutationCommits * edgesPerCommit;
@@ -278,6 +284,12 @@ void CommitIndexSimulator::simulateMutations(uint64_t& rngState) {
     _results._pageTableConsolidatedWrite._maxNsPerCommit = maxConsolidatedNs;
     _results._pageTableConsolidatedWrite._meanRewrittenPages = sumRewrittenPages / commits;
     _results._pageTableConsolidatedWrite._meanBytesPerCommit = sumConsolidatedBytes / commits;
+
+    // Patch structures retained across the whole mutation history; the load
+    // datapart's core index is added in computeIndexSpace().
+    _results._currentIndexBytes = sumCurrentIndexBytes;
+    _results._currentWrite._meanBytesPerCommit = sumCurrentIndexBytes / commits;
+    _results._pageTableConsolidatedIndexBytes = sumConsolidatedBytes;
 }
 
 void CommitIndexSimulator::computeGraphStats() {
@@ -350,6 +362,14 @@ void CommitIndexSimulator::computeIndexSpace() {
     _results._initialIndexBytes = initialBytes;
     _results._projectedDeltaGrowthBytes =
         _results._pageTableDeltaWrite._meanBytesPerCommit * (double)_workload._mutationCommits;
+
+    // Total index memory once the full commit history is retained. The current
+    // design adds the load datapart's core NodeEdgeData array on top of the
+    // accumulated patch structures; the page-table totals add the shared root
+    // and inner pages of the initial tree to the path-copied growth.
+    _results._currentIndexBytes += (double)numNodes * (double)_model._nodeEdgeDataBytes;
+    _results._pageTableDeltaIndexBytes = initialBytes + _results._projectedDeltaGrowthBytes;
+    _results._pageTableConsolidatedIndexBytes += initialBytes;
 }
 
 double CommitIndexSimulator::currentReadNs(size_t touchCount, size_t degree, bool hasCoreEdges) const {

--- a/samples/commit-index-sim/Simulator.h
+++ b/samples/commit-index-sim/Simulator.h
@@ -17,7 +17,8 @@ struct LatencyModel {
     double _dramNs {90.0};              // cold load that misses all caches
 
     double _hashProbeHitNs {160.0};     // populated unordered_map probe (~2 misses)
-    double _hashProbeMissNs {95.0};     // probe that misses (~1 miss)
+    double _hashProbeMissNs {95.0};     // probe that misses a populated map (~1 miss)
+    double _emptyHashProbeNs {4.0};     // probe of an empty patch map (hot single bucket)
     double _boundsCheckNs {2.0};        // hot in-range / out-of-range branch
 
     double _bandwidthBytesPerNs {12.0}; // sequential read bandwidth, single core
@@ -46,7 +47,8 @@ struct Workload {
     size_t _avgInitialDegree {8};       // out-edges per node from the bulk load
     size_t _loadDataparts {1};          // dataparts produced by the bulk load
     size_t _mutationCommits {2000};     // small commits appended afterwards
-    size_t _avgEdgesPerCommit {500};    // edges added by each mutation commit
+    size_t _avgEdgesPerCommit {500};    // edges added by each patching commit
+    double _patchFraction {1.0};        // fraction of commits that patch existing nodes
     double _skew {1.6};                 // >1 concentrates edges on hub nodes
     size_t _readSamples {100000};
     uint64_t _seed {42};
@@ -91,6 +93,7 @@ enum class ReadMix : size_t {
 
 struct SimResults {
     size_t _totalEdges {0};
+    size_t _patchingCommits {0};        // mutation commits that patched existing nodes
     size_t _maxDegree {0};
     double _avgDegree {0.0};
     size_t _maxTouchCount {0};

--- a/samples/commit-index-sim/Simulator.h
+++ b/samples/commit-index-sim/Simulator.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+
+namespace db {
+
+// Approximate per-operation latencies (nanoseconds) and memory characteristics
+// driving the cost model. Defaults model one core of a modern server. They are
+// deliberately coarse: the goal is relative comparison between designs, not an
+// absolute prediction. The most impactful constants are overridable on the CLI.
+struct LatencyModel {
+    double _l1Ns {1.0};
+    double _l2Ns {4.0};
+    double _l3Ns {14.0};
+    double _dramNs {90.0};              // cold load that misses all caches
+
+    double _hashProbeHitNs {160.0};     // populated unordered_map probe (~2 misses)
+    double _hashProbeMissNs {95.0};     // probe that misses (~1 miss)
+    double _boundsCheckNs {2.0};        // hot in-range / out-of-range branch
+
+    double _bandwidthBytesPerNs {12.0}; // sequential read bandwidth, single core
+    double _allocNs {30.0};             // allocate + link one fresh index page
+    double _hashInsertNs {120.0};       // insert one entry into a patch map
+    double _edgePlaceNs {6.0};          // place one edge while building a datapart
+    double _compareNs {2.0};            // one comparison in the build-time sort
+
+    size_t _edgeRecordBytes {32};       // EdgeID + NodeID + NodeID + EdgeTypeID
+    size_t _pointerBytes {8};
+    size_t _l1Bytes {32 * 1024};
+    size_t _l2Bytes {1024 * 1024};
+    size_t _l3Bytes {32 * 1024 * 1024};
+
+    double cacheLatencyForBytes(size_t bytes) const;
+};
+
+// The workload whose cost we estimate: an initial bulk load that creates every
+// node, followed by a long tail of small mutation commits, each adding edges to
+// already-existing nodes (the "patch edge" case that the current design pays for
+// on every reachable datapart).
+struct Workload {
+    size_t _numNodes {1000000};
+    size_t _avgInitialDegree {8};       // out-edges per node from the bulk load
+    size_t _loadDataparts {1};          // dataparts produced by the bulk load
+    size_t _mutationCommits {2000};     // small commits appended afterwards
+    size_t _avgEdgesPerCommit {500};    // edges added by each mutation commit
+    double _skew {1.6};                 // >1 concentrates edges on hub nodes
+    size_t _readSamples {100000};
+    uint64_t _seed {42};
+};
+
+// Geometry of the radix / page-table index. The top `_level1Bits` of a NodeID
+// index the root directory; each deeper level consumes `_pageBits` more bits
+// until the populated id-space is fully resolved at the leaves.
+struct PageTableConfig {
+    size_t _level1Bits {16};
+    size_t _pageBits {8};
+
+    // Derived once the populated id-space width is known.
+    size_t _effectiveBits {0};
+    size_t _levels {0};
+    std::vector<size_t> _pagePrefixShift;   // shift identifying a page at depth d
+    size_t _rootBytes {0};
+    size_t _innerPageBytes {0};
+
+    void compute(size_t numNodes, const LatencyModel& model);
+};
+
+struct ReadStats {
+    double _meanNs {0.0};
+    double _medianNs {0.0};
+    double _p99Ns {0.0};
+};
+
+struct WriteStats {
+    double _meanNsPerCommit {0.0};
+    double _maxNsPerCommit {0.0};
+    double _meanRewrittenPages {0.0};   // page-table designs only
+    double _meanBytesPerCommit {0.0};   // page-table designs only: persistent growth
+};
+
+// Read mixes: index 0 reads hub nodes proportionally to how often they are
+// touched (the realistic hot path); index 1 reads nodes uniformly at random.
+enum class ReadMix : size_t {
+    Hot = 0,
+    Uniform = 1,
+};
+
+struct SimResults {
+    size_t _totalEdges {0};
+    size_t _maxDegree {0};
+    double _avgDegree {0.0};
+    size_t _maxTouchCount {0};
+    double _avgTouchCount {0.0};
+
+    ReadStats _currentRead[2];
+    ReadStats _pageTableConsolidatedRead[2];
+    ReadStats _pageTableDeltaRead[2];
+
+    WriteStats _currentWrite;
+    WriteStats _pageTableConsolidatedWrite;
+    WriteStats _pageTableDeltaWrite;
+
+    double _initialIndexBytes {0.0};
+    double _projectedDeltaGrowthBytes {0.0};
+};
+
+// Estimates the per-operation cost of the current "probe every reachable
+// datapart" design against a per-commit page-table directory of node
+// neighborhoods, in two variants (consolidated leaves vs. per-commit deltas).
+class CommitIndexSimulator {
+public:
+    CommitIndexSimulator(const LatencyModel& model,
+                         const Workload& workload,
+                         const PageTableConfig& pageTable);
+    ~CommitIndexSimulator();
+
+    void run();
+
+    const SimResults& getResults() const { return _results; }
+
+private:
+    const LatencyModel& _model;
+    const Workload& _workload;
+    const PageTableConfig& _pageTable;
+    SimResults _results;
+
+    // Per-node accumulated state (indexed by NodeID, size = _numNodes).
+    std::vector<uint32_t> _coreDegree;        // out-edges from the bulk load
+    std::vector<uint32_t> _patchDegree;       // out-edges added by mutations
+    std::vector<uint32_t> _touchCount;        // distinct commits that patched the node
+    std::vector<uint32_t> _lastTouchCommit;   // de-dup marker within one commit
+
+    void bulkLoad(uint64_t& rngState);
+    void simulateMutations(uint64_t& rngState);
+    void computeGraphStats();
+    void measureReads(uint64_t& rngState);
+    void computeIndexSpace();
+
+    // Per-operation cost model.
+    double currentReadNs(size_t touchCount, size_t degree, bool hasCoreEdges) const;
+    double pageTableReadNs(bool consolidated,
+                           size_t touchCount,
+                           size_t degree,
+                           bool hasCoreEdges) const;
+    double pageTableWalkNs() const;
+};
+
+}

--- a/samples/commit-index-sim/Simulator.h
+++ b/samples/commit-index-sim/Simulator.h
@@ -27,6 +27,8 @@ struct LatencyModel {
     double _compareNs {2.0};            // one comparison in the build-time sort
 
     size_t _edgeRecordBytes {32};       // EdgeID + NodeID + NodeID + EdgeTypeID
+    size_t _nodeEdgeDataBytes {32};     // out/in edge ranges per node in a datapart
+    size_t _hashEntryBytes {48};        // one patch-node entry in an unordered_map
     size_t _pointerBytes {8};
     size_t _l1Bytes {32 * 1024};
     size_t _l2Bytes {1024 * 1024};
@@ -104,6 +106,11 @@ struct SimResults {
 
     double _initialIndexBytes {0.0};
     double _projectedDeltaGrowthBytes {0.0};
+
+    // Total index-structure memory once the whole commit history is retained.
+    double _currentIndexBytes {0.0};
+    double _pageTableDeltaIndexBytes {0.0};
+    double _pageTableConsolidatedIndexBytes {0.0};
 };
 
 // Estimates the per-operation cost of the current "probe every reachable

--- a/samples/commit-index-sim/main.cpp
+++ b/samples/commit-index-sim/main.cpp
@@ -253,15 +253,20 @@ int main(int argc, char** argv) {
            deltaWriteOverhead,
            consWriteOverhead);
 
-    printf("Index space (page-table directory; substructure shared across commits)\n");
-    formatBytes(results._initialIndexBytes, buf, sizeof(buf));
-    printf("  initial directory ..... %s  (one-time)\n", buf);
+    printf("--- MEMORY: index structure (excludes raw edges, identical for all) ---\n");
+    printf("  %-27s %14s %16s\n", "design", "per commit", "total (retained)");
+    formatBytes(results._currentWrite._meanBytesPerCommit, buf, sizeof(buf));
+    formatBytes(results._currentIndexBytes, buf2, sizeof(buf2));
+    printf("  %-27s %14s %16s\n", "current", buf, buf2);
     formatBytes(results._pageTableDeltaWrite._meanBytesPerCommit, buf, sizeof(buf));
-    formatBytes(results._projectedDeltaGrowthBytes, buf2, sizeof(buf2));
-    printf("  delta growth .......... %s/commit  ->  %s over %zu commits\n\n",
-           buf,
-           buf2,
-           workload._mutationCommits);
+    formatBytes(results._pageTableDeltaIndexBytes, buf2, sizeof(buf2));
+    printf("  %-27s %14s %16s\n", "page-table (delta)", buf, buf2);
+    formatBytes(results._pageTableConsolidatedWrite._meanBytesPerCommit, buf, sizeof(buf));
+    formatBytes(results._pageTableConsolidatedIndexBytes, buf2, sizeof(buf2));
+    printf("  %-27s %14s %16s\n", "page-table (consolidated)", buf, buf2);
+    formatBytes(results._initialIndexBytes, buf, sizeof(buf));
+    printf("  (page-table also shares a %s root/inner tree once, retained across commits)\n\n",
+           buf);
 
     // Dynamic, parameter-derived summary so the report stands on its own.
     const double readFloorNs = (double)workload._mutationCommits * model._hashProbeMissNs;

--- a/samples/commit-index-sim/main.cpp
+++ b/samples/commit-index-sim/main.cpp
@@ -1,0 +1,299 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <exception>
+#include <string>
+
+#include <argparse.hpp>
+
+#include "Simulator.h"
+
+using namespace db;
+
+namespace {
+
+// Formats a latency in ns, switching to us / ms so columns stay readable.
+void formatLatency(double ns, char* out, size_t size) {
+    if (ns < 1000.0) {
+        snprintf(out, size, "%.1f ns", ns);
+    } else if (ns < 1000000.0) {
+        snprintf(out, size, "%.2f us", ns / 1000.0);
+    } else {
+        snprintf(out, size, "%.2f ms", ns / 1000000.0);
+    }
+}
+
+void formatBytes(double bytes, char* out, size_t size) {
+    if (bytes < 1024.0) {
+        snprintf(out, size, "%.0f B", bytes);
+    } else if (bytes < 1024.0 * 1024.0) {
+        snprintf(out, size, "%.1f KB", bytes / 1024.0);
+    } else if (bytes < 1024.0 * 1024.0 * 1024.0) {
+        snprintf(out, size, "%.1f MB", bytes / (1024.0 * 1024.0));
+    } else {
+        snprintf(out, size, "%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0));
+    }
+}
+
+// Renders an integer-valued double with thousands separators.
+void formatCount(double value, char* out, size_t size) {
+    char raw[64];
+    snprintf(raw, sizeof(raw), "%.0f", value);
+
+    const size_t length = strlen(raw);
+    size_t written = 0;
+    for (size_t i = 0; i < length && written + 1 < size; i++) {
+        const size_t remaining = length - i;
+        if (i != 0 && remaining % 3 == 0) {
+            out[written++] = ',';
+            if (written + 1 >= size) {
+                break;
+            }
+        }
+        out[written++] = raw[i];
+    }
+    out[written] = '\0';
+}
+
+void printReadRow(const char* mix, const char* design, const ReadStats& stats) {
+    char meanBuf[32];
+    char medianBuf[32];
+    char p99Buf[32];
+
+    formatLatency(stats._meanNs, meanBuf, sizeof(meanBuf));
+    formatLatency(stats._medianNs, medianBuf, sizeof(medianBuf));
+    formatLatency(stats._p99Ns, p99Buf, sizeof(p99Buf));
+
+    printf("  %-8s %-27s %12s %12s %12s\n", mix, design, meanBuf, medianBuf, p99Buf);
+}
+
+void printWriteRow(const char* design, const WriteStats& stats, bool isPageTable) {
+    char meanBuf[32];
+    char maxBuf[32];
+    char pagesBuf[32];
+    char bytesBuf[32];
+
+    formatLatency(stats._meanNsPerCommit, meanBuf, sizeof(meanBuf));
+    formatLatency(stats._maxNsPerCommit, maxBuf, sizeof(maxBuf));
+
+    if (isPageTable) {
+        formatCount(stats._meanRewrittenPages, pagesBuf, sizeof(pagesBuf));
+        formatBytes(stats._meanBytesPerCommit, bytesBuf, sizeof(bytesBuf));
+    } else {
+        snprintf(pagesBuf, sizeof(pagesBuf), "-");
+        snprintf(bytesBuf, sizeof(bytesBuf), "-");
+    }
+
+    printf("  %-27s %12s %12s %12s %14s\n", design, meanBuf, maxBuf, pagesBuf, bytesBuf);
+}
+
+}
+
+int main(int argc, char** argv) {
+    argparse::ArgumentParser parser("commit-index-sim", "1.0", argparse::default_arguments::help);
+    parser.add_description(
+        "Estimates per-operation cost of a per-commit page-table neighborhood directory\n"
+        "versus TuringDB's current design of probing every reachable datapart.");
+
+    Workload workload;
+    PageTableConfig pageTable;
+    LatencyModel model;
+
+    parser.add_argument("--nodes")
+        .store_into(workload._numNodes)
+        .help("Number of nodes created by the bulk load (default: 1000000)");
+    parser.add_argument("--avg-degree")
+        .store_into(workload._avgInitialDegree)
+        .help("Average out-degree from the bulk load (default: 8)");
+    parser.add_argument("--load-dataparts")
+        .store_into(workload._loadDataparts)
+        .help("Dataparts produced by the bulk load (default: 1)");
+    parser.add_argument("--commits")
+        .store_into(workload._mutationCommits)
+        .help("Number of small mutation commits appended after the load (default: 2000)");
+    parser.add_argument("--edges-per-commit")
+        .store_into(workload._avgEdgesPerCommit)
+        .help("Edges added by each mutation commit (default: 500)");
+    parser.add_argument("--skew")
+        .store_into(workload._skew)
+        .help("Edge endpoint skew; >1 concentrates on hub nodes (default: 1.6)");
+    parser.add_argument("--read-samples")
+        .store_into(workload._readSamples)
+        .help("Neighborhood reads sampled per mix (default: 100000)");
+    parser.add_argument("--seed")
+        .store_into(workload._seed)
+        .help("RNG seed for reproducibility (default: 42)");
+
+    parser.add_argument("--level1-bits")
+        .store_into(pageTable._level1Bits)
+        .help("High NodeID bits indexing the root page directory (default: 16)");
+    parser.add_argument("--page-bits")
+        .store_into(pageTable._pageBits)
+        .help("NodeID bits consumed by each deeper page-table level (default: 8)");
+
+    parser.add_argument("--dram-ns")
+        .store_into(model._dramNs)
+        .help("Latency of a cache miss to DRAM, ns (default: 90)");
+    parser.add_argument("--hash-hit-ns")
+        .store_into(model._hashProbeHitNs)
+        .help("Latency of a populated hash-map probe, ns (default: 160)");
+    parser.add_argument("--hash-miss-ns")
+        .store_into(model._hashProbeMissNs)
+        .help("Latency of a missing hash-map probe, ns (default: 95)");
+    parser.add_argument("--bandwidth")
+        .store_into(model._bandwidthBytesPerNs)
+        .help("Sequential read bandwidth, bytes/ns (default: 12)");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::exception& error) {
+        fprintf(stderr, "%s\n", error.what());
+        return EXIT_FAILURE;
+    }
+
+    if (workload._numNodes < 2) {
+        fprintf(stderr, "--nodes must be at least 2\n");
+        return EXIT_FAILURE;
+    }
+    if (pageTable._pageBits < 1) {
+        fprintf(stderr, "--page-bits must be at least 1\n");
+        return EXIT_FAILURE;
+    }
+
+    pageTable.compute(workload._numNodes, model);
+
+    CommitIndexSimulator simulator(model, workload, pageTable);
+    simulator.run();
+    const SimResults& results = simulator.getResults();
+
+    char buf[64];
+    char buf2[64];
+
+    printf("=== TuringDB commit-index simulator ===\n");
+    printf("per-commit page-table neighborhood directory  vs  current probe-every-datapart design\n\n");
+
+    printf("Workload\n");
+    formatCount((double)workload._numNodes, buf, sizeof(buf));
+    printf("  nodes ................. %s\n", buf);
+    printf("  avg initial degree .... %zu  (load dataparts: %zu)\n",
+           workload._avgInitialDegree,
+           workload._loadDataparts);
+    formatCount((double)workload._mutationCommits, buf, sizeof(buf));
+    formatCount((double)workload._avgEdgesPerCommit, buf2, sizeof(buf2));
+    printf("  mutation commits ...... %s  x  %s edges/commit\n", buf, buf2);
+    printf("  edge skew ............. %.2f\n", workload._skew);
+    formatCount((double)workload._readSamples, buf, sizeof(buf));
+    printf("  read samples .......... %s per mix\n", buf);
+    printf("  seed .................. %llu\n\n", (unsigned long long)workload._seed);
+
+    printf("Page-table geometry\n");
+    printf("  effective id bits ..... %zu\n", pageTable._effectiveBits);
+    formatBytes((double)pageTable._rootBytes, buf, sizeof(buf));
+    printf("  level-1 bits .......... %zu  (root directory: %s)\n", pageTable._level1Bits, buf);
+    formatBytes((double)pageTable._innerPageBytes, buf, sizeof(buf));
+    printf("  page bits ............. %zu  (inner page: %s)\n", pageTable._pageBits, buf);
+    printf("  levels (walk depth) ... %zu\n\n", pageTable._levels);
+
+    printf("Latency assumptions\n");
+    printf("  DRAM miss ............. %.0f ns      hash probe hit ... %.0f ns\n",
+           model._dramNs,
+           model._hashProbeHitNs);
+    printf("  L1 / L2 / L3 .......... %.0f / %.0f / %.0f ns   hash probe miss .. %.0f ns\n",
+           model._l1Ns,
+           model._l2Ns,
+           model._l3Ns,
+           model._hashProbeMissNs);
+    printf("  seq bandwidth ......... %.0f B/ns      page alloc ....... %.0f ns\n\n",
+           model._bandwidthBytesPerNs,
+           model._allocNs);
+
+    printf("Simulated graph\n");
+    formatCount((double)results._totalEdges, buf, sizeof(buf));
+    printf("  total edges ........... %s\n", buf);
+    formatCount((double)results._maxDegree, buf, sizeof(buf));
+    printf("  avg / max degree ...... %.1f / %s\n", results._avgDegree, buf);
+    formatCount((double)results._maxTouchCount, buf, sizeof(buf));
+    printf("  avg / max touches ..... %.2f / %s  (mutation commits that patched a node)\n\n",
+           results._avgTouchCount,
+           buf);
+
+    printf("--- READ: neighborhood lookup (per operation) ---\n");
+    printf("  %-8s %-27s %12s %12s %12s\n", "mix", "design", "mean", "median", "p99");
+    printReadRow("hot", "current", results._currentRead[0]);
+    printReadRow("hot", "page-table (delta)", results._pageTableDeltaRead[0]);
+    printReadRow("hot", "page-table (consolidated)", results._pageTableConsolidatedRead[0]);
+    printReadRow("uniform", "current", results._currentRead[1]);
+    printReadRow("uniform", "page-table (delta)", results._pageTableDeltaRead[1]);
+    printReadRow("uniform", "page-table (consolidated)", results._pageTableConsolidatedRead[1]);
+
+    const double hotDeltaSpeedup = results._currentRead[0]._meanNs / results._pageTableDeltaRead[0]._meanNs;
+    const double hotConsSpeedup = results._currentRead[0]._meanNs / results._pageTableConsolidatedRead[0]._meanNs;
+    const double uniformDeltaSpeedup = results._currentRead[1]._meanNs / results._pageTableDeltaRead[1]._meanNs;
+    const double uniformConsSpeedup = results._currentRead[1]._meanNs / results._pageTableConsolidatedRead[1]._meanNs;
+
+    printf("\n  mean read speedup vs current:\n");
+    printf("    page-table (delta) ........ hot %.1fx   uniform %.1fx\n",
+           hotDeltaSpeedup,
+           uniformDeltaSpeedup);
+    printf("    page-table (consolidated) . hot %.1fx   uniform %.1fx\n\n",
+           hotConsSpeedup,
+           uniformConsSpeedup);
+
+    printf("--- WRITE: cost of committing one mutation commit ---\n");
+    printf("  %-27s %12s %12s %12s %14s\n", "design", "mean", "max", "pages", "index bytes");
+    printWriteRow("current", results._currentWrite, false);
+    printWriteRow("page-table (delta)", results._pageTableDeltaWrite, true);
+    printWriteRow("page-table (consolidated)", results._pageTableConsolidatedWrite, true);
+
+    const double deltaWriteOverhead =
+        results._pageTableDeltaWrite._meanNsPerCommit / results._currentWrite._meanNsPerCommit;
+    const double consWriteOverhead =
+        results._pageTableConsolidatedWrite._meanNsPerCommit / results._currentWrite._meanNsPerCommit;
+    printf("\n  write cost vs current:  delta %.2fx   consolidated %.2fx\n\n",
+           deltaWriteOverhead,
+           consWriteOverhead);
+
+    printf("Index space (page-table directory; substructure shared across commits)\n");
+    formatBytes(results._initialIndexBytes, buf, sizeof(buf));
+    printf("  initial directory ..... %s  (one-time)\n", buf);
+    formatBytes(results._pageTableDeltaWrite._meanBytesPerCommit, buf, sizeof(buf));
+    formatBytes(results._projectedDeltaGrowthBytes, buf2, sizeof(buf2));
+    printf("  delta growth .......... %s/commit  ->  %s over %zu commits\n\n",
+           buf,
+           buf2,
+           workload._mutationCommits);
+
+    // Dynamic, parameter-derived summary so the report stands on its own.
+    const double readFloorNs = (double)workload._mutationCommits * model._hashProbeMissNs;
+    const double walkNs = model.cacheLatencyForBytes(pageTable._rootBytes)
+                        + (double)(pageTable._levels - 1) * model._dramNs;
+    const double rootCopyNs = (double)pageTable._rootBytes / model._bandwidthBytesPerNs;
+    const double rootCopyShare = 100.0 * rootCopyNs / results._pageTableDeltaWrite._meanNsPerCommit;
+
+    char floorBuf[32];
+    char walkBuf[32];
+    formatLatency(readFloorNs, floorBuf, sizeof(floorBuf));
+    formatLatency(walkNs, walkBuf, sizeof(walkBuf));
+
+    printf("Takeaways\n");
+    printf("  - Reads today scan every reachable datapart: a floor of ~%s per read\n",
+           floorBuf);
+    printf("    (%zu probes x %.0f ns miss), independent of node degree or which part holds the edges.\n",
+           workload._mutationCommits,
+           model._hashProbeMissNs);
+    printf("  - The page-table replaces that with a fixed %zu-level walk (~%s), so the read\n",
+           pageTable._levels,
+           walkBuf);
+    printf("    win grows linearly with commit-history depth (merge/compaction shrinks it).\n");
+    printf("  - Page-table writes path-copy ~%.0f pages/commit; rewriting the root alone is\n",
+           results._pageTableDeltaWrite._meanRewrittenPages);
+    printf("    %.0f%% of the delta-write cost -> keep --level1-bits small for write-heavy loads.\n",
+           rootCopyShare);
+    printf("  - Consolidated leaves give the best reads but re-copy hub adjacency on every\n");
+    printf("    touch (%.2fx write cost); the delta variant avoids that (%.2fx) at the price of\n",
+           consWriteOverhead,
+           deltaWriteOverhead);
+    printf("    chaining per-commit spans on read.\n");
+
+    return EXIT_SUCCESS;
+}

--- a/samples/commit-index-sim/main.cpp
+++ b/samples/commit-index-sim/main.cpp
@@ -114,9 +114,13 @@ int main(int argc, char** argv) {
     parser.add_argument("--edges-per-commit")
         .store_into(workload._avgEdgesPerCommit)
         .help("Edges added by each mutation commit (default: 500)");
+    parser.add_argument("--patch-fraction")
+        .store_into(workload._patchFraction)
+        .help("Fraction of commits that patch existing nodes; the rest are append-only "
+              "with empty patch maps (default: 1.0; realistic append-heavy: ~0.05-0.2)");
     parser.add_argument("--skew")
         .store_into(workload._skew)
-        .help("Edge endpoint skew; >1 concentrates on hub nodes (default: 1.6)");
+        .help("Edge endpoint skew; >1 concentrates on hub nodes / categories (default: 1.6)");
     parser.add_argument("--read-samples")
         .store_into(workload._readSamples)
         .help("Neighborhood reads sampled per mix (default: 100000)");
@@ -159,6 +163,10 @@ int main(int argc, char** argv) {
         fprintf(stderr, "--page-bits must be at least 1\n");
         return EXIT_FAILURE;
     }
+    if (workload._patchFraction < 0.0 || workload._patchFraction > 1.0) {
+        fprintf(stderr, "--patch-fraction must be between 0 and 1\n");
+        return EXIT_FAILURE;
+    }
 
     pageTable.compute(workload._numNodes, model);
 
@@ -181,6 +189,8 @@ int main(int argc, char** argv) {
     formatCount((double)workload._mutationCommits, buf, sizeof(buf));
     formatCount((double)workload._avgEdgesPerCommit, buf2, sizeof(buf2));
     printf("  mutation commits ...... %s  x  %s edges/commit\n", buf, buf2);
+    printf("  patch fraction ........ %.2f  (rest are append-only, empty patch maps)\n",
+           workload._patchFraction);
     printf("  edge skew ............. %.2f\n", workload._skew);
     formatCount((double)workload._readSamples, buf, sizeof(buf));
     printf("  read samples .......... %s per mix\n", buf);
@@ -208,6 +218,9 @@ int main(int argc, char** argv) {
            model._allocNs);
 
     printf("Simulated graph\n");
+    formatCount((double)results._patchingCommits, buf, sizeof(buf));
+    formatCount((double)workload._mutationCommits, buf2, sizeof(buf2));
+    printf("  patching commits ...... %s of %s  (rest append-only)\n", buf, buf2);
     formatCount((double)results._totalEdges, buf, sizeof(buf));
     printf("  total edges ........... %s\n", buf);
     formatCount((double)results._maxDegree, buf, sizeof(buf));
@@ -239,7 +252,7 @@ int main(int argc, char** argv) {
            hotConsSpeedup,
            uniformConsSpeedup);
 
-    printf("--- WRITE: cost of committing one mutation commit ---\n");
+    printf("--- WRITE: cost of committing one patching commit ---\n");
     printf("  %-27s %12s %12s %12s %14s\n", "design", "mean", "max", "pages", "index bytes");
     printWriteRow("current", results._currentWrite, false);
     printWriteRow("page-table (delta)", results._pageTableDeltaWrite, true);

--- a/samples/commit-index-sim/run.sh
+++ b/samples/commit-index-sim/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./commit-index-sim


### PR DESCRIPTION
Quick simulator for the evaluation of an idea to speedup neighborhood expansion when the number of datapart grows.

## Overview

Currently, reading the neighborhood of a node means visiting *every* reachable datapart in the commit history and doing a hash probe in each to see whether edges have been added to that node. 

After a bulk load and a long tail of small commits, that's a lot of hash probes and almost all of them miss. 

We want to evaluate an idea: keep a per-commit **page-table directory** (a radix tree with NodeID bits as keys) that points to each node's neighborhood, so a read is a very short constant-depth tree walk (1-2 levels) instead of N hash probes. 

```mermaid
flowchart TD
    classDef shared fill:#eaf2ff,stroke:#4a7fe0,color:#10243e
    classDef new fill:#ffefe0,stroke:#e07b2a,color:#4a2606

    rN["root (commit N)"]:::shared
    rN1["root (commit N+1)"]:::new

    A["inner page A"]:::shared
    B["inner page B"]:::shared
    Bn["inner page B (copy)"]:::new

    la["leaf"]:::shared
    lb["leaf"]:::shared
    lc["leaf: changed node (old)"]:::shared
    lcn["leaf: changed node (new)"]:::new

    rN --> A
    rN --> B
    A --> la
    B --> lb
    B --> lc

    rN1 --> A
    rN1 --> Bn
    Bn --> lb
    Bn --> lcn
```

The tree is shared across commits. A new commit only rewrites the pages on the path from each changed node up to a fresh root. We want to know what gain it gives us on reads and what it costs on writes.

## How the simulator works

We implement a quick and dirty simulator as a sample tool that doesn't touch the engine. It replays a synthetic workload:
* bulk-load 1M nodes
* 2000 small commits that add edges to existing nodes, with hub skew so old nodes keep growing

It adds up approximate latencies per operation: cache/DRAM hits, hash probes, sequential edge scans, and page-copy bandwidth. 
It then reports read and write cost for the current design and for two flavors of the page-table: **delta** leaves (store just this commit's new edges) and **consolidated** leaves (store the node's fully merged neighborhood).

## Results 

Default run: 1M nodes, 2000 mutation commits. 

| Design | Neighborhood read | Commit write | Index mem/commit | Index mem total | The catch |
|---|---|---|---|---|---|
| Current (probe every datapart) | ~190 µs | ~72 µs | ~39 KB | ~107 MB | read cost scales with commit-history depth |
| Page-table — delta leaves | ~300–360 ns (~530–640×) | ~158 µs (2.2×) | ~1.5 MB | ~3.0 GB | cheap reads, modest write overhead |
| Page-table — consolidated leaves | ~210–220 ns (~860–915×) | ~218 µs (3.0×) | ~1.7 MB | ~3.4 GB | fastest reads, but re-copies hub adjacency every touch |

## How it scales with commit depth

The 2000-commit run above is the extreme case. The read win is really just the datapart count: today's cost is ~95 ns per probe × commits, while the page-table walk stays flat, so the speedup is roughly commits / 2.

Page-table figures below are the delta variant; consolidated is marginally faster on reads.

| Commits | Current read | Page-table read | Read speedup | Total index mem (current → delta) |
|---|---|---|---|---|
| 1 | ~308 ns | ~217 ns | ~1.4× | 31 MB → 124 MB |
| 2 | ~403 ns | ~217 ns | ~1.9× | 31 MB → 126 MB |
| 4 | ~593 ns | ~217 ns | ~2.7× | 31 MB → 129 MB |
| 50 | ~5.0 µs | ~221 ns | ~23× | 32 MB → 196 MB |
| 100 | ~9.7 µs | ~224 ns | ~43× | 34 MB → 270 MB |
| 200 | ~19 µs | ~232 ns | ~83× | 38 MB → 417 MB |
| 2000 | ~190 µs | ~360 ns | ~530× | 107 MB → 3.0 GB |

Write cost doesn't move with depth: current ~72 µs, delta ~158 µs (2.2×), consolidated ~218 µs (3.0×) at every row.

Memory is also far gentler when histories stay shallow: ~5–11× the current index at 50–200 commits, versus ~30× at 2000.

## Append-heavy histories (patch fraction)

So far every commit patches an existing node. Realistically, most commits in an append-heavy history only add new nodes — attached to a handful of hub, category, and constant nodes — and patch nothing else.

Those append-only commits hold an empty patch map, so a read of an existing node skips them in a few ns instead of paying a ~95 ns probe. `--patch-fraction` sets how many commits patch existing nodes.

At 2000 commits:

| Patch fraction | Patching commits | Current read | Read speedup |
|---|---|---|---|
| 1.0 | 2000 | ~190 µs | ~530× |
| 0.2 | 400 | ~45 µs | ~180× |
| 0.1 | 200 | ~26 µs | ~114× |
| 0.05 | 100 | ~17 µs | ~77× |
| 0 | 0 | ~8 µs | ~38× |

The same realistic patch fraction of 0.1, across the shallower histories a compacting engine actually keeps:

| Commits | Patching commits | Current read | Read speedup |
|---|---|---|---|
| 50 | 5 | ~0.9 µs | ~4× |
| 100 | 10 | ~1.5 µs | ~7× |
| 200 | 20 | ~2.8 µs | ~13× |

The page-table read stays flat at ~210 ns throughout, and its write and memory overhead scale down with the patch fraction too (fewer patching commits, fewer path-copies).

But even at a patch fraction of zero the current read still floors at ~8 µs at 2000 commits (2000 dataparts × ~4 ns), because it walks the whole history regardless. The page-table's real win is never visiting it — so the gap shrinks with fewer patches but never closes at depth.

## Quick cost model

Current model:
```
read latency = Base + n(4 + 91p)

where n is the number of commits and p is the patch fraction

Base  is fetching the core edges: 
DRAM + DRAM + 2.7*d where d is the node degree
assuming DRAM ~= 90ns is cold load latency,

Assuming a degree d=4, Base ~= 200ns
```

Page table model:
```
Neighborhood consolidated in leaf:

read latency = WALK + DRAM + 2.7*d

where WALK ~= 94 is the cost of descending the tree
and DRAM ~= 90 is the load of the node's neighborhood entry
```

## Conclusion

Reads get ~500–900× faster with 2000 commits, because the walk cost is fixed while today's probe cost grows with every commit. 

Writes get 2–3× more expensive from path-copying, mostly the root rewrite, which shrinks fast with a narrower root (`--level1-bits 10` drops delta to ~1.1×). 

The real price is memory: retaining a copied page tree per commit costs ~30× the current index (narrower pages and merge/compaction both bring it down). 