### PR TITLE
MLIR: implement skip

### DIFF
--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -60,6 +60,35 @@ ParseResult parseFactorRegion(OpAsmParser& parser, OperationState& result) {
     return parser.parseRegion(*factor, {});
 }
 
+// db.limit and db.skip both pass their columns straight through, so the results
+// must be exactly the input columns - same count, same types and in the same
+// order. Their row count is read from the first column during lowering, so a
+// pass-through over no column cannot be sized and is rejected here at the db
+// level. Shared by both verifiers.
+LogicalResult verifyPassThrough(Operation* op,
+                                OperandRange columns,
+                                Operation::result_range results) {
+    if (columns.empty()) {
+        return op->emitOpError("requires at least one column");
+    }
+
+    if (columns.size() != results.size()) {
+        return op->emitOpError("expects ") << columns.size()
+                                           << " results, one per input column, but has "
+                                           << results.size();
+    }
+
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        if (columns[columnIndex].getType() != results[columnIndex].getType()) {
+            return op->emitOpError("result ") << columnIndex
+                                              << " must have the same type as input column "
+                                              << columnIndex;
+        }
+    }
+
+    return success();
+}
+
 }
 
 // Builds the op from just the result types - the left factor's yielded columns
@@ -161,28 +190,10 @@ LogicalResult CrossProduct::verify() {
 // db.limit passes its columns straight through, so the results must be exactly
 // the input columns - same count, same types and in the same order.
 LogicalResult Limit::verify() {
-    const OperandRange columns = getColumns();
-    const Operation::result_range results = getResults();
+    return verifyPassThrough(getOperation(), getColumns(), getResults());
+}
 
-    // A limit's row count is read from its first column during lowering, so a
-    // limit over no column cannot be sized. Reject it here at the db level.
-    if (columns.empty()) {
-        return emitOpError("requires at least one column");
-    }
-
-    if (columns.size() != results.size()) {
-        return emitOpError("expects ") << columns.size()
-                                       << " results, one per input column, but has "
-                                       << results.size();
-    }
-
-    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
-        if (columns[columnIndex].getType() != results[columnIndex].getType()) {
-            return emitOpError("result ") << columnIndex
-                                          << " must have the same type as input column "
-                                          << columnIndex;
-        }
-    }
-
-    return success();
+// db.skip passes its columns straight through, the same as db.limit.
+LogicalResult Skip::verify() {
+    return verifyPassThrough(getOperation(), getColumns(), getResults());
 }

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -304,13 +304,6 @@ def Skip : TuringOp<"skip", [Pure]> {
       %a  = db.scan_nodes() : !db.column<"a">
       %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
       db.output(%sa) : !db.column<"a">
-
-    It lowers to a hoisted nl.skip handle, an nl.skip_update in the innermost loop
-    body, and an nl.skip_truncate that lifts each step's surviving suffix into a
-    fresh chunk just before the consumer. Unlike db.limit it threads no operand onto
-    the loops (a skip cannot early-exit) and does not fold into nl.output (the suffix
-    must be copied to the front). Reading past a prefix of the graph is
-    deterministic, so the op is Pure.
   }];
 
   // The columns flow through unchanged; count is unsigned - a count of rows to

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -292,4 +292,42 @@ def Limit : TuringOp<"limit", [Pure]> {
   let hasVerifier = 1;
 }
 
+/**
+* Skip
+*/
+def Skip : TuringOp<"skip", [Pure]> {
+  let summary = "Drop the first M rows of a column dataflow";
+  let description = [{
+    The declarative counterpart of a Cypher RETURN ... SKIP M. Drops the first M
+    rows of the columns flowing through it, passing the rest through unchanged:
+
+      %a  = db.scan_nodes() : !db.column<"a">
+      %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
+      db.output(%sa) : !db.column<"a">
+
+    It lowers to a hoisted nl.skip handle, an nl.skip_update in the innermost loop
+    body, and an nl.skip_truncate that lifts each step's surviving suffix into a
+    fresh chunk just before the consumer. Unlike db.limit it threads no operand onto
+    the loops (a skip cannot early-exit) and does not fold into nl.output (the suffix
+    must be copied to the front). Reading past a prefix of the graph is
+    deterministic, so the op is Pure.
+  }];
+
+  // The columns flow through unchanged; count is unsigned - a count of rows to
+  // drop is never negative, so a negative literal fails to parse rather than
+  // reaching the verifier.
+  let arguments = (ins Variadic<Column>:$columns, UI64Attr:$count);
+  let results   = (outs Variadic<Column>:$results);
+
+  // One result per input column, same types; functional-type prints the
+  // `(operandTypes) -> resultTypes` form and the named count attribute prints
+  // ahead of the colon, elided from attr-dict.
+  let assemblyFormat = [{
+    `(` $columns `)` `count` $count attr-dict `:` functional-type(operands, results)
+  }];
+
+  // results arity and types must equal the columns.
+  let hasVerifier = 1;
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -273,3 +273,15 @@ LogicalResult For::verify() {
     return success();
 }
 
+// A folded output reads the budgeted prefix (limit) or the surviving suffix
+// (skip) off a single handle - the truncate adjacent to it - so at most one may
+// be present. The interpreter reads them as an if(skip)/else if(limit) chain,
+// which would silently ignore the limit if both were set; reject that here.
+LogicalResult Output::verify() {
+    if (getLimit() && getSkip()) {
+        return emitOpError("carries both a limit and a skip handle; a folded output takes at most one");
+    }
+
+    return success();
+}
+

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -106,6 +106,20 @@ LogicalResult LimitTruncate::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// A skip truncate, like a limit truncate, passes its columns through unchanged -
+// only the dropped prefix is removed - so each result keeps its input column's
+// chunk type.
+LogicalResult SkipTruncate::inferReturnTypes(MLIRContext* context,
+                                             std::optional<Location> location,
+                                             SkipTruncate::Adaptor adaptor,
+                                             SmallVectorImpl<Type>& inferredReturnTypes) {
+    for (const Type columnType : adaptor.getColumns().getTypes()) {
+        inferredReturnTypes.push_back(columnType);
+    }
+
+    return success();
+}
+
 void For::build(OpBuilder& builder, OperationState& state, Value iterator) {
     For::build(builder, state, iterator, Value());
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -397,4 +397,84 @@ def LimitTruncate : NLOp<"limit_truncate", [InferTypeOpAdaptor]> {
   }];
 }
 
+/**
+* Skip
+*/
+// NOT Pure: each nl.skip is a distinct counter, so two must never be CSE'd into
+// one, and an unread one must not be DCE'd - its reset is a side effect. The skip
+// sibling of nl.limit.
+def Skip : NLOp<"skip", []> {
+  let summary = "Create (and reset) a row-skip counter, initialized to M rows to drop";
+  let description = [{
+    Sits at the top of the scope it governs - function scope for a top-level SKIP
+    - and re-initializes once per execution of that block. Produces the
+    !nl.skip_state handle nl.skip_update and nl.skip_truncate read. Unlike nl.limit
+    it never appears on an nl.for: a skip drives no loop early-exit, since every row
+    past the dropped prefix must still be produced. The result type is buildable and
+    omitted.
+  }];
+
+  // Unsigned: a count of rows to drop is never negative.
+  let arguments = (ins UI64Attr:$count);
+  let results   = (outs NLSkipState:$state);
+  let assemblyFormat = "`(` $count `)` attr-dict";
+}
+
+/**
+* SkipUpdate
+*/
+// NOT Pure: it mutates the handle, so it must run exactly where it sits and must
+// not be eliminated. The skip sibling of nl.limit_update.
+def SkipUpdate : NLOp<"skip_update", []> {
+  let summary = "Charge this step's rows against a skip counter";
+  let description = [{
+    Runs in the innermost loop body just before nl.skip_truncate. Reads the row
+    count of the representative chunk (the same column the consumer will read),
+    drops min(rows, remaining) of them from the front of this step, records that
+    offset and the emitted-row count nl.skip_truncate should copy, and subtracts the
+    dropped count from the budget. The sole mutator of the counter.
+  }];
+
+  let arguments = (ins NLSkipStateHandle:$state, NLChunk:$rows);
+  let assemblyFormat = "$state `,` $rows attr-dict `:` qualified(type($rows))";
+}
+
+/**
+* SkipTruncate
+*/
+// NOT Pure: it reads the handle's mutable skipThisStep/emitThisStep (set by the
+// preceding nl.skip_update), so it must run exactly where it sits and must not be
+// hoisted, CSE'd or reordered past the update. InferTypeOpAdaptor: the results
+// mirror the column operand types, copied across by inferReturnTypes, as on
+// nl.limit_truncate.
+def SkipTruncate : NLOp<"skip_truncate", [InferTypeOpAdaptor]> {
+  let summary = "Copy the surviving suffix of each column into fresh chunks";
+  let description = [{
+    The skip sibling of nl.limit_truncate. Sits in the producing loop body, just
+    after nl.skip_update and just before the columns' consumer - nl.output when the
+    query is not chained, the inner sub-pipeline when it is. Copies the suffix
+    [skipThisStep, skipThisStep + emitThisStep) of each input chunk (the offset and
+    count nl.skip_update recorded this step) into a fresh, independently-owned,
+    front-aligned chunk, so a downstream op reads a genuinely skipped chunk and
+    needs no skip awareness of its own. The columns pass through unchanged in type;
+    only the dropped prefix is removed. Unlike a limit there is no copy-free fold
+    into nl.output: the sink emits from row zero, so the surviving suffix must be
+    lifted to the front of a fresh chunk.
+
+      %a' = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>
+  }];
+
+  // The skip handle whose offset/count size the copy, then the columns to cut.
+  let arguments = (ins NLSkipStateHandle:$state, Variadic<NLChunk>:$columns);
+
+  // One result per input column, same type. The results are inferred from the
+  // column operands, so only the column chunk types are spelled, after the colon;
+  // the handle type is buildable and omitted.
+  let results = (outs Variadic<NLChunk>:$results);
+
+  let assemblyFormat = [{
+    $state `,` `(` $columns `)` attr-dict `:` qualified(type($columns))
+  }];
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -304,12 +304,27 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     never mutates the budget - it only reads how many rows to emit:
 
     nl.output(%targets) limit %h : !nl.chunk<!nl.node_id>
+
+    An optional `skip` operand carries an !nl.skip_state handle and is the skip
+    sibling of the limit form: when present, output emits the surviving suffix
+    [skip.getSkipThisStep(), skip.getSkipThisStep() + skip.getEmitThisStep()) set
+    by the preceding nl.skip_update - it reads the dropped-row count as a starting
+    offset rather than copying the suffix to the front. It is the fold of an
+    adjacent nl.skip_truncate whose only consumer was this output (the copy-free
+    path the suffix could not take through the sink before output learned an
+    offset). Like the limit form it never mutates the counter:
+
+    nl.output(%targets) skip %h : !nl.chunk<!nl.node_id>
   }];
 
-  // Two variable-length operand groups - the columns and the optional limit -
-  // so the op carries operand-segment sizes to tell them apart, the same as
-  // nl.cross_product's two column groups.
-  let arguments = (ins Variadic<NLChunk>:$columns, Optional<NLLimitStateHandle>:$limit);
+  // Three variable-length operand groups - the columns, the optional limit and
+  // the optional skip - so the op carries operand-segment sizes to tell them
+  // apart, the same as nl.cross_product's column groups. A folded output carries
+  // at most one of limit/skip (the truncate adjacent to it); the two are not
+  // produced together (see DBLowering::foldSkipTruncatesIntoOutputs).
+  let arguments = (ins Variadic<NLChunk>:$columns,
+                       Optional<NLLimitStateHandle>:$limit,
+                       Optional<NLSkipStateHandle>:$skip);
 
   // The chunk element types vary from call to call and - unlike the source
   // ops - cannot be inferred, so they are spelled after the colon. This keeps
@@ -317,10 +332,11 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   // printed list rather than looking it up on the defining nl.for (which MLIR
   // cannot do during a parse), the same reason nl.for keeps its : !nl.iter<...>
   // annotation. qualified(...) forces the leading !nl. on every printed type.
-  // The optional limit handle, when present, prints after a `limit` keyword; its
-  // type is buildable and so omitted.
+  // The optional limit and skip handles, when present, print after a `limit` or
+  // `skip` keyword; both types are buildable and so omitted. Each optional group
+  // has its own literal anchor, so the declarative parser tells them apart.
   let assemblyFormat = [{
-    `(` $columns `)` (`limit` $limit^)? attr-dict `:` qualified(type($columns))
+    `(` $columns `)` (`limit` $limit^)? (`skip` $skip^)? attr-dict `:` qualified(type($columns))
   }];
 }
 
@@ -457,9 +473,14 @@ def SkipTruncate : NLOp<"skip_truncate", [InferTypeOpAdaptor]> {
     count nl.skip_update recorded this step) into a fresh, independently-owned,
     front-aligned chunk, so a downstream op reads a genuinely skipped chunk and
     needs no skip awareness of its own. The columns pass through unchanged in type;
-    only the dropped prefix is removed. Unlike a limit there is no copy-free fold
-    into nl.output: the sink emits from row zero, so the surviving suffix must be
-    lifted to the front of a fresh chunk.
+    only the dropped prefix is removed.
+
+    When the sole consumer is the query sink, DBLowering folds this op away: an
+    nl.output gained an optional skip handle and emits the surviving suffix in
+    place at an offset (see foldSkipTruncatesIntoOutputs), the copy-free path the
+    suffix could not take while the sink only read from row zero. The copy here
+    survives only when the suffix feeds an inner sub-pipeline (a chained query)
+    that reads from row zero and so needs the rows lifted to the front.
 
       %a' = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>
   }];

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -338,6 +338,12 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   let assemblyFormat = [{
     `(` $columns `)` (`limit` $limit^)? (`skip` $skip^)? attr-dict `:` qualified(type($columns))
   }];
+
+  // Enforce the "at most one of limit/skip" invariant the description promises:
+  // a folded output carries the single handle of the truncate adjacent to it,
+  // never both. runOutput reads them as an if(skip)/else if(limit) chain, so a
+  // malformed both-handles op would silently drop the limit; reject it here.
+  let hasVerifier = 1;
 }
 
 /**

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -23,6 +23,17 @@ def NLLimitState : NLType<"LimitState", "limit_state"> {
     }];
 }
 
+def NLSkipState : NLType<"SkipState", "skip_state"> {
+    let summary = "A row-skip counter handle";
+    let description = [{
+        Stands for one SKIP's remaining rows-to-drop. Produced by nl.skip, read by
+        nl.skip_truncate, and decremented by nl.skip_update. The skip sibling of
+        !nl.limit_state: a handle, not a chunk - it holds a count, not values, and
+        is mutable as rows are dropped. Unlike a limit it drives no loop early-exit
+        (every row past the skip must still be produced), so no nl.for names it.
+    }];
+}
+
 def NLChunk : NLType<"Chunk", "chunk"> {
     let summary = "A bounded batch of values";
     let description = "One column chunk filled by a single database iterator step";
@@ -102,5 +113,15 @@ def NLLimitStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::LimitStateType>($_self)">,
         "limit state handle", "::mlir::nl::LimitStateType">,
     BuildableType<"::mlir::nl::LimitStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.skip_state handle, the same way
+// NLLimitStateHandle constrains the limit handle. The single concrete type
+// - there is only ever !nl.skip_state - is what lets nl.skip_update and
+// nl.skip_truncate omit the handle's type in their assembly, building it from
+// this recipe instead.
+def NLSkipStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::SkipStateType>($_self)">,
+        "skip state handle", "::mlir::nl::SkipStateType">,
+    BuildableType<"::mlir::nl::SkipStateType::get($_builder.getContext())">;
 
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -336,15 +336,31 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     const auto& cols = output->outputs();
     bioassert(!cols.empty(), "nl.output requires at least one column");
 
-    // With a limit (the folded terminal-LIMIT form), emit the prefix
-    // nl.limit_update sized this step - reading emitThisStep, not remaining, so
-    // the decrement already done does not affect the count. Without one, emit the
-    // whole chunk (already cut by an nl.limit_truncate when a limit governs it).
-    // Either way no row is copied here.
+    // Compute the [offset, offset + rowCount) window to emit, copy-free:
+    //  - skip (the folded terminal-SKIP form): emit the surviving suffix at offset
+    //    getSkipThisStep() for getEmitThisStep() rows, both sized by the preceding
+    //    nl.skip_update. Reading them, not remaining, so the decrement already done
+    //    does not affect the window.
+    //  - limit (the folded terminal-LIMIT form): emit the getEmitThisStep() prefix
+    //    nl.limit_update sized this step, from offset zero.
+    //  - neither: emit the whole chunk (already cut by a truncate when one governs
+    //    it).
+    // A folded output carries at most one of limit/skip, so the two never combine.
     const NLLimitState* limit = output->getLimit();
-    const size_t rowCount = limit ? limit->getEmitThisStep() : cols.front()->size();
+    const NLSkipState* skip = output->getSkip();
 
-    context->getSink()->appendChunks(cols, rowCount);
+    size_t offset = 0;
+    size_t rowCount = 0;
+    if (skip) {
+        offset = skip->getSkipThisStep();
+        rowCount = skip->getEmitThisStep();
+    } else if (limit) {
+        rowCount = limit->getEmitThisStep();
+    } else {
+        rowCount = cols.front()->size();
+    }
+
+    context->getSink()->appendChunks(cols, offset, rowCount);
 }
 
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -100,6 +100,23 @@ void tileColumn(const Column* input, size_t factor, size_t outputRowCount, Colum
     }
 }
 
+// Range copy: rows [inputOffset, inputOffset + rowCount) of the input land at
+// output indices [0, rowCount). This lifts a skip's surviving suffix to the front
+// of a fresh chunk - nl.skip_truncate passes inputOffset = skipThisStep and
+// rowCount = emitThisStep. std::copy of a contiguous range is lowered to memcpy.
+template <typename ElementType>
+void copyRangeColumn(const Column* input, size_t inputOffset, size_t rowCount, Column* output) {
+    const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
+    ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
+
+    const auto& inputRaw = typedInput->getRaw();
+    auto& outputRaw = typedOutput->getRaw();
+    outputRaw.resize(rowCount);
+
+    const auto first = inputRaw.begin() + inputOffset;
+    std::copy(first, first + rowCount, outputRaw.begin());
+}
+
 // Execute a get_out_edges/get_in_edges loop
 template <typename ChunkWriterType>
 void runEdgeLoopSteps(NLExecutionContext* context,
@@ -289,6 +306,31 @@ void NLExecutor::runLimitTruncate(NLExecutionContext* context, NLFunctionData* d
     }
 }
 
+void NLExecutor::runSkipInit(NLExecutionContext* context, NLFunctionData* data) {
+    const NLSkipInitData* init = static_cast<NLSkipInitData*>(data);
+    init->getState()->reset(init->getCount());
+}
+
+void NLExecutor::runSkipUpdate(NLExecutionContext* context, NLFunctionData* data) {
+    const NLSkipUpdateData* update = static_cast<NLSkipUpdateData*>(data);
+    update->getState()->update(update->getRows()->size());
+}
+
+void NLExecutor::runSkipTruncate(NLExecutionContext* context, NLFunctionData* data) {
+    const NLSkipTruncateData* truncate = static_cast<NLSkipTruncateData*>(data);
+    const NLSkipState* state = truncate->getState();
+
+    // Copy the surviving suffix [skipThisStep, skipThisStep + emitThisStep) of each
+    // column into the fresh front-aligned output chunk. Reads the offset and count
+    // (set by the preceding nl.skip_update); never mutates the counter.
+    const size_t offset = state->getSkipThisStep();
+    const size_t rowCount = state->getEmitThisStep();
+    for (const NLSkipColumn& column : truncate->columns()) {
+        const NLCopyFunction copySuffix = column.getCopy();
+        copySuffix(column.getInput(), offset, rowCount, column.getOutput());
+    }
+}
+
 void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     const NLOutputData* output = static_cast<NLOutputData*>(data);
     const auto& cols = output->outputs();
@@ -383,6 +425,38 @@ NLBroadcastFunction NLExecutor::selectOptTileFunction(ValueType valueType) {
     ValueTypeDispatcher(valueType).execute(select);
 
     return broadcast;
+}
+
+NLCopyFunction NLExecutor::selectCopyFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &copyRangeColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &copyRangeColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &copyRangeColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+// A nullable value chunk is a ColumnOptVector<Primitive> - that is,
+// ColumnVector<std::optional<Primitive>> - so the range copy template,
+// instantiated on std::optional<Primitive>, carries value and null together.
+NLCopyFunction NLExecutor::selectOptCopyFunction(ValueType valueType) {
+    NLCopyFunction copy = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        copy = &copyRangeColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return copy;
 }
 
 // Read one property of the current input chunk into a nullable value column.

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -59,6 +59,19 @@ public:
     // never mutates it.
     static void runLimitTruncate(NLExecutionContext* context, NLFunctionData* data);
 
+    // Reset a skip counter to its rows-to-drop; runs each time its block runs.
+    static void runSkipInit(NLExecutionContext* context, NLFunctionData* data);
+
+    // Charge the representative chunk's rows against a skip counter, recording how
+    // many rows the truncate should drop off the front this step and how many
+    // survive. The sole skip-counter mutator.
+    static void runSkipUpdate(NLExecutionContext* context, NLFunctionData* data);
+
+    // Copy the surviving suffix of each column into a fresh, front-aligned chunk,
+    // so a downstream consumer reads a genuinely skipped chunk. Reads the counter,
+    // never mutates it.
+    static void runSkipTruncate(NLExecutionContext* context, NLFunctionData* data);
+
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
@@ -73,6 +86,12 @@ public:
 
     // Tile for a nullable value chunk of this value type (inner column).
     static NLBroadcastFunction selectOptTileFunction(ValueType valueType);
+
+    // Range copy for an ID chunk of this kind (skip suffix copy).
+    static NLCopyFunction selectCopyFunction(NLChunkKind kind);
+
+    // Range copy for a nullable value chunk of this value type (skip suffix copy).
+    static NLCopyFunction selectOptCopyFunction(ValueType valueType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLOutputSink.h
+++ b/query/ir/interpreter/NLOutputSink.h
@@ -12,11 +12,14 @@ class NLOutputSink {
 public:
     virtual ~NLOutputSink();
 
-    // One call per chunk emission of the program. Only the first rowCount rows
-    // of each chunk are part of the result - the rest are a tail the limit
-    // clamped off, never truncated or copied - so an implementor reads
-    // [0, rowCount), not the column's full size.
-    virtual void appendChunks(std::span<const Column* const> chunks, size_t rowCount) = 0;
+    // One call per chunk emission of the program. Only rows
+    // [offset, offset + rowCount) of each chunk are part of the result - the rows
+    // before offset are a prefix a SKIP dropped, the rows after are a tail a LIMIT
+    // clamped off, and neither is ever copied - so an implementor reads that
+    // window, not the column's full size. offset is zero for a plain or
+    // limit-bounded emission; a folded SKIP emits its surviving suffix in place by
+    // setting offset to the dropped-row count.
+    virtual void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) = 0;
 };
 
 }

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -481,6 +481,8 @@ private:
 // (nl.skip_update does). The skip sibling of NLLimitTruncateData.
 class NLSkipTruncateData : public NLFunctionData {
 public:
+    using SkipColumns = std::vector<NLSkipColumn>;
+
     NLSkipTruncateData(NLSkipState* state)
         : _state(state)
     {
@@ -488,7 +490,7 @@ public:
 
     NLSkipState* getState() const { return _state; }
 
-    const std::vector<NLSkipColumn>& columns() const { return _columns; }
+    const SkipColumns& columns() const { return _columns; }
 
     void addColumn(const NLSkipColumn& column) {
         _columns.push_back(column);
@@ -496,7 +498,7 @@ public:
 
 private:
     NLSkipState* _state {nullptr};
-    std::vector<NLSkipColumn> _columns;
+    SkipColumns _columns;
 };
 
 // nl.output data

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -79,6 +79,39 @@ private:
     size_t _emitThisStep {0};
 };
 
+// Runtime state of one SKIP: the remaining rows still to drop, and - for the
+// current innermost step - how many of its rows to drop off the front
+// (skipThisStep, the offset into the chunk) and how many survive (emitThisStep).
+// nl.skip resets it, nl.skip_update is the sole mutator (called once per innermost
+// step before the truncate), and nl.skip_truncate only reads it. The skip sibling
+// of NLLimitState - but it never gates a loop, since every row past the dropped
+// prefix must still be produced.
+class NLSkipState {
+public:
+    void reset(size_t toSkip) {
+        _remaining = toSkip;
+        _skipThisStep = 0;
+        _emitThisStep = 0;
+    }
+
+    size_t getSkipThisStep() const { return _skipThisStep; }
+    size_t getEmitThisStep() const { return _emitThisStep; }
+
+    // Called once per innermost step by nl.skip_update, before nl.skip_truncate:
+    // drop min(rowsAvailable, remaining) rows off the front of this step, emit the
+    // rest, and charge the dropped count against the budget.
+    void update(size_t rowsAvailable) {
+        _skipThisStep = std::min(rowsAvailable, _remaining);
+        _remaining -= _skipThisStep;
+        _emitThisStep = rowsAvailable - _skipThisStep;
+    }
+
+private:
+    size_t _remaining {0};
+    size_t _skipThisStep {0};
+    size_t _emitThisStep {0};
+};
+
 // Holds the translated statements of a program or loop body
 class NLStmtContainer {
 public:
@@ -367,6 +400,105 @@ private:
     std::vector<NLCrossColumn> _columns;
 };
 
+// Copies rows [inputOffset, inputOffset + rowCount) of an input chunk into a
+// fresh, front-aligned output chunk. The skip suffix copy: nl.skip_truncate sets
+// inputOffset = skipThisStep and rowCount = emitThisStep, lifting the surviving
+// suffix to the front of the output. The block-repeat/tile broadcasts copy from
+// row zero and so cannot express the offset; this family does. Cleared and
+// resized to rowCount, the copy is a plain range copy (lowered to memcpy).
+using NLCopyFunction = void (*)(const Column* input,
+                                size_t inputOffset,
+                                size_t rowCount,
+                                Column* output);
+
+// One column used as operand of nl.skip_truncate: its input chunk, the fresh
+// output chunk to fill, and the range copy that lifts the surviving suffix from
+// one into the other. The skip sibling of NLCrossColumn - it pairs the same input
+// and output, but its copy takes an offset rather than a broadcast factor.
+class NLSkipColumn {
+public:
+    NLSkipColumn(const Column* input,
+                 Column* output,
+                 NLCopyFunction copy)
+        : _input(input),
+        _output(output),
+        _copy(copy)
+    {
+    }
+
+    const Column* getInput() const { return _input; }
+    Column* getOutput() const { return _output; }
+    NLCopyFunction getCopy() const { return _copy; }
+
+private:
+    const Column* _input {nullptr};
+    Column* _output {nullptr};
+    NLCopyFunction _copy {nullptr};
+};
+
+// nl.skip data: resets a counter to the number of rows to drop each time the
+// block it lives in runs - once at function scope for a top-level SKIP. The skip
+// sibling of NLLimitInitData.
+class NLSkipInitData : public NLFunctionData {
+public:
+    NLSkipInitData(NLSkipState* state, size_t count)
+        : _state(state),
+        _count(count)
+    {
+    }
+
+    NLSkipState* getState() const { return _state; }
+    size_t getCount() const { return _count; }
+
+private:
+    NLSkipState* _state {nullptr};
+    size_t _count {0};
+};
+
+// nl.skip_update data: the counter to charge and the representative column whose
+// row count is charged against it (the same column the consumer reads). The skip
+// sibling of NLLimitUpdateData.
+class NLSkipUpdateData : public NLFunctionData {
+public:
+    NLSkipUpdateData(NLSkipState* state, const Column* rows)
+        : _state(state),
+        _rows(rows)
+    {
+    }
+
+    NLSkipState* getState() const { return _state; }
+    const Column* getRows() const { return _rows; }
+
+private:
+    NLSkipState* _state {nullptr};
+    const Column* _rows {nullptr};
+};
+
+// nl.skip_truncate data: the counter whose skipThisStep/emitThisStep size the copy
+// and the columns to cut. Each NLSkipColumn pairs an input chunk with its fresh
+// output chunk and the range copy that lifts the surviving suffix
+// [skipThisStep, skipThisStep + emitThisStep) into it. It never mutates the counter
+// (nl.skip_update does). The skip sibling of NLLimitTruncateData.
+class NLSkipTruncateData : public NLFunctionData {
+public:
+    NLSkipTruncateData(NLSkipState* state)
+        : _state(state)
+    {
+    }
+
+    NLSkipState* getState() const { return _state; }
+
+    const std::vector<NLSkipColumn>& columns() const { return _columns; }
+
+    void addColumn(const NLSkipColumn& column) {
+        _columns.push_back(column);
+    }
+
+private:
+    NLSkipState* _state {nullptr};
+    std::vector<NLSkipColumn> _columns;
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:
@@ -414,6 +546,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one SKIP's runtime counter, owned by the program; the statements
+    // that reset, charge and read it hold a borrowed pointer. The skip sibling
+    // of allocLimitState.
+    NLSkipState* allocSkipState() {
+        auto state = std::make_unique<NLSkipState>();
+        NLSkipState* statePtr = state.get();
+        _skipStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -424,6 +566,7 @@ private:
     size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
     std::vector<std::unique_ptr<NLFunctionData>> _functionData;
     std::vector<std::unique_ptr<NLLimitState>> _limitStates;
+    std::vector<std::unique_ptr<NLSkipState>> _skipStates;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -516,9 +516,17 @@ public:
     NLLimitState* getLimit() const { return _limit; }
     void setLimit(NLLimitState* limit) { _limit = limit; }
 
+    // The governing skip counter, or null for a skip-oblivious output. When set
+    // (the folded terminal-SKIP form), output emits the surviving suffix at
+    // offset getSkipThisStep() for getEmitThisStep() rows; it never mutates the
+    // counter. A folded output carries at most one of limit/skip.
+    NLSkipState* getSkip() const { return _skip; }
+    void setSkip(NLSkipState* skip) { _skip = skip; }
+
 private:
     std::vector<const Column*> _columns;
     NLLimitState* _limit {nullptr};
+    NLSkipState* _skip {nullptr};
 };
 
 class NLProgram {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -136,6 +136,12 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateLimitUpdate(update, body);
         } else if (nl::LimitTruncate truncate = mlir::dyn_cast<nl::LimitTruncate>(operation)) {
             translateLimitTruncate(truncate, body);
+        } else if (nl::Skip skip = mlir::dyn_cast<nl::Skip>(operation)) {
+            translateSkip(skip, body);
+        } else if (nl::SkipUpdate update = mlir::dyn_cast<nl::SkipUpdate>(operation)) {
+            translateSkipUpdate(update, body);
+        } else if (nl::SkipTruncate truncate = mlir::dyn_cast<nl::SkipTruncate>(operation)) {
+            translateSkipTruncate(truncate, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -395,6 +401,93 @@ NLLimitState* NLTranslator::limitStateFor(mlir::Value handle) const {
     const auto stateIt = _limitStates.find(handle);
     if (stateIt == _limitStates.end()) {
         throw IRException("limit handle must be produced by an nl.limit");
+    }
+
+    return stateIt->second;
+}
+
+void NLTranslator::translateSkip(nl::Skip skip, NLStmtContainer* body) {
+    // Allocate the runtime counter and map the handle to it, so the update and the
+    // truncate that name the handle both find the same counter.
+    NLSkipState* state = _program->allocSkipState();
+    _skipStates[skip.getState()] = state;
+
+    // The reset runs each time the block holding this nl.skip runs: once at
+    // function scope for a top-level SKIP.
+    const size_t count = skip.getCount();
+    NLSkipInitData* initData = _program->allocFunctionData<NLSkipInitData>(state, count);
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSkipInit, initData});
+}
+
+void NLTranslator::translateSkipUpdate(nl::SkipUpdate update, NLStmtContainer* body) {
+    // The handle is a required operand, so skipStateFor returns its counter or
+    // throws if it was not produced by an nl.skip.
+    NLSkipState* state = skipStateFor(update.getState());
+
+    const Column* representative = getColumn(update.getRows());
+    NLSkipUpdateData* updateData = _program->allocFunctionData<NLSkipUpdateData>(state, representative);
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSkipUpdate, updateData});
+}
+
+void NLTranslator::translateSkipTruncate(nl::SkipTruncate truncate, NLStmtContainer* body) {
+    // The handle is a required operand, so skipStateFor returns its counter or
+    // throws if it was not produced by an nl.skip.
+    NLSkipState* state = skipStateFor(truncate.getState());
+
+    NLSkipTruncateData* data = _program->allocFunctionData<NLSkipTruncateData>(state);
+
+    // One fresh output column per input, walked in step with the results the
+    // downstream consumers are mapped to.
+    const mlir::OperandRange columns = truncate.getColumns();
+    const mlir::ResultRange results = truncate.getResults();
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        addSkipColumn(columns[columnIndex], results[columnIndex], data);
+    }
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSkipTruncate, data});
+}
+
+void NLTranslator::addSkipColumn(mlir::Value inputValue,
+                                 mlir::Value resultValue,
+                                 NLSkipTruncateData* data) {
+    const Column* input = getColumn(inputValue);
+
+    const auto chunkType = mlir::cast<nl::ChunkType>(inputValue.getType());
+    const mlir::Type elementType = chunkType.getElementType();
+
+    // The output keeps the input's element type; only the dropped prefix is
+    // removed. The copy is a range copy of the surviving suffix to the front of a
+    // fresh chunk, so it uses the copy families - by value type for a nullable
+    // value chunk, by chunk kind for an ID chunk.
+    Column* output = nullptr;
+    NLCopyFunction copySuffix = nullptr;
+
+    if (const auto nullableType = mlir::dyn_cast<nl::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        output = allocOptColumnForValueType(valueType);
+        copySuffix = NLExecutor::selectOptCopyFunction(valueType);
+    } else {
+        const NLChunkKind kind = getChunkKind(chunkType);
+        output = allocColumnForKind(kind);
+        copySuffix = NLExecutor::selectCopyFunction(kind);
+    }
+
+    _valueSlots[resultValue] = output;
+
+    const NLSkipColumn skipColumn(input, output, copySuffix);
+    data->addColumn(skipColumn);
+}
+
+NLSkipState* NLTranslator::skipStateFor(mlir::Value handle) const {
+    if (!handle) {
+        return nullptr;
+    }
+
+    const auto stateIt = _skipStates.find(handle);
+    if (stateIt == _skipStates.end()) {
+        throw IRException("skip handle must be produced by an nl.skip");
     }
 
     return stateIt->second;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -465,7 +465,7 @@ void NLTranslator::addSkipColumn(mlir::Value inputValue,
     Column* output = nullptr;
     NLCopyFunction copySuffix = nullptr;
 
-    if (const auto nullableType = mlir::dyn_cast<nl::NullableType>(elementType)) {
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         output = allocOptColumnForValueType(valueType);
         copySuffix = NLExecutor::selectOptCopyFunction(valueType);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -299,6 +299,7 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
 
     NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
     outputData->setLimit(limitStateFor(output.getLimit()));
+    outputData->setSkip(skipStateFor(output.getSkip()));
     for (const mlir::Value column : columns) {
         const auto columnArgument = mlir::dyn_cast<mlir::BlockArgument>(column);
         const bool isInnermostLoopVariable = columnArgument && columnArgument.getOwner() == outputBlock;

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -48,6 +48,10 @@ private:
     // nl.limit_update and nl.output that name the handle find the same counter
     llvm::DenseMap<mlir::Value, NLLimitState*> _limitStates;
 
+    // nl.skip handle SSA value -> the runtime counter it produces, so nl.skip_update
+    // and nl.skip_truncate that name the handle find the same counter
+    llvm::DenseMap<mlir::Value, NLSkipState*> _skipStates;
+
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
     void translateFor(mlir::nl::For forLoop, NLStmtContainer* body);
     void translateScanLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body);
@@ -73,6 +77,23 @@ private:
     // (an unbounded loop or output), the mapped counter otherwise. Throws if the
     // handle was not produced by an nl.limit translated earlier.
     NLLimitState* limitStateFor(mlir::Value handle) const;
+
+    // Translate an nl.skip: allocate its runtime counter, map the handle to it,
+    // and record the reset statement (run each time the enclosing block runs)
+    void translateSkip(mlir::nl::Skip skip, NLStmtContainer* body);
+
+    // Translate an nl.skip_update: look up the counter the handle names and record
+    // the charge against the representative chunk's row count
+    void translateSkipUpdate(mlir::nl::SkipUpdate update, NLStmtContainer* body);
+
+    // Translate an nl.skip_truncate: allocate one fresh output column per input,
+    // map each result to its output, and record the suffix-copy statement (each
+    // column's surviving suffix copied to the front of the output)
+    void translateSkipTruncate(mlir::nl::SkipTruncate truncate, NLStmtContainer* body);
+
+    // The runtime counter a skip handle names. The handle is a required operand of
+    // its consumers, so this throws if it was not produced by an nl.skip.
+    NLSkipState* skipStateFor(mlir::Value handle) const;
 
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the
@@ -103,6 +124,12 @@ private:
     void addTruncateColumn(mlir::Value inputValue,
                            mlir::Value resultValue,
                            NLLimitTruncateData* data);
+
+    // Allocate the fresh output column for one skipped column, map the op result
+    // to it, and append it (with its range suffix-copy) to data
+    void addSkipColumn(mlir::Value inputValue,
+                       mlir::Value resultValue,
+                       NLSkipTruncateData* data);
 
     Column* allocColumn(mlir::Value chunkValue);
     Column* allocColumnForKind(NLChunkKind kind);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -165,6 +165,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerCrossProduct(crossProduct);
     } else if (mlir::db::Limit limit = mlir::dyn_cast<mlir::db::Limit>(operation)) {
         lowerLimit(limit);
+    } else if (mlir::db::Skip skip = mlir::dyn_cast<mlir::db::Skip>(operation)) {
+        lowerSkip(skip);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -401,6 +403,53 @@ void DBLowering::lowerLimit(mlir::db::Limit limit) {
     // Map db.limit's results to the truncated chunks, so its consumer reads the
     // cut copies rather than the full producer chunks.
     const mlir::ResultRange dbResults = limit.getResults();
+    const mlir::ResultRange truncatedChunks = truncate.getResults();
+    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
+        _valueMap[dbResults[resultIndex]] = truncatedChunks[resultIndex];
+    }
+}
+
+void DBLowering::lowerSkip(mlir::db::Skip skip) {
+    // The nl chunks the skipped columns lowered to; these are what the truncate
+    // copies, and the consumer reads the cut copies.
+    llvm::SmallVector<mlir::Value, 4> chunks;
+    for (const mlir::Value column : skip.getColumns()) {
+        chunks.push_back(mapValue(column));
+    }
+
+    // Skip::verify rejects an empty db.skip, so reaching it here means unverified
+    // IR - a defensive backstop, as in lowerLimit.
+    if (chunks.empty()) {
+        throw IRException("db.skip requires at least one column");
+    }
+
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // Hoist the skip handle to the top of the entry block, above every loop, so it
+    // dominates the update and the truncate placed in the producing loop body.
+    // Unlike a limit, a skip threads no operand onto the loops (it cannot
+    // early-exit - every row past the dropped prefix must still be produced), so it
+    // needs no up-front pre-scan: the handle is created here, in program order,
+    // once the producing loops already exist.
+    _builder.setInsertionPointToStart(_entryBlock);
+    const mlir::Value handle = _builder.create<nl::Skip>(loc, skip.getCount()).getState();
+
+    // The representative is the first skipped column, in the innermost producing
+    // loop body (post-cross-product if there is one), so its row count is what this
+    // step charges and the truncate's suffix is cut from.
+    const mlir::Value representative = chunks.front();
+    setInsertionInto(ownerBlock(representative));
+
+    // Charge this step's rows, then lift the surviving suffix of every skipped
+    // column into fresh chunks, just before the consumer (nl.output when unchained,
+    // the inner sub-pipeline when chained). There is no fold into nl.output: the
+    // sink emits from row zero, so the suffix is always copied to the front.
+    _builder.create<nl::SkipUpdate>(loc, handle, representative);
+    nl::SkipTruncate truncate = _builder.create<nl::SkipTruncate>(loc, handle, chunks);
+
+    // Map db.skip's results to the truncated chunks, so its consumer reads the cut
+    // copies rather than the full producer chunks.
+    const mlir::ResultRange dbResults = skip.getResults();
     const mlir::ResultRange truncatedChunks = truncate.getResults();
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
         _valueMap[dbResults[resultIndex]] = truncatedChunks[resultIndex];

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1,5 +1,6 @@
 #include "DBLowering.h"
 
+#include <algorithm>
 #include <optional>
 
 #include "mlir/IR/Block.h"
@@ -55,6 +56,34 @@ mlir::Type valueTypeToElementType(mlir::OpBuilder& builder, ValueType valueType)
     }
 
     throw IRException("Unhandled property value type");
+}
+
+// The single nl.output that solely consumes every result in the range, or a null
+// op if any result has more than one use, a non-nl.output user, or a different
+// output than its siblings. Read the direction as "one shared output user => the
+// truncate's copy can be dropped": a terminal truncate folds into its output
+// exactly when this is non-null, and then erasing the truncate leaves nothing
+// dangling.
+nl::Output soleOutputConsumer(mlir::ResultRange results) {
+    // A result's one-and-only nl.output user, or a null op for any other shape
+    // (more than one use, or a lone use that is not an nl.output).
+    const auto soleOutputUser = [](const mlir::Value result) -> nl::Output {
+        if (!result.hasOneUse()) {
+            return nl::Output();
+        }
+        return mlir::dyn_cast<nl::Output>(*result.user_begin());
+    };
+
+    if (results.empty()) {
+        return nl::Output();
+    }
+
+    const nl::Output output = soleOutputUser(results.front());
+    const bool sharedByAllResults = output && std::all_of(results.begin(), results.end(), [&](const mlir::Value result) {
+        return soleOutputUser(result) == output;
+    });
+
+    return sharedByAllResults ? output : nl::Output();
 }
 
 }
@@ -509,24 +538,10 @@ void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
     nlFunction.walk([&](nl::LimitTruncate truncate) {
         const mlir::ResultRange results = truncate.getResults();
 
-        // Foldable only if a single nl.output is the sole consumer of every
-        // truncated column. Read the direction as "one shared output user => the
-        // copy can be dropped", not the reverse: the loop tests that precondition,
-        // gathering the shared user, and bails if any result has more than one use
-        // or a different user - so erasing the truncate would leave nothing dangling.
-        nl::Output output;
-        for (const mlir::Value result : results) {
-            if (!result.hasOneUse()) {
-                return;
-            }
-
-            nl::Output user = mlir::dyn_cast<nl::Output>(*result.user_begin());
-            if (!user || (output && output != user)) {
-                return;
-            }
-            output = user;
-        }
-
+        // Foldable only if a single nl.output solely consumes every truncated
+        // column; soleOutputConsumer returns that shared output (a null op if not).
+        // Not const: the nl.output accessors below are non-const, as MLIR generates.
+        nl::Output output = soleOutputConsumer(results);
         if (!output || output.getLimit()) {
             return;
         }
@@ -577,25 +592,15 @@ void DBLowering::foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
     nlFunction.walk([&](nl::SkipTruncate truncate) {
         const mlir::ResultRange results = truncate.getResults();
 
-        // Foldable only if a single nl.output is the sole consumer of every
-        // truncated column. The single-use test also self-excludes the SKIP+LIMIT
-        // case: there an nl.limit sits between this skip and the output, so the
-        // truncate's result feeds nl.limit_update (and the limit's own consumer),
-        // never one nl.output - hasOneUse is false and the skip stays a copy,
-        // bounded by the limit's loop early-exit. As in the limit fold, read the
-        // direction as "one shared output user => the copy can be dropped".
-        nl::Output output;
-        for (const mlir::Value result : results) {
-            if (!result.hasOneUse()) {
-                return;
-            }
-
-            nl::Output user = mlir::dyn_cast<nl::Output>(*result.user_begin());
-            if (!user || (output && output != user)) {
-                return;
-            }
-            output = user;
-        }
+        // Foldable only if a single nl.output solely consumes every truncated
+        // column; soleOutputConsumer returns that shared output (a null op if not).
+        // The single shared user also self-excludes the SKIP+LIMIT case: there an
+        // nl.limit sits between this skip and the output, so the truncate's result
+        // feeds nl.limit_update (and the limit's own consumer), never one nl.output
+        // - the shared-user test fails and the skip stays a copy, bounded by the
+        // limit's loop early-exit.
+        // Not const: the nl.output accessors below are non-const, as MLIR generates.
+        nl::Output output = soleOutputConsumer(results);
 
         // Bail if the output already carries a handle: a folded output carries at
         // most one of limit/skip, and the rebuild below would drop a pre-existing

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -142,6 +142,11 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     // instead of copying it - the copy-free path for a LIMIT that feeds the sink.
     foldTruncatesIntoOutputs(nlFunction);
 
+    // The skip sibling: a terminal SKIP folds its nl.skip_truncate into a
+    // skip-bearing nl.output that emits the surviving suffix in place (at an
+    // offset) instead of copying it to the front - the copy-free post-skip tail.
+    foldSkipTruncatesIntoOutputs(nlFunction);
+
     // Run MLIR verifier on the nlFunction
     if (mlir::failed(mlir::verify(nlFunction))) {
         throw IRException("DBLowering produced an invalid nl function");
@@ -442,8 +447,10 @@ void DBLowering::lowerSkip(mlir::db::Skip skip) {
 
     // Charge this step's rows, then lift the surviving suffix of every skipped
     // column into fresh chunks, just before the consumer (nl.output when unchained,
-    // the inner sub-pipeline when chained). There is no fold into nl.output: the
-    // sink emits from row zero, so the suffix is always copied to the front.
+    // the inner sub-pipeline when chained). The unchained case is folded away by
+    // foldSkipTruncatesIntoOutputs - nl.output emits the suffix in place at an
+    // offset - so this copy survives only when the suffix feeds an inner
+    // sub-pipeline that reads from row zero.
     _builder.create<nl::SkipUpdate>(loc, handle, representative);
     nl::SkipTruncate truncate = _builder.create<nl::SkipTruncate>(loc, handle, chunks);
 
@@ -553,7 +560,78 @@ void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         // The preceding nl.limit_update still sets that count. Drop the old output
         // and the now-unused truncate.
         _builder.setInsertionPoint(output);
-        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), truncate.getState());
+        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), truncate.getState(), mlir::Value());
+
+        output.erase();
+        truncate.erase();
+    }
+}
+
+void DBLowering::foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
+    // The skip sibling of foldTruncatesIntoOutputs: a terminal SKIP whose
+    // nl.skip_truncate feeds only an nl.output folds into a skip-bearing output
+    // that emits the surviving suffix in place (offset getSkipThisStep()) instead
+    // of copying it to the front. Collect first; erasing ops mid-walk is unsafe.
+    llvm::SmallVector<nl::SkipTruncate, 4> foldable;
+
+    nlFunction.walk([&](nl::SkipTruncate truncate) {
+        const mlir::ResultRange results = truncate.getResults();
+
+        // Foldable only if a single nl.output is the sole consumer of every
+        // truncated column. The single-use test also self-excludes the SKIP+LIMIT
+        // case: there an nl.limit sits between this skip and the output, so the
+        // truncate's result feeds nl.limit_update (and the limit's own consumer),
+        // never one nl.output - hasOneUse is false and the skip stays a copy,
+        // bounded by the limit's loop early-exit. As in the limit fold, read the
+        // direction as "one shared output user => the copy can be dropped".
+        nl::Output output;
+        for (const mlir::Value result : results) {
+            if (!result.hasOneUse()) {
+                return;
+            }
+
+            nl::Output user = mlir::dyn_cast<nl::Output>(*result.user_begin());
+            if (!user || (output && output != user)) {
+                return;
+            }
+            output = user;
+        }
+
+        // Bail if the output already carries a handle: a folded output carries at
+        // most one of limit/skip, and the rebuild below would drop a pre-existing
+        // one.
+        if (!output || output.getLimit() || output.getSkip()) {
+            return;
+        }
+
+        // The output must consume exactly the truncate's results - all of them, in
+        // the same order, and nothing else - so rebuilding it over the truncate's
+        // input columns preserves the projection. Same precondition as the limit
+        // fold.
+        const mlir::OperandRange outputColumns = output.getColumns();
+        if (outputColumns.size() != results.size()) {
+            return;
+        }
+
+        for (size_t columnIndex = 0; columnIndex < results.size(); columnIndex++) {
+            if (outputColumns[columnIndex] != results[columnIndex]) {
+                return;
+            }
+        }
+
+        foldable.push_back(truncate);
+    });
+
+    for (nl::SkipTruncate truncate : foldable) {
+        nl::Output output = mlir::cast<nl::Output>(*truncate.getResult(0).user_begin());
+
+        // Re-emit the output over the untruncated inputs, carrying the skip handle
+        // in the third operand, so it streams the surviving suffix off the counter
+        // (offset getSkipThisStep(), getEmitThisStep() rows) instead of a copy. The
+        // preceding nl.skip_update still sets that offset and count. Drop the old
+        // output and the now-unused truncate.
+        _builder.setInsertionPoint(output);
+        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), mlir::Value(), truncate.getState());
 
         output.erase();
         truncate.erase();
@@ -577,7 +655,7 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
     // case - where the truncate feeds only this output - into nl.output ... limit,
     // dropping the copy.
     setInsertionInto(ownerBlock(columns.front()));
-    _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value());
+    _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value(), mlir::Value());
 }
 
 void DBLowering::buildLoopForSource(mlir::Value iterator, mlir::Operation* dbOp) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -33,6 +33,12 @@ class GraphView;
 //                                          nl.limit_truncate that copies the prefix
 //                                          just before the consumer (nl.output when
 //                                          unchained, the inner query when chained)
+//   db.skip                            ->  a hoisted nl.skip handle, an
+//                                          nl.skip_update, and an nl.skip_truncate
+//                                          that lifts the surviving suffix just
+//                                          before the consumer. No loop operand (a
+//                                          skip cannot early-exit) and no fold into
+//                                          nl.output (the suffix must be copied)
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -104,6 +110,7 @@ private:
     void lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgeProperties);
     void lowerCrossProduct(mlir::db::CrossProduct product);
     void lowerLimit(mlir::db::Limit limit);
+    void lowerSkip(mlir::db::Skip skip);
     void lowerOutput(mlir::db::Output output);
 
     // Lower one factor region of a db.cross_product into a loop nest rooted at

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -37,8 +37,11 @@ class GraphView;
 //                                          nl.skip_update, and an nl.skip_truncate
 //                                          that lifts the surviving suffix just
 //                                          before the consumer. No loop operand (a
-//                                          skip cannot early-exit) and no fold into
-//                                          nl.output (the suffix must be copied)
+//                                          skip cannot early-exit). When unchained,
+//                                          the truncate folds into a skip-bearing
+//                                          nl.output that emits the suffix in place
+//                                          at an offset; the copy survives only for
+//                                          a chained suffix (reads from row zero)
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -139,6 +142,7 @@ private:
     // emits the budgeted prefix directly, dropping the truncate's copy. Chained
     // and mixed cases do not match and keep their truncate.
     void foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction);
+    void foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction);
 
     // The nl.get_property_type handle for a property name, inserted once at the
     // top of the entry block (above every loop) and reused on later lookups

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -228,12 +228,14 @@ void assembleFiles(mlir::MLIRContext& ctxt, mlir::ModuleOp& module, const std::v
 // The interpreter pushes one chunk per output column, all of the same length.
 class PrintingSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         if (chunks.empty()) {
             return;
         }
 
-        for (size_t row = 0; row < rowCount; row++) {
+        // Emit rows [offset, offset + rowCount): offset is non-zero only for a
+        // folded SKIP, whose surviving suffix starts past the dropped prefix.
+        for (size_t row = offset; row < offset + rowCount; row++) {
             std::cout << "(";
             for (size_t column = 0; column < chunks.size(); column++) {
                 if (column > 0) {
@@ -324,7 +326,7 @@ private:
 // execution time and flood the terminal on a large expansion.
 class CountingSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         _rowCount += rowCount;
     }
 

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -131,7 +131,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto outLoop = builder.create<mlir::nl::For>(loc, outEdges.getResult());
     mlir::Block* outLoopBody = outLoop.getBody();
     builder.setInsertionPointToStart(outLoopBody);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoopBody->getArgument(3)}, mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoopBody->getArgument(3)}, mlir::Value(), mlir::Value());
 
     // In-edges of the same node chunk: send the source (predecessor) node IDs.
     // Same chunk order, so argument 0 is the sources column.
@@ -140,7 +140,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto inLoop = builder.create<mlir::nl::For>(loc, inEdges.getResult());
     mlir::Block* inLoopBody = inLoop.getBody();
     builder.setInsertionPointToStart(inLoopBody);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoopBody->getArgument(0)}, mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoopBody->getArgument(0)}, mlir::Value(), mlir::Value());
 
     // MATCH (a)->(b)->(c): two out-edge hops where the second carries the `a`
     // of the current step. First hop a->b with an empty carry set; its loop
@@ -165,7 +165,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     const mlir::Value bFiltered = secondHopLoopBody->getArgument(0);
     const mlir::Value cChunk = secondHopLoopBody->getArgument(3);
     const mlir::Value filteredA = secondHopLoopBody->getArgument(4);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk}, mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk}, mlir::Value(), mlir::Value());
 }
 
 // A disconnected pattern in the set-at-a-time db dialect: MATCH (a), (b)

--- a/samples/mlir/skip.mlir
+++ b/samples/mlir/skip.mlir
@@ -1,0 +1,19 @@
+module {
+  func.func @main() {
+    // MATCH (a) RETURN a SKIP 3: a scan whose first three rows are dropped.
+    //
+    // db.skip lowers to a hoisted nl.skip handle, an nl.skip_update that charges
+    // each chunk against the remaining rows-to-drop, and an nl.skip_truncate that
+    // lifts the surviving suffix of each chunk into a fresh, front-aligned chunk
+    // before nl.output emits it. Unlike a limit it threads no operand onto the scan
+    // loop (a skip cannot early-exit) and does not fold into nl.output (the suffix
+    // must be copied to the front).
+    %a = db.scan_nodes() : !db.column<"a">
+
+    %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
+
+    db.output(%sa) : !db.column<"a">
+
+    return
+  }
+}

--- a/samples/mlir/skip.mlir
+++ b/samples/mlir/skip.mlir
@@ -4,10 +4,12 @@ module {
     //
     // db.skip lowers to a hoisted nl.skip handle, an nl.skip_update that charges
     // each chunk against the remaining rows-to-drop, and an nl.skip_truncate that
-    // lifts the surviving suffix of each chunk into a fresh, front-aligned chunk
-    // before nl.output emits it. Unlike a limit it threads no operand onto the scan
-    // loop (a skip cannot early-exit) and does not fold into nl.output (the suffix
-    // must be copied to the front).
+    // would lift the surviving suffix of each chunk into a fresh, front-aligned
+    // chunk. Unlike a limit it threads no operand onto the scan loop (a skip cannot
+    // early-exit). Here the truncate's only consumer is nl.output, so the fold
+    // collapses it: nl.output carries the skip handle and emits the surviving
+    // suffix in place at an offset (skipThisStep), with no copy at all - see the
+    // generated lowering in skip.nl.mlir.
     %a = db.scan_nodes() : !db.column<"a">
 
     %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">

--- a/samples/mlir/skip.nl.mlir
+++ b/samples/mlir/skip.nl.mlir
@@ -1,0 +1,15 @@
+// Generated nl-dialect lowering of skip.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered skip.mlir
+// This is the DBLowering output; edit skip.mlir, not this file.
+module {
+  func.func @main() {
+    %0 = nl.skip(3)
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!nl.node_id>> {
+      nl.skip_update %0, %arg0 : !nl.chunk<!nl.node_id>
+      %2 = nl.skip_truncate %0, (%arg0) : !nl.chunk<!nl.node_id>
+      nl.output(%2) : !nl.chunk<!nl.node_id>
+    }
+    return
+  }
+}

--- a/samples/mlir/skip.nl.mlir
+++ b/samples/mlir/skip.nl.mlir
@@ -7,8 +7,7 @@ module {
     %1 = nl.scan_nodes()
     nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!nl.node_id>> {
       nl.skip_update %0, %arg0 : !nl.chunk<!nl.node_id>
-      %2 = nl.skip_truncate %0, (%arg0) : !nl.chunk<!nl.node_id>
-      nl.output(%2) : !nl.chunk<!nl.node_id>
+      nl.output(%arg0) skip %0 : !nl.chunk<!nl.node_id>
     }
     return
   }

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -118,6 +118,27 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN a SKIP 3: a scan whose first three rows are dropped by db.skip,
+// one pass-through column.
+const char* const skipProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<"a">
+  %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
+  db.output(%sa) : !db.column<"a">
+  return
+}
+)mlir";
+
+// db.skip's count is a ui64 attribute, so a negative literal cannot parse.
+const char* const negativeSkipProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<"a">
+  %sa = db.skip(%a) count -1 : (!db.column<"a">) -> !db.column<"a">
+  db.output(%sa) : !db.column<"a">
+  return
+}
+)mlir";
+
 TEST_F(DBDialectTest, parsesCrossProductOfTwoScans) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
     ASSERT_TRUE(module);
@@ -324,6 +345,129 @@ TEST_F(DBDialectTest, verifierRejectsLimitColumnTypeMismatch) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(limit.getOperation())));
+}
+
+TEST_F(DBDialectTest, parsesSkip) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(skipProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Skip skip;
+    module.get().walk([&](mlir::db::Skip op) {
+        skip = op;
+    });
+    ASSERT_TRUE(skip);
+
+    // The count is the parsed ui64, and the single column passes through as the
+    // single result, same type.
+    EXPECT_EQ(skip.getCount(), 3u);
+    ASSERT_EQ(skip.getColumns().size(), 1u);
+    ASSERT_EQ(skip.getResults().size(), 1u);
+    EXPECT_EQ(skip.getColumns()[0].getType(), mlir::db::ColumnType::get(&_context, "a"));
+    EXPECT_EQ(skip.getResults()[0].getType(), mlir::db::ColumnType::get(&_context, "a"));
+}
+
+TEST_F(DBDialectTest, skipRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(skipProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.skip printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, rejectsNegativeSkipCount) {
+    // count is a ui64 attribute, so a negative literal fails to parse and the
+    // module is null.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(negativeSkipProgram);
+    EXPECT_FALSE(module);
+}
+
+// Builds a db.skip whose result count does not match its columns, exercising the
+// verifier's pass-through arity check on the programmatic builder path (the parser
+// path always derives the results from the printed functional type).
+TEST_F(DBDialectTest, verifierRejectsSkipArityMismatch) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
+
+    auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
+
+    // One input column but two declared results: the pass-through arity is wrong.
+    auto skip = builder.create<mlir::db::Skip>(loc,
+                                               mlir::TypeRange {colA, colB},
+                                               mlir::ValueRange {scanA.getResult()},
+                                               /*count=*/3u);
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(skip.getOperation())));
+}
+
+// Builds a db.skip with no columns. Its row count is read from the first column
+// during lowering, so the verifier rejects it here rather than leaving the empty
+// case to the lowering pass.
+TEST_F(DBDialectTest, verifierRejectsSkipWithoutColumns) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    // No input columns and no results: nothing to skip.
+    auto skip = builder.create<mlir::db::Skip>(loc,
+                                               mlir::TypeRange {},
+                                               mlir::ValueRange {},
+                                               /*count=*/3u);
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(skip.getOperation())));
+}
+
+// Builds a db.skip whose single result type differs from its single input column:
+// same arity, wrong type. This exercises the per-column type check the
+// arity-mismatch test never reaches.
+TEST_F(DBDialectTest, verifierRejectsSkipColumnTypeMismatch) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
+
+    auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
+
+    // One input column and one result, but the result type does not match it.
+    auto skip = builder.create<mlir::db::Skip>(loc,
+                                               mlir::TypeRange {colB},
+                                               mlir::ValueRange {scanA.getResult()},
+                                               /*count=*/3u);
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(skip.getOperation())));
 }
 
 }

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -122,9 +122,9 @@ func.func @main() {
 // one pass-through column.
 const char* const skipProgram = R"mlir(
 func.func @main() {
-  %a = db.scan_nodes() : !db.column<"a">
-  %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
-  db.output(%sa) : !db.column<"a">
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %sa = db.skip(%a) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%sa) : !db.column<!storage.node_id>
   return
 }
 )mlir";
@@ -132,9 +132,9 @@ func.func @main() {
 // db.skip's count is a ui64 attribute, so a negative literal cannot parse.
 const char* const negativeSkipProgram = R"mlir(
 func.func @main() {
-  %a = db.scan_nodes() : !db.column<"a">
-  %sa = db.skip(%a) count -1 : (!db.column<"a">) -> !db.column<"a">
-  db.output(%sa) : !db.column<"a">
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %sa = db.skip(%a) count -1 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%sa) : !db.column<!storage.node_id>
   return
 }
 )mlir";
@@ -362,8 +362,9 @@ TEST_F(DBDialectTest, parsesSkip) {
     EXPECT_EQ(skip.getCount(), 3u);
     ASSERT_EQ(skip.getColumns().size(), 1u);
     ASSERT_EQ(skip.getResults().size(), 1u);
-    EXPECT_EQ(skip.getColumns()[0].getType(), mlir::db::ColumnType::get(&_context, "a"));
-    EXPECT_EQ(skip.getResults()[0].getType(), mlir::db::ColumnType::get(&_context, "a"));
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    EXPECT_EQ(skip.getColumns()[0].getType(), nodeIDColumnType);
+    EXPECT_EQ(skip.getResults()[0].getType(), nodeIDColumnType);
 }
 
 TEST_F(DBDialectTest, skipRoundTripsThroughTextualForm) {
@@ -400,8 +401,8 @@ TEST_F(DBDialectTest, verifierRejectsSkipArityMismatch) {
     auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
     builder.setInsertionPointToStart(function.addEntryBlock());
 
-    const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
-    const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context);
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context);
 
     auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
 
@@ -453,8 +454,9 @@ TEST_F(DBDialectTest, verifierRejectsSkipColumnTypeMismatch) {
     auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
     builder.setInsertionPointToStart(function.addEntryBlock());
 
-    const mlir::Type colA = mlir::db::ColumnType::get(&_context, "a");
-    const mlir::Type colB = mlir::db::ColumnType::get(&_context, "b");
+    const mlir::Type nodeIDType = mlir::storage::NodeIDType::get(&_context);
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context, nodeIDType);
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context);
 
     auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
 

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -546,11 +546,11 @@ std::string twoLimitProgram(uint64_t outerCount, uint64_t innerCount) {
 // MATCH (a) RETURN a SKIP count: a scan whose first `count` rows are dropped.
 std::string skipScanProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
-                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
                        "  %sa = db.skip(%a) count ")
            + std::to_string(count)
-           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
-             "  db.output(%sa) : !db.column<\"a\">\n"
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%sa) : !db.column<!storage.node_id>\n"
              "  return\n"
              "}\n";
 }
@@ -560,13 +560,13 @@ std::string skipScanProgram(uint64_t count) {
 // innermost body and never gates a loop, so the whole nest runs to exhaustion.
 std::string skipTwoHopProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
-                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
-                       "  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<\"a\">) -> (!db.column<\"a1\">, !db.column<\"e0\">, !db.column<\"et0\">, !db.column<\"b\">)\n"
-                       "  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<\"b\">, !db.column<\"a1\">) -> (!db.column<\"b2\">, !db.column<\"e1\">, !db.column<\"et1\">, !db.column<\"c\">, !db.column<\"a2\">)\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)\n"
+                       "  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)\n"
                        "  %sc = db.skip(%c) count ")
            + std::to_string(count)
-           + " : (!db.column<\"c\">) -> !db.column<\"c\">\n"
-             "  db.output(%sc) : !db.column<\"c\">\n"
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%sc) : !db.column<!storage.node_id>\n"
              "  return\n"
              "}\n";
 }
@@ -576,12 +576,12 @@ std::string skipTwoHopProgram(uint64_t count) {
 // column together. The representative is the first column, the node IDs.
 std::string skipNodePropertyProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
-                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
-                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<\"a\">) -> !db.column<\"a.score\">\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
                        "  %sa, %sscore = db.skip(%a, %score) count ")
            + std::to_string(count)
-           + " : (!db.column<\"a\">, !db.column<\"a.score\">) -> (!db.column<\"a\">, !db.column<\"a.score\">)\n"
-             "  db.output(%sa, %sscore) : !db.column<\"a\">, !db.column<\"a.score\">\n"
+           + " : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)\n"
+             "  db.output(%sa, %sscore) : !db.column<!storage.node_id>, !db.column<none>\n"
              "  return\n"
              "}\n";
 }
@@ -592,14 +592,14 @@ std::string skipNodePropertyProgram(uint64_t count) {
 // the producing loop); the skip drops the prefix in front of it.
 std::string skipThenLimitProgram(uint64_t skipCount, uint64_t limitCount) {
     return std::string("func.func @main() {\n"
-                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
                        "  %sa = db.skip(%a) count ")
            + std::to_string(skipCount)
-           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
              "  %la = db.limit(%sa) count "
            + std::to_string(limitCount)
-           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
-             "  db.output(%la) : !db.column<\"a\">\n"
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%la) : !db.column<!storage.node_id>\n"
              "  return\n"
              "}\n";
 }
@@ -610,16 +610,16 @@ std::string skipThenLimitProgram(uint64_t skipCount, uint64_t limitCount) {
 std::string skipCrossProductProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
                        "  %0:2 = db.cross_product factor {\n"
-                       "    %a = db.scan_nodes() : !db.column<\"a\">\n"
-                       "    db.yield %a : !db.column<\"a\">\n"
+                       "    %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "    db.yield %a : !db.column<!storage.node_id>\n"
                        "  } factor {\n"
-                       "    %b = db.scan_nodes() : !db.column<\"b\">\n"
-                       "    db.yield %b : !db.column<\"b\">\n"
+                       "    %b = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "    db.yield %b : !db.column<!storage.node_id>\n"
                        "  }\n"
                        "  %sa, %sb = db.skip(%0#0, %0#1) count ")
            + std::to_string(count)
-           + " : (!db.column<\"a\">, !db.column<\"b\">) -> (!db.column<\"a\">, !db.column<\"b\">)\n"
-             "  db.output(%sa, %sb) : !db.column<\"a\">, !db.column<\"b\">\n"
+           + " : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)\n"
+             "  db.output(%sa, %sb) : !db.column<!storage.node_id>, !db.column<!storage.node_id>\n"
              "  return\n"
              "}\n";
 }
@@ -631,12 +631,12 @@ std::string skipCrossProductProgram(uint64_t count) {
 // truncate and limit/skip-oblivious.
 std::string chainedSkipProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
-                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
                        "  %sa = db.skip(%a) count ")
            + std::to_string(count)
-           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
-             "  %a1, %e0, %et0, %b = db.get_out_edges(%sa, {}) : (!db.column<\"a\">) -> (!db.column<\"a1\">, !db.column<\"e0\">, !db.column<\"et0\">, !db.column<\"b\">)\n"
-             "  db.output(%b) : !db.column<\"b\">\n"
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  %a1, %e0, %et0, %b = db.get_out_edges(%sa, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)\n"
+             "  db.output(%b) : !db.column<!storage.node_id>\n"
              "  return\n"
              "}\n";
 }
@@ -1070,6 +1070,7 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
 
     mlir::MLIRContext context;
     context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
 
@@ -1721,6 +1722,7 @@ TEST_F(DBLoweringTest, lowersTerminalSkipToFoldedOutput) {
 
     mlir::MLIRContext context;
     context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
 
@@ -1843,6 +1845,7 @@ TEST_F(DBLoweringTest, skipThenLimitFoldsLimitButKeepsSkipCopy) {
 
     mlir::MLIRContext context;
     context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
 
@@ -1929,6 +1932,7 @@ TEST_F(DBLoweringTest, lowersChainedSkipWithConsumerEdgeLoop) {
 
     mlir::MLIRContext context;
     context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
 

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -176,8 +176,26 @@ public:
     }
 
     void sortedRows(std::vector<std::pair<uint64_t, std::optional<std::vector<float>>>>& rows) const {
-        rows = _rows;
-        std::sort(rows.begin(), rows.end());
+        // Sort a size_t permutation rather than std::sort-ing the rows directly:
+        // GCC 13's __insertion_sort emits a spurious -Wmaybe-uninitialized when it
+        // moves a std::pair holding an std::optional<std::vector<float>>, and that
+        // middle-end warning cannot be silenced by a diagnostic pragma (its location
+        // is inside the std header). Ordering an index permutation never moves the
+        // heavy element, sidestepping the false positive; the result is identical.
+        std::vector<size_t> order(_rows.size());
+        for (size_t index = 0; index < order.size(); index++) {
+            order[index] = index;
+        }
+
+        std::sort(order.begin(), order.end(), [this](size_t left, size_t right) {
+            return _rows[left] < _rows[right];
+        });
+
+        rows.clear();
+        rows.reserve(_rows.size());
+        for (const size_t index : order) {
+            rows.push_back(_rows[index]);
+        }
     }
 
 private:
@@ -520,6 +538,87 @@ std::string twoLimitProgram(uint64_t outerCount, uint64_t innerCount) {
            + std::to_string(innerCount)
            + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
              "  db.output(%lb) : !db.column<!storage.node_id>\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN a SKIP count: a scan whose first `count` rows are dropped.
+std::string skipScanProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %sa = db.skip(%a) count ")
+           + std::to_string(count)
+           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
+             "  db.output(%sa) : !db.column<\"a\">\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a)->(b)->(c) RETURN c SKIP count: a two-hop traversal (a three-deep loop
+// nest) whose first `count` result rows are dropped. The skip sits in the
+// innermost body and never gates a loop, so the whole nest runs to exhaustion.
+std::string skipTwoHopProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<\"a\">) -> (!db.column<\"a1\">, !db.column<\"e0\">, !db.column<\"et0\">, !db.column<\"b\">)\n"
+                       "  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<\"b\">, !db.column<\"a1\">) -> (!db.column<\"b2\">, !db.column<\"e1\">, !db.column<\"et1\">, !db.column<\"c\">, !db.column<\"a2\">)\n"
+                       "  %sc = db.skip(%c) count ")
+           + std::to_string(count)
+           + " : (!db.column<\"c\">) -> !db.column<\"c\">\n"
+             "  db.output(%sc) : !db.column<\"c\">\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN a, a.score SKIP count: a property fetch result is a trailing
+// output column, so the suffix copy must lift the node IDs and the nullable value
+// column together. The representative is the first column, the node IDs.
+std::string skipNodePropertyProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<\"a\">) -> !db.column<\"a.score\">\n"
+                       "  %sa, %sscore = db.skip(%a, %score) count ")
+           + std::to_string(count)
+           + " : (!db.column<\"a\">, !db.column<\"a.score\">) -> (!db.column<\"a\">, !db.column<\"a.score\">)\n"
+             "  db.output(%sa, %sscore) : !db.column<\"a\">, !db.column<\"a.score\">\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN a SKIP skipCount LIMIT limitCount: a skip stacked under a limit,
+// the page of a paginated scan. db.skip drops the first skipCount rows and db.limit
+// then keeps the next limitCount. The limit governs the scan's early-exit (it claims
+// the producing loop); the skip drops the prefix in front of it.
+std::string skipThenLimitProgram(uint64_t skipCount, uint64_t limitCount) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %sa = db.skip(%a) count ")
+           + std::to_string(skipCount)
+           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
+             "  %la = db.limit(%sa) count "
+           + std::to_string(limitCount)
+           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
+             "  db.output(%la) : !db.column<\"a\">\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a), (b) RETURN a, b SKIP count: a cross product whose first `count` pairs
+// are dropped. The representative is the post-cross-product column, so the count
+// is right; the cross product is built in full (a skip cannot cap the build).
+std::string skipCrossProductProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %0:2 = db.cross_product factor {\n"
+                       "    %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "    db.yield %a : !db.column<\"a\">\n"
+                       "  } factor {\n"
+                       "    %b = db.scan_nodes() : !db.column<\"b\">\n"
+                       "    db.yield %b : !db.column<\"b\">\n"
+                       "  }\n"
+                       "  %sa, %sb = db.skip(%0#0, %0#1) count ")
+           + std::to_string(count)
+           + " : (!db.column<\"a\">, !db.column<\"b\">) -> (!db.column<\"a\">, !db.column<\"b\">)\n"
+             "  db.output(%sa, %sb) : !db.column<\"a\">, !db.column<\"b\">\n"
              "  return\n"
              "}\n";
 }
@@ -1456,6 +1555,271 @@ TEST_F(DBLoweringTest, limitsWhenPropertyFetchIsRepresentative) {
     runLoweredProgram(program.c_str(), reader.getView(), sink);
 
     EXPECT_EQ(sink.getTotalRows(), 2u);
+}
+
+TEST_F(DBLoweringTest, skipsScanByDroppingPrefix) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    const std::string program = skipScanProgram(3);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    // Four nodes, SKIP 3: one row survives (the first three scanned are dropped).
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows.size(), 1u);
+}
+
+TEST_F(DBLoweringTest, skipZeroEmitsAllRows) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    const std::string program = skipScanProgram(0);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    // SKIP 0 drops nothing, so every node is emitted.
+    const std::vector<std::vector<uint64_t>> expected {{0}, {1}, {2}, {3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, skipExceedingNodeCountEmitsNothing) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // SKIP 10 over four nodes: the whole scan is dropped, so nothing is emitted.
+    // The scan still runs to exhaustion (a skip never early-exits), but every step
+    // emits a zero-row suffix.
+    CountingSink sink;
+    const std::string program = skipScanProgram(10);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 0u);
+}
+
+TEST_F(DBLoweringTest, skipEmitsSuffixAcrossChunkBoundary) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes in chunks of two, SKIP 1: the first chunk drops one of its two
+    // rows and emits a one-row suffix, the second drops none and emits both - three
+    // rows over two appendChunks calls. Unlike a limit, the scan runs to
+    // exhaustion: a skip never terminates the loop early.
+    CountingSink sink;
+    const std::string program = skipScanProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/2);
+
+    EXPECT_EQ(sink.getCalls(), 2u);
+    EXPECT_EQ(sink.getTotalRows(), 3u);
+}
+
+TEST_F(DBLoweringTest, skipsTwoHopTraversal) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond has two two-hop paths, both ending at node 3. SKIP 1 drops one,
+    // leaving a single (c) row, which is node 3 either way - order-independent.
+    CollectingNodeSink sink;
+    const std::string program = skipTwoHopProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, skipsCrossProduct) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes crossed with four is sixteen pairs; SKIP 5 drops the first five,
+    // leaving eleven. The representative is the post-cross-product column, so the
+    // count is right.
+    CountingSink sink;
+    const std::string program = skipCrossProductProgram(5);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 11u);
+}
+
+TEST_F(DBLoweringTest, skipsNodePropertyOutput) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Three nodes carry (or lack) a score; SKIP 1 drops one, leaving two
+    // (node, score) rows, the node ID column and the nullable value column lifted
+    // together. Each surviving row pairs a node with its own score, so every
+    // emitted pair belongs to the known result set - proving the value column was
+    // copied in step with the node IDs, not misaligned.
+    CollectingNodeIntPropSink sink;
+    const std::string program = skipNodePropertyProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    ASSERT_EQ(rows.size(), 2u);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> all {
+        {0, 100}, {1, 200}, {2, std::nullopt}
+    };
+    for (const std::pair<uint64_t, std::optional<int64_t>>& row : rows) {
+        EXPECT_NE(std::find(all.begin(), all.end(), row), all.end());
+    }
+}
+
+TEST_F(DBLoweringTest, skipsNodePropertyOutputEmitsAllWhenZero) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // SKIP 0 drops nothing, so every (node, score) row survives, with node 2's
+    // missing score still null - the skip path does not disturb the property values.
+    CollectingNodeIntPropSink sink;
+    const std::string program = skipNodePropertyProgram(0);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}, {2, std::nullopt}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = skipTwoHopProgram(3);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // A skip never folds into nl.output (the surviving suffix must be copied to the
+    // front) and never gates a loop. Result: one hoisted nl.skip, one nl.skip_update
+    // and one nl.skip_truncate, a three-deep loop nest where NO nl.for carries a
+    // handle, and a plain nl.output with no limit handle.
+    size_t skipCount = 0;
+    size_t forCount = 0;
+    size_t forsWithLimit = 0;
+    size_t updateCount = 0;
+    size_t truncateCount = 0;
+    mlir::nl::Skip skipOp;
+    mlir::nl::SkipUpdate updateOp;
+    mlir::nl::SkipTruncate truncateOp;
+    mlir::nl::Output outputOp;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::Skip found = mlir::dyn_cast<mlir::nl::Skip>(operation)) {
+            skipOp = found;
+            skipCount++;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            forCount++;
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        } else if (mlir::nl::SkipUpdate found = mlir::dyn_cast<mlir::nl::SkipUpdate>(operation)) {
+            updateOp = found;
+            updateCount++;
+        } else if (mlir::nl::SkipTruncate found = mlir::dyn_cast<mlir::nl::SkipTruncate>(operation)) {
+            truncateOp = found;
+            truncateCount++;
+        } else if (mlir::nl::Output found = mlir::dyn_cast<mlir::nl::Output>(operation)) {
+            outputOp = found;
+        }
+    });
+
+    EXPECT_EQ(skipCount, 1u);
+    EXPECT_EQ(forCount, 3u);
+    EXPECT_EQ(forsWithLimit, 0u);
+    EXPECT_EQ(updateCount, 1u);
+    EXPECT_EQ(truncateCount, 1u);
+    ASSERT_TRUE(skipOp);
+    ASSERT_TRUE(updateOp);
+    ASSERT_TRUE(truncateOp);
+    ASSERT_TRUE(outputOp);
+
+    // The update and the truncate both name the one hoisted handle; the output
+    // carries no limit handle (a skip never folds into it).
+    const mlir::Value handle = skipOp.getState();
+    EXPECT_EQ(updateOp.getState(), handle);
+    EXPECT_EQ(truncateOp.getState(), handle);
+    EXPECT_FALSE(outputOp.getLimit());
+
+    // The update and the truncate sit in the innermost loop body, the same block as
+    // the output that consumes the truncated columns.
+    EXPECT_EQ(updateOp->getBlock(), truncateOp->getBlock());
+    EXPECT_EQ(truncateOp->getBlock(), outputOp->getBlock());
+    EXPECT_TRUE(mlir::isa<mlir::nl::For>(updateOp->getParentOp()));
+}
+
+TEST_F(DBLoweringTest, skipThenLimitPagesTheScan) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes, SKIP 1 LIMIT 2: drop the first row, then keep the next two -
+    // min(4 - 1, 2) = 2 rows. This exercises the two ops stacked, the skip's suffix
+    // copy feeding the limit's representative inside the same loop body.
+    CountingSink sink;
+    const std::string program = skipThenLimitProgram(1, 2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 2u);
+}
+
+TEST_F(DBLoweringTest, skipThenLimitStableAcrossChunkSizes) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // SKIP 1 LIMIT 2 over four nodes is the page [position 1, position 3) of the
+    // scan. Chunking only batches the scan, never reorders it, so the page must be
+    // the same two rows whatever the chunk size - even when the skip's drop and the
+    // limit's cut straddle a chunk boundary (chunkSize 1: drop in chunk 0, then one
+    // kept row each in chunks 1 and 2; chunkSize 2: drop one of chunk 0's two rows,
+    // emit its suffix, then a one-row prefix of chunk 1). The reference is the
+    // result at a chunk size that holds the whole scan in one chunk.
+    const std::string program = skipThenLimitProgram(1, 2);
+
+    CollectingNodeSink wholeScanSink;
+    runLoweredProgram(program.c_str(), reader.getView(), wholeScanSink, /*chunkSize=*/4);
+    std::vector<std::vector<uint64_t>> expected;
+    wholeScanSink.sortedRows(expected);
+    ASSERT_EQ(expected.size(), 2u);
+
+    for (size_t chunkSize = 1; chunkSize <= 5; chunkSize++) {
+        CollectingNodeSink sink;
+        runLoweredProgram(program.c_str(), reader.getView(), sink, chunkSize);
+
+        std::vector<std::vector<uint64_t>> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "page differs at chunkSize " << chunkSize;
+    }
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -59,8 +59,9 @@ public:
             const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[columnIndex]);
             ASSERT_NE(nodeIDs, nullptr);
 
-            // Only the first rowCount rows are part of the result; the rest are
-            // the tail the limit clamped off.
+            // Only rows [offset, offset + rowCount) are part of the result: the
+            // prefix before offset is what a SKIP dropped, the tail after is what
+            // a LIMIT clamped off.
             for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
                 _columns[columnIndex].push_back((*nodeIDs)[rowIndex].getValue());
             }
@@ -1071,7 +1072,6 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
     context.getOrLoadDialect<mlir::func::FuncDialect>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
-    context.getOrLoadDialect<mlir::storage::Storage>();
 
     const mlir::ParserConfig parserConfig(&context);
     mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(crossProductScansProgram, parserConfig);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -48,7 +48,7 @@ namespace {
 // All test programs output node ID chunks only.
 class CollectingNodeSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         if (_columns.empty()) {
             _columns.resize(chunks.size());
         }
@@ -61,7 +61,7 @@ public:
 
             // Only the first rowCount rows are part of the result; the rest are
             // the tail the limit clamped off.
-            for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
                 _columns[columnIndex].push_back((*nodeIDs)[rowIndex].getValue());
             }
         }
@@ -92,7 +92,7 @@ private:
 // an Int64 property emit a node ID chunk and a !storage.nullable<i64> value chunk.
 class CollectingNodeIntPropSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 2u);
 
         const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
@@ -103,7 +103,7 @@ public:
 
         const auto& idRaw = nodeIDs->getRaw();
         const auto& valueRaw = values->getRaw();
-        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
             _rows.push_back({idRaw[rowIndex].getValue(), valueRaw[rowIndex]});
         }
     }
@@ -121,7 +121,7 @@ private:
 // !storage.nullable<!storage.string> chunk, storage's ColumnOptVector<string_view>.
 class CollectingNodeStringPropSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 2u);
 
         const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
@@ -132,7 +132,7 @@ public:
 
         const auto& idRaw = nodeIDs->getRaw();
         const auto& valueRaw = values->getRaw();
-        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
             std::optional<std::string> value;
             if (valueRaw[rowIndex]) {
                 value = std::string(*valueRaw[rowIndex]);
@@ -155,7 +155,7 @@ private:
 // each span is copied out since it points into the live graph storage.
 class CollectingNodeEmbeddingPropSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 2u);
 
         const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
@@ -166,7 +166,7 @@ public:
 
         const auto& idRaw = nodeIDs->getRaw();
         const auto& valueRaw = values->getRaw();
-        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
             std::optional<std::vector<float>> value;
             if (valueRaw[rowIndex]) {
                 value = std::vector<float>(valueRaw[rowIndex]->begin(), valueRaw[rowIndex]->end());
@@ -206,7 +206,7 @@ private:
 // edge property emit an edge ID chunk and a !storage.nullable<i64> value chunk.
 class CollectingEdgeIntPropSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 2u);
 
         const auto* edgeIDs = dynamic_cast<const ColumnEdgeIDs*>(chunks[0]);
@@ -217,7 +217,7 @@ public:
 
         const auto& idRaw = edgeIDs->getRaw();
         const auto& valueRaw = values->getRaw();
-        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
             _rows.push_back({idRaw[rowIndex].getValue(), valueRaw[rowIndex]});
         }
     }
@@ -413,7 +413,7 @@ func.func @main() {
 // clamp - to prove a limited cross product caps the product it builds.
 class CountingSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         _calls++;
         _totalRows += rowCount;
 
@@ -1714,7 +1714,7 @@ TEST_F(DBLoweringTest, skipsNodePropertyOutputEmitsAllWhenZero) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
+TEST_F(DBLoweringTest, lowersTerminalSkipToFoldedOutput) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
@@ -1736,10 +1736,12 @@ TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
     DBLowering lowering(&context, &reader.getView());
     lowering.lower(dbFunction, *nlModule);
 
-    // A skip never folds into nl.output (the surviving suffix must be copied to the
-    // front) and never gates a loop. Result: one hoisted nl.skip, one nl.skip_update
-    // and one nl.skip_truncate, a three-deep loop nest where NO nl.for carries a
-    // handle, and a plain nl.output with no limit handle.
+    // A terminal SKIP: the skip feeds db.output directly, so foldSkipTruncatesIntoOutputs
+    // folds the truncate into a skip-bearing output that emits the surviving suffix
+    // in place at an offset. Result: one hoisted nl.skip, one nl.skip_update, NO
+    // nl.skip_truncate (folded away), a three-deep loop nest where NO nl.for carries
+    // a handle (a skip never gates a loop), and an nl.output that carries the skip
+    // handle but no limit.
     size_t skipCount = 0;
     size_t forCount = 0;
     size_t forsWithLimit = 0;
@@ -1747,7 +1749,6 @@ TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
     size_t truncateCount = 0;
     mlir::nl::Skip skipOp;
     mlir::nl::SkipUpdate updateOp;
-    mlir::nl::SkipTruncate truncateOp;
     mlir::nl::Output outputOp;
 
     nlModule->walk([&](mlir::Operation* operation) {
@@ -1762,8 +1763,7 @@ TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
         } else if (mlir::nl::SkipUpdate found = mlir::dyn_cast<mlir::nl::SkipUpdate>(operation)) {
             updateOp = found;
             updateCount++;
-        } else if (mlir::nl::SkipTruncate found = mlir::dyn_cast<mlir::nl::SkipTruncate>(operation)) {
-            truncateOp = found;
+        } else if (mlir::isa<mlir::nl::SkipTruncate>(operation)) {
             truncateCount++;
         } else if (mlir::nl::Output found = mlir::dyn_cast<mlir::nl::Output>(operation)) {
             outputOp = found;
@@ -1774,23 +1774,20 @@ TEST_F(DBLoweringTest, lowersSkipToHandleUpdateAndTruncate) {
     EXPECT_EQ(forCount, 3u);
     EXPECT_EQ(forsWithLimit, 0u);
     EXPECT_EQ(updateCount, 1u);
-    EXPECT_EQ(truncateCount, 1u);
+    EXPECT_EQ(truncateCount, 0u);
     ASSERT_TRUE(skipOp);
     ASSERT_TRUE(updateOp);
-    ASSERT_TRUE(truncateOp);
     ASSERT_TRUE(outputOp);
 
-    // The update and the truncate both name the one hoisted handle; the output
-    // carries no limit handle (a skip never folds into it).
+    // The update and the folded output both name the one hoisted handle; the output
+    // carries the skip handle in its skip operand and no limit.
     const mlir::Value handle = skipOp.getState();
     EXPECT_EQ(updateOp.getState(), handle);
-    EXPECT_EQ(truncateOp.getState(), handle);
+    EXPECT_EQ(outputOp.getSkip(), handle);
     EXPECT_FALSE(outputOp.getLimit());
 
-    // The update and the truncate sit in the innermost loop body, the same block as
-    // the output that consumes the truncated columns.
-    EXPECT_EQ(updateOp->getBlock(), truncateOp->getBlock());
-    EXPECT_EQ(truncateOp->getBlock(), outputOp->getBlock());
+    // The update sits in the innermost loop body, the same block as the output.
+    EXPECT_EQ(updateOp->getBlock(), outputOp->getBlock());
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(updateOp->getParentOp()));
 }
 
@@ -1837,6 +1834,76 @@ TEST_F(DBLoweringTest, skipThenLimitStableAcrossChunkSizes) {
         sink.sortedRows(rows);
         EXPECT_EQ(rows, expected) << "page differs at chunkSize " << chunkSize;
     }
+}
+
+TEST_F(DBLoweringTest, skipThenLimitFoldsLimitButKeepsSkipCopy) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = skipThenLimitProgram(1, 2);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // SKIP 1 LIMIT 2: the skip's nl.skip_truncate feeds nl.limit_update (and, after
+    // the limit folds, the output too) - two uses, never one nl.output - so the skip
+    // fold's hasOneUse test bails and the skip copy stays. The limit, adjacent to the
+    // output, folds. Result: one nl.skip + one surviving nl.skip_truncate, one
+    // nl.limit + NO nl.limit_truncate, and an nl.output that carries the limit handle
+    // but no skip. The scan loop carries the limit (its early-exit bounds the skip
+    // copy's cost).
+    size_t skipTruncateCount = 0;
+    size_t limitTruncateCount = 0;
+    size_t skipCount = 0;
+    size_t limitCount = 0;
+    size_t forsWithLimit = 0;
+    mlir::nl::Limit limitOp;
+    mlir::nl::Output outputOp;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::Limit found = mlir::dyn_cast<mlir::nl::Limit>(operation)) {
+            limitOp = found;
+            limitCount++;
+        } else if (mlir::isa<mlir::nl::Skip>(operation)) {
+            skipCount++;
+        } else if (mlir::isa<mlir::nl::SkipTruncate>(operation)) {
+            skipTruncateCount++;
+        } else if (mlir::isa<mlir::nl::LimitTruncate>(operation)) {
+            limitTruncateCount++;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        } else if (mlir::nl::Output found = mlir::dyn_cast<mlir::nl::Output>(operation)) {
+            outputOp = found;
+        }
+    });
+
+    EXPECT_EQ(skipCount, 1u);
+    EXPECT_EQ(limitCount, 1u);
+    EXPECT_EQ(skipTruncateCount, 1u);
+    EXPECT_EQ(limitTruncateCount, 0u);
+    EXPECT_EQ(forsWithLimit, 1u);
+    ASSERT_TRUE(limitOp);
+    ASSERT_TRUE(outputOp);
+
+    // The output folded the limit (not the skip): it carries the limit handle and no
+    // skip. The skip copy survives upstream, feeding the limit's representative.
+    EXPECT_EQ(outputOp.getLimit(), limitOp.getState());
+    EXPECT_FALSE(outputOp.getSkip());
 }
 
 TEST_F(DBLoweringTest, skipsChainedMidQueryFansOutFromSurvivors) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -623,6 +623,23 @@ std::string skipCrossProductProgram(uint64_t count) {
              "}\n";
 }
 
+// MATCH (a) WITH a SKIP count MATCH (a)-->(b) RETURN b: a mid-query (chained) skip.
+// db.skip feeds db.get_out_edges, not db.output, so the skip drops the first `count`
+// intermediate `a`s and each surviving `a` then fans out all its out-edges. The scan
+// (a's producer) holds the skip; the edge loop is a consumer, built after the
+// truncate and limit/skip-oblivious.
+std::string chainedSkipProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<\"a\">\n"
+                       "  %sa = db.skip(%a) count ")
+           + std::to_string(count)
+           + " : (!db.column<\"a\">) -> !db.column<\"a\">\n"
+             "  %a1, %e0, %et0, %b = db.get_out_edges(%sa, {}) : (!db.column<\"a\">) -> (!db.column<\"a1\">, !db.column<\"e0\">, !db.column<\"et0\">, !db.column<\"b\">)\n"
+             "  db.output(%b) : !db.column<\"b\">\n"
+             "  return\n"
+             "}\n";
+}
+
 }
 
 class DBLoweringTest : public TuringTest {
@@ -1820,6 +1837,88 @@ TEST_F(DBLoweringTest, skipThenLimitStableAcrossChunkSizes) {
         sink.sortedRows(rows);
         EXPECT_EQ(rows, expected) << "page differs at chunkSize " << chunkSize;
     }
+}
+
+TEST_F(DBLoweringTest, skipsChainedMidQueryFansOutFromSurvivors) {
+    auto graph = buildRegularOutGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // WITH a SKIP 1 drops one of the four nodes; the three survivors each have
+    // out-degree two, so the expansion emits six b rows. The downstream fan-out is
+    // NOT itself skipped - six rows from a SKIP of one proves the skip bounds the
+    // intermediate `a`, with the edge loop a limit/skip-oblivious consumer.
+    CountingSink sink;
+    const std::string program = chainedSkipProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 6u);
+}
+
+TEST_F(DBLoweringTest, lowersChainedSkipWithConsumerEdgeLoop) {
+    auto graph = buildRegularOutGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = chainedSkipProgram(1);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // One skip, one update, one truncate, two loops (scan + edges) - and NO loop
+    // carries a handle (a skip never gates a loop). The truncate stays (no fold for
+    // skip), and the edge loop is built inside the scan body, after the truncate,
+    // consuming the cut chunk - so it fans out freely.
+    size_t skipCount = 0;
+    size_t updateCount = 0;
+    size_t truncateCount = 0;
+    size_t forsWithLimit = 0;
+    mlir::nl::SkipTruncate truncateOp;
+    mlir::nl::For edgeLoop;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::nl::Skip>(operation)) {
+            skipCount++;
+        } else if (mlir::isa<mlir::nl::SkipUpdate>(operation)) {
+            updateCount++;
+        } else if (mlir::nl::SkipTruncate found = mlir::dyn_cast<mlir::nl::SkipTruncate>(operation)) {
+            truncateOp = found;
+            truncateCount++;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+
+            mlir::Operation* const iteratorDef = forOp.getIterator().getDefiningOp();
+            if (mlir::isa<mlir::nl::GetOutEdges>(iteratorDef)) {
+                edgeLoop = forOp;
+            }
+        }
+    });
+
+    EXPECT_EQ(skipCount, 1u);
+    EXPECT_EQ(updateCount, 1u);
+    EXPECT_EQ(truncateCount, 1u);
+    EXPECT_EQ(forsWithLimit, 0u);
+    ASSERT_TRUE(truncateOp);
+    ASSERT_TRUE(edgeLoop);
+
+    // The consuming edge loop is nested in the scan body, downstream of the truncate
+    // that feeds it - the chained shape, where the cut chunk drives the fan-out.
+    EXPECT_EQ(edgeLoop->getBlock(), truncateOp->getBlock());
+    EXPECT_TRUE(edgeLoop.getIterator().getDefiningOp<mlir::nl::GetOutEdges>());
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -62,6 +62,27 @@ TEST_F(NLDialectTest, verifierAcceptsLimitTruncate) {
     EXPECT_EQ(truncate.getResult(0).getType(), chunk.getType());
 }
 
+// An nl.skip_truncate passes its column types through unchanged - results mirror
+// the operand chunk types - and verifies in a skip/update/truncate/output chain.
+TEST_F(NLDialectTest, verifierAcceptsSkipTruncate) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value handle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
+    builder.create<mlir::nl::SkipUpdate>(loc, handle, chunk);
+    mlir::nl::SkipTruncate truncate = builder.create<mlir::nl::SkipTruncate>(loc, handle, mlir::ValueRange {chunk});
+    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value());
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(truncate.getResult(0).getType(), chunk.getType());
+}
+
 // nl.output with no limit handle is unbounded and verifies on its own.
 TEST_F(NLDialectTest, verifierAcceptsOutput) {
     mlir::OpBuilder builder(&_context);

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -143,4 +143,26 @@ TEST_F(NLDialectTest, verifierAcceptsOutputWithSkip) {
     EXPECT_FALSE(output.getLimit());
 }
 
+// A folded nl.output carries the single handle of the truncate adjacent to it,
+// never both: an output with both a limit and a skip handle fails verification.
+TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value limitHandle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
+    const mlir::Value skipHandle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, limitHandle, skipHandle);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(function)));
+}
+
 }

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -55,7 +55,7 @@ TEST_F(NLDialectTest, verifierAcceptsLimitTruncate) {
     const mlir::Value handle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::LimitUpdate>(loc, handle, chunk);
     mlir::nl::LimitTruncate truncate = builder.create<mlir::nl::LimitTruncate>(loc, handle, mlir::ValueRange {chunk});
-    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -76,7 +76,7 @@ TEST_F(NLDialectTest, verifierAcceptsSkipTruncate) {
     const mlir::Value handle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::SkipUpdate>(loc, handle, chunk);
     mlir::nl::SkipTruncate truncate = builder.create<mlir::nl::SkipTruncate>(loc, handle, mlir::ValueRange {chunk});
-    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -93,7 +93,7 @@ TEST_F(NLDialectTest, verifierAcceptsOutput) {
     mlir::Block& entryBlock = function.getBody().front();
     const mlir::Value chunk = entryBlock.getArgument(0);
 
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -112,11 +112,35 @@ TEST_F(NLDialectTest, verifierAcceptsOutputWithLimit) {
 
     const mlir::Value handle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::LimitUpdate>(loc, handle, chunk);
-    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, handle);
+    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, handle, mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
     EXPECT_EQ(output.getLimit(), handle);
+}
+
+// nl.output may carry an optional skip handle (the folded terminal-SKIP form),
+// emitting the surviving suffix at the offset the preceding nl.skip_update sized.
+// The skip sibling of verifierAcceptsOutputWithLimit.
+TEST_F(NLDialectTest, verifierAcceptsOutputWithSkip) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value handle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
+    builder.create<mlir::nl::SkipUpdate>(loc, handle, chunk);
+    // The skip handle goes in the third operand (no limit), so the columns, limit
+    // and skip operand segments are all distinct.
+    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), handle);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(output.getSkip(), handle);
+    EXPECT_FALSE(output.getLimit());
 }
 
 }

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -323,6 +323,25 @@ std::string nlLimitOuterLoopOnlyProgram(uint64_t count) {
              "}\n";
 }
 
+// Scan all nodes and output them, with a top-level nl.skip dropping the first
+// `count` rows. The handle is hoisted, charged by skip_update, and the truncate
+// lifts each step's surviving suffix to the front before the plain output. Unlike
+// a limit, the loop carries NO handle: a skip runs the scan to exhaustion.
+std::string nlSkipScanProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %h = nl.skip(")
+           + std::to_string(count)
+           + ")\n"
+             "  %nodes = nl.scan_nodes()\n"
+             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {\n"
+             "    nl.skip_update %h, %a : !nl.chunk<!nl.node_id>\n"
+             "    %sa = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>\n"
+             "    nl.output(%sa) : !nl.chunk<!nl.node_id>\n"
+             "  }\n"
+             "  func.return\n"
+             "}\n";
+}
+
 }
 
 class NLExecutorTest : public TuringTest {
@@ -700,6 +719,67 @@ TEST_F(NLExecutorTest, limitHaltsOuterLoopWhenBudgetSpent) {
 
     EXPECT_EQ(sink.getCalls(), 1u);
     EXPECT_EQ(sink.getTotalRows(), 1u);
+}
+
+TEST_F(NLExecutorTest, skipScanDropsPrefix) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    const std::string program = nlSkipScanProgram(1);
+    runProgram(program.c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // Four nodes, SKIP 1: three rows survive (the first scanned node is dropped).
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows.size(), 3u);
+}
+
+TEST_F(NLExecutorTest, skipZeroEmitsAll) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // SKIP 0: nothing is dropped, so every node survives.
+    CollectingNodeSink sink;
+    const std::string program = nlSkipScanProgram(0);
+    runProgram(program.c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0}, {1}, {2}, {3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, skipExceedingCountEmitsNothing) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // SKIP 10 over four nodes: the whole scan is dropped, so no row is emitted.
+    CountingSink sink;
+    const std::string program = nlSkipScanProgram(10);
+    runProgram(program.c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 0u);
+}
+
+TEST_F(NLExecutorTest, skipEmitsSuffixAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 2 over four nodes, SKIP 1: the first chunk drops one of its two
+    // rows and emits the one-row suffix, the second chunk drops none and emits
+    // both. The scan runs to exhaustion (a skip never early-exits) - two calls,
+    // three rows.
+    CountingSink sink;
+    const std::string program = nlSkipScanProgram(1);
+    runProgram(program.c_str(), reader.getView(), 2, sink);
+
+    EXPECT_EQ(sink.getCalls(), 2u);
+    EXPECT_EQ(sink.getTotalRows(), 3u);
 }
 
 TEST_F(NLExecutorTest, rejectsCrossLoopOutputColumns) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -334,10 +334,10 @@ std::string nlSkipScanProgram(uint64_t count) {
            + std::to_string(count)
            + ")\n"
              "  %nodes = nl.scan_nodes()\n"
-             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {\n"
-             "    nl.skip_update %h, %a : !nl.chunk<!nl.node_id>\n"
-             "    %sa = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>\n"
-             "    nl.output(%sa) : !nl.chunk<!nl.node_id>\n"
+             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {\n"
+             "    nl.skip_update %h, %a : !nl.chunk<!storage.node_id>\n"
+             "    %sa = nl.skip_truncate %h, (%a) : !nl.chunk<!storage.node_id>\n"
+             "    nl.output(%sa) : !nl.chunk<!storage.node_id>\n"
              "  }\n"
              "  func.return\n"
              "}\n";
@@ -353,9 +353,9 @@ std::string nlSkipFoldedScanProgram(uint64_t count) {
            + std::to_string(count)
            + ")\n"
              "  %nodes = nl.scan_nodes()\n"
-             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {\n"
-             "    nl.skip_update %h, %a : !nl.chunk<!nl.node_id>\n"
-             "    nl.output(%a) skip %h : !nl.chunk<!nl.node_id>\n"
+             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {\n"
+             "    nl.skip_update %h, %a : !nl.chunk<!storage.node_id>\n"
+             "    nl.output(%a) skip %h : !nl.chunk<!storage.node_id>\n"
              "  }\n"
              "  func.return\n"
              "}\n";

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -44,7 +44,7 @@ namespace {
 // All test programs output node ID chunks only.
 class CollectingNodeSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         if (_columns.empty()) {
             _columns.resize(chunks.size());
         }
@@ -55,9 +55,10 @@ public:
             const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[columnIndex]);
             ASSERT_NE(nodeIDs, nullptr);
 
-            // Only the first rowCount rows are part of the result; the rest are
-            // the tail the limit clamped off.
-            for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            // Only rows [offset, offset + rowCount) are part of the result: the
+            // prefix before offset is what a SKIP dropped, the tail after is what
+            // a LIMIT clamped off.
+            for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
                 _columns[columnIndex].push_back((*nodeIDs)[rowIndex].getValue());
             }
         }
@@ -90,7 +91,7 @@ private:
 // Int64 property: a node ID chunk and a !storage.nullable<i64> value chunk.
 class CollectingNodeIntPropSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 2u);
 
         const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
@@ -101,7 +102,7 @@ public:
 
         const auto& idRaw = nodeIDs->getRaw();
         const auto& valueRaw = values->getRaw();
-        for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
             _rows.push_back({idRaw[rowIndex].getValue(), valueRaw[rowIndex]});
         }
     }
@@ -246,7 +247,7 @@ func.func @main() {
 // emits a clamped prefix (a partial final chunk) and stops the loop early.
 class CountingSink : public NLOutputSink {
 public:
-    void appendChunks(std::span<const Column* const> chunks, size_t rowCount) override {
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         _calls++;
         _totalRows += rowCount;
     }
@@ -337,6 +338,24 @@ std::string nlSkipScanProgram(uint64_t count) {
              "    nl.skip_update %h, %a : !nl.chunk<!nl.node_id>\n"
              "    %sa = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>\n"
              "    nl.output(%sa) : !nl.chunk<!nl.node_id>\n"
+             "  }\n"
+             "  func.return\n"
+             "}\n";
+}
+
+// The folded terminal-SKIP form that foldSkipTruncatesIntoOutputs produces: no
+// nl.skip_truncate, and the nl.output carries the skip handle so it emits the
+// surviving suffix in place at offset skipThisStep, with no copy. Same result as
+// nlSkipScanProgram - this exercises the copy-free output path.
+std::string nlSkipFoldedScanProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %h = nl.skip(")
+           + std::to_string(count)
+           + ")\n"
+             "  %nodes = nl.scan_nodes()\n"
+             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {\n"
+             "    nl.skip_update %h, %a : !nl.chunk<!nl.node_id>\n"
+             "    nl.output(%a) skip %h : !nl.chunk<!nl.node_id>\n"
              "  }\n"
              "  func.return\n"
              "}\n";
@@ -780,6 +799,49 @@ TEST_F(NLExecutorTest, skipEmitsSuffixAcrossChunks) {
 
     EXPECT_EQ(sink.getCalls(), 2u);
     EXPECT_EQ(sink.getTotalRows(), 3u);
+}
+
+TEST_F(NLExecutorTest, skipFoldedEmitsSuffixInPlace) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The folded form, chunkSize 2 over nodes {0,1,2,3}, SKIP 1. The first chunk
+    // [0,1] emits its suffix in place at offset 1 (node 1), the tail chunk [2,3]
+    // passes through whole at offset 0 (nodes 2, 3) - both with no copy. The
+    // surviving set is {1,2,3}; were the offset ignored, node 0 would survive and
+    // node 1 would be dropped, giving the wrong {0,2,3}.
+    CollectingNodeSink sink;
+    const std::string program = nlSkipFoldedScanProgram(1);
+    runProgram(program.c_str(), reader.getView(), 2, sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, skipFoldedMatchesTruncated) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The copy-free folded output must emit exactly what the nl.skip_truncate copy
+    // path does, for the same SKIP and chunkSize - the fold is a peephole, not a
+    // behaviour change.
+    CollectingNodeSink truncatedSink;
+    const std::string truncatedProgram = nlSkipScanProgram(1);
+    runProgram(truncatedProgram.c_str(), reader.getView(), 2, truncatedSink);
+
+    CollectingNodeSink foldedSink;
+    const std::string foldedProgram = nlSkipFoldedScanProgram(1);
+    runProgram(foldedProgram.c_str(), reader.getView(), 2, foldedSink);
+
+    std::vector<std::vector<uint64_t>> truncatedRows;
+    std::vector<std::vector<uint64_t>> foldedRows;
+    truncatedSink.sortedRows(truncatedRows);
+    foldedSink.sortedRows(foldedRows);
+    EXPECT_EQ(foldedRows, truncatedRows);
 }
 
 TEST_F(NLExecutorTest, rejectsCrossLoopOutputColumns) {


### PR DESCRIPTION
Implement the SKIP operation across the db and nl dialects.

* Fuses skip + output into output skip-aware

```
Before:
nl.skip_update %0, %arg0 : !nl.chunk<!nl.node_id>
%2 = nl.skip_truncate %0, (%arg0) : !nl.chunk<!nl.node_id>   // copy
nl.output(%2) : !nl.chunk<!nl.node_id>

After:
nl.skip_update %0, %arg0 : !nl.chunk<!nl.node_id>
nl.output(%arg0) skip %0 : !nl.chunk<!nl.node_id>
``` 