### PR TITLE
MLIR: implement db.get_in_edges and its lowering

### DIFF
--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -52,6 +52,45 @@ def GetOutEdges : TuringOp<"get_out_edges", [Pure]> {
 }
 
 /**
+* GetInEdges
+*/
+def GetInEdges : TuringOp<"get_in_edges", [Pure]> {
+  let summary = "Fetch node and edge predecessors of input, filtering carried columns alongside";
+
+  let description = [{
+    The reverse-direction sibling of get_out_edges: where that walks each node's
+    successors, this walks its predecessors. In `MATCH (a)<-(b)<-(c)` the `a` we
+    return are not the raw scan but the nodes with a predecessor `b` that itself
+    has a predecessor `c`, so each hop must filter the columns carried from
+    earlier hops.
+
+    `columns_to_filter` is that carry set; each one comes back in `filtered_columns`:
+
+      %b = get_in_edges(%a, {})
+      %c, %b2, %a2 = get_in_edges(%b, {%a})   // eids/etypes omitted
+
+    The result chunk shape - srcids, eids, etypes, tgtids - matches
+    get_out_edges, so the two are interchangeable in a hop.
+  }];
+
+  // `columns_to_filter`: the only variadic operand, after the fixed `input_nodes`.
+  let arguments = (ins Column:$input_nodes, Variadic<Column>:$columns_to_filter);
+
+  // `filtered_columns`: one per carried column, after the four fixed results.
+  let results   = (outs ColumnNodeIDs:$srcids,
+                        ColumnEdgeIDs:$eids,
+                        ColumnEdgeTypes:$etypes,
+                        ColumnNodeIDs:$tgtids,
+                        Variadic<Column>:$filtered_columns);
+
+  // Brace-wrap the carry set so it reads like `get_in_edges(%b, {%a})`.
+  let assemblyFormat = [{
+    `(` $input_nodes `,` `{` $columns_to_filter `}` `)` attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+
+/**
 * GetNodeProperties
 */
 def GetNodeProperties : TuringOp<"get_node_properties", [Pure]> {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -155,6 +155,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerScanNodes(scanNodes);
     } else if (mlir::db::GetOutEdges getOutEdges = mlir::dyn_cast<mlir::db::GetOutEdges>(operation)) {
         lowerGetOutEdges(getOutEdges);
+    } else if (mlir::db::GetInEdges getInEdges = mlir::dyn_cast<mlir::db::GetInEdges>(operation)) {
+        lowerGetInEdges(getInEdges);
     } else if (mlir::db::GetNodeProperties getNodeProperties = mlir::dyn_cast<mlir::db::GetNodeProperties>(operation)) {
         lowerGetNodeProperties(getNodeProperties);
     } else if (mlir::db::GetEdgeProperties getEdgeProperties = mlir::dyn_cast<mlir::db::GetEdgeProperties>(operation)) {
@@ -199,6 +201,25 @@ void DBLowering::lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges) {
     // carried chunk - is inferred from the operands.
     nl::GetOutEdges edges = _builder.create<nl::GetOutEdges>(_builder.getUnknownLoc(), inputChunk, carriedChunks);
     buildLoopForSource(edges.getResult(), getOutEdges.getOperation());
+}
+
+void DBLowering::lowerGetInEdges(mlir::db::GetInEdges getInEdges) {
+    // The predecessor counterpart of lowerGetOutEdges: same shape, reverse
+    // direction. Map the input node column and the carry set to the nl chunks
+    // they lowered to. The fetch nests in the loop that binds its input chunk.
+    const mlir::Value inputChunk = mapValue(getInEdges.getInputNodes());
+
+    llvm::SmallVector<mlir::Value, 4> carriedChunks;
+    for (const mlir::Value carriedColumn : getInEdges.getColumnsToFilter()) {
+        carriedChunks.push_back(mapValue(carriedColumn));
+    }
+
+    setInsertionInto(ownerBlock(inputChunk));
+
+    // The result iterator type - the four fixed edge chunks plus one per
+    // carried chunk - is inferred from the operands.
+    nl::GetInEdges edges = _builder.create<nl::GetInEdges>(_builder.getUnknownLoc(), inputChunk, carriedChunks);
+    buildLoopForSource(edges.getResult(), getInEdges.getOperation());
 }
 
 void DBLowering::lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties) {
@@ -395,7 +416,7 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
         return;
     }
 
-    const bool opensLoop = mlir::isa<mlir::db::ScanNodes, mlir::db::GetOutEdges>(definingOp);
+    const bool opensLoop = mlir::isa<mlir::db::ScanNodes, mlir::db::GetOutEdges, mlir::db::GetInEdges>(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
     // The first limit, in program order, to claim a producer wins, so a loop

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -99,6 +99,7 @@ private:
     void lowerOperation(mlir::Operation& operation);
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
+    void lowerGetInEdges(mlir::db::GetInEdges getInEdges);
     void lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties);
     void lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgeProperties);
     void lowerCrossProduct(mlir::db::CrossProduct product);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -232,6 +232,18 @@ func.func @main() {
 }
 )mlir";
 
+// One hop along in-edges, outputting (source, target) pairs. The writer fills
+// the source side and the target side is gathered from the input, so the
+// output pairs are the same edge set as the out-edges hop
+constexpr const char* oneHopInProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // Two hops a->b->c carrying a through the second hop, outputting (a, c) pairs
 constexpr const char* twoHopProgram = R"mlir(
 func.func @main() {
@@ -682,6 +694,20 @@ TEST_F(DBLoweringTest, lowersOneHopOutEdges) {
 
     CollectingNodeSink sink;
     runLoweredProgram(oneHopOutProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersOneHopInEdges) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(oneHopInProgram, reader.getView(), sink);
 
     const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
     std::vector<std::vector<uint64_t>> rows;

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -255,6 +255,20 @@ func.func @main() {
 }
 )mlir";
 
+// The in-edges mirror of twoHopProgram: two predecessor hops a<-b<-c carrying a
+// through the second hop, outputting (a, c) pairs. Each hop's source side (the
+// predecessor it discovers) feeds the next hop, while the input side (b, then
+// the carried a) is gathered along, exercising the carry set through in-edges.
+constexpr const char* twoHopInProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %b, %e0, %et0, %a1 = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %c, %e1, %et1, %b2, %a2 = db.get_in_edges(%b, {%a1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%a2, %c) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // Scan all nodes and output each node with its "score" property, which some
 // nodes lack (those come back null, none are dropped)
 constexpr const char* nodePropertiesProgram = R"mlir(
@@ -710,6 +724,22 @@ TEST_F(DBLoweringTest, lowersOneHopInEdges) {
     runLoweredProgram(oneHopInProgram, reader.getView(), sink);
 
     const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersTwoHopInEdgesWithCarriedColumn) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(twoHopInProgram, reader.getView(), sink);
+
+    // Both two-hop predecessor chains end at 3 and trace back to 0, one through
+    // 1 and one through 2, so each emits (a, c) = (3, 0)
+    const std::vector<std::vector<uint64_t>> expected {{3, 0}, {3, 0}};
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -173,6 +173,27 @@ func.func @main() {
 }
 )mlir";
 
+// The in-edges mirror of twoHopProgram: two predecessor hops a<-b<-c carrying a
+// through the second hop, outputting (a, c) pairs. Each hop's discovered
+// predecessor (%srcs, the source side) feeds the next hop, while the input side
+// (a, then the carried a) is gathered along, exercising the carry set through
+// in-edges execution.
+constexpr const char* twoHopInProgram = R"mlir(
+func.func @main() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %edges = nl.get_in_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %aIn in %edges : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      %hop = nl.get_in_edges(%srcs, {%aIn}) : !nl.chunk<!storage.node_id>
+      nl.for %srcs2, %eids2, %etypes2, %bIn, %aCarried in %hop : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%aCarried, %srcs2) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      }
+    }
+  }
+  func.return
+}
+)mlir";
+
 // Verifier-legal but rejected by the translator: outputs an outer loop
 // variable from the inner loop instead of carrying it through the carry set
 constexpr const char* crossLoopOutputProgram = R"mlir(
@@ -532,6 +553,22 @@ TEST_F(NLExecutorTest, twoHopWithCarriedColumn) {
 
     // Both two-hop paths go from 0 to 3, one through 1 and one through 2
     const std::vector<std::vector<uint64_t>> expected {{0, 3}, {0, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, twoHopInWithCarriedColumn) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(twoHopInProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // Both two-hop predecessor chains end at 3 and trace back to 0, one through
+    // 1 and one through 2, so each emits (a, c) = (3, 0)
+    const std::vector<std::vector<uint64_t>> expected {{3, 0}, {3, 0}};
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);


### PR DESCRIPTION
Add the db.get_in_edges op as a strongly-typed mirror of db.get_out_edges and lower it to the existing nl.get_in_edges.