### PR TITLE
MLIR: db.cross_product op and its lowering to the nl dialect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Key points:
 - Prefer `size_t` for indices and counts in new code (row groups, columns, rows, batch sizes). Narrow with `static_cast<int>(...)` at third-party API boundaries inside the `.cpp`.
 - Don't wrap unused parameter names in `/*comments*/` — just name them normally. `-Wunused-parameter` isn't enabled in this codebase, so there's no warning to silence.
 - Don't add `(void)param;` lines in function bodies to mark a parameter as used. Same reason: no warning to silence; it's pure noise.
+- **Fill columns with `std::fill`/`std::fill_n`/`std::copy`, not `reserve` + `push_back` loops.** A `push_back` loop does not vectorise; `std::fill_n` (repeated value) and `std::copy` (range, commonly lowered to `memcpy`) do. When laying out a column whose size is known up front, `resize` the output's `getRaw()` to the final size, then write ranges through an iterator with these algorithms — see `CartesianProductProcessor` and the `blockRepeatColumn`/`tileColumn` helpers in `NLExecutor.cpp`.
 
 ## Design Conventions
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -1,5 +1,152 @@
 #include "DBOps.h"
 #include "DBDialect.h"
 
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+using namespace mlir::db;
+
 #define GET_OP_CLASSES
 #include "DBOps.cpp.inc"
+
+namespace {
+
+// The keyword that introduces each factor region in the textual form
+// `db.cross_product factor { ... } factor { ... }`.
+const char* const factorKeyword = "factor";
+
+// The db.yield that terminates a factor region, or a null Yield if the region
+// is empty or does not end with one. A factor's yield names the columns that
+// factor contributes to the product.
+Yield getFactorYield(Region& factor) {
+    Operation* terminator = nullptr;
+    if (!factor.empty()) {
+        Block& block = factor.front();
+        if (!block.empty()) {
+            terminator = &block.back();
+        }
+    }
+
+    return dyn_cast_or_null<Yield>(terminator);
+}
+
+// Appends the columns yielded by a factor region to resultTypes, failing with a
+// diagnostic if the factor is not terminated by a db.yield.
+ParseResult appendFactorYieldTypes(OpAsmParser& parser,
+                                   Region& factor,
+                                   llvm::SmallVectorImpl<Type>& resultTypes) {
+    Yield yield = getFactorYield(factor);
+    if (!yield) {
+        return parser.emitError(parser.getCurrentLocation(),
+                                "cross_product factor must end with a db.yield");
+    }
+
+    for (const Type columnType : yield.getColumns().getTypes()) {
+        resultTypes.push_back(columnType);
+    }
+
+    return success();
+}
+
+// Parses `factor { ... }` into a fresh region of result. The factor takes no
+// operands and no block arguments, so the region is parsed with an empty
+// argument list.
+ParseResult parseFactorRegion(OpAsmParser& parser, OperationState& result) {
+    if (parser.parseKeyword(factorKeyword)) {
+        return failure();
+    }
+
+    Region* factor = result.addRegion();
+    return parser.parseRegion(*factor, {});
+}
+
+}
+
+// Builds the op from just the result types - the left factor's yielded columns
+// followed by the right factor's - and creates the two empty factor blocks. The
+// caller fills each region and terminates it with a db.yield whose operands
+// match the result types contributed by that factor. The insertion guard keeps
+// the block creation from leaking out of the builder.
+void CrossProduct::build(OpBuilder& builder, OperationState& state, TypeRange resultTypes) {
+    const OpBuilder::InsertionGuard guard(builder);
+
+    state.addTypes(resultTypes);
+
+    Region* leftFactor = state.addRegion();
+    builder.createBlock(leftFactor);
+
+    Region* rightFactor = state.addRegion();
+    builder.createBlock(rightFactor);
+}
+
+// Custom syntax, mirroring the disconnected pattern it models:
+//
+//   %a, %b = db.cross_product factor { ... db.yield %x : ... }
+//                             factor { ... db.yield %y : ... }
+//
+// Nothing is spelled after the regions: the result types are recovered from the
+// two factors' yields - the left factor's yielded columns followed by the
+// right factor's - matching the result count parsed from the `%a, %b =` list.
+ParseResult CrossProduct::parse(OpAsmParser& parser, OperationState& result) {
+    const bool regionsFailed = parseFactorRegion(parser, result)
+                               || parseFactorRegion(parser, result)
+                               || parser.parseOptionalAttrDict(result.attributes);
+    if (regionsFailed) {
+        return failure();
+    }
+
+    Region& leftFactor = *result.regions[0];
+    Region& rightFactor = *result.regions[1];
+    if (appendFactorYieldTypes(parser, leftFactor, result.types)
+        || appendFactorYieldTypes(parser, rightFactor, result.types)) {
+        return failure();
+    }
+
+    return success();
+}
+
+void CrossProduct::print(OpAsmPrinter& printer) {
+    printer << " " << factorKeyword << " ";
+    printer.printRegion(getLeftFactor());
+
+    printer << " " << factorKeyword << " ";
+    printer.printRegion(getRightFactor());
+
+    printer.printOptionalAttrDict((*this)->getAttrs());
+}
+
+// The results must be exactly the columns yielded by the two factors: the left
+// factor's yielded columns followed by the right factor's. The yields drive the
+// result types during parsing, so this guards the programmatic builder path and
+// re-checks parsed IR.
+LogicalResult CrossProduct::verify() {
+    Yield leftYield = getFactorYield(getLeftFactor());
+    Yield rightYield = getFactorYield(getRightFactor());
+    if (!leftYield || !rightYield) {
+        return emitOpError("each factor region must end with a db.yield");
+    }
+
+    llvm::SmallVector<Type> expectedResultTypes;
+    for (const Type columnType : leftYield.getColumns().getTypes()) {
+        expectedResultTypes.push_back(columnType);
+    }
+    for (const Type columnType : rightYield.getColumns().getTypes()) {
+        expectedResultTypes.push_back(columnType);
+    }
+
+    const Operation::result_type_range resultTypes = getOperation()->getResultTypes();
+    if (resultTypes.size() != expectedResultTypes.size()) {
+        return emitOpError("expects ") << expectedResultTypes.size()
+                                       << " results, the columns yielded by the two factors, but has "
+                                       << resultTypes.size();
+    }
+
+    for (size_t resultIndex = 0; resultIndex < expectedResultTypes.size(); resultIndex++) {
+        if (resultTypes[resultIndex] != expectedResultTypes[resultIndex]) {
+            return emitOpError("result ") << resultIndex << " must be the yielded column type "
+                                          << expectedResultTypes[resultIndex];
+        }
+    }
+
+    return success();
+}

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -126,6 +126,13 @@ LogicalResult CrossProduct::verify() {
         return emitOpError("each factor region must end with a db.yield");
     }
 
+    // Each factor must contribute at least one column. A side's row count is read
+    // from its first yielded column during lowering, so a factor that surfaces no
+    // column (an empty db.yield) cannot be sized - reject it here at the db level.
+    if (leftYield.getColumns().empty() || rightYield.getColumns().empty()) {
+        return emitOpError("each factor must yield at least one column");
+    }
+
     llvm::SmallVector<Type> expectedResultTypes;
     for (const Type columnType : leftYield.getColumns().getTypes()) {
         expectedResultTypes.push_back(columnType);

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -116,6 +116,83 @@ def GetEdgeProperties : TuringOp<"get_edge_properties", [Pure]> {
 }
 
 /**
+* CrossProduct
+*/
+def CrossProduct : TuringOp<"cross_product", [Pure]> {
+  let summary = "Cross every row of one column dataflow with every row of another";
+
+  let description = [{
+    Models a Cypher disconnected pattern, e.g. `MATCH (a)-->(b), (c)-->(d)`: two
+    column dataflows that share no variable, whose result is the cartesian
+    product of their rows. Each side is a self-contained db dataflow held in its
+    own region - `leftFactor` and `rightFactor` - with no operands and no block
+    arguments, so the two factors share no SSA value.
+
+      %a, %b = db.cross_product factor {
+        %x = db.scan_nodes() : !db.column<"a">
+        db.yield %x : !db.column<"a">
+      } factor {
+        %y = db.scan_nodes() : !db.column<"b">
+        db.yield %y : !db.column<"b">
+      }
+
+    Because the factors are disconnected, which columns end up in the result
+    cannot be read off a data dependency (unlike get_out_edges' carry set within
+    a connected traversal) - it must be stated. Each region ends with a db.yield
+    naming exactly the columns that factor contributes, and the op's results are
+    the left factor's yielded columns followed by the right factor's. An empty
+    db.yield is allowed: `MATCH (a),(b) RETURN a` multiplies cardinality by |b|
+    while surfacing no `b` column.
+
+    The result types are not spelled after the regions; the parser recovers them
+    from the two yields and the verifier checks they line up. Reading the graph
+    is deterministic, so the op is Pure.
+  }];
+
+  // The results are the concatenation of the two factors' yielded columns; the
+  // count and types are recovered from the yields, never spelled out.
+  let results = (outs Variadic<Column>:$results);
+
+  // Each factor is exactly one block: a self-contained dataflow ending in a
+  // db.yield, with no operands and no block arguments.
+  let regions = (region SizedRegion<1>:$leftFactor, SizedRegion<1>:$rightFactor);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  // The only builder takes the result types and creates the two empty factor
+  // blocks; the caller fills each region and terminates it with a db.yield
+  // whose operands match the result types contributed by that factor.
+  let skipDefaultBuilders = 1;
+  let builders = [
+      OpBuilder<(ins "::mlir::TypeRange":$resultTypes)>
+  ];
+}
+
+/**
+* Yield
+*/
+def Yield : TuringOp<"yield", [Pure, Terminator, HasParent<"CrossProduct">]> {
+  let summary = "Name the columns a cross_product factor contributes to the result";
+
+  let description = [{
+    Terminates a db.cross_product factor region, naming the columns that factor
+    contributes to the product. The cross_product's results are the left
+    factor's yielded columns followed by the right factor's. An empty yield is
+    allowed - a factor can multiply the result cardinality while surfacing no
+    column of its own.
+  }];
+
+  let arguments = (ins Variadic<Column>:$columns);
+
+  // The yielded column types vary from query to query and cannot be built from
+  // a recipe, so - when present - they are spelled after the colon, as in
+  // db.output. The optional group, anchored on the operands, prints nothing for
+  // an empty yield (`db.yield`).
+  let assemblyFormat = "( $columns^ `:` qualified(type($columns)) )? attr-dict";
+}
+
+/**
 * Output
 */
 def Output : TuringOp<"output"> {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -140,9 +140,10 @@ def CrossProduct : TuringOp<"cross_product", [Pure]> {
     cannot be read off a data dependency (unlike get_out_edges' carry set within
     a connected traversal) - it must be stated. Each region ends with a db.yield
     naming exactly the columns that factor contributes, and the op's results are
-    the left factor's yielded columns followed by the right factor's. An empty
-    db.yield is allowed: `MATCH (a),(b) RETURN a` multiplies cardinality by |b|
-    while surfacing no `b` column.
+    the left factor's yielded columns followed by the right factor's. Each factor
+    must yield at least one column: a side's row count is read from its first
+    yielded column, so a factor that surfaces none cannot be sized and the
+    verifier rejects an empty db.yield.
 
     The result types are not spelled after the regions; the parser recovers them
     from the two yields and the verifier checks they line up. Reading the graph
@@ -178,17 +179,18 @@ def Yield : TuringOp<"yield", [Pure, Terminator, HasParent<"CrossProduct">]> {
   let description = [{
     Terminates a db.cross_product factor region, naming the columns that factor
     contributes to the product. The cross_product's results are the left
-    factor's yielded columns followed by the right factor's. An empty yield is
-    allowed - a factor can multiply the result cardinality while surfacing no
-    column of its own.
+    factor's yielded columns followed by the right factor's. A factor must yield
+    at least one column - the cross_product verifier rejects an empty yield,
+    since a side's row count is read from its first yielded column.
   }];
 
   let arguments = (ins Variadic<Column>:$columns);
 
   // The yielded column types vary from query to query and cannot be built from
   // a recipe, so - when present - they are spelled after the colon, as in
-  // db.output. The optional group, anchored on the operands, prints nothing for
-  // an empty yield (`db.yield`).
+  // db.output. The optional group, anchored on the operands, keeps the syntax
+  // total: an empty yield (`db.yield`) still parses, then the cross_product
+  // verifier rejects it with a clear db-level diagnostic.
   let assemblyFormat = "( $columns^ `:` qualified(type($columns)) )? attr-dict";
 }
 

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -73,6 +73,24 @@ LogicalResult GetInEdges::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// A cross product yields one chunk per crossed column - the outer columns
+// followed by the inner - each keeping its input chunk's element type, since
+// the broadcast only changes the row count, not the element kind.
+LogicalResult CrossProduct::inferReturnTypes(MLIRContext* context,
+                                             std::optional<Location> location,
+                                             CrossProduct::Adaptor adaptor,
+                                             SmallVectorImpl<Type>& inferredReturnTypes) {
+    for (const Type columnType : adaptor.getOuterColumns().getTypes()) {
+        inferredReturnTypes.push_back(columnType);
+    }
+
+    for (const Type columnType : adaptor.getInnerColumns().getTypes()) {
+        inferredReturnTypes.push_back(columnType);
+    }
+
+    return success();
+}
+
 // Build a loop from just the iterator value: its iterator type carries the
 // chunk types, which become the loop variables (the body block arguments).
 // The body is created with its implicit nl.yield terminator, ready for the

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -208,6 +208,49 @@ def Yield : NLOp<"yield", [Pure, Terminator, HasParent<"For">]> {
 }
 
 /**
+* CrossProduct
+*/
+def CrossProduct : NLOp<"cross_product", [Pure, InferTypeOpAdaptor, AttrSizedOperandSegments]> {
+  let summary = "Cross every row of one loop's chunks with every row of another";
+
+  let description = [{
+    Given an outer chunk of N rows and an inner chunk of M rows it produces N*M
+    rows: each outer column is block-repeated x M (outer row i becomes M
+    consecutive rows) and each inner column is tiled x N (the whole inner chunk
+    repeated N times), so result row k pairs outer row k/M with inner row k%M -
+    every outer row against every inner row.
+
+      %a, %b = nl.cross_product {%a} {%b}
+                 : {!nl.chunk<!nl.node_id>} {!nl.chunk<!nl.node_id>}
+
+    The two brace groups are the columns each factor contributes, in db.yield
+    order; the op's results are the outer columns followed by the inner, each
+    result chunk keeping its input's element type - only the row count changes.
+    N and M are read from the first column of each group, so each group must be
+    non-empty.
+  }];
+
+  // The outer and inner column groups to cross. Two variadic groups of
+  // independent size need AttrSizedOperandSegments to record each group's size.
+  let arguments = (ins Variadic<NLChunk>:$outer_columns,
+                       Variadic<NLChunk>:$inner_columns);
+
+  // One result per crossed column, outer group then inner group; inferred from
+  // the operands since the broadcast keeps each chunk's element type.
+  let results = (outs Variadic<NLChunk>:$results);
+
+  // The two SSA brace groups mirror the two factors. The result types are
+  // inferred, so only the operand chunk types are spelled - the same two
+  // groups, each in braces, after the colon (as nl.output spells its chunk
+  // types). The operandSegmentSizes attribute is populated and elided
+  // automatically by the generated parser/printer.
+  let assemblyFormat = [{
+    `{` $outer_columns `}` `{` $inner_columns `}` attr-dict `:`
+    `{` qualified(type($outer_columns)) `}` `{` qualified(type($inner_columns)) `}`
+  }];
+}
+
+/**
 * Output
 */
 def Output : NLOp<"output"> {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -203,11 +203,13 @@ void NLExecutor::runCrossProduct(NLExecutionContext* context, NLFunctionData* da
     const size_t innerRowCount = innerColumns.front().getInput()->size();
 
     for (const NLCrossColumn& column : outerColumns) {
-        column.getBroadcast()(column.getInput(), innerRowCount, column.getOutput());
+        const NLBroadcastFunction broadcast = column.getBroadcast();
+        broadcast(column.getInput(), innerRowCount, column.getOutput());
     }
 
     for (const NLCrossColumn& column : innerColumns) {
-        column.getBroadcast()(column.getInput(), outerRowCount, column.getOutput());
+        const NLBroadcastFunction broadcast = column.getBroadcast();
+        broadcast(column.getInput(), outerRowCount, column.getOutput());
     }
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -60,8 +60,6 @@ void blockRepeatColumn(const Column* input, size_t factor, Column* output) {
     auto& outputRaw = typedOutput->getRaw();
     outputRaw.resize(inputRaw.size() * factor);
 
-    // fill_n each input value into its `factor`-wide run; vectorises where the
-    // push_back loop would not.
     auto outputIt = outputRaw.begin();
     for (const ElementType& value : inputRaw) {
         std::fill_n(outputIt, factor, value);
@@ -82,8 +80,6 @@ void tileColumn(const Column* input, size_t factor, Column* output) {
     auto& outputRaw = typedOutput->getRaw();
     outputRaw.resize(inputRaw.size() * factor);
 
-    // Copy the whole input chunk into each `factor` repeat; copy commonly lowers
-    // to a memcpy whereas the push_back loop would not.
     auto outputIt = outputRaw.begin();
     for (size_t repeat = 0; repeat < factor; repeat++) {
         outputIt = std::copy(inputRaw.begin(), inputRaw.end(), outputIt);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -283,73 +283,23 @@ NLBroadcastFunction NLExecutor::selectTileFunction(NLChunkKind kind) {
 // ColumnVector<std::optional<Primitive>> - so the same broadcast templates,
 // instantiated on std::optional<Primitive>, carry value and null together.
 NLBroadcastFunction NLExecutor::selectOptBlockRepeatFunction(ValueType valueType) {
-    switch (valueType) {
-        case ValueType::Int64:
-            return &blockRepeatColumn<std::optional<types::Int64::Primitive>>;
-        break;
+    NLBroadcastFunction broadcast = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        broadcast = &blockRepeatColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
 
-        case ValueType::UInt64:
-            return &blockRepeatColumn<std::optional<types::UInt64::Primitive>>;
-        break;
-
-        case ValueType::Double:
-            return &blockRepeatColumn<std::optional<types::Double::Primitive>>;
-        break;
-
-        case ValueType::Bool:
-            return &blockRepeatColumn<std::optional<types::Bool::Primitive>>;
-        break;
-
-        case ValueType::String:
-            return &blockRepeatColumn<std::optional<types::String::Primitive>>;
-        break;
-
-        case ValueType::Embedding:
-            return &blockRepeatColumn<std::optional<types::Embedding::Primitive>>;
-        break;
-
-        case ValueType::Invalid:
-        case ValueType::_SIZE:
-            throw IRException("Invalid property value type");
-        break;
-    }
-
-    throw IRException("Unhandled property value type");
+    return broadcast;
 }
 
 NLBroadcastFunction NLExecutor::selectOptTileFunction(ValueType valueType) {
-    switch (valueType) {
-        case ValueType::Int64:
-            return &tileColumn<std::optional<types::Int64::Primitive>>;
-        break;
+    NLBroadcastFunction broadcast = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        broadcast = &tileColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
 
-        case ValueType::UInt64:
-            return &tileColumn<std::optional<types::UInt64::Primitive>>;
-        break;
-
-        case ValueType::Double:
-            return &tileColumn<std::optional<types::Double::Primitive>>;
-        break;
-
-        case ValueType::Bool:
-            return &tileColumn<std::optional<types::Bool::Primitive>>;
-        break;
-
-        case ValueType::String:
-            return &tileColumn<std::optional<types::String::Primitive>>;
-        break;
-
-        case ValueType::Embedding:
-            return &tileColumn<std::optional<types::Embedding::Primitive>>;
-        break;
-
-        case ValueType::Invalid:
-        case ValueType::_SIZE:
-            throw IRException("Invalid property value type");
-        break;
-    }
-
-    throw IRException("Unhandled property value type");
+    return broadcast;
 }
 
 // Read one property of the current input chunk into a nullable value column.

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -12,6 +12,7 @@
 #include "NLProgram.h"
 #include "NLOutputSink.h"
 
+#include "IRException.h"
 #include "BioAssert.h"
 
 using namespace db;
@@ -42,6 +43,47 @@ void gatherColumn(const Column* input,
 
     for (const size_t index : indicesRaw) {
         typedOutput->push_back(typedInputRaw[index]);
+    }
+}
+
+// Block-repeat: each input row is emitted `factor` times in a row, so an input
+// of N rows becomes N*factor rows with input row i at output indices
+// [i*factor, (i+1)*factor). This lays out an outer column of a cross product,
+// where each outer row pairs with the whole inner chunk.
+template <typename ElementType>
+void blockRepeatColumn(const Column* input, size_t factor, Column* output) {
+    const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
+    ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
+
+    typedOutput->clear();
+    typedOutput->reserve(typedInput->size() * factor);
+
+    auto& outputRaw = typedOutput->getRaw();
+    for (const ElementType& value : typedInput->getRaw()) {
+        for (size_t repeat = 0; repeat < factor; repeat++) {
+            outputRaw.push_back(value);
+        }
+    }
+}
+
+// Tile: the whole input chunk is emitted `factor` times back to back, so an
+// input of M rows becomes M*factor rows with input row j at output indices
+// j, j+M, j+2M, ... This lays out an inner column of a cross product, where the
+// inner chunk repeats once per outer row.
+template <typename ElementType>
+void tileColumn(const Column* input, size_t factor, Column* output) {
+    const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
+    ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
+
+    typedOutput->clear();
+    typedOutput->reserve(typedInput->size() * factor);
+
+    auto& outputRaw = typedOutput->getRaw();
+    const auto& inputRaw = typedInput->getRaw();
+    for (size_t repeat = 0; repeat < factor; repeat++) {
+        for (const ElementType& value : inputRaw) {
+            outputRaw.push_back(value);
+        }
     }
 }
 
@@ -145,6 +187,30 @@ void NLExecutor::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* 
     runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getTargets());
 }
 
+void NLExecutor::runCrossProduct(NLExecutionContext* context, NLFunctionData* data) {
+    NLCrossProductData* cross = static_cast<NLCrossProductData*>(data);
+
+    const NLCrossProductData::Columns& outerColumns = cross->outerColumns();
+    const NLCrossProductData::Columns& innerColumns = cross->innerColumns();
+    bioassert(!outerColumns.empty() && !innerColumns.empty(),
+              "nl.cross_product needs a column on each side to size the product");
+
+    // N outer rows crossed with M inner rows: each outer column is
+    // block-repeated x M and each inner column tiled x N, so every outer row
+    // pairs with every inner row. The counts come from the first column of each
+    // side; all columns of a side are row-aligned, so any one measures it.
+    const size_t outerRowCount = outerColumns.front().getInput()->size();
+    const size_t innerRowCount = innerColumns.front().getInput()->size();
+
+    for (const NLCrossColumn& column : outerColumns) {
+        column.getBroadcast()(column.getInput(), innerRowCount, column.getOutput());
+    }
+
+    for (const NLCrossColumn& column : innerColumns) {
+        column.getBroadcast()(column.getInput(), outerRowCount, column.getOutput());
+    }
+}
+
 void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     const NLOutputData* output = static_cast<NLOutputData*>(data);
     const auto& cols = output->outputs();
@@ -171,6 +237,117 @@ NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
 
     bioassert(false, "Unknown NLChunkKind");
     return nullptr;
+}
+
+NLBroadcastFunction NLExecutor::selectBlockRepeatFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &blockRepeatColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &blockRepeatColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &blockRepeatColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+NLBroadcastFunction NLExecutor::selectTileFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &tileColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &tileColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &tileColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+// A nullable value chunk is a ColumnOptVector<Primitive> - that is,
+// ColumnVector<std::optional<Primitive>> - so the same broadcast templates,
+// instantiated on std::optional<Primitive>, carry value and null together.
+NLBroadcastFunction NLExecutor::selectOptBlockRepeatFunction(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return &blockRepeatColumn<std::optional<types::Int64::Primitive>>;
+        break;
+
+        case ValueType::UInt64:
+            return &blockRepeatColumn<std::optional<types::UInt64::Primitive>>;
+        break;
+
+        case ValueType::Double:
+            return &blockRepeatColumn<std::optional<types::Double::Primitive>>;
+        break;
+
+        case ValueType::Bool:
+            return &blockRepeatColumn<std::optional<types::Bool::Primitive>>;
+        break;
+
+        case ValueType::String:
+            return &blockRepeatColumn<std::optional<types::String::Primitive>>;
+        break;
+
+        case ValueType::Embedding:
+            return &blockRepeatColumn<std::optional<types::Embedding::Primitive>>;
+        break;
+
+        case ValueType::Invalid:
+        case ValueType::_SIZE:
+            throw IRException("Invalid property value type");
+        break;
+    }
+
+    throw IRException("Unhandled property value type");
+}
+
+NLBroadcastFunction NLExecutor::selectOptTileFunction(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return &tileColumn<std::optional<types::Int64::Primitive>>;
+        break;
+
+        case ValueType::UInt64:
+            return &tileColumn<std::optional<types::UInt64::Primitive>>;
+        break;
+
+        case ValueType::Double:
+            return &tileColumn<std::optional<types::Double::Primitive>>;
+        break;
+
+        case ValueType::Bool:
+            return &tileColumn<std::optional<types::Bool::Primitive>>;
+        break;
+
+        case ValueType::String:
+            return &tileColumn<std::optional<types::String::Primitive>>;
+        break;
+
+        case ValueType::Embedding:
+            return &tileColumn<std::optional<types::Embedding::Primitive>>;
+        break;
+
+        case ValueType::Invalid:
+        case ValueType::_SIZE:
+            throw IRException("Invalid property value type");
+        break;
+    }
+
+    throw IRException("Unhandled property value type");
 }
 
 // Read one property of the current input chunk into a nullable value column.

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1,5 +1,6 @@
 #include "NLExecutor.h"
 
+#include <algorithm>
 #include <type_traits>
 
 #include "iterators/GetInEdgesIterator.h"
@@ -55,14 +56,16 @@ void blockRepeatColumn(const Column* input, size_t factor, Column* output) {
     const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
     ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
 
-    typedOutput->clear();
-    typedOutput->reserve(typedInput->size() * factor);
-
+    const auto& inputRaw = typedInput->getRaw();
     auto& outputRaw = typedOutput->getRaw();
-    for (const ElementType& value : typedInput->getRaw()) {
-        for (size_t repeat = 0; repeat < factor; repeat++) {
-            outputRaw.push_back(value);
-        }
+    outputRaw.resize(inputRaw.size() * factor);
+
+    // fill_n each input value into its `factor`-wide run; vectorises where the
+    // push_back loop would not.
+    auto outputIt = outputRaw.begin();
+    for (const ElementType& value : inputRaw) {
+        std::fill_n(outputIt, factor, value);
+        outputIt += factor;
     }
 }
 
@@ -75,15 +78,15 @@ void tileColumn(const Column* input, size_t factor, Column* output) {
     const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
     ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
 
-    typedOutput->clear();
-    typedOutput->reserve(typedInput->size() * factor);
-
-    auto& outputRaw = typedOutput->getRaw();
     const auto& inputRaw = typedInput->getRaw();
+    auto& outputRaw = typedOutput->getRaw();
+    outputRaw.resize(inputRaw.size() * factor);
+
+    // Copy the whole input chunk into each `factor` repeat; copy commonly lowers
+    // to a memcpy whereas the push_back loop would not.
+    auto outputIt = outputRaw.begin();
     for (size_t repeat = 0; repeat < factor; repeat++) {
-        for (const ElementType& value : inputRaw) {
-            outputRaw.push_back(value);
-        }
+        outputIt = std::copy(inputRaw.begin(), inputRaw.end(), outputIt);
     }
 }
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -2,6 +2,8 @@
 
 #include <stddef.h>
 
+#include "metadata/PropertyType.h"
+
 #include "NLProgram.h"
 
 namespace db {
@@ -43,8 +45,18 @@ public:
     static void runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runCrossProduct(NLExecutionContext* context, NLFunctionData* data);
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
+
+    // The broadcast for one crossed column, picked by the translator from the
+    // column's element type and its side of the product. Outer columns are
+    // block-repeated, inner columns tiled; ID chunks dispatch on their chunk
+    // kind, nullable value chunks on their property value type.
+    static NLBroadcastFunction selectBlockRepeatFunction(NLChunkKind kind);
+    static NLBroadcastFunction selectTileFunction(NLChunkKind kind);
+    static NLBroadcastFunction selectOptBlockRepeatFunction(ValueType valueType);
+    static NLBroadcastFunction selectOptTileFunction(ValueType valueType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -49,13 +49,16 @@ public:
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
-    // The broadcast for one crossed column, picked by the translator from the
-    // column's element type and its side of the product. Outer columns are
-    // block-repeated, inner columns tiled; ID chunks dispatch on their chunk
-    // kind, nullable value chunks on their property value type.
+    // Block-repeat for an ID chunk of this kind (outer column).
     static NLBroadcastFunction selectBlockRepeatFunction(NLChunkKind kind);
+
+    // Tile for an ID chunk of this kind (inner column).
     static NLBroadcastFunction selectTileFunction(NLChunkKind kind);
+
+    // Block-repeat for a nullable value chunk of this value type (outer column).
     static NLBroadcastFunction selectOptBlockRepeatFunction(ValueType valueType);
+
+    // Tile for a nullable value chunk of this value type (inner column).
     static NLBroadcastFunction selectOptTileFunction(ValueType valueType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -194,17 +194,18 @@ private:
     PropertyTypeID _propertyTypeID;
 };
 
-// Broadcasts one input chunk into an output chunk by a runtime factor. The two
-// sides of a cross product broadcast differently - an outer column is
-// block-repeated (each row repeated `factor` times), an inner column is tiled
-// (the whole chunk repeated `factor` times) - but share this signature, so a
-// cross column stores whichever broadcast fits its side.
+// A cross product emits N*M rows (every outer row paired with every inner row),
+// but an input column holds only its N or M values, so its values must be
+// repeated to fill an N*M-row output column. That repetition is the broadcast.
+// With outer [a0,a1] (N=2) and inner [b0,b1,b2] (M=3) the result is:
+//   outer -> [a0,a0,a0, a1,a1,a1]   each outer row repeated M times (block-repeat)
+//   inner -> [b0,b1,b2, b0,b1,b2]   whole inner chunk repeated N times (tile)
+// so row k across all columns is one (outer, inner) pair. `factor` is M for an
+// outer column, N for an inner one; both directions share this signature.
 using NLBroadcastFunction = void (*)(const Column* input, size_t factor, Column* output);
 
-// One column crossed by nl.cross_product: its input chunk (a loop variable of
-// an enclosing nl.for, stable while the inner loop iterates), the output chunk
-// the broadcast fills, and the broadcast that fills it (block-repeat for an
-// outer column, tile for an inner one).
+// One column used as operand of nl.cross_product: its input chunk, the output
+// chunk to fill, and the broadcast that fills one from the other.
 class NLCrossColumn {
 public:
     NLCrossColumn(const Column* input,

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -227,10 +227,10 @@ private:
     NLBroadcastFunction _broadcast {nullptr};
 };
 
-// nl.cross_product data: the outer and inner columns of a cartesian product. N
-// (outer rows) and M (inner rows) are read at run time from the first column of
-// each group; each outer column is then block-repeated x M and each inner
-// column tiled x N, so the product has N*M rows.
+// nl.cross_product data: the outer and inner columns of a cartesian product.
+// N (outer rows) and M (inner rows) are read at run time from the first column
+// of each group. Each outer column is block-repeated x M and each inner column
+// is tiled x N, so the product has N*M rows.
 class NLCrossProductData : public NLFunctionData {
 public:
     using Columns = std::vector<NLCrossColumn>;

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -194,6 +194,62 @@ private:
     PropertyTypeID _propertyTypeID;
 };
 
+// Broadcasts one input chunk into an output chunk by a runtime factor. The two
+// sides of a cross product broadcast differently - an outer column is
+// block-repeated (each row repeated `factor` times), an inner column is tiled
+// (the whole chunk repeated `factor` times) - but share this signature, so a
+// cross column stores whichever broadcast fits its side.
+using NLBroadcastFunction = void (*)(const Column* input, size_t factor, Column* output);
+
+// One column crossed by nl.cross_product: its input chunk (a loop variable of
+// an enclosing nl.for, stable while the inner loop iterates), the output chunk
+// the broadcast fills, and the broadcast that fills it (block-repeat for an
+// outer column, tile for an inner one).
+class NLCrossColumn {
+public:
+    NLCrossColumn(const Column* input,
+                  Column* output,
+                  NLBroadcastFunction broadcast)
+        : _input(input),
+        _output(output),
+        _broadcast(broadcast)
+    {
+    }
+
+    const Column* getInput() const { return _input; }
+    Column* getOutput() const { return _output; }
+    NLBroadcastFunction getBroadcast() const { return _broadcast; }
+
+private:
+    const Column* _input {nullptr};
+    Column* _output {nullptr};
+    NLBroadcastFunction _broadcast {nullptr};
+};
+
+// nl.cross_product data: the outer and inner columns of a cartesian product. N
+// (outer rows) and M (inner rows) are read at run time from the first column of
+// each group; each outer column is then block-repeated x M and each inner
+// column tiled x N, so the product has N*M rows.
+class NLCrossProductData : public NLFunctionData {
+public:
+    using Columns = std::vector<NLCrossColumn>;
+
+    const Columns& outerColumns() const { return _outerColumns; }
+    const Columns& innerColumns() const { return _innerColumns; }
+
+    void addOuterColumn(const NLCrossColumn& column) {
+        _outerColumns.push_back(column);
+    }
+
+    void addInnerColumn(const NLCrossColumn& column) {
+        _innerColumns.push_back(column);
+    }
+
+private:
+    Columns _outerColumns;
+    Columns _innerColumns;
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -5,6 +5,7 @@
 #include <spdlog/fmt/bundled/format.h>
 
 #include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Verifier.h"
 
 #include "columns/ColumnOptVector.h"
@@ -69,6 +70,33 @@ NLHandlerFunction selectPropertyFetchHandler(bool isNode, ValueType valueType) {
     throw IRException("Unhandled property value type");
 }
 
+// Reverse of DBLowering's valueTypeToElementType: recover the storage value
+// type baked into a nullable value chunk's element type. A cross product result
+// keeps its input chunk's element type, so a crossed property column carries the
+// same !nl.nullable<...> the fetch produced, and this maps it back to allocate
+// the matching nullable value column and pick the broadcast.
+ValueType valueTypeFromElementType(mlir::Type elementType) {
+    if (mlir::isa<nl::StringType>(elementType)) {
+        return ValueType::String;
+    } else if (mlir::isa<nl::EmbeddingType>(elementType)) {
+        return ValueType::Embedding;
+    } else if (mlir::isa<mlir::Float64Type>(elementType)) {
+        return ValueType::Double;
+    } else if (const auto intType = mlir::dyn_cast<mlir::IntegerType>(elementType)) {
+        const bool isBool = intType.getWidth() == 1;
+        const bool isUnsigned = intType.isUnsigned();
+        if (isBool) {
+            return ValueType::Bool;
+        } else if (isUnsigned) {
+            return ValueType::UInt64;
+        } else {
+            return ValueType::Int64;
+        }
+    }
+
+    throw IRException("Unsupported nullable value chunk element type");
+}
+
 }
 
 NLTranslator::NLTranslator(NLProgram* program, LocalMemory* memory, const GraphView* view)
@@ -125,6 +153,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
                                    getEdgeProperties.getValues(),
                                    /*isNode=*/false,
                                    body);
+        } else if (nl::CrossProduct crossProduct = mlir::dyn_cast<nl::CrossProduct>(operation)) {
+            translateCrossProduct(crossProduct, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -288,6 +318,74 @@ void NLTranslator::translateOutput(const nl::Output& output, NLStmtContainer* bo
     }
 
     body->addStmt(NLFunctionDescriptor {&NLExecutor::runOutput, outputData});
+}
+
+void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {
+    const mlir::OperandRange outerColumns = cross.getOuterColumns();
+    const mlir::OperandRange innerColumns = cross.getInnerColumns();
+
+    // The product reads each side's row count from its first column, so each
+    // side must contribute at least one. The lowering enforces this (it rejects
+    // a factor that yields no column), but a hand-written nl module might not.
+    if (outerColumns.empty() || innerColumns.empty()) {
+        throw IRException("nl.cross_product needs at least one column on each side");
+    }
+
+    NLCrossProductData* data = _program->allocFunctionData<NLCrossProductData>();
+
+    // The results are the outer columns followed by the inner, the order
+    // inferReturnTypes lays them out, so walk the result list in step.
+    const mlir::ResultRange results = cross.getResults();
+    size_t resultIndex = 0;
+
+    for (const mlir::Value column : outerColumns) {
+        addCrossColumn(column, results[resultIndex], /*isOuter=*/true, data);
+        resultIndex++;
+    }
+
+    for (const mlir::Value column : innerColumns) {
+        addCrossColumn(column, results[resultIndex], /*isOuter=*/false, data);
+        resultIndex++;
+    }
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCrossProduct, data});
+}
+
+void NLTranslator::addCrossColumn(mlir::Value inputValue,
+                                  mlir::Value resultValue,
+                                  bool isOuter,
+                                  NLCrossProductData* data) {
+    const Column* input = getColumn(inputValue);
+
+    const auto chunkType = mlir::cast<nl::ChunkType>(inputValue.getType());
+    const mlir::Type elementType = chunkType.getElementType();
+
+    // The output keeps the input's element type, only the row count changes. A
+    // nullable value chunk allocates a ColumnOptVector and broadcasts on its
+    // value type; an ID chunk allocates on its chunk kind.
+    Column* output = nullptr;
+    NLBroadcastFunction broadcast = nullptr;
+
+    if (const auto nullableType = mlir::dyn_cast<nl::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        output = allocOptColumnForValueType(valueType);
+        broadcast = isOuter ? NLExecutor::selectOptBlockRepeatFunction(valueType)
+                            : NLExecutor::selectOptTileFunction(valueType);
+    } else {
+        const NLChunkKind kind = getChunkKind(chunkType);
+        output = allocColumnForKind(kind);
+        broadcast = isOuter ? NLExecutor::selectBlockRepeatFunction(kind)
+                            : NLExecutor::selectTileFunction(kind);
+    }
+
+    _valueSlots[resultValue] = output;
+
+    const NLCrossColumn crossColumn(input, output, broadcast);
+    if (isOuter) {
+        data->addOuterColumn(crossColumn);
+    } else {
+        data->addInnerColumn(crossColumn);
+    }
 }
 
 Column* NLTranslator::allocColumn(mlir::Value chunkValue) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -30,44 +30,18 @@ namespace {
 // value-type dispatch with the rest of translation; the handler bodies live in
 // NLExecutor.
 NLHandlerFunction selectPropertyFetchHandler(bool isNode, ValueType valueType) {
-    switch (valueType) {
-        case ValueType::Int64:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::Int64>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::Int64>;
-        break;
+    // The handler is the runPropertyFetch instantiation for the node or edge ID
+    // type and the property's value type; ValueTypeDispatcher maps the runtime
+    // value type to that compile-time type, so the per-type fan-out lives in one
+    // shared place rather than a switch repeated across the lowering.
+    NLHandlerFunction handler = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        handler = isNode ? &NLExecutor::runPropertyFetch<NodeID, T>
+                         : &NLExecutor::runPropertyFetch<EdgeID, T>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
 
-        case ValueType::UInt64:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::UInt64>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::UInt64>;
-        break;
-
-        case ValueType::Double:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::Double>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::Double>;
-        break;
-
-        case ValueType::Bool:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::Bool>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::Bool>;
-        break;
-
-        case ValueType::String:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::String>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::String>;
-        break;
-
-        case ValueType::Embedding:
-            return isNode ? &NLExecutor::runPropertyFetch<NodeID, types::Embedding>
-                          : &NLExecutor::runPropertyFetch<EdgeID, types::Embedding>;
-        break;
-
-        case ValueType::Invalid:
-        case ValueType::_SIZE:
-            throw IRException("Invalid property value type");
-        break;
-    }
-
-    throw IRException("Unhandled property value type");
+    return handler;
 }
 
 // Reverse of DBLowering's valueTypeToElementType: recover the storage value
@@ -435,57 +409,18 @@ Column* NLTranslator::allocColumnForKind(NLChunkKind kind) {
 Column* NLTranslator::allocOptColumnForValueType(ValueType valueType) {
     const size_t chunkSize = _program->getChunkSize();
 
-    switch (valueType) {
-        case ValueType::Int64: {
-            ColumnOptVector<types::Int64::Primitive>* column = _memory->alloc<ColumnOptVector<types::Int64::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
+    // Allocate a ColumnOptVector for the value type's primitive, reserving a
+    // full chunk so execution stays allocation-free; ValueTypeDispatcher maps
+    // the runtime value type to that compile-time primitive.
+    Column* column = nullptr;
+    const auto allocate = [&]<SupportedType T>() {
+        ColumnOptVector<typename T::Primitive>* typed = _memory->alloc<ColumnOptVector<typename T::Primitive>>();
+        typed->reserve(chunkSize);
+        column = typed;
+    };
+    ValueTypeDispatcher(valueType).execute(allocate);
 
-        case ValueType::UInt64: {
-            ColumnOptVector<types::UInt64::Primitive>* column = _memory->alloc<ColumnOptVector<types::UInt64::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
-
-        case ValueType::Double: {
-            ColumnOptVector<types::Double::Primitive>* column = _memory->alloc<ColumnOptVector<types::Double::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
-
-        case ValueType::Bool: {
-            ColumnOptVector<types::Bool::Primitive>* column = _memory->alloc<ColumnOptVector<types::Bool::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
-
-        case ValueType::String: {
-            ColumnOptVector<types::String::Primitive>* column = _memory->alloc<ColumnOptVector<types::String::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
-
-        case ValueType::Embedding: {
-            ColumnOptVector<types::Embedding::Primitive>* column = _memory->alloc<ColumnOptVector<types::Embedding::Primitive>>();
-            column->reserve(chunkSize);
-            return column;
-        }
-        break;
-
-        case ValueType::Invalid:
-        case ValueType::_SIZE:
-            throw IRException("Invalid property value type");
-        break;
-    }
-
-    bioassert(false, "Unhandled property value type");
-    return nullptr;
+    return column;
 }
 
 Column* NLTranslator::getColumn(mlir::Value chunkValue) const {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -324,9 +324,9 @@ void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer
     const mlir::OperandRange outerColumns = cross.getOuterColumns();
     const mlir::OperandRange innerColumns = cross.getInnerColumns();
 
-    // The product reads each side's row count from its first column, so each
-    // side must contribute at least one. The lowering enforces this (it rejects
-    // a factor that yields no column), but a hand-written nl module might not.
+    // At run time runCrossProduct takes N from the first outer column and M from
+    // the first inner column, so a side with no column cannot be sized. Reject
+    // that here: DBLowering never emits it, but the nl IR may come from elsewhere.
     if (outerColumns.empty() || innerColumns.empty()) {
         throw IRException("nl.cross_product needs at least one column on each side");
     }

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -62,6 +62,19 @@ private:
                                 NLStmtContainer* body);
     void translateOutput(const mlir::nl::Output& output, NLStmtContainer* body);
 
+    // Translate an nl.cross_product: allocate an output column per crossed
+    // column, map each to the matching op result, and record the broadcast
+    // statement (outer columns block-repeated, inner columns tiled)
+    void translateCrossProduct(mlir::nl::CrossProduct cross, NLStmtContainer* body);
+
+    // Allocate the output column for one crossed column, map the op result to
+    // it, and append it (with its block-repeat/tile broadcast) to the outer or
+    // inner list of data
+    void addCrossColumn(mlir::Value inputValue,
+                        mlir::Value resultValue,
+                        bool isOuter,
+                        NLCrossProductData* data);
+
     Column* allocColumn(mlir::Value chunkValue);
     Column* allocColumnForKind(NLChunkKind kind);
     Column* allocOptColumnForValueType(ValueType valueType);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -91,9 +91,12 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     _builder.setInsertionPointToStart(_entryBlock);
     _builder.create<mlir::func::ReturnOp>(loc);
 
-    // Lower each operation of the db function
+    // Lower each operation of the db function. Top-level scans root their loop
+    // in the entry block; a cross product retargets the root per factor.
     _valueMap.clear();
     _propertyTypes.clear();
+    _rootBlock = _entryBlock;
+    _innermostLoopBody = nullptr;
     for (mlir::Operation& operation : dbBody.front()) {
         lowerOperation(operation);
     }
@@ -115,6 +118,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerGetNodeProperties(getNodeProperties);
     } else if (mlir::db::GetEdgeProperties getEdgeProperties = mlir::dyn_cast<mlir::db::GetEdgeProperties>(operation)) {
         lowerGetEdgeProperties(getEdgeProperties);
+    } else if (mlir::db::CrossProduct crossProduct = mlir::dyn_cast<mlir::db::CrossProduct>(operation)) {
+        lowerCrossProduct(crossProduct);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -126,8 +131,10 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
 }
 
 void DBLowering::lowerScanNodes(mlir::db::ScanNodes scanNodes) {
-    // A scan reads no column, so its loop sits at the top of the function body.
-    setInsertionInto(_entryBlock);
+    // A scan reads no column, so its loop sits at the top of the current root
+    // block: the function entry at top level, or - inside a cross product - the
+    // outer factor's innermost loop body, so the inner factor nests under it.
+    setInsertionInto(_rootBlock);
 
     nl::ScanNodes nodes = _builder.create<nl::ScanNodes>(_builder.getUnknownLoc());
     buildLoopForSource(nodes.getResult(), scanNodes.getOperation());
@@ -184,6 +191,78 @@ void DBLowering::lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgePrope
                                                                          inputChunk,
                                                                          handle);
     _valueMap[getEdgeProperties.getResult()] = fetch.getValues();
+}
+
+void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
+    // The outer factor roots where this op would have - the entry block at top
+    // level. The inner factor roots inside the outer factor's innermost loop
+    // body, so its loops nest under the outer loop: a nested-loop join where the
+    // inner factor re-runs once per outer chunk.
+    mlir::Block* const rootBlock = _rootBlock;
+
+    llvm::SmallVector<mlir::Value, 4> outerColumns;
+    mlir::Block* const outerBody = lowerFactor(product.getLeftFactor(), rootBlock, outerColumns);
+
+    llvm::SmallVector<mlir::Value, 4> innerColumns;
+    mlir::Block* const innerBody = lowerFactor(product.getRightFactor(), outerBody, innerColumns);
+
+    // The cross sits at the deepest point - the inner factor's innermost loop
+    // body, where both factors have a chunk bound - just before whatever
+    // consumes the product (the lowered db.output).
+    setInsertionInto(innerBody);
+
+    nl::CrossProduct cross = _builder.create<nl::CrossProduct>(_builder.getUnknownLoc(),
+                                                               outerColumns,
+                                                               innerColumns);
+
+    // The product's results are the outer factor's yielded columns followed by
+    // the inner's, the same order nl.cross_product lays out its results.
+    const mlir::ResultRange dbResults = product.getResults();
+    const mlir::ResultRange crossResults = cross.getResults();
+    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
+        _valueMap[dbResults[resultIndex]] = crossResults[resultIndex];
+    }
+}
+
+mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
+                                     mlir::Block* rootBlock,
+                                     llvm::SmallVectorImpl<mlir::Value>& yieldedChunks) {
+    // Root this factor's scans at rootBlock and track its own innermost loop;
+    // save and restore the caller's so nested or sibling products are unaffected.
+    mlir::Block* const previousRoot = _rootBlock;
+    mlir::Block* const previousInnermostLoopBody = _innermostLoopBody;
+    _rootBlock = rootBlock;
+    _innermostLoopBody = nullptr;
+
+    // A factor is one self-contained block ending in a db.yield. Lower each op
+    // as at top level; the yield names the columns this factor contributes, so
+    // map its operands to the nl chunks they lowered to rather than lowering it.
+    for (mlir::Operation& operation : factor.front()) {
+        if (mlir::db::Yield yield = mlir::dyn_cast<mlir::db::Yield>(operation)) {
+            for (const mlir::Value column : yield.getColumns()) {
+                yieldedChunks.push_back(mapValue(column));
+            }
+        } else {
+            lowerOperation(operation);
+        }
+    }
+
+    if (!_innermostLoopBody) {
+        throw IRException("cross_product factor opened no loop to iterate");
+    }
+
+    // A factor that yields no column still multiplies cardinality, but the cross
+    // product reads each side's row count from its first column, so an empty
+    // factor has no row count to read - not yet supported by lowering.
+    if (yieldedChunks.empty()) {
+        throw IRException("cross_product lowering does not support a factor that yields no column");
+    }
+
+    mlir::Block* const innermostBody = _innermostLoopBody;
+    _rootBlock = previousRoot;
+    _innermostLoopBody = previousInnermostLoopBody;
+
+    return innermostBody;
 }
 
 mlir::Value DBLowering::getOrCreatePropertyTypeHandle(llvm::StringRef propertyName) {
@@ -245,6 +324,11 @@ void DBLowering::buildLoopForSource(mlir::Value iterator, mlir::Operation* dbOp)
     // filtered chunk per carried column. Recording db result -> loop variable
     // lets a later op find the chunk each column lowered to.
     mlir::Block* loopBody = forLoop.getBody();
+
+    // This is the innermost loop opened so far in the current factor (loops
+    // nest in dataflow order), so a cross product nests at this body.
+    _innermostLoopBody = loopBody;
+
     const mlir::ResultRange dbResults = dbOp->getResults();
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
         _valueMap[dbResults[resultIndex]] = loopBody->getArgument(static_cast<unsigned>(resultIndex));

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -251,11 +251,12 @@ mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
         throw IRException("cross_product factor opened no loop to iterate");
     }
 
-    // A factor that yields no column still multiplies cardinality, but the cross
-    // product reads each side's row count from its first column, so an empty
-    // factor has no row count to read - not yet supported by lowering.
+    // A factor's row count is read from its first yielded column, so a factor
+    // that yields none cannot size its side of the product. The db.cross_product
+    // verifier rejects this, so reaching it here means unverified IR - a
+    // defensive backstop.
     if (yieldedChunks.empty()) {
-        throw IRException("cross_product lowering does not support a factor that yields no column");
+        throw IRException("cross_product factor yields no column");
     }
 
     mlir::Block* const innermostBody = _innermostLoopBody;

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -33,6 +33,12 @@ class GraphView;
 // one nl.get_property_type above the loops, and the concrete value type is baked
 // into the nullable value chunk the fetch produces inside the binding loop.
 //
+// db.cross_product lowers to two nested factor loop nests - the inner factor's
+// loops nested inside the outer factor's innermost loop body, so the inner
+// factor re-runs once per outer chunk (a nested-loop join, bounded memory) -
+// bridged at the deepest point by an nl.cross_product that crosses the two
+// factors' yielded chunks just before db.output consumes them.
+//
 class DBLowering {
 public:
     DBLowering(mlir::MLIRContext* context, const GraphView* view);
@@ -57,12 +63,35 @@ private:
     // Entry block of the nl function being built
     mlir::Block* _entryBlock {nullptr};
 
+    // The block a root scan opens its loop in. It is the entry block at top
+    // level, but a db.cross_product lowers its inner factor with the outer
+    // factor's innermost loop body as the root, so the inner factor's scans
+    // nest inside the outer loop (the nested-loop join).
+    mlir::Block* _rootBlock {nullptr};
+
+    // The body of the most recent loop buildLoopForSource opened. A factor's
+    // dataflow is linear and each loop nests inside the previous, so the last
+    // loop opened is the factor's innermost one; lowerFactor reads this once the
+    // factor is lowered to root the inner factor there and to place the cross
+    // product at that deepest point. Not an insertion cursor - the builder is
+    // not left in the loop body - just a record of which block is innermost.
+    mlir::Block* _innermostLoopBody {nullptr};
+
     void lowerOperation(mlir::Operation& operation);
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties);
     void lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgeProperties);
+    void lowerCrossProduct(mlir::db::CrossProduct product);
     void lowerOutput(mlir::db::Output output);
+
+    // Lower one factor region of a db.cross_product into a loop nest rooted at
+    // rootBlock, collecting its db.yield columns (mapped to their nl chunks) in
+    // yieldedChunks and returning the factor's innermost loop body - where the
+    // cross product, or a deeper factor, nests.
+    mlir::Block* lowerFactor(mlir::Region& factor,
+                             mlir::Block* rootBlock,
+                             llvm::SmallVectorImpl<mlir::Value>& yieldedChunks);
 
     // Wrap an nl source op's iterator in an nl.for and bind each db result
     // column to the matching loop variable

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -157,11 +157,49 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk});
 }
 
+// A disconnected pattern in the set-at-a-time db dialect: MATCH (a), (b)
+// RETURN a, b crosses every node with every node. The two scans share no
+// variable, so each lives in its own factor region of a db.cross_product and
+// names, via db.yield, the single column it contributes. The op's results are
+// the left factor's yielded columns followed by the right factor's.
+void addCrossProductFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
+    startFunction(builder, module, "cross_product");
+
+    mlir::MLIRContext* ctxt = builder.getContext();
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    const mlir::Type colA = mlir::db::ColumnType::get(ctxt, "a");
+    const mlir::Type colB = mlir::db::ColumnType::get(ctxt, "b");
+
+    // Build the op with its two empty factor blocks; the result types are the
+    // columns the factors will yield - here one column each, `a` then `b`.
+    auto product = builder.create<mlir::db::CrossProduct>(loc, mlir::TypeRange {colA, colB});
+
+    // Left factor: scan `a` and yield it as this factor's contribution.
+    mlir::Block* leftFactor = &product.getLeftFactor().front();
+    builder.setInsertionPointToStart(leftFactor);
+    auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
+    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {scanA.getResult()});
+
+    // Right factor: scan `b` and yield it.
+    mlir::Block* rightFactor = &product.getRightFactor().front();
+    builder.setInsertionPointToStart(rightFactor);
+    auto scanB = builder.create<mlir::db::ScanNodes>(loc, colB);
+    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {scanB.getResult()});
+
+    // Back in the function body, project the crossed (a, b) pair.
+    builder.setInsertionPointAfter(product);
+    builder.create<mlir::db::Output>(loc, product.getResults());
+
+    builder.create<mlir::func::ReturnOp>(loc);
+}
+
 void helloModule(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     std::cout << "hello from mlir" << '\n';
 
     addDBFunction(builder, module);
     addNestedLoopFunction(builder, module);
+    addCrossProductFunction(builder, module);
 }
 
 void assembleFiles(mlir::MLIRContext& ctxt, mlir::ModuleOp& module, const std::vector<std::string>& files) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -13,3 +13,4 @@ endfunction()
 
 add_ir_tests(test_query_ir_nlexecutor NLExecutorTest.cpp)
 add_ir_tests(test_query_ir_dblowering DBLoweringTest.cpp)
+add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+
+namespace {
+
+// A context with just the dialects a db-dialect program needs: db for the query
+// ops and func for the enclosing function.
+class DBDialectTest : public ::testing::Test {
+protected:
+    DBDialectTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    // Parses a db-dialect module, returning a null module on failure. The
+    // diagnostics are swallowed so a deliberately malformed program does not
+    // print to the test log.
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+            return mlir::success();
+        });
+
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    // The single db.cross_product in the module's only function.
+    static mlir::db::CrossProduct findCrossProduct(mlir::ModuleOp module) {
+        mlir::db::CrossProduct product;
+        module.walk([&](mlir::db::CrossProduct op) {
+            product = op;
+        });
+
+        return product;
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// MATCH (a), (b) RETURN a, b: two disconnected scans, one column yielded per
+// factor, two columns in the product.
+const char* const crossProductProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    db.yield %a : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    db.yield %b : !db.column<"b">
+  }
+  db.output(%0#0, %0#1) : !db.column<"a">, !db.column<"b">
+  return
+}
+)mlir";
+
+// MATCH (a), (b) RETURN a: the right factor multiplies cardinality but surfaces
+// no column, so its db.yield is empty and the product has a single result.
+const char* const zeroYieldProgram = R"mlir(
+func.func @main() {
+  %0 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    db.yield %a : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    db.yield
+  }
+  db.output(%0) : !db.column<"a">
+  return
+}
+)mlir";
+
+// A factor whose region does not end in a db.yield: the parser cannot recover
+// the result types and rejects it.
+const char* const missingYieldProgram = R"mlir(
+func.func @main() {
+  %0 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    db.yield %b : !db.column<"b">
+  }
+  return
+}
+)mlir";
+
+TEST_F(DBDialectTest, parsesCrossProductOfTwoScans) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::CrossProduct product = findCrossProduct(*module);
+    ASSERT_TRUE(product);
+
+    // The results are the left factor's yielded column followed by the right's.
+    const mlir::Operation::result_range results = product.getResults();
+    ASSERT_EQ(results.size(), 2u);
+    EXPECT_EQ(results[0].getType(), mlir::db::ColumnType::get(&_context, "a"));
+    EXPECT_EQ(results[1].getType(), mlir::db::ColumnType::get(&_context, "b"));
+
+    // Each factor is one self-contained block ending in a db.yield.
+    EXPECT_TRUE(mlir::isa<mlir::db::Yield>(product.getLeftFactor().front().getTerminator()));
+    EXPECT_TRUE(mlir::isa<mlir::db::Yield>(product.getRightFactor().front().getTerminator()));
+}
+
+TEST_F(DBDialectTest, roundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // custom printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, parsesZeroYieldFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(zeroYieldProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::CrossProduct product = findCrossProduct(*module);
+    ASSERT_TRUE(product);
+
+    // An empty right yield surfaces no column, so the product has one result.
+    EXPECT_EQ(product.getResults().size(), 1u);
+    EXPECT_EQ(product.getRightFactor().front().getTerminator()->getNumOperands(), 0u);
+}
+
+TEST_F(DBDialectTest, rejectsFactorWithoutYield) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(missingYieldProgram);
+    EXPECT_FALSE(module);
+}
+
+// Builds a cross_product whose declared results do not match the columns its
+// factors yield, exercising the verifier's backstop on the programmatic builder
+// path (the parser path always derives the results from the yields).
+TEST_F(DBDialectTest, verifierRejectsResultsNotMatchingYields) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    // Hold the op in a module so it lives in a block and is cleaned up with it.
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
+
+    // Declare two results but make the factors yield only one column in total:
+    // the left yields `a`, the right yields nothing.
+    auto product = builder.create<mlir::db::CrossProduct>(loc, mlir::TypeRange {colA, colB});
+
+    mlir::Block* leftFactor = &product.getLeftFactor().front();
+    builder.setInsertionPointToStart(leftFactor);
+    auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
+    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {scanA.getResult()});
+
+    mlir::Block* rightFactor = &product.getRightFactor().front();
+    builder.setInsertionPointToStart(rightFactor);
+    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {});
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(product.getOperation())));
+}
+
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -64,8 +64,9 @@ func.func @main() {
 }
 )mlir";
 
-// MATCH (a), (b) RETURN a: the right factor multiplies cardinality but surfaces
-// no column, so its db.yield is empty and the product has a single result.
+// MATCH (a), (b) RETURN a: the right factor surfaces no column, so its db.yield
+// is empty - which the verifier rejects, since a side's row count is read from
+// its first yielded column.
 const char* const zeroYieldProgram = R"mlir(
 func.func @main() {
   %0 = db.cross_product factor {
@@ -127,16 +128,11 @@ TEST_F(DBDialectTest, roundTripsThroughTextualForm) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
-TEST_F(DBDialectTest, parsesZeroYieldFactor) {
+TEST_F(DBDialectTest, rejectsZeroYieldFactor) {
+    // An empty db.yield surfaces no column, so the factor cannot be sized; the
+    // verifier rejects it and the module fails to verify during parsing.
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(zeroYieldProgram);
-    ASSERT_TRUE(module);
-
-    mlir::db::CrossProduct product = findCrossProduct(*module);
-    ASSERT_TRUE(product);
-
-    // An empty right yield surfaces no column, so the product has one result.
-    EXPECT_EQ(product.getResults().size(), 1u);
-    EXPECT_EQ(product.getRightFactor().front().getTerminator()->getNumOperands(), 0u);
+    EXPECT_FALSE(module);
 }
 
 TEST_F(DBDialectTest, rejectsFactorWithoutYield) {
@@ -160,9 +156,9 @@ TEST_F(DBDialectTest, verifierRejectsResultsNotMatchingYields) {
     const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
     const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
 
-    // Declare two results but make the factors yield only one column in total:
-    // the left yields `a`, the right yields nothing.
-    auto product = builder.create<mlir::db::CrossProduct>(loc, mlir::TypeRange {colA, colB});
+    // Declare a single result but make the factors yield two columns in total:
+    // the left yields `a` and the right yields `b`, so the result count is wrong.
+    auto product = builder.create<mlir::db::CrossProduct>(loc, mlir::TypeRange {colA});
 
     mlir::Block* leftFactor = &product.getLeftFactor().front();
     builder.setInsertionPointToStart(leftFactor);
@@ -171,7 +167,8 @@ TEST_F(DBDialectTest, verifierRejectsResultsNotMatchingYields) {
 
     mlir::Block* rightFactor = &product.getRightFactor().front();
     builder.setInsertionPointToStart(rightFactor);
-    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {});
+    auto scanB = builder.create<mlir::db::ScanNodes>(loc, colB);
+    builder.create<mlir::db::Yield>(loc, mlir::ValueRange {scanB.getResult()});
 
     const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
         return mlir::success();

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -34,6 +34,7 @@
 #include "LocalMemory.h"
 #include "NLDialect.h"
 #include "NLInterpreter.h"
+#include "NLOps.h"
 #include "NLOutputSink.h"
 
 #include "TuringTest.h"
@@ -691,6 +692,65 @@ TEST_F(DBLoweringTest, crossProductZeroYieldFactorNotLowered) {
     // rejects the product rather than producing a wrong row count
     CollectingNodeSink sink;
     EXPECT_THROW(runLoweredProgram(crossProductZeroYieldProgram, reader.getView(), sink), IRException);
+}
+
+TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
+    // DBLowering takes a view, but the scans program reads no property, so the
+    // lowered structure does not depend on the graph contents.
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(crossProductScansProgram, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // The product becomes a loop nest, not two sibling loops: exactly one
+    // nl.cross_product and exactly two nl.for loops (one scan per factor).
+    size_t crossProductCount = 0;
+    size_t forCount = 0;
+    mlir::nl::CrossProduct cross;
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::CrossProduct found = mlir::dyn_cast<mlir::nl::CrossProduct>(operation)) {
+            cross = found;
+            crossProductCount++;
+        } else if (mlir::isa<mlir::nl::For>(operation)) {
+            forCount++;
+        }
+    });
+
+    EXPECT_EQ(crossProductCount, 1u);
+    EXPECT_EQ(forCount, 2u);
+    ASSERT_TRUE(cross);
+
+    // One column contributed by each factor, two results (outer ++ inner).
+    EXPECT_EQ(cross.getOuterColumns().size(), 1u);
+    EXPECT_EQ(cross.getInnerColumns().size(), 1u);
+    EXPECT_EQ(cross.getResults().size(), 2u);
+
+    // The cross sits in the inner loop body, itself nested in the outer loop
+    // body - so the inner factor re-runs once per outer chunk.
+    auto innerFor = mlir::dyn_cast<mlir::nl::For>(cross->getParentOp());
+    ASSERT_TRUE(innerFor);
+    auto outerFor = mlir::dyn_cast<mlir::nl::For>(innerFor->getParentOp());
+    ASSERT_TRUE(outerFor);
+
+    // The crossed columns are exactly those two loops' chunk variables: the
+    // outer column is the outer loop's chunk, the inner column the inner's.
+    EXPECT_EQ(cross.getOuterColumns()[0], outerFor.getBody()->getArgument(0));
+    EXPECT_EQ(cross.getInnerColumns()[0], innerFor.getBody()->getArgument(0));
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -30,7 +30,6 @@
 
 #include "DBDialect.h"
 #include "DBLowering.h"
-#include "IRException.h"
 #include "LocalMemory.h"
 #include "NLDialect.h"
 #include "NLInterpreter.h"
@@ -356,22 +355,6 @@ func.func @main() {
     db.yield %b, %score : !db.column<"b">, !db.column<"b.score">
   }
   db.output(%0#0, %0#2) : !db.column<"a">, !db.column<"b.score">
-  return
-}
-)mlir";
-
-// A cross product whose right factor yields no column: lowering does not yet
-// support it (the empty side has no column to measure its row count from)
-constexpr const char* crossProductZeroYieldProgram = R"mlir(
-func.func @main() {
-  %0 = db.cross_product factor {
-    %a = db.scan_nodes() : !db.column<"a">
-    db.yield %a : !db.column<"a">
-  } factor {
-    %b = db.scan_nodes() : !db.column<"b">
-    db.yield
-  }
-  db.output(%0) : !db.column<"a">
   return
 }
 )mlir";
@@ -727,17 +710,6 @@ TEST_F(DBLoweringTest, executesCrossProductOfNodeProperty) {
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
-}
-
-TEST_F(DBLoweringTest, crossProductZeroYieldFactorNotLowered) {
-    auto graph = buildDiamondGraph();
-    const FrozenCommitTx transaction = graph->openTransaction();
-    const GraphReader reader = transaction.readGraph();
-
-    // The right factor yields no column, so lowering cannot size that side and
-    // rejects the product rather than producing a wrong row count
-    CollectingNodeSink sink;
-    EXPECT_THROW(runLoweredProgram(crossProductZeroYieldProgram, reader.getView(), sink), IRException);
 }
 
 TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -320,6 +320,28 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a)->(b)->(c), (d) RETURN a, b, c, d: an asymmetric product. The left
+// factor is a two-hop traversal carrying `a` through the second hop (a 3-deep
+// loop nest yielding three row-aligned columns), the right factor a bare scan
+// (1-deep). The cross sits at the deepest point of the left nest, so this
+// exercises rooting a shallow factor inside a deep one and crossing a carried
+// column. Result: every two-hop path (a, b, c) crossed with every node d.
+constexpr const char* crossProductTwoHopAndScanProgram = R"mlir(
+func.func @main() {
+  %0:4 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<"a">) -> (!db.column<"a1">, !db.column<"e0">, !db.column<"et0">, !db.column<"b">)
+    %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<"b">, !db.column<"a1">) -> (!db.column<"b2">, !db.column<"e1">, !db.column<"et1">, !db.column<"c">, !db.column<"a2">)
+    db.yield %a2, %b2, %c : !db.column<"a2">, !db.column<"b2">, !db.column<"c">
+  } factor {
+    %d = db.scan_nodes() : !db.column<"d">
+    db.yield %d : !db.column<"d">
+  }
+  db.output(%0#0, %0#1, %0#2, %0#3) : !db.column<"a2">, !db.column<"b2">, !db.column<"c">, !db.column<"d">
+  return
+}
+)mlir";
+
 // MATCH (a), (b) RETURN a, b.score: the inner factor fetches a node property
 // inside the factor, so the crossed value column is a nullable value chunk -
 // the outer node IDs are block-repeated and the inner scores tiled together
@@ -650,6 +672,30 @@ TEST_F(DBLoweringTest, executesCrossProductOfHops) {
     for (const std::pair<uint64_t, uint64_t>& outer : edges) {
         for (const std::pair<uint64_t, uint64_t>& inner : edges) {
             expected.push_back({outer.first, outer.second, inner.first, inner.second});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesCrossProductOfTwoHopAndScan) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(crossProductTwoHopAndScanProgram, reader.getView(), sink);
+
+    // The diamond's two-hop paths (a, b, c) are 0->1->3 and 0->2->3; cross each
+    // with every node d in {0, 1, 2, 3}, so 2 * 4 = 8 rows of (a, b, c, d)
+    const std::vector<std::vector<uint64_t>> twoHopPaths {{0, 1, 3}, {0, 2, 3}};
+    std::vector<std::vector<uint64_t>> expected;
+    for (const std::vector<uint64_t>& path : twoHopPaths) {
+        for (uint64_t d = 0; d < 4; d++) {
+            expected.push_back({path[0], path[1], path[2], d});
         }
     }
     std::sort(expected.begin(), expected.end());

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -285,6 +285,74 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a), (b) RETURN a, b: two disconnected scans crossed, |nodes|^2 rows
+constexpr const char* crossProductScansProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    db.yield %a : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    db.yield %b : !db.column<"b">
+  }
+  db.output(%0#0, %0#1) : !db.column<"a">, !db.column<"b">
+  return
+}
+)mlir";
+
+// MATCH (a)->(b), (c)->(d) RETURN a, b, c, d: each factor walks one hop and
+// yields the (source, target) of its edge; the product crosses every edge of
+// one factor with every edge of the other, |edges|^2 rows
+constexpr const char* crossProductHopsProgram = R"mlir(
+func.func @main() {
+  %0:4 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    %asrc, %ae, %aet, %b = db.get_out_edges(%a, {}) : (!db.column<"a">) -> (!db.column<"asrc">, !db.column<"ae">, !db.column<"aet">, !db.column<"b">)
+    db.yield %asrc, %b : !db.column<"asrc">, !db.column<"b">
+  } factor {
+    %c = db.scan_nodes() : !db.column<"c">
+    %csrc, %ce, %cet, %d = db.get_out_edges(%c, {}) : (!db.column<"c">) -> (!db.column<"csrc">, !db.column<"ce">, !db.column<"cet">, !db.column<"d">)
+    db.yield %csrc, %d : !db.column<"csrc">, !db.column<"d">
+  }
+  db.output(%0#0, %0#1, %0#2, %0#3) : !db.column<"asrc">, !db.column<"b">, !db.column<"csrc">, !db.column<"d">
+  return
+}
+)mlir";
+
+// MATCH (a), (b) RETURN a, b.score: the inner factor fetches a node property
+// inside the factor, so the crossed value column is a nullable value chunk -
+// the outer node IDs are block-repeated and the inner scores tiled together
+constexpr const char* crossProductNodePropertyProgram = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    db.yield %a : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    %score = db.get_node_properties(%b, "score") : (!db.column<"b">) -> !db.column<"b.score">
+    db.yield %b, %score : !db.column<"b">, !db.column<"b.score">
+  }
+  db.output(%0#0, %0#2) : !db.column<"a">, !db.column<"b.score">
+  return
+}
+)mlir";
+
+// A cross product whose right factor yields no column: lowering does not yet
+// support it (the empty side has no column to measure its row count from)
+constexpr const char* crossProductZeroYieldProgram = R"mlir(
+func.func @main() {
+  %0 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<"a">
+    db.yield %a : !db.column<"a">
+  } factor {
+    %b = db.scan_nodes() : !db.column<"b">
+    db.yield
+  }
+  db.output(%0) : !db.column<"a">
+  return
+}
+)mlir";
+
 }
 
 class DBLoweringTest : public TuringTest {
@@ -380,10 +448,12 @@ protected:
     }
 
     // Parses a db-dialect program, lowers it to nl with DBLowering, and runs
-    // the lowered nl function against the graph view
+    // the lowered nl function against the graph view. The chunk size is exposed
+    // so a test can force a product to span chunk boundaries.
     void runLoweredProgram(const char* programText,
                            const GraphView& view,
-                           NLOutputSink& sink) {
+                           NLOutputSink& sink,
+                           size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
         mlir::MLIRContext context;
         context.getOrLoadDialect<mlir::func::FuncDialect>();
         context.getOrLoadDialect<mlir::db::DB>();
@@ -402,7 +472,7 @@ protected:
         lowering.lower(dbFunction, *nlModule);
 
         LocalMemory memory;
-        NLInterpreter interpreter(*nlModule, &view, &sink, &memory);
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
         interpreter.run();
     }
 
@@ -517,6 +587,110 @@ TEST_F(DBLoweringTest, lowersGetEdgeProperties) {
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesCrossProductOfScans) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(crossProductScansProgram, reader.getView(), sink);
+
+    // Every node crossed with every node: the 16 (a, b) pairs over four nodes
+    std::vector<std::vector<uint64_t>> expected;
+    for (uint64_t a = 0; a < 4; a++) {
+        for (uint64_t b = 0; b < 4; b++) {
+            expected.push_back({a, b});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesCrossProductSpanningChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A chunk of three over four nodes splits each scan into two chunks, so the
+    // product must cross rows that land in different chunks - still all 16 pairs
+    CollectingNodeSink sink;
+    runLoweredProgram(crossProductScansProgram, reader.getView(), sink, /*chunkSize=*/3);
+
+    std::vector<std::vector<uint64_t>> expected;
+    for (uint64_t a = 0; a < 4; a++) {
+        for (uint64_t b = 0; b < 4; b++) {
+            expected.push_back({a, b});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesCrossProductOfHops) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(crossProductHopsProgram, reader.getView(), sink);
+
+    // Every edge crossed with every edge: each row is (outer src, outer tgt,
+    // inner src, inner tgt) for the four diamond edges, so 16 rows
+    const std::vector<std::pair<uint64_t, uint64_t>> edges {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> expected;
+    for (const std::pair<uint64_t, uint64_t>& outer : edges) {
+        for (const std::pair<uint64_t, uint64_t>& inner : edges) {
+            expected.push_back({outer.first, outer.second, inner.first, inner.second});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesCrossProductOfNodeProperty) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A node ID crossed with a nullable property column: node 2 has no score,
+    // so its value comes back null and is broadcast like any other value
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(crossProductNodePropertyProgram, reader.getView(), sink);
+
+    const std::vector<std::optional<int64_t>> scores {100, 200, std::nullopt};
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected;
+    for (uint64_t a = 0; a < 3; a++) {
+        for (const std::optional<int64_t>& score : scores) {
+            expected.push_back({a, score});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, crossProductZeroYieldFactorNotLowered) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The right factor yields no column, so lowering cannot size that side and
+    // rejects the product rather than producing a wrong row count
+    CollectingNodeSink sink;
+    EXPECT_THROW(runLoweredProgram(crossProductZeroYieldProgram, reader.getView(), sink), IRException);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Add the db.cross_product op and lower it to a nested-loop. The nl.cross_product operation implements the cross product of chunks at the innermost point of the loop nest.