### PR TITLE
MLIR: implement sort in the db/nl dialects with a fused top-K path

### DIFF
--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -197,3 +197,56 @@ LogicalResult Limit::verify() {
 LogicalResult Skip::verify() {
     return verifyPassThrough(getOperation(), getColumns(), getResults());
 }
+
+// db.sort passes its columns straight through reordered, so the results must be
+// exactly the input columns - same count, same types, same order. The two key
+// arrays must be parallel and every key must index a column that exists.
+LogicalResult Sort::verify() {
+    const OperandRange columns = getColumns();
+    const Operation::result_range results = getResults();
+
+    // A sort with no column has nothing to reorder, and its row count would have
+    // no column to be read from during lowering. Reject it here at the db level.
+    if (columns.empty()) {
+        return emitOpError("requires at least one column");
+    }
+
+    if (columns.size() != results.size()) {
+        return emitOpError("expects ") << columns.size()
+                                       << " results, one per input column, but has "
+                                       << results.size();
+    }
+
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        if (columns[columnIndex].getType() != results[columnIndex].getType()) {
+            return emitOpError("result ") << columnIndex
+                                          << " must have the same type as input column "
+                                          << columnIndex;
+        }
+    }
+
+    const ArrayRef<int64_t> keyColumns = getKeyColumns();
+    const ArrayRef<bool> keyAscending = getKeyAscending();
+
+    // At least one key, and one direction per key: the two arrays describe the
+    // same list of sort keys, so a mismatch is malformed IR.
+    if (keyColumns.empty()) {
+        return emitOpError("requires at least one sort key");
+    }
+
+    if (keyColumns.size() != keyAscending.size()) {
+        return emitOpError("expects one ascending flag per key, but has ")
+               << keyColumns.size() << " keys and " << keyAscending.size() << " flags";
+    }
+
+    // Every key names a column to sort by, so it must index one of the columns.
+    for (const int64_t keyColumn : keyColumns) {
+        const bool inRange = keyColumn >= 0 && static_cast<size_t>(keyColumn) < columns.size();
+        if (!inRange) {
+            return emitOpError("sort key ") << keyColumn << " is out of range for "
+                                            << columns.size() << " columns";
+        }
+    }
+
+    return success();
+}

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -323,4 +323,56 @@ def Skip : TuringOp<"skip", [Pure]> {
   let hasVerifier = 1;
 }
 
+/**
+* Sort
+*/
+def Sort : TuringOp<"sort", [Pure]> {
+  let summary = "Reorder the rows of a column set by one or more key columns";
+  let description = [{
+    The declarative counterpart of a Cypher RETURN ... ORDER BY. Takes the whole
+    set of columns flowing into db.output and emits them with their rows reordered
+    so that the key columns are sorted; every column moves as one row, so the
+    projection stays row-aligned:
+
+      %a     = db.scan_nodes() : !db.column<"a">
+      %score = db.get_node_properties(%a, "score") : (!db.column<"a">) -> !db.column<"a.score">
+      %sa, %sscore = db.sort(%a, %score) keys [1] ascending [true]
+                       : (!db.column<"a">, !db.column<"a.score">) -> (!db.column<"a">, !db.column<"a.score">)
+      db.output(%sa, %sscore) : !db.column<"a">, !db.column<"a.score">
+
+    A row is sorted across several columns: `keys` is the list of column indices
+    to sort by, most significant first (so `keys [1, 0]` sorts by column 1, ties
+    broken by column 0), and `ascending` gives the direction of each key. The
+    columns pass through unchanged in count and type - only the row order changes.
+
+    Sort is a pipeline breaker: it must see every row before it can emit any, so
+    it lowers to an nl.sort_buffer accumulator hoisted above the loops, an
+    nl.sort_collect in the producing loop body that appends each chunk, and an
+    nl.sort source iterator after the loop whose nl.for emits the sorted rows.
+    Reordering a deterministic read of the graph is itself deterministic, so the
+    op is Pure.
+  }];
+
+  // The columns flow through unchanged. keyColumns are indices into $columns,
+  // most significant first; keyAscending gives one direction per key (true =
+  // ascending). The two arrays are parallel and the verifier checks they line up.
+  let arguments = (ins Variadic<Column>:$columns,
+                       DenseI64ArrayAttr:$keyColumns,
+                       DenseBoolArrayAttr:$keyAscending);
+  let results   = (outs Variadic<Column>:$results);
+
+  // One result per input column, same types; functional-type prints the
+  // `(operandTypes) -> resultTypes` form. The two key arrays print after their
+  // keywords (`keys array<i64: ...>`, `ascending array<i1: ...>`) ahead of the
+  // colon, elided from attr-dict because the format already names them.
+  let assemblyFormat = [{
+    `(` $columns `)` `keys` $keyColumns `ascending` $keyAscending attr-dict `:`
+    functional-type(operands, results)
+  }];
+
+  // results arity and types must equal the columns, and the key arrays must be
+  // parallel and reference columns in range.
+  let hasVerifier = 1;
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -120,6 +120,36 @@ LogicalResult SkipTruncate::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// An nl.sort_buffer needs at least one key, and one direction per key: the two
+// arrays describe the same list of sort keys. The buffers' column count is not
+// known here (the types live on the feeding nl.sort_collect), so key indices are
+// range-checked during translation rather than at the buffer op.
+LogicalResult SortBuffer::verify() {
+    const ArrayRef<int64_t> keyColumns = getKeyColumns();
+    const ArrayRef<bool> keyAscending = getKeyAscending();
+
+    if (keyColumns.empty()) {
+        return emitOpError("requires at least one sort key");
+    }
+
+    if (keyColumns.size() != keyAscending.size()) {
+        return emitOpError("expects one ascending flag per key, but has ")
+               << keyColumns.size() << " keys and " << keyAscending.size() << " flags";
+    }
+
+    return success();
+}
+
+// An nl.sort_collect must append at least one column - an empty append could not
+// size the accumulated row set and there would be nothing to sort.
+LogicalResult SortCollect::verify() {
+    if (getColumns().empty()) {
+        return emitOpError("requires at least one column to collect");
+    }
+
+    return success();
+}
+
 void For::build(OpBuilder& builder, OperationState& state, Value iterator) {
     For::build(builder, state, iterator, Value());
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -504,4 +504,98 @@ def SkipTruncate : NLOp<"skip_truncate", [InferTypeOpAdaptor]> {
   }];
 }
 
+/**
+* SortBuffer
+*/
+// NOT Pure: each nl.sort_buffer is a distinct accumulator, so two must never be
+// CSE'd into one, and an unread one must not be DCE'd - resetting its buffers is
+// a side effect (like nl.limit).
+def SortBuffer : NLOp<"sort_buffer", []> {
+  let summary = "Create (and reset) a row accumulator for one ORDER BY";
+  let description = [{
+    Sits at the top of the scope it governs - function scope for a top-level
+    ORDER BY - where it re-initializes the per-column buffers once per enclosing
+    step. Produces the !nl.sort_state handle that nl.sort_collect appends to and
+    the nl.for over nl.sort drains.
+
+    `keys` is the list of column indices to sort by, most significant first;
+    `ascending` gives the direction of each key (true = ascending). The buffers'
+    column types are not spelled here - they are recovered from the nl.sort_collect
+    that feeds the same handle - so only the sort spec appears. The result type is
+    buildable and omitted.
+
+      %state = nl.sort_buffer keys [1] ascending [true]
+  }];
+
+  // keyColumns are indices into the collected column set, most significant first;
+  // keyAscending gives one direction per key. The two arrays are parallel.
+  let arguments = (ins DenseI64ArrayAttr:$keyColumns, DenseBoolArrayAttr:$keyAscending);
+  let results   = (outs NLSortState:$state);
+
+  let assemblyFormat = "`keys` $keyColumns `ascending` $keyAscending attr-dict";
+  let hasVerifier = 1;
+}
+
+/**
+* SortCollect
+*/
+// NOT Pure: it appends the current chunk's rows to the handle's buffers, so it
+// must run exactly where it sits, once per producing-loop step, and must not be
+// hoisted, CSE'd or eliminated.
+def SortCollect : NLOp<"sort_collect", []> {
+  let summary = "Append this step's chunk of every column to a sort accumulator";
+  let description = [{
+    Runs in the producing loop body, once per step. Appends the current chunk of
+    each column - the whole row set of this step - to the matching buffer of the
+    handle, so that by the time the producing loop is exhausted the buffers hold
+    every row. The columns are taken together so the buffers stay row-aligned.
+
+      nl.sort_collect %state, (%a, %score) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>
+  }];
+
+  // The accumulator handle, then the columns to append. The column chunk types
+  // are spelled after the colon (as nl.output does), since the buffers' element
+  // types are recovered from them.
+  let arguments = (ins NLSortStateHandle:$state, Variadic<NLChunk>:$columns);
+
+  let assemblyFormat = [{
+    $state `,` `(` $columns `)` attr-dict `:` qualified(type($columns))
+  }];
+  let hasVerifier = 1;
+}
+
+/**
+* Sort
+*/
+// Pure: given a filled accumulator it deterministically yields the same sorted
+// iterator, and it produces no side effect of its own - the sort and the
+// chunk-by-chunk emission happen in the driving nl.for. Mirrors nl.scan_nodes:
+// a source op whose nl.for does the work.
+def Sort : NLOp<"sort", [Pure]> {
+  let summary = "Create a database iterator over the sorted rows of an accumulator";
+  let description = [{
+    The source op for the emit phase of an ORDER BY, the sorted counterpart of
+    nl.scan_nodes. It consumes a filled nl.sort_state and produces an iterator
+    whose steps yield the accumulated rows sorted by the handle's keys, one chunk
+    per column per step - the same chunk shape the buffers were collected with, so
+    an enclosing nl.for binds one loop variable per column:
+
+      %sorted = nl.sort(%state) : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>>
+      nl.for %a, %score in %sorted : !nl.iter<...> {
+        nl.output(%a, %score) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>
+      }
+
+    The iterator chunk types match the collected columns, but cannot be inferred
+    from the parameterless state handle, so they are spelled after the colon (as
+    the nl.for iterator type is). The sort itself runs once when the driving loop
+    first steps; placing nl.sort after the producing loop guarantees the buffers
+    are full by then.
+  }];
+
+  let arguments = (ins NLSortStateHandle:$state);
+  let results   = (outs NLIterator:$result);
+
+  let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -525,14 +525,26 @@ def SortBuffer : NLOp<"sort_buffer", []> {
     buildable and omitted.
 
       %state = nl.sort_buffer keys [1] ascending [true]
+
+    An optional `limit` count turns the accumulator into a bounded top-K: it keeps
+    only the `limit` best rows seen so far rather than every row, so the memory is
+    O(limit) instead of O(rows) and the sort is O(rows log limit). It is the fused
+    form of an ORDER BY ... LIMIT k - a constant bound, distinct from the mutable
+    !nl.limit_state handle the streaming limits carry, since the bound is private
+    to the sort and never decremented:
+
+      %state = nl.sort_buffer keys [1] ascending [true] limit 10
   }];
 
   // keyColumns are indices into the collected column set, most significant first;
-  // keyAscending gives one direction per key. The two arrays are parallel.
-  let arguments = (ins DenseI64ArrayAttr:$keyColumns, DenseBoolArrayAttr:$keyAscending);
+  // keyAscending gives one direction per key. The two arrays are parallel. The
+  // optional topK count, when present, bounds the accumulator to its best rows.
+  let arguments = (ins DenseI64ArrayAttr:$keyColumns,
+                       DenseBoolArrayAttr:$keyAscending,
+                       OptionalAttr<UI64Attr>:$topK);
   let results   = (outs NLSortState:$state);
 
-  let assemblyFormat = "`keys` $keyColumns `ascending` $keyAscending attr-dict";
+  let assemblyFormat = "`keys` $keyColumns `ascending` $keyAscending (`limit` $topK^)? attr-dict";
   let hasVerifier = 1;
 }
 

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -34,6 +34,19 @@ def NLSkipState : NLType<"SkipState", "skip_state"> {
     }];
 }
 
+def NLSortState : NLType<"SortState", "sort_state"> {
+    let summary = "A sort accumulator handle";
+    let description = [{
+        Stands for one ORDER BY's row accumulator. Produced by nl.sort_buffer,
+        appended to by nl.sort_collect once per producing-loop step, and drained by
+        the nl.for over the nl.sort source iterator, which sorts the accumulated
+        rows by the keys and yields them chunk by chunk. It is a handle, not a
+        chunk: it owns the growing per-column buffers and the sort spec, not a
+        single chunk of values. Modeled on !nl.limit_state, but it accumulates
+        rows rather than counting them.
+    }];
+}
+
 def NLChunk : NLType<"Chunk", "chunk"> {
     let summary = "A bounded batch of values";
     let description = "One column chunk filled by a single database iterator step";
@@ -123,5 +136,14 @@ def NLSkipStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::SkipStateType>($_self)">,
         "skip state handle", "::mlir::nl::SkipStateType">,
     BuildableType<"::mlir::nl::SkipStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.sort_state handle, the same way
+// NLLimitStateHandle constrains the limit handle. The single concrete type -
+// there is only ever !nl.sort_state - is what lets nl.sort_collect and nl.sort
+// omit the handle's type in their assembly, building it from this recipe instead.
+def NLSortStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::SortStateType>($_self)">,
+        "sort state handle", "::mlir::nl::SortStateType">,
+    BuildableType<"::mlir::nl::SortStateType::get($_builder.getContext())">;
 
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -117,6 +117,66 @@ void copyRangeColumn(const Column* input, size_t inputOffset, size_t rowCount, C
     std::copy(first, first + rowCount, outputRaw.begin());
 }
 
+// Append every row of an input chunk onto the tail of a growing buffer of the
+// same element type. nl.sort_collect calls this once per producing-loop step, so
+// the buffer accumulates every row across all chunks, row-aligned with the other
+// buffers of the same accumulator.
+template <typename ElementType>
+void appendColumn(const Column* input, Column* buffer) {
+    const ColumnVector<ElementType>* typedInput = static_cast<const ColumnVector<ElementType>*>(input);
+    ColumnVector<ElementType>* typedBuffer = static_cast<ColumnVector<ElementType>*>(buffer);
+
+    const auto& inputRaw = typedInput->getRaw();
+    auto& bufferRaw = typedBuffer->getRaw();
+
+    bufferRaw.insert(bufferRaw.end(), inputRaw.begin(), inputRaw.end());
+}
+
+// 3-way compare two rows of a non-null orderable column (an ID column): negative
+// if row a sorts before row b, positive if after, zero if they are equal.
+template <typename ElementType>
+int compareColumn(const Column* column, size_t a, size_t b) {
+    const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
+    const ElementType& valueA = raw[a];
+    const ElementType& valueB = raw[b];
+
+    if (valueA < valueB) {
+        return -1;
+    } else if (valueB < valueA) {
+        return 1;
+    }
+
+    return 0;
+}
+
+// 3-way compare two rows of a nullable value column. A null sorts after every
+// value, so an ascending order places nulls last (matching Cypher's ORDER BY),
+// and two nulls tie; non-null values compare by their natural order.
+template <typename Primitive>
+int compareOptColumn(const Column* column, size_t a, size_t b) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
+    const std::optional<Primitive>& valueA = raw[a];
+    const std::optional<Primitive>& valueB = raw[b];
+
+    const bool aNull = !valueA.has_value();
+    const bool bNull = !valueB.has_value();
+    if (aNull || bNull) {
+        if (aNull && bNull) {
+            return 0;
+        }
+
+        return aNull ? 1 : -1;
+    }
+
+    if (*valueA < *valueB) {
+        return -1;
+    } else if (*valueB < *valueA) {
+        return 1;
+    }
+
+    return 0;
+}
+
 // Execute a get_out_edges/get_in_edges loop
 template <typename ChunkWriterType>
 void runEdgeLoopSteps(NLExecutionContext* context,
@@ -363,6 +423,53 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     context->getSink()->appendChunks(cols, offset, rowCount);
 }
 
+void NLExecutor::runSortReset(NLExecutionContext* context, NLFunctionData* data) {
+    const NLSortResetData* reset = static_cast<NLSortResetData*>(data);
+    reset->getState()->reset();
+}
+
+void NLExecutor::runSortCollect(NLExecutionContext* context, NLFunctionData* data) {
+    const NLSortCollectData* collect = static_cast<NLSortCollectData*>(data);
+
+    // Append this step's chunk of every column onto its buffer's tail; the
+    // columns are taken together so the buffers stay row-aligned.
+    for (const NLSortCollectData::Append& append : collect->appends()) {
+        append._append(append._input, append._buffer);
+    }
+}
+
+void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLSortLoopData* loopData = static_cast<NLSortLoopData*>(data);
+    NLSortState* state = loopData->getState();
+
+    // Sort the accumulated rows once: the permutation is the global row order the
+    // emit chunks read in.
+    state->sort();
+    const std::vector<size_t>& permutation = state->permutation().getRaw();
+    const size_t totalRows = permutation.size();
+
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    const size_t chunkSize = context->getChunkSize();
+    ColumnVector<size_t>* indices = loopData->getIndices();
+
+    // Re-chunk the sorted rows: each step gathers the next chunkSize rows, in
+    // permutation order, into the loop variables, then runs the body (nl.output).
+    // The last chunk may be partial; an empty result runs the body zero times.
+    for (size_t offset = 0; offset < totalRows; offset += chunkSize) {
+        const size_t stepRows = std::min(chunkSize, totalRows - offset);
+
+        std::vector<size_t>& indicesRaw = indices->getRaw();
+        indicesRaw.assign(permutation.begin() + offset, permutation.begin() + offset + stepRows);
+
+        for (const NLCarriedColumn& column : loopData->columns()) {
+            const NLGatherFunction gather = column.getGatherFunc();
+            gather(column.getInput(), indices, column.getOutput());
+        }
+
+        runBody(context, loopBody);
+    }
+}
+
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
@@ -462,6 +569,37 @@ NLCopyFunction NLExecutor::selectCopyFunction(NLChunkKind kind) {
     return nullptr;
 }
 
+// A nullable value chunk gathers the same way an ID chunk does - copy the indexed
+// rows - on the ColumnOptVector<Primitive> instantiation of the gather template.
+NLGatherFunction NLExecutor::selectOptGatherFunction(ValueType valueType) {
+    NLGatherFunction gather = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        gather = &gatherColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return gather;
+}
+
+NLAppendFunction NLExecutor::selectAppendFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &appendColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &appendColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &appendColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
 // A nullable value chunk is a ColumnOptVector<Primitive> - that is,
 // ColumnVector<std::optional<Primitive>> - so the range copy template,
 // instantiated on std::optional<Primitive>, carries value and null together.
@@ -473,6 +611,75 @@ NLCopyFunction NLExecutor::selectOptCopyFunction(ValueType valueType) {
     ValueTypeDispatcher(valueType).execute(select);
 
     return copy;
+}
+
+NLAppendFunction NLExecutor::selectOptAppendFunction(ValueType valueType) {
+    NLAppendFunction append = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        append = &appendColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return append;
+}
+
+NLCompareFunction NLExecutor::selectCompareFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &compareColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &compareColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &compareColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+// Selected per key from its value type. A manual switch, not ValueTypeDispatcher,
+// because an embedding has no order: dispatching would instantiate the comparator
+// for std::span<const float>, which does not compile. The embedding case throws
+// instead, so that instantiation is never named.
+NLCompareFunction NLExecutor::selectOptCompareFunction(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return &compareOptColumn<types::Int64::Primitive>;
+        break;
+
+        case ValueType::UInt64:
+            return &compareOptColumn<types::UInt64::Primitive>;
+        break;
+
+        case ValueType::Double:
+            return &compareOptColumn<types::Double::Primitive>;
+        break;
+
+        case ValueType::Bool:
+            return &compareOptColumn<types::Bool::Primitive>;
+        break;
+
+        case ValueType::String:
+            return &compareOptColumn<types::String::Primitive>;
+        break;
+
+        case ValueType::Embedding:
+            throw IRException("cannot sort by an embedding column");
+        break;
+
+        case ValueType::Invalid:
+        case ValueType::_SIZE:
+            throw IRException("invalid sort key value type");
+        break;
+    }
+
+    bioassert(false, "Unhandled value type");
+    return nullptr;
 }
 
 // Read one property of the current input chunk into a nullable value column.

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -436,6 +436,11 @@ void NLExecutor::runSortCollect(NLExecutionContext* context, NLFunctionData* dat
     for (const NLSortCollectData::Append& append : collect->appends()) {
         append._append(append._input, append._buffer);
     }
+
+    // For a bounded (top-K) accumulator, drop all but the best k once the buffers
+    // have grown past the bound, so memory stays O(k) rather than O(rows). A
+    // no-op for an unbounded sort.
+    collect->getState()->trimIfNeeded();
 }
 
 void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -72,8 +72,34 @@ public:
     // never mutates it.
     static void runSkipTruncate(NLExecutionContext* context, NLFunctionData* data);
 
+    // Empty the buffers of a sort accumulator; runs each time its block runs.
+    static void runSortReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Append the current chunk of every column to its sort buffer. Runs once per
+    // producing-loop step, growing the buffers row-aligned.
+    static void runSortCollect(NLExecutionContext* context, NLFunctionData* data);
+
+    // The emit phase of an ORDER BY: sort the accumulator once, then re-chunk the
+    // sorted rows - gathering each chunk-sized permutation slice into the loop
+    // variables and running the body (the nl.output) per chunk.
+    static void runSortLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
+
+    // Gather for a nullable value chunk of this value type (sort emit re-chunk).
+    static NLGatherFunction selectOptGatherFunction(ValueType valueType);
+
+    // Append (onto a buffer tail) for an ID chunk of this kind / a nullable value
+    // chunk of this value type. Used by nl.sort_collect.
+    static NLAppendFunction selectAppendFunction(NLChunkKind kind);
+    static NLAppendFunction selectOptAppendFunction(ValueType valueType);
+
+    // The 3-way row comparator for an ID key column of this kind / a nullable
+    // value key column of this value type. The value-type selector throws for a
+    // value type with no order (an embedding), which cannot be a sort key.
+    static NLCompareFunction selectCompareFunction(NLChunkKind kind);
+    static NLCompareFunction selectOptCompareFunction(ValueType valueType);
 
     // Block-repeat for an ID chunk of this kind (outer column).
     static NLBroadcastFunction selectBlockRepeatFunction(NLChunkKind kind);

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -1,9 +1,58 @@
 #include "NLProgram.h"
 
+#include <algorithm>
+#include <numeric>
+
 using namespace db;
 
 NLProgram::NLProgram() {
 }
 
 NLProgram::~NLProgram() {
+}
+
+void NLSortState::reset() {
+    for (Column* buffer : _buffers) {
+        buffer->clear();
+    }
+
+    _permutation.clear();
+    _sorted = false;
+}
+
+void NLSortState::sort() {
+    // The first emit step sorts; a later call (there is only one emit loop today)
+    // finds the order already computed and returns.
+    if (_sorted) {
+        return;
+    }
+
+    // Every buffer is row-aligned, so any one gives the accumulated row count.
+    const size_t rowCount = _buffers.empty() ? 0 : _buffers.front()->size();
+
+    std::vector<size_t>& permutation = _permutation.getRaw();
+    permutation.resize(rowCount);
+    std::iota(permutation.begin(), permutation.end(), size_t {0});
+
+    // Order rows by the keys, most significant first; the first key that breaks
+    // the tie decides, and its direction flips the comparator's sign. stable_sort
+    // keeps rows that tie on every key in their collected order, so the result is
+    // deterministic regardless of how the producing loop chunked them.
+    const std::vector<Key>& keys = _keys;
+    std::stable_sort(permutation.begin(), permutation.end(), [&keys](size_t leftRow, size_t rightRow) {
+        for (const Key& key : keys) {
+            int comparison = key._compare(key._buffer, leftRow, rightRow);
+            if (!key._ascending) {
+                comparison = -comparison;
+            }
+
+            if (comparison != 0) {
+                return comparison < 0;
+            }
+        }
+
+        return false;
+    });
+
+    _sorted = true;
 }

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -1,6 +1,7 @@
 #include "NLProgram.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 
 using namespace db;
@@ -44,9 +45,13 @@ void NLSortState::trimIfNeeded() {
 
     // Trim only once the buffers have grown well past the bound, so the cost is
     // amortized: the buffers hold at most ~2 * topK rows (plus the chunk just
-    // appended) between trims, never the full input.
+    // appended) between trims, never the full input. Saturate the doubled bound so
+    // a pathologically large topK (2 * topK overflowing size_t) never fires a trim
+    // rather than wrapping to a small threshold.
     const size_t rowCount = _buffers.front()->size();
-    if (rowCount <= 2 * _topK) {
+    const size_t maxSize = std::numeric_limits<size_t>::max();
+    const size_t trimThreshold = _topK > maxSize / 2 ? maxSize : 2 * _topK;
+    if (rowCount <= trimThreshold) {
         return;
     }
 

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -20,6 +20,62 @@ void NLSortState::reset() {
     _sorted = false;
 }
 
+bool NLSortState::rowLess(size_t leftRow, size_t rightRow) const {
+    // The first key that breaks the tie decides, most significant first; its
+    // direction flips the comparator's sign.
+    for (const Key& key : _keys) {
+        int comparison = key._compare(key._buffer, leftRow, rightRow);
+        if (!key._ascending) {
+            comparison = -comparison;
+        }
+
+        if (comparison != 0) {
+            return comparison < 0;
+        }
+    }
+
+    return false;
+}
+
+void NLSortState::trimIfNeeded() {
+    if (!_bounded || _buffers.empty()) {
+        return;
+    }
+
+    // Trim only once the buffers have grown well past the bound, so the cost is
+    // amortized: the buffers hold at most ~2 * topK rows (plus the chunk just
+    // appended) between trims, never the full input.
+    const size_t rowCount = _buffers.front()->size();
+    if (rowCount <= 2 * _topK) {
+        return;
+    }
+
+    trimToTopK(rowCount);
+}
+
+void NLSortState::trimToTopK(size_t rowCount) {
+    // Select the best topK rows: nth_element partitions the index permutation so
+    // its first topK entries are the smallest by the sort order (ties at the
+    // boundary broken arbitrarily, as LIMIT allows), then we keep that prefix.
+    std::vector<size_t>& kept = _keptIndices.getRaw();
+    kept.resize(rowCount);
+    std::iota(kept.begin(), kept.end(), size_t {0});
+
+    if (_topK < rowCount) {
+        const auto less = [this](size_t leftRow, size_t rightRow) { return rowLess(leftRow, rightRow); };
+        std::nth_element(kept.begin(), kept.begin() + _topK, kept.end(), less);
+        kept.resize(_topK);
+    }
+
+    // Compact every buffer to the kept rows: gather the survivors into the scratch
+    // column, then copy them back. Each column is independent and reads its own
+    // buffer before overwriting it, so the shared kept-index list stays valid.
+    for (size_t columnIndex = 0; columnIndex < _buffers.size(); columnIndex++) {
+        _gathers[columnIndex](_buffers[columnIndex], &_keptIndices, _tempBuffers[columnIndex]);
+        _buffers[columnIndex]->assign(_tempBuffers[columnIndex]);
+    }
+}
+
 void NLSortState::sort() {
     // The first emit step sorts; a later call (there is only one emit loop today)
     // finds the order already computed and returns.
@@ -27,32 +83,26 @@ void NLSortState::sort() {
         return;
     }
 
-    // Every buffer is row-aligned, so any one gives the accumulated row count.
+    // Every buffer is row-aligned, so any one gives the accumulated row count. For
+    // a bounded accumulator this is at most ~2 * topK (the residual the last trim
+    // left), not the full input.
     const size_t rowCount = _buffers.empty() ? 0 : _buffers.front()->size();
 
     std::vector<size_t>& permutation = _permutation.getRaw();
     permutation.resize(rowCount);
     std::iota(permutation.begin(), permutation.end(), size_t {0});
 
-    // Order rows by the keys, most significant first; the first key that breaks
-    // the tie decides, and its direction flips the comparator's sign. stable_sort
-    // keeps rows that tie on every key in their collected order, so the result is
-    // deterministic regardless of how the producing loop chunked them.
-    const std::vector<Key>& keys = _keys;
-    std::stable_sort(permutation.begin(), permutation.end(), [&keys](size_t leftRow, size_t rightRow) {
-        for (const Key& key : keys) {
-            int comparison = key._compare(key._buffer, leftRow, rightRow);
-            if (!key._ascending) {
-                comparison = -comparison;
-            }
+    // Order rows by the keys; stable_sort keeps rows that tie on every key in
+    // their collected order, so the result is deterministic regardless of how the
+    // producing loop chunked them.
+    const auto less = [this](size_t leftRow, size_t rightRow) { return rowLess(leftRow, rightRow); };
+    std::stable_sort(permutation.begin(), permutation.end(), less);
 
-            if (comparison != 0) {
-                return comparison < 0;
-            }
-        }
-
-        return false;
-    });
+    // A bounded accumulator emits only its best topK rows: cap the permutation
+    // after the sort, dropping the residual the amortized trim left in the buffer.
+    if (_bounded && permutation.size() > _topK) {
+        permutation.resize(_topK);
+    }
 
     _sorted = true;
 }

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -501,6 +501,140 @@ private:
     SkipColumns _columns;
 };
 
+// Type of handle that appends one input chunk's rows to a growing sort buffer of
+// the same element type. One per column kind / value type, selected during
+// translation, the same way the gather and broadcast families are.
+using NLAppendFunction = void (*)(const Column* input, Column* buffer);
+
+// Type of handle that 3-way compares two rows of one sort key column: negative
+// if row a sorts before row b, positive if after, zero if they tie on this key.
+// Direction (ascending vs descending) is applied by the caller, so the function
+// itself is direction-free; it is selected per key from the column's element type.
+using NLCompareFunction = int (*)(const Column* column, size_t a, size_t b);
+
+// Runtime state of one ORDER BY: the growing per-column row buffers, the sort
+// keys (each a buffer column, a direction and a 3-way comparator), and the row
+// permutation computed once when the emit loop first steps. nl.sort_buffer
+// resets it, nl.sort_collect appends one chunk to every buffer, and the nl.for
+// over nl.sort sorts it (once) and reads the rows in permutation order. The
+// buffer columns are borrowed: the translator pool-allocates them in the same
+// arena as the loop columns; the state only records the pointers.
+class NLSortState {
+public:
+    // One sort key: the buffer column it orders by, its direction (true =
+    // ascending), and the 3-way comparator for that column's element type.
+    struct Key {
+        const Column* _buffer {nullptr};
+        bool _ascending {true};
+        NLCompareFunction _compare {nullptr};
+    };
+
+    void addBuffer(Column* buffer) { _buffers.push_back(buffer); }
+    const std::vector<Column*>& buffers() const { return _buffers; }
+    Column* buffer(size_t index) const { return _buffers[index]; }
+
+    void addKey(const Key& key) { _keys.push_back(key); }
+
+    // Clear every buffer and drop the computed order, so the accumulator is empty
+    // again. Runs each time nl.sort_buffer's block runs (once at function scope).
+    void reset();
+
+    // Compute the row permutation that orders the buffers by the keys, stable so
+    // rows equal on every key keep their collected order. Idempotent: the first
+    // emit step sorts, later calls are no-ops.
+    void sort();
+
+    const ColumnVector<size_t>& permutation() const { return _permutation; }
+
+private:
+    // One buffer per collected column, row-aligned, grown by nl.sort_collect.
+    std::vector<Column*> _buffers;
+
+    // The sort keys, most significant first.
+    std::vector<Key> _keys;
+
+    // Row order computed by sort(); read by the emit loop in chunk-sized slices.
+    ColumnVector<size_t> _permutation;
+
+    bool _sorted {false};
+};
+
+// nl.sort_buffer data: resets an accumulator to empty each time the block it
+// lives in runs - once at function scope for a top-level ORDER BY.
+class NLSortResetData : public NLFunctionData {
+public:
+    NLSortResetData(NLSortState* state)
+        : _state(state)
+    {
+    }
+
+    NLSortState* getState() const { return _state; }
+
+private:
+    NLSortState* _state {nullptr};
+};
+
+// nl.sort_collect data: appends the current chunk of every column to the matching
+// buffer of the accumulator. Each entry pairs the loop's input chunk with the
+// buffer it grows and the append that copies one into the other.
+class NLSortCollectData : public NLFunctionData {
+public:
+    struct Append {
+        const Column* _input {nullptr};
+        Column* _buffer {nullptr};
+        NLAppendFunction _append {nullptr};
+    };
+
+    NLSortCollectData(NLSortState* state)
+        : _state(state)
+    {
+    }
+
+    NLSortState* getState() const { return _state; }
+
+    const std::vector<Append>& appends() const { return _appends; }
+
+    void addAppend(const Append& append) {
+        _appends.push_back(append);
+    }
+
+private:
+    NLSortState* _state {nullptr};
+    std::vector<Append> _appends;
+};
+
+// nl.for over nl.sort data: the emit phase of an ORDER BY. Holds the accumulator
+// (sorted on the first step), and per column the buffer to read, the loop
+// variable to fill and the gather that copies a chunk of rows by index - reusing
+// the same NLCarriedColumn (input, output, gather) shape the edge loops use. The
+// indices scratch holds the permutation slice of the current emit step.
+class NLSortLoopData : public NLFunctionData {
+public:
+    NLSortLoopData(NLSortState* state)
+        : _state(state)
+    {
+    }
+
+    NLSortState* getState() const { return _state; }
+
+    const std::vector<NLCarriedColumn>& columns() const { return _columns; }
+
+    void addColumn(const NLCarriedColumn& column) {
+        _columns.push_back(column);
+    }
+
+    ColumnVector<size_t>* getIndices() { return &_indices; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    NLSortState* _state {nullptr};
+    std::vector<NLCarriedColumn> _columns;
+    ColumnVector<size_t> _indices;
+    NLStmtContainer _stmts;
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:
@@ -566,6 +700,15 @@ public:
         return statePtr;
     }
 
+    // Allocate one ORDER BY's runtime accumulator, owned by the program; the
+    // collect, reset and emit statements that share it hold a borrowed pointer.
+    NLSortState* allocSortState() {
+        auto state = std::make_unique<NLSortState>();
+        NLSortState* statePtr = state.get();
+        _sortStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -577,6 +720,7 @@ private:
     std::vector<std::unique_ptr<NLFunctionData>> _functionData;
     std::vector<std::unique_ptr<NLLimitState>> _limitStates;
     std::vector<std::unique_ptr<NLSkipState>> _skipStates;
+    std::vector<std::unique_ptr<NLSortState>> _sortStates;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -519,6 +519,11 @@ using NLCompareFunction = int (*)(const Column* column, size_t a, size_t b);
 // over nl.sort sorts it (once) and reads the rows in permutation order. The
 // buffer columns are borrowed: the translator pool-allocates them in the same
 // arena as the loop columns; the state only records the pointers.
+//
+// A bounded accumulator (the fused ORDER BY ... LIMIT k) keeps only the best k
+// rows: nl.sort_collect appends a chunk then calls trimIfNeeded, which selects
+// the best k and reclaims the rest, so memory stays O(k) and the final sort runs
+// over O(k) rows rather than every row.
 class NLSortState {
 public:
     // One sort key: the buffer column it orders by, its direction (true =
@@ -529,7 +534,24 @@ public:
         NLCompareFunction _compare {nullptr};
     };
 
-    void addBuffer(Column* buffer) { _buffers.push_back(buffer); }
+    // Bound the accumulator to the best topK rows (the fused top-K form). Left
+    // unbounded, it keeps every collected row.
+    void setTopK(size_t topK) {
+        _topK = topK;
+        _bounded = true;
+    }
+
+    bool isBounded() const { return _bounded; }
+
+    // Record one column: its buffer, the scratch the trim gathers the survivors
+    // into (null when unbounded - no trimming happens), and the gather that fills
+    // one from the other. Kept parallel, one entry per collected column.
+    void addColumnBuffer(Column* buffer, Column* temp, NLGatherFunction gather) {
+        _buffers.push_back(buffer);
+        _tempBuffers.push_back(temp);
+        _gathers.push_back(gather);
+    }
+
     const std::vector<Column*>& buffers() const { return _buffers; }
     Column* buffer(size_t index) const { return _buffers[index]; }
 
@@ -539,22 +561,47 @@ public:
     // again. Runs each time nl.sort_buffer's block runs (once at function scope).
     void reset();
 
+    // For a bounded accumulator, once the buffers have grown well past the bound,
+    // drop all but the best topK rows so memory stays O(topK). A no-op when
+    // unbounded or still within the bound.
+    void trimIfNeeded();
+
     // Compute the row permutation that orders the buffers by the keys, stable so
-    // rows equal on every key keep their collected order. Idempotent: the first
-    // emit step sorts, later calls are no-ops.
+    // rows equal on every key keep their collected order; for a bounded
+    // accumulator the permutation is then capped to the best topK. Idempotent:
+    // the first emit step sorts, later calls are no-ops.
     void sort();
 
     const ColumnVector<size_t>& permutation() const { return _permutation; }
 
 private:
+    // Strict-weak-ordering row comparison by the keys, most significant first;
+    // each key's direction flips the sign. Shared by sort() and the trim.
+    bool rowLess(size_t leftRow, size_t rightRow) const;
+
+    // Select the best topK rows into _keptIndices and compact every buffer to
+    // them, reclaiming the rest. Called by trimIfNeeded once the buffers overflow.
+    void trimToTopK(size_t rowCount);
+
     // One buffer per collected column, row-aligned, grown by nl.sort_collect.
     std::vector<Column*> _buffers;
+
+    // Per-buffer compaction scratch and gather, used only by a bounded trim.
+    std::vector<Column*> _tempBuffers;
+    std::vector<NLGatherFunction> _gathers;
 
     // The sort keys, most significant first.
     std::vector<Key> _keys;
 
     // Row order computed by sort(); read by the emit loop in chunk-sized slices.
     ColumnVector<size_t> _permutation;
+
+    // The kept-row indices a trim selects, fed to the per-buffer gather.
+    ColumnVector<size_t> _keptIndices;
+
+    // The top-K bound (valid only when _bounded); 0 with _bounded means keep none.
+    size_t _topK {0};
+    bool _bounded {false};
 
     bool _sorted {false};
 };

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -112,6 +112,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             const mlir::OperandRange carriedColumns = getInEdges.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
             _iteratorConfigs[getInEdges.getResult()] = config;
+        } else if (nl::Sort sort = mlir::dyn_cast<nl::Sort>(operation)) {
+            _iteratorConfigs[sort.getResult()] = IteratorConfig {IteratorKind::Sort, {}, {}, sortStateFor(sort.getState())};
         } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType>(operation)) {
@@ -142,6 +144,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateSkipUpdate(update, body);
         } else if (nl::SkipTruncate truncate = mlir::dyn_cast<nl::SkipTruncate>(operation)) {
             translateSkipTruncate(truncate, body);
+        } else if (nl::SortBuffer sortBuffer = mlir::dyn_cast<nl::SortBuffer>(operation)) {
+            translateSortBuffer(sortBuffer, body);
+        } else if (nl::SortCollect sortCollect = mlir::dyn_cast<nl::SortCollect>(operation)) {
+            translateSortCollect(sortCollect, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -171,6 +177,9 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
     // Translate the loop differently depending on the kind of iterator associated
     if (config._kind == IteratorKind::ScanNodes) {
         translateScanLoop(loopBody, limit, body);
+    } else if (config._kind == IteratorKind::Sort) {
+        // A sort emit loop is never limit-bounded: ORDER BY must see every row.
+        translateSortLoop(config, loopBody, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -492,6 +501,175 @@ NLSkipState* NLTranslator::skipStateFor(mlir::Value handle) const {
     }
 
     return stateIt->second;
+}
+
+void NLTranslator::translateSortBuffer(nl::SortBuffer buffer, NLStmtContainer* body) {
+    // Allocate the runtime accumulator and map the handle to it, so the collect
+    // and the emit loop that name the handle share the same buffers. The buffer
+    // columns themselves are allocated by the collect, which knows their types.
+    NLSortState* state = _program->allocSortState();
+    _sortStates[buffer.getState()] = state;
+
+    // The reset empties the buffers each time the block holding this nl.sort_buffer
+    // runs: once at function scope for a top-level ORDER BY.
+    NLSortResetData* resetData = _program->allocFunctionData<NLSortResetData>(state);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSortReset, resetData});
+}
+
+void NLTranslator::translateSortCollect(nl::SortCollect collect, NLStmtContainer* body) {
+    NLSortState* state = sortStateFor(collect.getState());
+
+    // The sort spec lives on the nl.sort_buffer that produced the handle.
+    nl::SortBuffer buffer = collect.getState().getDefiningOp<nl::SortBuffer>();
+    if (!buffer) {
+        throw IRException("sort_collect state must come from nl.sort_buffer");
+    }
+
+    // The buffers are allocated once, by the single collect feeding a buffer.
+    // Generated IR has exactly one collect per accumulator; a second would append
+    // to the same buffers and double the rows, so it is rejected here.
+    if (!state->buffers().empty()) {
+        throw IRException("an nl.sort_buffer must be fed by a single nl.sort_collect");
+    }
+
+    NLSortCollectData* data = _program->allocFunctionData<NLSortCollectData>(state);
+
+    // One growing buffer per collected column, row-aligned. The buffer keeps the
+    // column's element type; the append copies a chunk's rows onto its tail.
+    const mlir::OperandRange columns = collect.getColumns();
+    for (const mlir::Value column : columns) {
+        Column* bufferColumn = allocColumnForChunkType(column.getType());
+        state->addBuffer(bufferColumn);
+
+        const NLSortCollectData::Append append {getColumn(column),
+                                                bufferColumn,
+                                                selectAppendForChunkType(column.getType())};
+        data->addAppend(append);
+    }
+
+    // Build the comparators from the spec, most significant key first. Each key
+    // indexes a collected column, so the index must be in range, and the column's
+    // element type must have an order (an embedding key is rejected by the
+    // selector). The buffer column is the one the comparator reads at run time.
+    const llvm::ArrayRef<int64_t> keyColumns = buffer.getKeyColumns();
+    const llvm::ArrayRef<bool> keyAscending = buffer.getKeyAscending();
+    for (size_t keyIndex = 0; keyIndex < keyColumns.size(); keyIndex++) {
+        const int64_t keyColumn = keyColumns[keyIndex];
+        const bool inRange = keyColumn >= 0 && static_cast<size_t>(keyColumn) < columns.size();
+        if (!inRange) {
+            throw IRException("sort key column index is out of range");
+        }
+
+        const mlir::Type keyType = columns[static_cast<size_t>(keyColumn)].getType();
+        const NLSortState::Key key {state->buffer(static_cast<size_t>(keyColumn)),
+                                    keyAscending[keyIndex],
+                                    selectCompareForChunkType(keyType)};
+        state->addKey(key);
+    }
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSortCollect, data});
+}
+
+void NLTranslator::translateSortLoop(const IteratorConfig& config,
+                                     mlir::Block& loopBody,
+                                     NLStmtContainer* body) {
+    NLSortState* state = config._sortState;
+    if (!state) {
+        throw IRException("nl.sort iterator must carry a sort accumulator");
+    }
+
+    // For::verify binds one loop variable per iterator chunk, and the sort
+    // iterator's chunk types are the collected column types, so the loop must
+    // take exactly one variable per buffer.
+    const size_t bufferCount = state->buffers().size();
+    if (loopBody.getNumArguments() != bufferCount) {
+        throw IRException("nl.sort loop must bind one variable per collected column");
+    }
+
+    NLSortLoopData* loopData = _program->allocFunctionData<NLSortLoopData>(state);
+
+    // Reserve the permutation-slice scratch so the per-step gather stays
+    // allocation-free, the same as the edge loop's indices column.
+    loopData->getIndices()->reserve(_program->getChunkSize());
+
+    // Each loop variable is filled from its buffer by gathering the rows the
+    // current emit step covers, in permutation order. The buffer is the read
+    // side, the loop variable the write side - the NLCarriedColumn (input,
+    // output, gather) shape the edge loops already use.
+    for (size_t columnIndex = 0; columnIndex < bufferCount; columnIndex++) {
+        const mlir::Value loopVariable = loopBody.getArgument(static_cast<unsigned>(columnIndex));
+
+        Column* output = allocColumnForChunkType(loopVariable.getType());
+        _valueSlots[loopVariable] = output;
+
+        const NLCarriedColumn column(state->buffer(columnIndex),
+                                     output,
+                                     selectGatherForChunkType(loopVariable.getType()));
+        loopData->addColumn(column);
+    }
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runSortLoop, loopData});
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+NLSortState* NLTranslator::sortStateFor(mlir::Value handle) const {
+    const auto stateIt = _sortStates.find(handle);
+    if (stateIt == _sortStates.end()) {
+        throw IRException("sort handle must be produced by an nl.sort_buffer");
+    }
+
+    return stateIt->second;
+}
+
+// An ID chunk allocates an ID column on its kind; a !nl.nullable<...> chunk
+// allocates a ColumnOptVector on its value type. Mirrors addCrossColumn's split.
+Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return allocOptColumnForValueType(valueType);
+    }
+
+    return allocColumnForKind(getChunkKind(chunkType));
+}
+
+NLAppendFunction NLTranslator::selectAppendForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptAppendFunction(valueType);
+    }
+
+    return NLExecutor::selectAppendFunction(getChunkKind(chunkType));
+}
+
+NLGatherFunction NLTranslator::selectGatherForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptGatherFunction(valueType);
+    }
+
+    return NLExecutor::selectGatherFunction(getChunkKind(chunkType));
+}
+
+NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptCompareFunction(valueType);
+    }
+
+    return NLExecutor::selectCompareFunction(getChunkKind(chunkType));
 }
 
 void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -510,6 +510,12 @@ void NLTranslator::translateSortBuffer(nl::SortBuffer buffer, NLStmtContainer* b
     NLSortState* state = _program->allocSortState();
     _sortStates[buffer.getState()] = state;
 
+    // A fused ORDER BY ... LIMIT carries the bound as the top-K count, so the
+    // accumulator keeps only the best k rows. Absent, it keeps every row.
+    if (const std::optional<uint64_t> topK = buffer.getTopK()) {
+        state->setTopK(*topK);
+    }
+
     // The reset empties the buffers each time the block holding this nl.sort_buffer
     // runs: once at function scope for a top-level ORDER BY.
     NLSortResetData* resetData = _program->allocFunctionData<NLSortResetData>(state);
@@ -535,11 +541,17 @@ void NLTranslator::translateSortCollect(nl::SortCollect collect, NLStmtContainer
     NLSortCollectData* data = _program->allocFunctionData<NLSortCollectData>(state);
 
     // One growing buffer per collected column, row-aligned. The buffer keeps the
-    // column's element type; the append copies a chunk's rows onto its tail.
+    // column's element type; the append copies a chunk's rows onto its tail. A
+    // bounded accumulator also gets a compaction scratch column and the gather
+    // that fills it, so the trim can drop all but the best k rows.
+    const bool bounded = state->isBounded();
     const mlir::OperandRange columns = collect.getColumns();
     for (const mlir::Value column : columns) {
         Column* bufferColumn = allocColumnForChunkType(column.getType());
-        state->addBuffer(bufferColumn);
+
+        Column* tempColumn = bounded ? allocColumnForChunkType(column.getType()) : nullptr;
+        const NLGatherFunction gather = bounded ? selectGatherForChunkType(column.getType()) : nullptr;
+        state->addColumnBuffer(bufferColumn, tempColumn, gather);
 
         const NLSortCollectData::Append append {getColumn(column),
                                                 bufferColumn,

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -523,10 +523,11 @@ void NLTranslator::translateSortBuffer(nl::SortBuffer buffer, NLStmtContainer* b
 }
 
 void NLTranslator::translateSortCollect(nl::SortCollect collect, NLStmtContainer* body) {
-    NLSortState* state = sortStateFor(collect.getState());
+    const mlir::Value collectState = collect.getState();
+    NLSortState* state = sortStateFor(collectState);
 
     // The sort spec lives on the nl.sort_buffer that produced the handle.
-    nl::SortBuffer buffer = collect.getState().getDefiningOp<nl::SortBuffer>();
+    nl::SortBuffer buffer = collectState.getDefiningOp<nl::SortBuffer>();
     if (!buffer) {
         throw IRException("sort_collect state must come from nl.sort_buffer");
     }
@@ -645,7 +646,7 @@ Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
         return allocOptColumnForValueType(valueType);
     }
 
-    return allocColumnForKind(getChunkKind(chunkType));
+    return allocColumnForKind(chunkKindFromElementType(elementType));
 }
 
 NLAppendFunction NLTranslator::selectAppendForChunkType(mlir::Type chunkType) {
@@ -657,7 +658,7 @@ NLAppendFunction NLTranslator::selectAppendForChunkType(mlir::Type chunkType) {
         return NLExecutor::selectOptAppendFunction(valueType);
     }
 
-    return NLExecutor::selectAppendFunction(getChunkKind(chunkType));
+    return NLExecutor::selectAppendFunction(chunkKindFromElementType(elementType));
 }
 
 NLGatherFunction NLTranslator::selectGatherForChunkType(mlir::Type chunkType) {
@@ -669,7 +670,7 @@ NLGatherFunction NLTranslator::selectGatherForChunkType(mlir::Type chunkType) {
         return NLExecutor::selectOptGatherFunction(valueType);
     }
 
-    return NLExecutor::selectGatherFunction(getChunkKind(chunkType));
+    return NLExecutor::selectGatherFunction(chunkKindFromElementType(elementType));
 }
 
 NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) {
@@ -681,7 +682,7 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
         return NLExecutor::selectOptCompareFunction(valueType);
     }
 
-    return NLExecutor::selectCompareFunction(getChunkKind(chunkType));
+    return NLExecutor::selectCompareFunction(chunkKindFromElementType(elementType));
 }
 
 void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {
@@ -833,7 +834,10 @@ NLChunkKind NLTranslator::getChunkKind(mlir::Type chunkType) {
         throw IRException("Expected an !nl.chunk type");
     }
 
-    const mlir::Type elementType = chunk.getElementType();
+    return chunkKindFromElementType(chunk.getElementType());
+}
+
+NLChunkKind NLTranslator::chunkKindFromElementType(mlir::Type elementType) {
     if (mlir::isa<storage::NodeIDType>(elementType)) {
         return NLChunkKind::NodeID;
     } else if (mlir::isa<storage::EdgeIDType>(elementType)) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -173,6 +173,7 @@ private:
     Column* allocOptColumnForValueType(ValueType valueType);
     Column* getColumn(mlir::Value chunkValue) const;
     static NLChunkKind getChunkKind(mlir::Type chunkType);
+    static NLChunkKind chunkKindFromElementType(mlir::Type elementType);
 };
 
 }

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -29,6 +29,7 @@ private:
         ScanNodes,
         GetOutEdges,
         GetInEdges,
+        Sort,
     };
 
     // Settings of the iterators passed to each for loop
@@ -36,6 +37,9 @@ private:
         IteratorKind _kind {IteratorKind::ScanNodes};
         mlir::Value _inputNodes;
         llvm::SmallVector<mlir::Value, 4> _carriedColumns;
+
+        // The accumulator a Sort iterator drains; null for the other kinds.
+        NLSortState* _sortState {nullptr};
     };
 
     NLProgram* _program {nullptr};
@@ -51,6 +55,10 @@ private:
     // nl.skip handle SSA value -> the runtime counter it produces, so nl.skip_update
     // and nl.skip_truncate that name the handle find the same counter
     llvm::DenseMap<mlir::Value, NLSkipState*> _skipStates;
+
+    // nl.sort_buffer handle SSA value -> the runtime accumulator it produces, so
+    // nl.sort_collect and the nl.for over nl.sort find the same buffers
+    llvm::DenseMap<mlir::Value, NLSortState*> _sortStates;
 
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
     void translateFor(mlir::nl::For forLoop, NLStmtContainer* body);
@@ -94,6 +102,35 @@ private:
     // The runtime counter a skip handle names. The handle is a required operand of
     // its consumers, so this throws if it was not produced by an nl.skip.
     NLSkipState* skipStateFor(mlir::Value handle) const;
+
+    // Translate an nl.sort_buffer: allocate its runtime accumulator, map the
+    // handle to it, and record the reset statement (run each time the block runs)
+    void translateSortBuffer(mlir::nl::SortBuffer buffer, NLStmtContainer* body);
+
+    // Translate an nl.sort_collect: allocate one growing buffer per collected
+    // column (mapped into the accumulator), build the key comparators from the
+    // nl.sort_buffer spec, and record the per-step append statement
+    void translateSortCollect(mlir::nl::SortCollect collect, NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.sort iterator: allocate one loop variable
+    // per buffer, set up the gather that fills it from the buffer in permutation
+    // order, and record the emit-loop statement (sort once, then re-chunk)
+    void translateSortLoop(const IteratorConfig& config,
+                           mlir::Block& loopBody,
+                           NLStmtContainer* body);
+
+    // The runtime accumulator a sort handle names. Throws if the handle was not
+    // produced by an nl.sort_buffer translated earlier.
+    NLSortState* sortStateFor(mlir::Value handle) const;
+
+    // Pool-allocate a buffer/loop column matching a chunk type - an ID column for
+    // an ID chunk, a nullable value column for a !nl.nullable<...> chunk - and the
+    // append/gather/compare handler for that element type. The compare selector
+    // throws for chunk types that have no order (an embedding key).
+    Column* allocColumnForChunkType(mlir::Type chunkType);
+    static NLAppendFunction selectAppendForChunkType(mlir::Type chunkType);
+    static NLGatherFunction selectGatherForChunkType(mlir::Type chunkType);
+    static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
 
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -129,13 +129,23 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     _innermostLoopBody = nullptr;
     _limitHandles.clear();
     _loopLimitHandle.clear();
+    _sortTopK.clear();
+    _fusedLimits.clear();
+
+    // Find ORDER BY ... LIMIT k: a db.limit capping a db.sort's result fuses into
+    // a bounded top-K, so the limit gets no streaming handle and the sort carries
+    // the bound. Detect before the limit pre-scan so the fused ones are skipped.
+    detectTopKFusion(dbFunction);
 
     // Pre-scan for db.limits before any loop is built: nl.for's limit operand is
     // fixed at build time, so each handle must exist first to be threaded in, and
-    // which loops a handle attaches to must be known up front.
+    // which loops a handle attaches to must be known up front. A limit fused into
+    // a sort's top-K carries no streaming handle, so it is left out here.
     llvm::SmallVector<mlir::db::Limit, 2> limits;
     dbFunction.walk([&](mlir::db::Limit limit) {
-        limits.push_back(limit);
+        if (!_fusedLimits.count(limit.getOperation())) {
+            limits.push_back(limit);
+        }
     });
 
     // Hoist one nl.limit handle per db.limit to the top of the entry block, where
@@ -408,6 +418,20 @@ mlir::Type DBLowering::propertyValueChunkType(llvm::StringRef propertyName) {
 }
 
 void DBLowering::lowerLimit(mlir::db::Limit limit) {
+    // A limit fused into a sort's top-K does no work of its own: the sort already
+    // emits at most k sorted rows, so the limit forwards each input chunk straight
+    // to its matching result. The db.output that follows then reads the sort's
+    // emit-loop variables, exactly as if the limit were not there.
+    if (_fusedLimits.count(limit.getOperation())) {
+        const mlir::ResultRange results = limit.getResults();
+        const mlir::OperandRange columns = limit.getColumns();
+        for (size_t columnIndex = 0; columnIndex < results.size(); columnIndex++) {
+            _valueMap[results[columnIndex]] = mapValue(columns[columnIndex]);
+        }
+
+        return;
+    }
+
     // The nl chunks the limited columns lowered to; these are what the truncate
     // copies, and the consumer reads the cut copies.
     llvm::SmallVector<mlir::Value, 4> chunks;
@@ -494,6 +518,44 @@ void DBLowering::lowerSkip(mlir::db::Skip skip) {
     }
 }
 
+void DBLowering::detectTopKFusion(mlir::func::FuncOp dbFunction) {
+    dbFunction.walk([&](mlir::db::Limit limit) {
+        const mlir::OperandRange columns = limit.getColumns();
+        if (columns.empty()) {
+            return;
+        }
+
+        // Every column the limit caps must come from one db.sort - otherwise the
+        // limit is not a terminal ORDER BY ... LIMIT and the streaming limit path
+        // handles it.
+        mlir::db::Sort sort;
+        for (const mlir::Value column : columns) {
+            mlir::db::Sort definingSort = column.getDefiningOp<mlir::db::Sort>();
+            if (!definingSort || (sort && sort != definingSort)) {
+                return;
+            }
+
+            sort = definingSort;
+        }
+
+        // Capping the sort to top-K must not starve another consumer, so the limit
+        // must be the sole user of every result the sort produces.
+        for (const mlir::Value result : sort.getResults()) {
+            for (mlir::Operation* const user : result.getUsers()) {
+                if (user != limit.getOperation()) {
+                    return;
+                }
+            }
+        }
+
+        // First limit (program order) to claim a sort wins; record the fusion.
+        if (!_sortTopK.count(sort.getOperation())) {
+            _sortTopK[sort.getOperation()] = limit.getCount();
+            _fusedLimits.insert(limit.getOperation());
+        }
+    });
+}
+
 void DBLowering::lowerSort(mlir::db::Sort sort) {
     // The nl chunks the sorted columns lowered to; these are what sort_collect
     // appends to the buffers, and the emit loop yields back sorted.
@@ -512,11 +574,21 @@ void DBLowering::lowerSort(mlir::db::Sort sort) {
 
     // The accumulator and its sort spec are hoisted to the top of the entry
     // block, above every loop, so the buffers exist before the producing loop
-    // fills them and the handle dominates the collect and the emit loop.
+    // fills them and the handle dominates the collect and the emit loop. A sort
+    // fused with a terminal db.limit carries that count as its top-K bound, so the
+    // accumulator keeps only the best k rows; an unfused sort keeps every row.
     _builder.setInsertionPointToStart(_entryBlock);
+
+    const auto topK = _sortTopK.find(sort.getOperation());
+    mlir::IntegerAttr topKAttr;
+    if (topK != _sortTopK.end()) {
+        topKAttr = _builder.getIntegerAttr(_builder.getIntegerType(64, /*isSigned=*/false), topK->second);
+    }
+
     nl::SortBuffer bufferOp = _builder.create<nl::SortBuffer>(loc,
                                                               sort.getKeyColumnsAttr(),
-                                                              sort.getKeyAscendingAttr());
+                                                              sort.getKeyAscendingAttr(),
+                                                              topKAttr);
     const mlir::Value state = bufferOp.getState();
 
     // The collect appends each step's chunk of every column to the buffers. It

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -201,6 +201,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerLimit(limit);
     } else if (mlir::db::Skip skip = mlir::dyn_cast<mlir::db::Skip>(operation)) {
         lowerSkip(skip);
+    } else if (mlir::db::Sort sort = mlir::dyn_cast<mlir::db::Sort>(operation)) {
+        lowerSort(sort);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -490,6 +492,61 @@ void DBLowering::lowerSkip(mlir::db::Skip skip) {
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
         _valueMap[dbResults[resultIndex]] = truncatedChunks[resultIndex];
     }
+}
+
+void DBLowering::lowerSort(mlir::db::Sort sort) {
+    // The nl chunks the sorted columns lowered to; these are what sort_collect
+    // appends to the buffers, and the emit loop yields back sorted.
+    llvm::SmallVector<mlir::Value, 4> chunks;
+    for (const mlir::Value column : sort.getColumns()) {
+        chunks.push_back(mapValue(column));
+    }
+
+    // Sort::verify rejects an empty db.sort, so reaching it here means unverified
+    // IR - a defensive backstop, as in lowerFactor and lowerLimit.
+    if (chunks.empty()) {
+        throw IRException("db.sort requires at least one column");
+    }
+
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // The accumulator and its sort spec are hoisted to the top of the entry
+    // block, above every loop, so the buffers exist before the producing loop
+    // fills them and the handle dominates the collect and the emit loop.
+    _builder.setInsertionPointToStart(_entryBlock);
+    nl::SortBuffer bufferOp = _builder.create<nl::SortBuffer>(loc,
+                                                              sort.getKeyColumnsAttr(),
+                                                              sort.getKeyAscendingAttr());
+    const mlir::Value state = bufferOp.getState();
+
+    // The collect appends each step's chunk of every column to the buffers. It
+    // sits in the innermost producing loop body, where all sorted columns are
+    // bound together (the same block db.output would emit from), so the buffers
+    // stay row-aligned.
+    const mlir::Value representative = chunks.front();
+    setInsertionInto(ownerBlock(representative));
+    _builder.create<nl::SortCollect>(loc, state, chunks);
+
+    // The emit phase is an nl.sort source iterator plus its nl.for, placed after
+    // the producing loop (before the func.return) so the buffers are full when
+    // the loop first steps. The iterator yields one chunk per collected column,
+    // so its chunk types are exactly the collected chunk types.
+    llvm::SmallVector<mlir::Type, 4> chunkTypes;
+    for (const mlir::Value chunk : chunks) {
+        chunkTypes.push_back(chunk.getType());
+    }
+
+    const nl::IteratorType iteratorType = nl::IteratorType::get(_builder.getContext(), chunkTypes);
+
+    setInsertionInto(_entryBlock);
+    nl::Sort sortOp = _builder.create<nl::Sort>(loc, iteratorType, state);
+
+    // The emit loop binds one variable per sorted column and is never bounded by
+    // a limit (sort must see every row), so the iterator-only loop builder is
+    // used. buildLoopForSource maps db.sort's results to the loop variables, so
+    // the db.output that follows lowers into the emit loop body reading the
+    // sorted chunks.
+    buildLoopForSource(sortOp.getResult(), sort.getOperation());
 }
 
 void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -548,11 +548,10 @@ void DBLowering::detectTopKFusion(mlir::func::FuncOp dbFunction) {
             }
         }
 
-        // First limit (program order) to claim a sort wins; record the fusion.
-        if (!_sortTopK.count(sort.getOperation())) {
-            _sortTopK[sort.getOperation()] = limit.getCount();
-            _fusedLimits.insert(limit.getOperation());
-        }
+        // The sole-user check above guarantees this limit is the only consumer of
+        // the sort, so no other limit can claim it; record the fusion.
+        _sortTopK[sort.getOperation()] = limit.getCount();
+        _fusedLimits.insert(limit.getOperation());
     });
 }
 

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -114,6 +114,15 @@ private:
     void lowerCrossProduct(mlir::db::CrossProduct product);
     void lowerLimit(mlir::db::Limit limit);
     void lowerSkip(mlir::db::Skip skip);
+
+    // Lower a db.sort: hoist an nl.sort_buffer accumulator (carrying the key
+    // spec) to the top of the entry block, place an nl.sort_collect in the
+    // innermost producing loop body to append each chunk, then - after the
+    // producing loop - emit an nl.sort source iterator and an nl.for over it that
+    // yields the sorted rows. db.sort's results map to that emit loop's
+    // variables, so the db.output that follows lowers into the emit loop body.
+    void lowerSort(mlir::db::Sort sort);
+
     void lowerOutput(mlir::db::Output output);
 
     // Lower one factor region of a db.cross_product into a loop nest rooted at

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -4,6 +4,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 
@@ -105,6 +106,14 @@ private:
     // two handles. Absent (null on lookup) for a consumer loop, which fans out.
     llvm::DenseMap<mlir::Operation*, mlir::Value> _loopLimitHandle;  // db producer -> handle
 
+    // A db.sort whose result is capped by an adjacent terminal db.limit fuses into
+    // a bounded top-K: the count is baked into the nl.sort_buffer and the db.limit
+    // becomes a pass-through. _sortTopK maps the fused db.sort to its bound;
+    // _fusedLimits is the set of db.limits absorbed this way, so the limit pre-scan
+    // and lowering skip them.
+    llvm::DenseMap<mlir::Operation*, uint64_t> _sortTopK;   // db.sort -> top-K bound
+    llvm::DenseSet<mlir::Operation*> _fusedLimits;          // db.limits fused into a sort
+
     void lowerOperation(mlir::Operation& operation);
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
@@ -114,6 +123,14 @@ private:
     void lowerCrossProduct(mlir::db::CrossProduct product);
     void lowerLimit(mlir::db::Limit limit);
     void lowerSkip(mlir::db::Skip skip);
+
+    // Find db.sort results capped by an adjacent terminal db.limit (the
+    // ORDER BY ... LIMIT k shape) and record the fusion: the sort is the limit's
+    // sole consumer and every limit column comes from it. Fills _sortTopK and
+    // _fusedLimits so the limit pre-scan skips the fused limit (no nl.limit
+    // handle, no producing-loop early-exit - top-K must scan every row), lowerSort
+    // bakes the count into the nl.sort_buffer, and lowerLimit passes through.
+    void detectTopKFusion(mlir::func::FuncOp dbFunction);
 
     // Lower a db.sort: hoist an nl.sort_buffer accumulator (carrying the key
     // spec) to the top of the entry block, place an nl.sort_collect in the

--- a/samples/mlir/sort.mlir
+++ b/samples/mlir/sort.mlir
@@ -1,0 +1,19 @@
+module {
+  func.func @main() {
+    // MATCH (a) RETURN a ORDER BY a DESC: scan every node, then sort the node
+    // column by itself, descending.
+    //
+    // db.sort is a pipeline breaker, so it lowers to a hoisted nl.sort_buffer
+    // accumulator, an nl.sort_collect inside the scan loop that appends each
+    // chunk, and - after the loop - an nl.sort source iterator whose nl.for emits
+    // the accumulated rows in sorted order. `keys [0]` sorts by column 0 (the
+    // only column) and `ascending [false]` makes it descending.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %sa = db.sort(%a) keys [0] ascending [false] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    db.output(%sa) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/sort.nl.mlir
+++ b/samples/mlir/sort.nl.mlir
@@ -1,0 +1,17 @@
+// Generated nl-dialect lowering of sort.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered sort.mlir
+// This is the DBLowering output; edit sort.mlir, not this file.
+module {
+  func.func @main() {
+    %0 = nl.sort_buffer keys [0] ascending [false]
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.sort_collect %0, (%arg0) : !nl.chunk<!storage.node_id>
+    }
+    %2 = nl.sort(%0) : !nl.iter<!nl.chunk<!storage.node_id>>
+    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.output(%arg0) : !nl.chunk<!storage.node_id>
+    }
+    return
+  }
+}

--- a/samples/mlir/sort_topk.mlir
+++ b/samples/mlir/sort_topk.mlir
@@ -1,0 +1,21 @@
+module {
+  func.func @main() {
+    // MATCH (a) RETURN a ORDER BY a DESC LIMIT 2: the top-2 nodes by descending
+    // ID. The db.limit capping a db.sort's result is the ORDER BY ... LIMIT k
+    // shape, so DBLowering fuses them: the count is baked into nl.sort_buffer as a
+    // top-K bound and the db.limit becomes a pass-through.
+    //
+    // The lowered nl (see sort_topk.nl.mlir) has no nl.limit at all - the
+    // accumulator keeps only the best 2 rows (O(k) memory, O(rows log k) sort)
+    // and the scan loop stays unbounded, since top-K must still see every row.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %sa = db.sort(%a) keys [0] ascending [false] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    %la = db.limit(%sa) count 2 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    db.output(%la) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/sort_topk.nl.mlir
+++ b/samples/mlir/sort_topk.nl.mlir
@@ -1,0 +1,22 @@
+// Generated nl-dialect lowering of sort_topk.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered sort_topk.mlir
+// This is the DBLowering output; edit sort_topk.mlir, not this file.
+//
+// Note the ORDER BY ... LIMIT 2 fused away: no nl.limit / nl.limit_update /
+// nl.limit_truncate. The bound lives on nl.sort_buffer as `limit 2`, so the
+// accumulator keeps only the best 2 rows, and the scan loop is unbounded because
+// top-K must still scan every row.
+module {
+  func.func @main() {
+    %0 = nl.sort_buffer keys [0] ascending [false] limit 2
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.sort_collect %0, (%arg0) : !nl.chunk<!storage.node_id>
+    }
+    %2 = nl.sort(%0) : !nl.iter<!nl.chunk<!storage.node_id>>
+    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.output(%arg0) : !nl.chunk<!storage.node_id>
+    }
+    return
+  }
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -129,11 +129,43 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN a, a.score ORDER BY a.score DESC: two columns passed through,
+// sorted by the second one (the score), descending.
+const char* const sortProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %sa, %sscore = db.sort(%a, %score) keys [1] ascending [false] : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  db.output(%sa, %sscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+// A sort key indexing a column that does not exist: only one column, key 5.
+const char* const sortKeyOutOfRangeProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %sa = db.sort(%a) keys [5] ascending [true] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%sa) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // db.skip's count is a ui64 attribute, so a negative literal cannot parse.
 const char* const negativeSkipProgram = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %sa = db.skip(%a) count -1 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%sa) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// Two keys but one direction: the parallel key arrays disagree on length.
+const char* const sortMismatchedKeysProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %sa = db.sort(%a) keys [0, 0] ascending [true] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
   db.output(%sa) : !db.column<!storage.node_id>
   return
 }
@@ -382,6 +414,45 @@ TEST_F(DBDialectTest, skipRoundTripsThroughTextualForm) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
+TEST_F(DBDialectTest, parsesSort) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(sortProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Sort sort;
+    module.get().walk([&](mlir::db::Sort op) {
+        sort = op;
+    });
+    ASSERT_TRUE(sort);
+
+    // Two columns pass through as two results of the same types.
+    ASSERT_EQ(sort.getColumns().size(), 2u);
+    ASSERT_EQ(sort.getResults().size(), 2u);
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    EXPECT_EQ(sort.getColumns()[0].getType(), nodeIDColumnType);
+    EXPECT_EQ(sort.getResults()[0].getType(), nodeIDColumnType);
+
+    // The single key is column 1 (the score), descending.
+    ASSERT_EQ(sort.getKeyColumns().size(), 1u);
+    EXPECT_EQ(sort.getKeyColumns()[0], 1);
+    ASSERT_EQ(sort.getKeyAscending().size(), 1u);
+    EXPECT_FALSE(sort.getKeyAscending()[0]);
+}
+
+TEST_F(DBDialectTest, sortRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(sortProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.sort printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
 TEST_F(DBDialectTest, rejectsNegativeSkipCount) {
     // count is a ui64 attribute, so a negative literal fails to parse and the
     // module is null.
@@ -470,6 +541,45 @@ TEST_F(DBDialectTest, verifierRejectsSkipColumnTypeMismatch) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(skip.getOperation())));
+}
+
+TEST_F(DBDialectTest, rejectsSortKeyOutOfRange) {
+    // The verifier runs during parsing, so a key that indexes no column makes the
+    // module fail to parse.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(sortKeyOutOfRangeProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, rejectsSortMismatchedKeyArrays) {
+    // Two key indices but one direction: the parallel arrays disagree, so the
+    // verifier rejects it during parsing.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(sortMismatchedKeysProgram);
+    EXPECT_FALSE(module);
+}
+
+// Builds a db.sort with no columns and no keys. Its row order is read from its
+// columns during lowering, so the verifier rejects the empty case here rather
+// than leaving it to the lowering pass.
+TEST_F(DBDialectTest, verifierRejectsSortWithoutColumns) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    // No columns, no results, no keys: nothing to sort.
+    auto sort = builder.create<mlir::db::Sort>(loc,
+                                               mlir::TypeRange {},
+                                               mlir::ValueRange {},
+                                               builder.getDenseI64ArrayAttr({}),
+                                               builder.getDenseBoolArrayAttr({}));
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(sort.getOperation())));
 }
 
 }

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -773,6 +773,23 @@ protected:
         return graph;
     }
 
+    // A second datapart with nodes 4, 5 and the edge 4 -> 5, growing the node
+    // count past the top-K trim threshold in the trims-across-chunks test.
+    void addSecondPart(Graph& graph) {
+        auto change = graph.newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const NodeID nodeE = builder.addNode(labelset);
+        const NodeID nodeF = builder.addNode(labelset);
+
+        builder.addEdge(0, nodeE, nodeF);
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+    }
+
     // A line graph 0 -> 1 -> 2 where nodes 0 and 1 carry "score" (Int64),
     // "name" (String) and "vec" (Embedding) properties and node 2 carries none,
     // so a read of any of them returns null for node 2. The edge 0 -> 1 carries
@@ -2290,18 +2307,23 @@ TEST_F(DBLoweringTest, topKNodesByIdDescending) {
 }
 
 TEST_F(DBLoweringTest, topKTrimsAcrossChunkBoundaries) {
+    // Six nodes (two dataparts) so the buffer grows past the 2 * topK = 4 trim
+    // threshold; the four-node diamond alone never crosses it, so trimToTopK would
+    // never run.
     auto graph = buildDiamondGraph();
+    addSecondPart(*graph);
+
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
 
-    // chunkSize 1 over four nodes: the accumulator is fed one row at a time and
-    // trims as it overflows the bound, so the top-2 must survive the trimming and
-    // still come out 3, 2.
+    // chunkSize 1 over six nodes: the accumulator is fed one row at a time and
+    // trims once it overflows the bound, so the top-2 must survive the trimming
+    // and still come out 5, 4.
     CollectingNodeSink sink;
     const std::string program = topKNodesDescProgram(2);
     runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
 
-    const std::vector<std::vector<uint64_t>> expected {{3}, {2}};
+    const std::vector<std::vector<uint64_t>> expected {{5}, {4}};
     std::vector<std::vector<uint64_t>> rows;
     sink.orderedRows(rows);
     EXPECT_EQ(rows, expected);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -71,6 +71,13 @@ public:
     // Fills rows zipped from the columns and sorted: chunk order depends on
     // datapart-major iteration, so tests compare order-independently
     void sortedRows(std::vector<std::vector<uint64_t>>& rows) const {
+        orderedRows(rows);
+        std::sort(rows.begin(), rows.end());
+    }
+
+    // Fills rows zipped from the columns in emission order, unsorted: a sort test
+    // observes the order the program emitted, not a re-sorted copy.
+    void orderedRows(std::vector<std::vector<uint64_t>>& rows) const {
         rows.clear();
         const size_t rowCount = _columns.empty() ? 0 : _columns.front().size();
 
@@ -81,8 +88,6 @@ public:
             }
             rows.push_back(row);
         }
-
-        std::sort(rows.begin(), rows.end());
     }
 
 private:
@@ -112,6 +117,12 @@ public:
     void sortedRows(std::vector<std::pair<uint64_t, std::optional<int64_t>>>& rows) const {
         rows = _rows;
         std::sort(rows.begin(), rows.end());
+    }
+
+    // The rows in emission order, unsorted: a sort test observes the program's
+    // own order rather than a re-sorted copy.
+    void orderedRows(std::vector<std::pair<uint64_t, std::optional<int64_t>>>& rows) const {
+        rows = _rows;
     }
 
 private:
@@ -640,6 +651,56 @@ std::string chainedSkipProgram(uint64_t count) {
              "  return\n"
              "}\n";
 }
+
+// MATCH (a) RETURN a ORDER BY a DESC: scan every node, then sort the single node
+// ID column by itself, descending. The output order is fully determined by the
+// sort, independent of the scan's chunking.
+constexpr const char* sortNodesDescProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %sa = db.sort(%a) keys [0] ascending [false] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%sa) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN a, a.score ORDER BY a.score ASC: read each node's score, then
+// sort the (node, score) rows by score ascending. A node without a score sorts
+// last (null is greatest).
+constexpr const char* sortByScoreAscProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %sa, %sscore = db.sort(%a, %score) keys [1] ascending [true] : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  db.output(%sa, %sscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+// The same, descending: the null score now sorts first (null is greatest, so a
+// descending order puts it at the front).
+constexpr const char* sortByScoreDescProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %sa, %sscore = db.sort(%a, %score) keys [1] ascending [false] : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  db.output(%sa, %sscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+// MATCH (a)-->(b) RETURN a, b ORDER BY a ASC, b DESC: one hop, then sort the
+// (source, target) edge rows by source ascending and - within a source - target
+// descending. A two-key sort whose primary key has real ties.
+constexpr const char* sortEdgesMultiKeyProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %ssrc, %stgt = db.sort(%srcs, %b) keys [0, 1] ascending [true, false] : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%ssrc, %stgt) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
 
 }
 
@@ -1990,6 +2051,197 @@ TEST_F(DBLoweringTest, lowersChainedSkipWithConsumerEdgeLoop) {
     // that feeds it - the chained shape, where the cut chunk drives the fan-out.
     EXPECT_EQ(edgeLoop->getBlock(), truncateOp->getBlock());
     EXPECT_TRUE(edgeLoop.getIterator().getDefiningOp<mlir::nl::GetOutEdges>());
+}
+
+TEST_F(DBLoweringTest, sortsNodesByIdDescending) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(sortNodesDescProgram, reader.getView(), sink);
+
+    // Four nodes sorted descending: the emit order is exactly 3, 2, 1, 0,
+    // regardless of the order the scan produced them.
+    const std::vector<std::vector<uint64_t>> expected {{3}, {2}, {1}, {0}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortByIdDescendingAcrossChunkBoundaries) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A chunk size of two over four nodes makes the scan collect two chunks and
+    // the emit re-chunk into two, so the result proves accumulation across chunks
+    // and the chunked emit both preserve the global sorted order.
+    CollectingNodeSink sink;
+    runLoweredProgram(sortNodesDescProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {2}, {1}, {0}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortsByPropertyAscendingNullsLast) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Scores are 100 (node 0), 200 (node 1) and absent (node 2). Ascending, the
+    // null sorts last: (0,100), (1,200), (2,null).
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(sortByScoreAscProgram, reader.getView(), sink);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}, {2, std::nullopt}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortsByPropertyDescendingNullsFirst) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Descending, the null score (greatest) leads: (2,null), (1,200), (0,100).
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(sortByScoreDescProgram, reader.getView(), sink);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {2, std::nullopt}, {1, 200}, {0, 100}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortsByPropertyAcrossChunkBoundaries) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 forces the null-scored node into its own chunk and refills the
+    // value buffer over three steps; the sorted result must not depend on it.
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(sortByScoreAscProgram, reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}, {2, std::nullopt}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortsByTwoKeys) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond's edges are (0,1), (0,2), (1,3), (2,3). Sorting by source
+    // ascending then target descending groups by source and, within source 0,
+    // orders the targets 2 then 1: (0,2), (0,1), (1,3), (2,3).
+    CollectingNodeSink sink;
+    runLoweredProgram(sortEdgesMultiKeyProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 2}, {0, 1}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortOfEmptyGraphEmitsNothing) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // No rows to accumulate: the emit loop runs zero times, so nothing is output.
+    CountingSink sink;
+    runLoweredProgram(sortNodesDescProgram, reader.getView(), sink);
+
+    EXPECT_EQ(sink.getCalls(), 0u);
+    EXPECT_EQ(sink.getTotalRows(), 0u);
+}
+
+TEST_F(DBLoweringTest, lowersSortToBufferCollectAndEmitLoop) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(sortNodesDescProgram, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // db.sort lowers to one hoisted nl.sort_buffer, one nl.sort_collect in the
+    // producing (scan) loop, one nl.sort source op, and two nl.for loops: the
+    // producing scan loop and the emit loop over nl.sort.
+    size_t bufferCount = 0;
+    size_t collectCount = 0;
+    size_t sortCount = 0;
+    size_t forCount = 0;
+    mlir::nl::SortBuffer bufferOp;
+    mlir::nl::SortCollect collectOp;
+    mlir::nl::Sort sortOp;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::SortBuffer found = mlir::dyn_cast<mlir::nl::SortBuffer>(operation)) {
+            bufferOp = found;
+            bufferCount++;
+        } else if (mlir::nl::SortCollect found = mlir::dyn_cast<mlir::nl::SortCollect>(operation)) {
+            collectOp = found;
+            collectCount++;
+        } else if (mlir::nl::Sort found = mlir::dyn_cast<mlir::nl::Sort>(operation)) {
+            sortOp = found;
+            sortCount++;
+        } else if (mlir::isa<mlir::nl::For>(operation)) {
+            forCount++;
+        }
+    });
+
+    EXPECT_EQ(bufferCount, 1u);
+    EXPECT_EQ(collectCount, 1u);
+    EXPECT_EQ(sortCount, 1u);
+    EXPECT_EQ(forCount, 2u);
+    ASSERT_TRUE(bufferOp);
+    ASSERT_TRUE(collectOp);
+    ASSERT_TRUE(sortOp);
+
+    // The collect, the sort source and the emit loop all name the one hoisted
+    // accumulator handle.
+    const mlir::Value handle = bufferOp.getState();
+    EXPECT_EQ(collectOp.getState(), handle);
+    EXPECT_EQ(sortOp.getState(), handle);
+
+    // The single sort key is column 0 (the node IDs), descending.
+    ASSERT_EQ(bufferOp.getKeyColumns().size(), 1u);
+    EXPECT_EQ(bufferOp.getKeyColumns()[0], 0);
+    ASSERT_EQ(bufferOp.getKeyAscending().size(), 1u);
+    EXPECT_FALSE(bufferOp.getKeyAscending()[0]);
+
+    // The collect runs inside an nl.for (the producing scan loop); the emit loop
+    // iterates the nl.sort iterator.
+    EXPECT_TRUE(mlir::isa<mlir::nl::For>(collectOp->getParentOp()));
+    EXPECT_TRUE(sortOp.getResult().hasOneUse());
+    EXPECT_TRUE(mlir::isa<mlir::nl::For>(*sortOp.getResult().user_begin()));
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -702,6 +702,35 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN a ORDER BY a DESC LIMIT count: the db.limit caps the db.sort's
+// result, so lowering fuses them into a bounded top-K (no separate nl.limit).
+std::string topKNodesDescProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %sa = db.sort(%a) keys [0] ascending [false] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+                       "  %la = db.limit(%sa) count ")
+           + std::to_string(count)
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%la) : !db.column<!storage.node_id>\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN a, a.score ORDER BY a.score ASC LIMIT count: top-K over a
+// (node, score) projection, sorted by the nullable score ascending.
+std::string topKByScoreAscProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+                       "  %sa, %sscore = db.sort(%a, %score) keys [1] ascending [true] : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)\n"
+                       "  %la, %lscore = db.limit(%sa, %sscore) count ")
+           + std::to_string(count)
+           + " : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)\n"
+             "  db.output(%la, %lscore) : !db.column<!storage.node_id>, !db.column<none>\n"
+             "  return\n"
+             "}\n";
+}
+
 }
 
 class DBLoweringTest : public TuringTest {
@@ -2242,6 +2271,173 @@ TEST_F(DBLoweringTest, lowersSortToBufferCollectAndEmitLoop) {
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(collectOp->getParentOp()));
     EXPECT_TRUE(sortOp.getResult().hasOneUse());
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(*sortOp.getResult().user_begin()));
+}
+
+TEST_F(DBLoweringTest, topKNodesByIdDescending) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes, ORDER BY a DESC LIMIT 2: the two largest IDs, in order: 3, 2.
+    CollectingNodeSink sink;
+    const std::string program = topKNodesDescProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, topKTrimsAcrossChunkBoundaries) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 over four nodes: the accumulator is fed one row at a time and
+    // trims as it overflows the bound, so the top-2 must survive the trimming and
+    // still come out 3, 2.
+    CollectingNodeSink sink;
+    const std::string program = topKNodesDescProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, topKExceedingInputSortsAll) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // LIMIT 10 over four nodes: the bound exceeds the input, so every node is
+    // kept and the result is the full descending sort.
+    CollectingNodeSink sink;
+    const std::string program = topKNodesDescProgram(10);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {2}, {1}, {0}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, topKByPropertyAscendingDropsNulls) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Scores 100 (node 0), 200 (node 1), null (node 2). ASC LIMIT 2 keeps the two
+    // smallest - 100 then 200 - so the null-scored node falls outside the bound.
+    CollectingNodeIntPropSink sink;
+    const std::string program = topKByScoreAscProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, topKByPropertyAscendingAcrossChunks) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 forces per-row collection and trimming; the top-2 by ascending
+    // score must be the same regardless of chunking.
+    CollectingNodeIntPropSink sink;
+    const std::string program = topKByScoreAscProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}
+    };
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, topKZeroEmitsNothing) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // LIMIT 0 fused into the sort: the bounded accumulator keeps no rows, so the
+    // emit loop runs zero times.
+    CountingSink sink;
+    const std::string program = topKNodesDescProgram(0);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getCalls(), 0u);
+    EXPECT_EQ(sink.getTotalRows(), 0u);
+}
+
+TEST_F(DBLoweringTest, lowersTopKToBoundedSortBufferWithoutLimitOps) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = topKNodesDescProgram(2);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // The terminal db.limit fuses into the sort: the bound lives on nl.sort_buffer
+    // and the streaming limit ops vanish entirely. No nl.limit, no nl.limit_update,
+    // no nl.limit_truncate; one bounded nl.sort_buffer; and the scan loop carries
+    // no limit handle, since top-K must still scan every row.
+    size_t bufferCount = 0;
+    size_t limitCount = 0;
+    size_t updateCount = 0;
+    size_t truncateCount = 0;
+    size_t forsWithLimit = 0;
+    mlir::nl::SortBuffer bufferOp;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::SortBuffer found = mlir::dyn_cast<mlir::nl::SortBuffer>(operation)) {
+            bufferOp = found;
+            bufferCount++;
+        } else if (mlir::isa<mlir::nl::Limit>(operation)) {
+            limitCount++;
+        } else if (mlir::isa<mlir::nl::LimitUpdate>(operation)) {
+            updateCount++;
+        } else if (mlir::isa<mlir::nl::LimitTruncate>(operation)) {
+            truncateCount++;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        }
+    });
+
+    EXPECT_EQ(bufferCount, 1u);
+    EXPECT_EQ(limitCount, 0u);
+    EXPECT_EQ(updateCount, 0u);
+    EXPECT_EQ(truncateCount, 0u);
+    EXPECT_EQ(forsWithLimit, 0u);
+
+    // The accumulator carries the fused bound as its top-K count.
+    ASSERT_TRUE(bufferOp);
+    ASSERT_TRUE(bufferOp.getTopK().has_value());
+    EXPECT_EQ(*bufferOp.getTopK(), 2u);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -157,7 +157,8 @@ TEST_F(NLDialectTest, verifierAcceptsSortChain) {
 
     const mlir::Value handle = builder.create<mlir::nl::SortBuffer>(loc,
                                                                     builder.getDenseI64ArrayAttr({0}),
-                                                                    builder.getDenseBoolArrayAttr({false})).getState();
+                                                                    builder.getDenseBoolArrayAttr({false}),
+                                                                    /*topK=*/mlir::IntegerAttr()).getState();
     builder.create<mlir::nl::SortCollect>(loc, handle, mlir::ValueRange {chunk});
 
     const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {chunk.getType()});
@@ -205,12 +206,33 @@ TEST_F(NLDialectTest, verifierRejectsSortBufferMismatchedKeys) {
 
     auto buffer = builder.create<mlir::nl::SortBuffer>(loc,
                                                        builder.getDenseI64ArrayAttr({0, 1}),
-                                                       builder.getDenseBoolArrayAttr({true}));
+                                                       builder.getDenseBoolArrayAttr({true}),
+                                                       /*topK=*/mlir::IntegerAttr());
 
     const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(buffer.getOperation())));
+}
+
+// nl.sort_buffer may carry an optional top-K bound (the fused ORDER BY ... LIMIT
+// form); the accessor reports it and the op still verifies.
+TEST_F(NLDialectTest, verifierAcceptsBoundedSortBuffer) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    buildOneChunkFunction(builder, *module);
+
+    const mlir::IntegerAttr topK = builder.getIntegerAttr(builder.getIntegerType(64, /*isSigned=*/false), 5);
+    mlir::nl::SortBuffer buffer = builder.create<mlir::nl::SortBuffer>(loc,
+                                                                      builder.getDenseI64ArrayAttr({0}),
+                                                                      builder.getDenseBoolArrayAttr({true}),
+                                                                      topK);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(buffer.getOperation())));
+    ASSERT_TRUE(buffer.getTopK().has_value());
+    EXPECT_EQ(*buffer.getTopK(), 5u);
 }
 
 }

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -143,6 +143,32 @@ TEST_F(NLDialectTest, verifierAcceptsOutputWithSkip) {
     EXPECT_FALSE(output.getLimit());
 }
 
+// The sort chain verifies: an nl.sort_buffer carrying the key spec, an
+// nl.sort_collect appending the chunk, and an nl.sort yielding a sorted iterator
+// over that chunk type, all naming the one accumulator handle.
+TEST_F(NLDialectTest, verifierAcceptsSortChain) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value handle = builder.create<mlir::nl::SortBuffer>(loc,
+                                                                    builder.getDenseI64ArrayAttr({0}),
+                                                                    builder.getDenseBoolArrayAttr({false})).getState();
+    builder.create<mlir::nl::SortCollect>(loc, handle, mlir::ValueRange {chunk});
+
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {chunk.getType()});
+    mlir::nl::Sort sort = builder.create<mlir::nl::Sort>(loc, iteratorType, handle);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(sort.getState(), handle);
+    EXPECT_EQ(sort.getResult().getType(), iteratorType);
+}
+
 // A folded nl.output carries the single handle of the truncate adjacent to it,
 // never both: an output with both a limit and a skip handle fails verification.
 TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {
@@ -163,6 +189,28 @@ TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(function)));
+}
+
+// nl.sort_buffer requires one direction per key: two key indices with one
+// direction is malformed and the verifier rejects it.
+TEST_F(NLDialectTest, verifierRejectsSortBufferMismatchedKeys) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+
+    // Position the builder inside a function body; the op under test is verified
+    // on its own, so the returned function handle is not needed.
+    buildOneChunkFunction(builder, *module);
+
+    auto buffer = builder.create<mlir::nl::SortBuffer>(loc,
+                                                       builder.getDenseI64ArrayAttr({0, 1}),
+                                                       builder.getDenseBoolArrayAttr({true}));
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(buffer.getOperation())));
 }
 
 }

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -261,6 +261,24 @@ func.func @main() {
 }
 )mlir";
 
+// The same, but the accumulator is bounded to the best 2 rows (a fused top-K):
+// nl.sort_buffer carries `limit 2`, so sort_collect keeps only the top 2 by the
+// descending node ID and the emit loop yields just those.
+constexpr const char* nlTopKDescProgram = R"mlir(
+func.func @main() {
+  %state = nl.sort_buffer keys [0] ascending [false] limit 2
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.sort_collect %state, (%a) : !nl.chunk<!storage.node_id>
+  }
+  %sorted = nl.sort(%state) : !nl.iter<!nl.chunk<!storage.node_id>>
+  nl.for %sa in %sorted : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%sa) : !nl.chunk<!storage.node_id>
+  }
+  func.return
+}
+)mlir";
+
 // Counts appendChunks calls and the total rows emitted, to prove a limited run
 // emits a clamped prefix (a partial final chunk) and stops the loop early.
 class CountingSink : public NLOutputSink {
@@ -896,6 +914,35 @@ TEST_F(NLExecutorTest, sortsScannedNodesDescendingAcrossChunks) {
 
     ASSERT_EQ(sink.getColumns().size(), 1u);
     const std::vector<uint64_t> expected {3, 2, 1, 0};
+    EXPECT_EQ(sink.getColumns()[0], expected);
+}
+
+TEST_F(NLExecutorTest, topKBoundedAccumulatorKeepsBest) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes, top-2 descending: the bounded accumulator emits exactly 3, 2.
+    CollectingNodeSink sink;
+    runProgram(nlTopKDescProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    const std::vector<uint64_t> expected {3, 2};
+    EXPECT_EQ(sink.getColumns()[0], expected);
+}
+
+TEST_F(NLExecutorTest, topKBoundedAccumulatorTrimsAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 feeds the accumulator one row at a time, so it trims repeatedly
+    // as it overflows the bound; the surviving top-2 are still 3, 2.
+    CollectingNodeSink sink;
+    runProgram(nlTopKDescProgram, reader.getView(), 1, sink);
+
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    const std::vector<uint64_t> expected {3, 2};
     EXPECT_EQ(sink.getColumns()[0], expected);
 }
 

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -932,17 +932,23 @@ TEST_F(NLExecutorTest, topKBoundedAccumulatorKeepsBest) {
 }
 
 TEST_F(NLExecutorTest, topKBoundedAccumulatorTrimsAcrossChunks) {
+    // Six nodes (two dataparts) so the buffer grows past the 2 * topK = 4 trim
+    // threshold; the four-node diamond alone never crosses it, so trimToTopK would
+    // never run.
     auto graph = buildDiamondGraph();
+    addSecondPart(*graph);
+
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
 
-    // chunkSize 1 feeds the accumulator one row at a time, so it trims repeatedly
-    // as it overflows the bound; the surviving top-2 are still 3, 2.
+    // chunkSize 1 feeds the accumulator one row at a time, so once the sixth row
+    // arrives it overflows the bound and trimToTopK runs; the surviving top-2 by
+    // descending node ID are 5, 4.
     CollectingNodeSink sink;
     runProgram(nlTopKDescProgram, reader.getView(), 1, sink);
 
     ASSERT_EQ(sink.getColumns().size(), 1u);
-    const std::vector<uint64_t> expected {3, 2};
+    const std::vector<uint64_t> expected {5, 4};
     EXPECT_EQ(sink.getColumns()[0], expected);
 }
 

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -243,6 +243,24 @@ func.func @main() {
 }
 )mlir";
 
+// Scan all nodes, accumulate them into a sort buffer, then emit them sorted by
+// node ID descending. The sort_collect runs in the scan loop; the nl.sort source
+// drives the emit loop that outputs the sorted chunks.
+constexpr const char* nlSortDescProgram = R"mlir(
+func.func @main() {
+  %state = nl.sort_buffer keys [0] ascending [false]
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.sort_collect %state, (%a) : !nl.chunk<!storage.node_id>
+  }
+  %sorted = nl.sort(%state) : !nl.iter<!nl.chunk<!storage.node_id>>
+  nl.for %sa in %sorted : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%sa) : !nl.chunk<!storage.node_id>
+  }
+  func.return
+}
+)mlir";
+
 // Counts appendChunks calls and the total rows emitted, to prove a limited run
 // emits a clamped prefix (a partial final chunk) and stops the loop early.
 class CountingSink : public NLOutputSink {
@@ -850,6 +868,35 @@ TEST_F(NLExecutorTest, rejectsCrossLoopOutputColumns) {
 
 TEST_F(NLExecutorTest, rejectsCrossLoopCarriedColumns) {
     expectTranslationFailure(crossLoopCarryProgram);
+}
+
+TEST_F(NLExecutorTest, sortsScannedNodesDescending) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(nlSortDescProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // Four nodes, sorted descending: emitted as exactly 3, 2, 1, 0.
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    const std::vector<uint64_t> expected {3, 2, 1, 0};
+    EXPECT_EQ(sink.getColumns()[0], expected);
+}
+
+TEST_F(NLExecutorTest, sortsScannedNodesDescendingAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 2 makes the scan collect two chunks into the buffer and the emit
+    // re-chunk into two; the global descending order must still be 3, 2, 1, 0.
+    CollectingNodeSink sink;
+    runProgram(nlSortDescProgram, reader.getView(), 2, sink);
+
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    const std::vector<uint64_t> expected {3, 2, 1, 0};
+    EXPECT_EQ(sink.getColumns()[0], expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Add a column-set sort op to the db and nl dialects lowered all the way to execution, plus a fused bounded top-K when a terminal LIMIT caps an ORDER BY.