### PR TITLE
MLIR: implement remove_duplicates across the db and nl dialects

### DIFF
--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -250,3 +250,11 @@ LogicalResult Sort::verify() {
 
     return success();
 }
+
+// db.remove_duplicates passes its columns straight through (minus duplicate rows),
+// so the results must be exactly the input columns - same count, same types, same
+// order - the shared pass-through check db.limit and db.skip use. The dedup key is
+// the whole row, so - unlike db.sort - there are no key arrays to validate.
+LogicalResult RemoveDuplicates::verify() {
+    return verifyPassThrough(getOperation(), getColumns(), getResults());
+}

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -375,4 +375,48 @@ def Sort : TuringOp<"sort", [Pure]> {
   let hasVerifier = 1;
 }
 
+/**
+* RemoveDuplicates
+*/
+def RemoveDuplicates : TuringOp<"remove_duplicates", [Pure]> {
+  let summary = "Emit each distinct row of a column set once";
+  let description = [{
+    The declarative counterpart of a Cypher RETURN DISTINCT / WITH DISTINCT. Takes
+    the whole set of columns flowing through it and emits only the first occurrence
+    of each distinct row, dropping later duplicates. A row's identity is the tuple
+    across all its columns - so the whole projection is the dedup key - and two
+    nulls count as equal, as Cypher DISTINCT dedups nulls together. The columns
+    pass through unchanged in count and type; only duplicate rows are removed:
+
+      %a  = db.scan_nodes() : !db.column<"a">
+      %da = db.remove_duplicates(%a) : (!db.column<"a">) -> !db.column<"a">
+      db.output(%da) : !db.column<"a">
+
+    Unlike db.sort it is not a pipeline breaker: it emits a row the moment it first
+    sees it, keeping only a growing seen-set. It lowers to a hoisted nl.distinct
+    seen-set handle and an nl.distinct_filter in the producing loop body that emits
+    each step's not-yet-seen rows as fresh chunks - consumed by db.output when the
+    query ends here, or by a downstream traversal when a WITH DISTINCT feeds a
+    further MATCH. Because it streams and shrinks each chunk, a following db.limit
+    charges the deduped survivor count and bounds the producing loop through the
+    ordinary early-exit, so DISTINCT ... LIMIT k needs no special fusion - the scan
+    stops once k distinct rows are found. Deduplicating a deterministic read of the
+    graph is itself deterministic, so the op is Pure.
+  }];
+
+  // The columns flow through unchanged; every column is part of the dedup key, so
+  // - unlike db.sort's keys - no key attribute is needed.
+  let arguments = (ins Variadic<Column>:$columns);
+  let results   = (outs Variadic<Column>:$results);
+
+  // One result per input column, same types; functional-type prints the
+  // `(operandTypes) -> resultTypes` form, the same as db.limit and db.sort.
+  let assemblyFormat = [{
+    `(` $columns `)` attr-dict `:` functional-type(operands, results)
+  }];
+
+  // results arity and types must equal the columns (the shared pass-through check).
+  let hasVerifier = 1;
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -150,6 +150,30 @@ LogicalResult SortCollect::verify() {
     return success();
 }
 
+// A distinct filter passes its columns through unchanged - only duplicate rows
+// are removed - so each result keeps its input column's chunk type, the same as
+// nl.limit_truncate.
+LogicalResult DistinctFilter::inferReturnTypes(MLIRContext* context,
+                                              std::optional<Location> location,
+                                              DistinctFilter::Adaptor adaptor,
+                                              SmallVectorImpl<Type>& inferredReturnTypes) {
+    for (const Type columnType : adaptor.getColumns().getTypes()) {
+        inferredReturnTypes.push_back(columnType);
+    }
+
+    return success();
+}
+
+// An nl.distinct_filter must filter at least one column - the columns together
+// are the dedup key, and an empty filter could not size the row set to dedup.
+LogicalResult DistinctFilter::verify() {
+    if (getColumns().empty()) {
+        return emitOpError("requires at least one column to filter");
+    }
+
+    return success();
+}
+
 void For::build(OpBuilder& builder, OperationState& state, Value iterator) {
     For::build(builder, state, iterator, Value());
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -610,24 +610,16 @@ def Sort : NLOp<"sort", [Pure]> {
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }
 
-/**
-* Distinct
-*/
-// NOT Pure: each nl.distinct is a distinct seen-set, so two must never be CSE'd
-// into one, and an unread one must not be DCE'd - resetting the set is a side
-// effect (like nl.limit / nl.sort_buffer).
+// NOT Pure: resetting the seen-set is a side effect, and two seen-sets must never
+// be CSE'd into one (like nl.limit / nl.sort_buffer).
 def Distinct : NLOp<"distinct", []> {
   let summary = "Create (and reset) a seen-set for one DISTINCT";
   let description = [{
-    Sits at the top of the scope it governs - function scope for a top-level or
-    mid-query DISTINCT - where it empties the seen-set once per execution of that
-    block. Produces the !nl.distinct_state handle nl.distinct_filter reads and
-    mutates.
-
-    Unlike nl.sort_buffer it is not a pipeline breaker: DISTINCT streams, emitting
-    each row the first time it is seen, so no nl.for names this handle - the filter
-    runs inside the producing loop, not after it. The result type is buildable and
-    omitted.
+    Hoisted to the top of the scope it governs (function scope for a top-level or
+    mid-query DISTINCT), where it empties the seen-set. Produces the
+    !nl.distinct_state handle nl.distinct_filter reads and mutates. DISTINCT streams
+    rather than breaking the pipeline, so no nl.for names this handle - the filter
+    runs inside the producing loop.
 
       %s = nl.distinct
   }];
@@ -636,44 +628,26 @@ def Distinct : NLOp<"distinct", []> {
   let assemblyFormat = "attr-dict";
 }
 
-/**
-* DistinctFilter
-*/
-// NOT Pure: it inserts the current chunk's rows into the seen-set, so it must run
-// exactly where it sits, once per producing-loop step, and must not be hoisted,
-// CSE'd or eliminated. InferTypeOpAdaptor: the results mirror the column operand
-// types, copied across by inferReturnTypes, as on nl.limit_truncate.
+// NOT Pure: it mutates the seen-set, so it must run where it sits and must not be
+// hoisted, CSE'd or eliminated. InferTypeOpAdaptor: results mirror the columns.
 def DistinctFilter : NLOp<"distinct_filter", [InferTypeOpAdaptor]> {
   let summary = "Keep only the rows of each column not seen before, as fresh chunks";
   let description = [{
-    Sits in the producing loop body, once per step, just before the deduped
-    columns' consumer. Reads the current chunk of every column together, treats
-    each row as the tuple across all columns (Cypher DISTINCT dedups on the whole
-    projection, and on nulls too), and for each row not yet in the seen-set copies
-    it into fresh, front-aligned output chunks while recording it in the set. A row
-    already in the set is dropped. The columns pass through unchanged in type; only
-    the duplicate rows are removed.
+    Runs in the producing loop body, once per step. Treats each row as the tuple
+    across all columns (Cypher DISTINCT dedups the whole projection, nulls included),
+    copies the rows not yet in the seen-set into fresh output chunks and records
+    them, and drops the duplicates. The columns pass through unchanged in type.
 
-    Because it produces genuinely cut chunks (like nl.limit_truncate), a downstream
-    op needs no DISTINCT awareness: nl.output emits the survivors when the query
-    ends here, or a downstream nl.get_out_edges fans out from them when a
-    WITH DISTINCT feeds a further traversal (the chained case). And because it
-    streams and shrinks each chunk, a following nl.limit_update charges the deduped
-    survivor count, so a downstream LIMIT bounds the producing loop through the
-    existing early-exit - DISTINCT ... LIMIT k scans only until k distinct rows are
-    found, and the seen-set never exceeds ~k entries.
+    It emits genuinely cut chunks like nl.limit_truncate, so a downstream consumer -
+    an nl.output, or a further nl.get_out_edges in the chained case - needs no
+    DISTINCT awareness. And because it shrinks each chunk, a following nl.limit_update
+    charges the deduped count, so a downstream LIMIT bounds the producing loop.
 
       %da = nl.distinct_filter %s, (%a) : !nl.chunk<!nl.node_id>
   }];
 
-  // The seen-set handle whose membership sizes the copy, then the columns to
-  // filter - all of them together form the dedup key.
   let arguments = (ins NLDistinctStateHandle:$state, Variadic<NLChunk>:$columns);
-
-  // One result per input column, same type. The results are inferred from the
-  // column operands, so only the column chunk types are spelled, after the colon;
-  // the handle type is buildable and omitted.
-  let results = (outs Variadic<NLChunk>:$results);
+  let results   = (outs Variadic<NLChunk>:$results);
 
   let assemblyFormat = [{
     $state `,` `(` $columns `)` attr-dict `:` qualified(type($columns))

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -610,4 +610,76 @@ def Sort : NLOp<"sort", [Pure]> {
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }
 
+/**
+* Distinct
+*/
+// NOT Pure: each nl.distinct is a distinct seen-set, so two must never be CSE'd
+// into one, and an unread one must not be DCE'd - resetting the set is a side
+// effect (like nl.limit / nl.sort_buffer).
+def Distinct : NLOp<"distinct", []> {
+  let summary = "Create (and reset) a seen-set for one DISTINCT";
+  let description = [{
+    Sits at the top of the scope it governs - function scope for a top-level or
+    mid-query DISTINCT - where it empties the seen-set once per execution of that
+    block. Produces the !nl.distinct_state handle nl.distinct_filter reads and
+    mutates.
+
+    Unlike nl.sort_buffer it is not a pipeline breaker: DISTINCT streams, emitting
+    each row the first time it is seen, so no nl.for names this handle - the filter
+    runs inside the producing loop, not after it. The result type is buildable and
+    omitted.
+
+      %s = nl.distinct
+  }];
+
+  let results = (outs NLDistinctState:$state);
+  let assemblyFormat = "attr-dict";
+}
+
+/**
+* DistinctFilter
+*/
+// NOT Pure: it inserts the current chunk's rows into the seen-set, so it must run
+// exactly where it sits, once per producing-loop step, and must not be hoisted,
+// CSE'd or eliminated. InferTypeOpAdaptor: the results mirror the column operand
+// types, copied across by inferReturnTypes, as on nl.limit_truncate.
+def DistinctFilter : NLOp<"distinct_filter", [InferTypeOpAdaptor]> {
+  let summary = "Keep only the rows of each column not seen before, as fresh chunks";
+  let description = [{
+    Sits in the producing loop body, once per step, just before the deduped
+    columns' consumer. Reads the current chunk of every column together, treats
+    each row as the tuple across all columns (Cypher DISTINCT dedups on the whole
+    projection, and on nulls too), and for each row not yet in the seen-set copies
+    it into fresh, front-aligned output chunks while recording it in the set. A row
+    already in the set is dropped. The columns pass through unchanged in type; only
+    the duplicate rows are removed.
+
+    Because it produces genuinely cut chunks (like nl.limit_truncate), a downstream
+    op needs no DISTINCT awareness: nl.output emits the survivors when the query
+    ends here, or a downstream nl.get_out_edges fans out from them when a
+    WITH DISTINCT feeds a further traversal (the chained case). And because it
+    streams and shrinks each chunk, a following nl.limit_update charges the deduped
+    survivor count, so a downstream LIMIT bounds the producing loop through the
+    existing early-exit - DISTINCT ... LIMIT k scans only until k distinct rows are
+    found, and the seen-set never exceeds ~k entries.
+
+      %da = nl.distinct_filter %s, (%a) : !nl.chunk<!nl.node_id>
+  }];
+
+  // The seen-set handle whose membership sizes the copy, then the columns to
+  // filter - all of them together form the dedup key.
+  let arguments = (ins NLDistinctStateHandle:$state, Variadic<NLChunk>:$columns);
+
+  // One result per input column, same type. The results are inferred from the
+  // column operands, so only the column chunk types are spelled, after the colon;
+  // the handle type is buildable and omitted.
+  let results = (outs Variadic<NLChunk>:$results);
+
+  let assemblyFormat = [{
+    $state `,` `(` $columns `)` attr-dict `:` qualified(type($columns))
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -47,6 +47,18 @@ def NLSortState : NLType<"SortState", "sort_state"> {
     }];
 }
 
+def NLDistinctState : NLType<"DistinctState", "distinct_state"> {
+    let summary = "A DISTINCT seen-set handle";
+    let description = [{
+        Stands for one DISTINCT's set of rows already emitted. Produced by
+        nl.distinct and read and mutated by nl.distinct_filter, which drops a row
+        whose key is already in the set and records a new one. It is a handle, not
+        a chunk: it owns the growing seen-set, not a chunk of values. The streaming
+        sibling of !nl.sort_state - it filters rows as they arrive rather than
+        accumulating and reordering them, so no nl.for drains it.
+    }];
+}
+
 def NLChunk : NLType<"Chunk", "chunk"> {
     let summary = "A bounded batch of values";
     let description = "One column chunk filled by a single database iterator step";
@@ -145,5 +157,14 @@ def NLSortStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::SortStateType>($_self)">,
         "sort state handle", "::mlir::nl::SortStateType">,
     BuildableType<"::mlir::nl::SortStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.distinct_state handle, the same way
+// NLSortStateHandle constrains the sort handle. The single concrete type - there
+// is only ever !nl.distinct_state - is what lets nl.distinct_filter omit the
+// handle's type in its assembly, building it from this recipe instead.
+def NLDistinctStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::DistinctStateType>($_self)">,
+        "distinct state handle", "::mlir::nl::DistinctStateType">,
+    BuildableType<"::mlir::nl::DistinctStateType::get($_builder.getContext())">;
 
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -179,36 +179,38 @@ int compareOptColumn(const Column* column, size_t a, size_t b) {
     return 0;
 }
 
-// Append the raw bytes of a present property value to a row key. A
-// trivially-copyable primitive copies its object bytes; a string copies a length
-// prefix then its characters, so two rows never collide by concatenation (so
-// "a"+"b" and "ab"+"" get distinct keys).
+// Append the raw bytes of a present property value to a distinct row key. The key
+// is a std::string used purely as a growable byte buffer - not text - so the value
+// is appended verbatim: a trivially-copyable primitive copies its object bytes; a
+// string copies a length prefix then its characters, so two rows never collide by
+// concatenation (so "a"+"b" and "ab"+"" get distinct keys).
 template <typename Primitive>
-void appendValueBytes(std::string& key, const Primitive& value) {
+void distinctAppendValueBytes(std::string& key, const Primitive& value) {
     key.append(reinterpret_cast<const char*>(&value), sizeof(Primitive));
 }
 
-void appendValueBytes(std::string& key, std::string_view value) {
+void distinctAppendValueBytes(std::string& key, std::string_view value) {
     const size_t length = value.size();
     key.append(reinterpret_cast<const char*>(&length), sizeof(length));
     key.append(value.data(), value.size());
 }
 
-// Serialize one row of an ID column (node/edge/edge-type IDs) into the row key:
-// the ID's underlying integer value, byte for byte.
+// Serialize one row of an ID column (node/edge/edge-type IDs) into the row key -
+// a std::string used as a byte buffer, not text - as the ID's underlying integer
+// value, byte for byte.
 template <typename ElementType>
-void keyAppendColumn(const Column* column, size_t row, std::string& key) {
+void distinctKeyAppendColumn(const Column* column, size_t row, std::string& key) {
     const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
     const auto value = raw[row].getValue();
-    appendValueBytes(key, value);
+    distinctAppendValueBytes(key, value);
 }
 
-// Serialize one row of a nullable value column into the row key: a tag byte
-// telling null from present, then - when present - the value's bytes. A null
-// serializes to the tag alone, so all nulls share a key and DISTINCT dedups them
-// together, matching Cypher.
+// Serialize one row of a nullable value column into the row key - a std::string
+// used as a byte buffer, not text - as a tag byte telling null from present, then,
+// when present, the value's bytes. A null serializes to the tag alone, so all
+// nulls share a key and DISTINCT dedups them together, matching Cypher.
 template <typename Primitive>
-void keyAppendOptColumn(const Column* column, size_t row, std::string& key) {
+void distinctKeyAppendOptColumn(const Column* column, size_t row, std::string& key) {
     const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
     const std::optional<Primitive>& value = raw[row];
 
@@ -218,7 +220,7 @@ void keyAppendOptColumn(const Column* column, size_t row, std::string& key) {
     }
 
     key.push_back('\1');
-    appendValueBytes(key, *value);
+    distinctAppendValueBytes(key, *value);
 }
 
 // Execute a get_out_edges/get_in_edges loop
@@ -717,15 +719,15 @@ NLAppendFunction NLExecutor::selectOptAppendFunction(ValueType valueType) {
 NLKeyAppendFunction NLExecutor::selectKeyAppendFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
-            return &keyAppendColumn<NodeID>;
+            return &distinctKeyAppendColumn<NodeID>;
         break;
 
         case NLChunkKind::EdgeID:
-            return &keyAppendColumn<EdgeID>;
+            return &distinctKeyAppendColumn<EdgeID>;
         break;
 
         case NLChunkKind::EdgeTypeID:
-            return &keyAppendColumn<EdgeTypeID>;
+            return &distinctKeyAppendColumn<EdgeTypeID>;
         break;
     }
 
@@ -741,23 +743,23 @@ NLKeyAppendFunction NLExecutor::selectKeyAppendFunction(NLChunkKind kind) {
 NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) {
     switch (valueType) {
         case ValueType::Int64:
-            return &keyAppendOptColumn<types::Int64::Primitive>;
+            return &distinctKeyAppendOptColumn<types::Int64::Primitive>;
         break;
 
         case ValueType::UInt64:
-            return &keyAppendOptColumn<types::UInt64::Primitive>;
+            return &distinctKeyAppendOptColumn<types::UInt64::Primitive>;
         break;
 
         case ValueType::Double:
-            return &keyAppendOptColumn<types::Double::Primitive>;
+            return &distinctKeyAppendOptColumn<types::Double::Primitive>;
         break;
 
         case ValueType::Bool:
-            return &keyAppendOptColumn<types::Bool::Primitive>;
+            return &distinctKeyAppendOptColumn<types::Bool::Primitive>;
         break;
 
         case ValueType::String:
-            return &keyAppendOptColumn<types::String::Primitive>;
+            return &distinctKeyAppendOptColumn<types::String::Primitive>;
         break;
 
         case ValueType::Embedding:

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1,6 +1,8 @@
 #include "NLExecutor.h"
 
 #include <algorithm>
+#include <string>
+#include <string_view>
 #include <type_traits>
 
 #include "iterators/GetInEdgesIterator.h"
@@ -175,6 +177,48 @@ int compareOptColumn(const Column* column, size_t a, size_t b) {
     }
 
     return 0;
+}
+
+// Append the raw bytes of a present property value to a row key. A
+// trivially-copyable primitive copies its object bytes; a string copies a length
+// prefix then its characters, so two rows never collide by concatenation (so
+// "a"+"b" and "ab"+"" get distinct keys).
+template <typename Primitive>
+void appendValueBytes(std::string& key, const Primitive& value) {
+    key.append(reinterpret_cast<const char*>(&value), sizeof(Primitive));
+}
+
+void appendValueBytes(std::string& key, std::string_view value) {
+    const size_t length = value.size();
+    key.append(reinterpret_cast<const char*>(&length), sizeof(length));
+    key.append(value.data(), value.size());
+}
+
+// Serialize one row of an ID column (node/edge/edge-type IDs) into the row key:
+// the ID's underlying integer value, byte for byte.
+template <typename ElementType>
+void keyAppendColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
+    const auto value = raw[row].getValue();
+    appendValueBytes(key, value);
+}
+
+// Serialize one row of a nullable value column into the row key: a tag byte
+// telling null from present, then - when present - the value's bytes. A null
+// serializes to the tag alone, so all nulls share a key and DISTINCT dedups them
+// together, matching Cypher.
+template <typename Primitive>
+void keyAppendOptColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
+    const std::optional<Primitive>& value = raw[row];
+
+    if (!value.has_value()) {
+        key.push_back('\0');
+        return;
+    }
+
+    key.push_back('\1');
+    appendValueBytes(key, *value);
 }
 
 // Execute a get_out_edges/get_in_edges loop
@@ -475,6 +519,48 @@ void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) 
     }
 }
 
+void NLExecutor::runDistinctReset(NLExecutionContext* context, NLFunctionData* data) {
+    const NLDistinctResetData* reset = static_cast<NLDistinctResetData*>(data);
+    reset->getState()->reset();
+}
+
+void NLExecutor::runDistinctFilter(NLExecutionContext* context, NLFunctionData* data) {
+    NLDistinctFilterData* filter = static_cast<NLDistinctFilterData*>(data);
+    NLDistinctState* state = filter->getState();
+
+    const std::vector<NLDistinctFilterData::FilterColumn>& columns = filter->columns();
+    bioassert(!columns.empty(), "nl.distinct_filter needs at least one column");
+
+    // Every column is row-aligned, so the first sizes this step's row set.
+    const size_t rowCount = columns.front()._input->size();
+
+    // Collect this step's surviving row indices: a row survives iff its key - the
+    // concatenation of every column's serialized value at that row - is new to the
+    // seen-set. insertIfNew both tests membership and records the new key, so a
+    // duplicate later in the same chunk is caught by an earlier row of it too.
+    ColumnVector<size_t>* indices = filter->getIndices();
+    std::vector<size_t>& survivingRaw = indices->getRaw();
+    survivingRaw.clear();
+
+    std::string* key = filter->getKeyScratch();
+    for (size_t row = 0; row < rowCount; row++) {
+        key->clear();
+        for (const NLDistinctFilterData::FilterColumn& column : columns) {
+            column._keyAppend(column._input, row, *key);
+        }
+
+        if (state->insertIfNew(*key)) {
+            survivingRaw.push_back(row);
+        }
+    }
+
+    // Gather the survivors into the fresh output chunks, in first-seen order, so a
+    // downstream consumer reads a genuinely deduped chunk.
+    for (const NLDistinctFilterData::FilterColumn& column : columns) {
+        column._gather(column._input, indices, column._output);
+    }
+}
+
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
@@ -626,6 +712,66 @@ NLAppendFunction NLExecutor::selectOptAppendFunction(ValueType valueType) {
     ValueTypeDispatcher(valueType).execute(select);
 
     return append;
+}
+
+NLKeyAppendFunction NLExecutor::selectKeyAppendFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &keyAppendColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &keyAppendColumn<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &keyAppendColumn<EdgeTypeID>;
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+// Selected per column from its value type. A manual switch, not ValueTypeDispatcher,
+// because an embedding has no byte identity to key on: dispatching would instantiate
+// the serializer for std::span<const float> - a view, not owned bytes - which cannot
+// be a DISTINCT key. The embedding case throws instead, so that instantiation is
+// never named, the same shape as selectOptCompareFunction.
+NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return &keyAppendOptColumn<types::Int64::Primitive>;
+        break;
+
+        case ValueType::UInt64:
+            return &keyAppendOptColumn<types::UInt64::Primitive>;
+        break;
+
+        case ValueType::Double:
+            return &keyAppendOptColumn<types::Double::Primitive>;
+        break;
+
+        case ValueType::Bool:
+            return &keyAppendOptColumn<types::Bool::Primitive>;
+        break;
+
+        case ValueType::String:
+            return &keyAppendOptColumn<types::String::Primitive>;
+        break;
+
+        case ValueType::Embedding:
+            throw IRException("cannot remove duplicates on an embedding column");
+        break;
+
+        case ValueType::Invalid:
+        case ValueType::_SIZE:
+            throw IRException("invalid distinct key value type");
+        break;
+    }
+
+    bioassert(false, "Unhandled value type");
+    return nullptr;
 }
 
 NLCompareFunction NLExecutor::selectCompareFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -84,6 +84,14 @@ public:
     // variables and running the body (the nl.output) per chunk.
     static void runSortLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    // Empty the seen-set of a DISTINCT; runs each time its block runs.
+    static void runDistinctReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Keep only the rows of this step's chunk not seen before: serialize each row
+    // across all columns into a key, insert the new keys into the seen-set, and
+    // gather the surviving rows into fresh output chunks. The sole seen-set mutator.
+    static void runDistinctFilter(NLExecutionContext* context, NLFunctionData* data);
+
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
@@ -118,6 +126,13 @@ public:
 
     // Range copy for a nullable value chunk of this value type (skip suffix copy).
     static NLCopyFunction selectOptCopyFunction(ValueType valueType);
+
+    // Row-key serialization for an ID chunk of this kind / a nullable value chunk
+    // of this value type. Used by nl.distinct_filter to build each row's seen-set
+    // key. The value-type selector throws for a value type with no byte identity
+    // as a key (an embedding), which cannot be a DISTINCT key.
+    static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
+    static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -3,6 +3,8 @@
 #include <stddef.h>
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "ID.h"
@@ -682,6 +684,98 @@ private:
     NLStmtContainer _stmts;
 };
 
+// Type of handle that appends the raw bytes of one row of a column to a growing
+// row-key buffer. One per column kind / value type, selected during translation,
+// the same way the gather and append families are. The concatenated key of a row
+// (all its columns in order) is what nl.distinct_filter looks up in the seen-set:
+// bytewise key equality is row equality. A null serializes to a fixed tag byte, so
+// all nulls share a key and DISTINCT dedups them together, matching Cypher; a
+// string serializes as a length prefix then its characters, so two rows never
+// collide by concatenation (e.g. "a"+"b" versus "ab"+"").
+using NLKeyAppendFunction = void (*)(const Column* column, size_t row, std::string& key);
+
+// Runtime state of one DISTINCT: the set of serialized row keys already emitted.
+// nl.distinct resets it (once at function scope for a top-level or mid-query
+// DISTINCT), and nl.distinct_filter is the sole reader and mutator - it looks up
+// each incoming row's key and inserts the new ones. The streaming sibling of
+// NLSortState: it filters rows as they arrive rather than accumulating them, so it
+// holds only the keys, not the row values (a survivor is emitted from the incoming
+// chunk it appeared in, never rebuilt).
+class NLDistinctState {
+public:
+    // Empty the seen-set, so DISTINCT starts fresh. Runs each time nl.distinct's
+    // block runs (once at function scope for a top-level / mid-query DISTINCT).
+    void reset() { _seen.clear(); }
+
+    // Record a row's serialized key; returns true if the row is new (not seen
+    // before) and should survive, false if it duplicates an earlier row. The sole
+    // mutator of the set.
+    bool insertIfNew(const std::string& key) { return _seen.insert(key).second; }
+
+private:
+    // One serialized key per distinct row seen so far.
+    std::unordered_set<std::string> _seen;
+};
+
+// nl.distinct data: resets a seen-set to empty each time the block it lives in
+// runs - once at function scope for a top-level DISTINCT. The distinct sibling of
+// NLSortResetData.
+class NLDistinctResetData : public NLFunctionData {
+public:
+    NLDistinctResetData(NLDistinctState* state)
+        : _state(state)
+    {
+    }
+
+    NLDistinctState* getState() const { return _state; }
+
+private:
+    NLDistinctState* _state {nullptr};
+};
+
+// nl.distinct_filter data: the seen-set to look each row up in, and per column its
+// input chunk, the fresh output chunk to fill, the key-append that serializes one
+// of its rows into the row key, and the gather that copies the surviving rows into
+// the output. All columns together form each row's key; the surviving rows are
+// gathered from the incoming chunk (reusing the NLGatherFunction the edge loops
+// use), so no row values are stored. The indices scratch holds this step's
+// surviving row indices and the key scratch is reused per row.
+class NLDistinctFilterData : public NLFunctionData {
+public:
+    struct FilterColumn {
+        const Column* _input {nullptr};
+        Column* _output {nullptr};
+        NLKeyAppendFunction _keyAppend {nullptr};
+        NLGatherFunction _gather {nullptr};
+    };
+
+    NLDistinctFilterData(NLDistinctState* state)
+        : _state(state)
+    {
+    }
+
+    NLDistinctState* getState() const { return _state; }
+
+    const std::vector<FilterColumn>& columns() const { return _columns; }
+
+    void addColumn(const FilterColumn& column) {
+        _columns.push_back(column);
+    }
+
+    ColumnVector<size_t>* getIndices() { return &_indices; }
+    std::string* getKeyScratch() { return &_key; }
+
+private:
+    NLDistinctState* _state {nullptr};
+    std::vector<FilterColumn> _columns;
+
+    // Scratch for this step's surviving row indices, fed to the per-column gather
+    ColumnVector<size_t> _indices;
+
+    // Scratch reused to build each row's key, cleared once per row
+    std::string _key;
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:
@@ -756,6 +850,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one DISTINCT's runtime seen-set, owned by the program; the reset
+    // and filter statements that share it hold a borrowed pointer. The distinct
+    // sibling of allocSortState.
+    NLDistinctState* allocDistinctState() {
+        auto state = std::make_unique<NLDistinctState>();
+        NLDistinctState* statePtr = state.get();
+        _distinctStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -768,6 +872,7 @@ private:
     std::vector<std::unique_ptr<NLLimitState>> _limitStates;
     std::vector<std::unique_ptr<NLSkipState>> _skipStates;
     std::vector<std::unique_ptr<NLSortState>> _sortStates;
+    std::vector<std::unique_ptr<NLDistinctState>> _distinctStates;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -148,6 +148,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateSortBuffer(sortBuffer, body);
         } else if (nl::SortCollect sortCollect = mlir::dyn_cast<nl::SortCollect>(operation)) {
             translateSortCollect(sortCollect, body);
+        } else if (nl::Distinct distinct = mlir::dyn_cast<nl::Distinct>(operation)) {
+            translateDistinctState(distinct, body);
+        } else if (nl::DistinctFilter distinctFilter = mlir::dyn_cast<nl::DistinctFilter>(operation)) {
+            translateDistinctFilter(distinctFilter, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -635,6 +639,68 @@ NLSortState* NLTranslator::sortStateFor(mlir::Value handle) const {
     return stateIt->second;
 }
 
+void NLTranslator::translateDistinctState(nl::Distinct distinct, NLStmtContainer* body) {
+    // Allocate the runtime seen-set and map the handle to it, so the filter that
+    // names the handle finds the same set.
+    NLDistinctState* state = _program->allocDistinctState();
+    _distinctStates[distinct.getState()] = state;
+
+    // The reset empties the set each time the block holding this nl.distinct runs:
+    // once at function scope for a top-level / mid-query DISTINCT.
+    NLDistinctResetData* resetData = _program->allocFunctionData<NLDistinctResetData>(state);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runDistinctReset, resetData});
+}
+
+void NLTranslator::translateDistinctFilter(nl::DistinctFilter filter, NLStmtContainer* body) {
+    // The handle is a required operand, so distinctStateFor returns its set or
+    // throws if it was not produced by an nl.distinct.
+    NLDistinctState* state = distinctStateFor(filter.getState());
+
+    NLDistinctFilterData* data = _program->allocFunctionData<NLDistinctFilterData>(state);
+
+    // Reserve the surviving-indices scratch so the per-step gather stays
+    // allocation-free, the same as the edge and sort loops' indices column.
+    data->getIndices()->reserve(_program->getChunkSize());
+
+    // One fresh output column per input, walked in step with the results the
+    // downstream consumers are mapped to.
+    const mlir::OperandRange columns = filter.getColumns();
+    const mlir::ResultRange results = filter.getResults();
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        addDistinctColumn(columns[columnIndex], results[columnIndex], data);
+    }
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runDistinctFilter, data});
+}
+
+void NLTranslator::addDistinctColumn(mlir::Value inputValue,
+                                     mlir::Value resultValue,
+                                     NLDistinctFilterData* data) {
+    const Column* input = getColumn(inputValue);
+
+    // The output keeps the input's element type; only duplicate rows are removed.
+    // The key-append serializes one of its rows into the shared row key, and the
+    // gather copies the survivors into the fresh output - the same gather family
+    // the edge and sort loops use, selected by chunk type.
+    Column* output = allocColumnForChunkType(inputValue.getType());
+    _valueSlots[resultValue] = output;
+
+    const NLDistinctFilterData::FilterColumn column {input,
+                                                     output,
+                                                     selectKeyAppendForChunkType(inputValue.getType()),
+                                                     selectGatherForChunkType(inputValue.getType())};
+    data->addColumn(column);
+}
+
+NLDistinctState* NLTranslator::distinctStateFor(mlir::Value handle) const {
+    const auto stateIt = _distinctStates.find(handle);
+    if (stateIt == _distinctStates.end()) {
+        throw IRException("distinct handle must be produced by an nl.distinct");
+    }
+
+    return stateIt->second;
+}
+
 // An ID chunk allocates an ID column on its kind; a !nl.nullable<...> chunk
 // allocates a ColumnOptVector on its value type. Mirrors addCrossColumn's split.
 Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
@@ -683,6 +749,18 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
     }
 
     return NLExecutor::selectCompareFunction(chunkKindFromElementType(elementType));
+}
+
+NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptKeyAppendFunction(valueType);
+    }
+
+    return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
 }
 
 void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -60,6 +60,10 @@ private:
     // nl.sort_collect and the nl.for over nl.sort find the same buffers
     llvm::DenseMap<mlir::Value, NLSortState*> _sortStates;
 
+    // nl.distinct handle SSA value -> the runtime seen-set it produces, so the
+    // nl.distinct_filter that names the handle finds the same set
+    llvm::DenseMap<mlir::Value, NLDistinctState*> _distinctStates;
+
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
     void translateFor(mlir::nl::For forLoop, NLStmtContainer* body);
     void translateScanLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body);
@@ -123,6 +127,28 @@ private:
     // produced by an nl.sort_buffer translated earlier.
     NLSortState* sortStateFor(mlir::Value handle) const;
 
+    // Translate an nl.distinct: allocate its runtime seen-set, map the handle to
+    // it, and record the reset statement (run each time the block runs)
+    void translateDistinctState(mlir::nl::Distinct distinct, NLStmtContainer* body);
+
+    // Translate an nl.distinct_filter: look up the seen-set the handle names,
+    // allocate one fresh output column per input, map each result to its output,
+    // and record the filter statement (serialize each row's key across all
+    // columns, keep the not-yet-seen rows, gather them into the outputs)
+    void translateDistinctFilter(mlir::nl::DistinctFilter filter, NLStmtContainer* body);
+
+    // Allocate the fresh output column for one filtered column, map the op result
+    // to it, and append it (with its key-append serializer and its survivor
+    // gather) to data
+    void addDistinctColumn(mlir::Value inputValue,
+                           mlir::Value resultValue,
+                           NLDistinctFilterData* data);
+
+    // The runtime seen-set a distinct handle names. The handle is a required
+    // operand of nl.distinct_filter, so this throws if it was not produced by an
+    // nl.distinct.
+    NLDistinctState* distinctStateFor(mlir::Value handle) const;
+
     // Pool-allocate a buffer/loop column matching a chunk type - an ID column for
     // an ID chunk, a nullable value column for a !nl.nullable<...> chunk - and the
     // append/gather/compare handler for that element type. The compare selector
@@ -131,6 +157,7 @@ private:
     static NLAppendFunction selectAppendForChunkType(mlir::Type chunkType);
     static NLGatherFunction selectGatherForChunkType(mlir::Type chunkType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
+    static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
 
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -213,6 +213,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerSkip(skip);
     } else if (mlir::db::Sort sort = mlir::dyn_cast<mlir::db::Sort>(operation)) {
         lowerSort(sort);
+    } else if (mlir::db::RemoveDuplicates distinct = mlir::dyn_cast<mlir::db::RemoveDuplicates>(operation)) {
+        lowerRemoveDuplicates(distinct);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -618,6 +620,51 @@ void DBLowering::lowerSort(mlir::db::Sort sort) {
     // the db.output that follows lowers into the emit loop body reading the
     // sorted chunks.
     buildLoopForSource(sortOp.getResult(), sort.getOperation());
+}
+
+void DBLowering::lowerRemoveDuplicates(mlir::db::RemoveDuplicates distinct) {
+    // The nl chunks the deduped columns lowered to; these are what the filter
+    // reads to build each row's key, and gathers the survivors from.
+    llvm::SmallVector<mlir::Value, 4> chunks;
+    for (const mlir::Value column : distinct.getColumns()) {
+        chunks.push_back(mapValue(column));
+    }
+
+    // RemoveDuplicates::verify rejects an empty db.remove_duplicates, so reaching
+    // it here means unverified IR - a defensive backstop, as in lowerSort.
+    if (chunks.empty()) {
+        throw IRException("db.remove_duplicates requires at least one column");
+    }
+
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // The seen-set handle is hoisted to the top of the entry block, above every
+    // loop, so it is reset once at function scope and dominates the filter placed
+    // in the producing loop body. A correlated DISTINCT (reset per enclosing step)
+    // would hoist into its enclosing loop body instead - future work, as for the
+    // streaming limit.
+    _builder.setInsertionPointToStart(_entryBlock);
+    const mlir::Value state = _builder.create<nl::Distinct>(loc).getState();
+
+    // The filter sits in the innermost producing loop body, where all deduped
+    // columns are bound together (the same block db.output would emit from), and
+    // emits each step's not-yet-seen rows as fresh survivor chunks. It opens no
+    // loop of its own: DISTINCT streams, so - unlike db.sort - the rows are
+    // filtered in place in the producing loop, not accumulated and re-emitted.
+    const mlir::Value representative = chunks.front();
+    setInsertionInto(ownerBlock(representative));
+    nl::DistinctFilter filter = _builder.create<nl::DistinctFilter>(loc, state, chunks);
+
+    // Map db.remove_duplicates' results to the survivor chunks, so its consumer
+    // reads the deduped rows: nl.output when the query ends here, or a downstream
+    // traversal when a WITH DISTINCT feeds a further MATCH (the chained case). The
+    // survivor chunk is a genuine cut chunk (like nl.limit_truncate's), so that
+    // consumer needs no DISTINCT awareness of its own.
+    const mlir::ResultRange dbResults = distinct.getResults();
+    const mlir::ResultRange filteredChunks = filter.getResults();
+    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
+        _valueMap[dbResults[resultIndex]] = filteredChunks[resultIndex];
+    }
 }
 
 void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -43,6 +43,17 @@ class GraphView;
 //                                          nl.output that emits the suffix in place
 //                                          at an offset; the copy survives only for
 //                                          a chained suffix (reads from row zero)
+//   db.remove_duplicates               ->  a hoisted nl.distinct seen-set handle
+//                                          and an nl.distinct_filter in the
+//                                          producing loop body that emits each
+//                                          step's not-yet-seen rows as fresh chunks.
+//                                          A streaming filter, not a pipeline
+//                                          breaker: it stays in the producing loop
+//                                          (no emit loop like db.sort), so a
+//                                          downstream LIMIT bounds the loop through
+//                                          the ordinary early-exit, and a chained
+//                                          WITH DISTINCT feeds the survivor chunks
+//                                          straight into the next traversal
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -139,6 +150,17 @@ private:
     // yields the sorted rows. db.sort's results map to that emit loop's
     // variables, so the db.output that follows lowers into the emit loop body.
     void lowerSort(mlir::db::Sort sort);
+
+    // Lower a db.remove_duplicates: hoist an nl.distinct seen-set handle to the
+    // top of the entry block, then place an nl.distinct_filter in the innermost
+    // producing loop body that emits each step's not-yet-seen rows as fresh
+    // chunks. db.remove_duplicates' results map to those survivor chunks, so its
+    // consumer - nl.output, or a downstream traversal when chained - reads the
+    // deduped rows. It opens no loop of its own (a streaming filter, unlike the
+    // pipeline-breaking db.sort), so the limit machinery bounds it unchanged: a
+    // db.limit over its results reaches the real producing loops through
+    // assignProducerLoops' operand recursion and early-exits them.
+    void lowerRemoveDuplicates(mlir::db::RemoveDuplicates distinct);
 
     void lowerOutput(mlir::db::Output output);
 

--- a/samples/mlir/remove_duplicates.mlir
+++ b/samples/mlir/remove_duplicates.mlir
@@ -1,0 +1,20 @@
+module {
+  func.func @main() {
+    // MATCH (a)-[]->(b) RETURN DISTINCT b: scan every node, walk its out-edges,
+    // and emit each distinct target once. Several sources can point at the same
+    // target, so the b column has duplicates that DISTINCT removes.
+    //
+    // db.remove_duplicates is a streaming filter, not a pipeline breaker: it lowers
+    // to a hoisted nl.distinct seen-set and an nl.distinct_filter inside the edge
+    // loop that emits each step's not-yet-seen targets as a fresh chunk. There is
+    // no emit loop (unlike db.sort) - the rows are filtered in place.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    %srcs, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    %ub = db.remove_duplicates(%b) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    db.output(%ub) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/remove_duplicates.nl.mlir
+++ b/samples/mlir/remove_duplicates.nl.mlir
@@ -1,0 +1,21 @@
+// Generated nl-dialect lowering of remove_duplicates.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered remove_duplicates.mlir
+// This is the DBLowering output; edit remove_duplicates.mlir, not this file.
+//
+// db.remove_duplicates is a streaming filter, not a pipeline breaker: a hoisted
+// nl.distinct seen-set, and an nl.distinct_filter inside the edge loop that emits
+// each step's not-yet-seen targets as a fresh chunk. No emit loop (unlike db.sort).
+module {
+  func.func @main() {
+    %0 = nl.distinct
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %2 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        %3 = nl.distinct_filter %0, (%arg4) : !nl.chunk<!storage.node_id>
+        nl.output(%3) : !nl.chunk<!storage.node_id>
+      }
+    }
+    return
+  }
+}

--- a/samples/mlir/remove_duplicates_chained.mlir
+++ b/samples/mlir/remove_duplicates_chained.mlir
@@ -1,0 +1,23 @@
+module {
+  func.func @main() {
+    // MATCH (a)-[]->(b) WITH DISTINCT a MATCH (a)-[]->(c) RETURN c: a mid-query
+    // (chained) DISTINCT. The first hop's sources `a` repeat once per out-edge;
+    // WITH DISTINCT collapses them to the unique source nodes, and the second hop
+    // then fans out from each unique `a` exactly once - fewer driver rows than the
+    // raw (duplicated) source column would give.
+    //
+    // Like the chained LIMIT, db.remove_duplicates feeds the next db.get_out_edges,
+    // not db.output: nl.distinct_filter hands the traversal a genuinely deduped
+    // chunk, so the downstream loop stays DISTINCT-oblivious.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    %srcs, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    %da = db.remove_duplicates(%srcs) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    %a2, %e1, %et1, %c = db.get_out_edges(%da, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    db.output(%c) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/remove_duplicates_chained.nl.mlir
+++ b/samples/mlir/remove_duplicates_chained.nl.mlir
@@ -1,0 +1,24 @@
+// Generated nl-dialect lowering of remove_duplicates_chained.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered remove_duplicates_chained.mlir
+// This is the DBLowering output; edit remove_duplicates_chained.mlir, not this file.
+//
+// The chained case: nl.distinct_filter emits the deduped sources (%3) and the next
+// nl.get_out_edges fans out from that genuinely-cut chunk, nesting a further loop -
+// no DISTINCT awareness needed downstream, exactly as a chained nl.limit_truncate.
+module {
+  func.func @main() {
+    %0 = nl.distinct
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %2 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        %3 = nl.distinct_filter %0, (%arg1) : !nl.chunk<!storage.node_id>
+        %4 = nl.get_out_edges(%3, {})
+        nl.for %arg5, %arg6, %arg7, %arg8 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+          nl.output(%arg8) : !nl.chunk<!storage.node_id>
+        }
+      }
+    }
+    return
+  }
+}

--- a/samples/mlir/remove_duplicates_limit.mlir
+++ b/samples/mlir/remove_duplicates_limit.mlir
@@ -1,0 +1,21 @@
+module {
+  func.func @main() {
+    // MATCH (a)-[]->(b) RETURN DISTINCT b LIMIT 2: the first two distinct targets.
+    // DISTINCT streams, so the LIMIT bounds it through the ordinary early-exit -
+    // the producing loops carry the budget and halt once two distinct b's are
+    // emitted. No top-K fusion (unlike ORDER BY ... LIMIT): the lowered nl keeps
+    // the loops' `limit` operand, and an nl.limit_update charges the deduped
+    // survivor count so the loops stop after two distinct rows rather than two
+    // scanned rows.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    %srcs, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    %ub = db.remove_duplicates(%b) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    %lb = db.limit(%ub) count 2 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+
+    db.output(%lb) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/remove_duplicates_limit.nl.mlir
+++ b/samples/mlir/remove_duplicates_limit.nl.mlir
@@ -1,0 +1,23 @@
+// Generated nl-dialect lowering of remove_duplicates_limit.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered remove_duplicates_limit.mlir
+// This is the DBLowering output; edit remove_duplicates_limit.mlir, not this file.
+//
+// DISTINCT ... LIMIT is the streaming path, not a fused top-K: both loops carry the
+// `limit %1` handle (early-exit), and nl.limit_update charges the deduped survivor
+// chunk %4 - so the loops stop once two distinct rows are emitted, not two scanned.
+module {
+  func.func @main() {
+    %0 = nl.distinct
+    %1 = nl.limit(2)
+    %2 = nl.scan_nodes()
+    nl.for %arg0 in %2 limit %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %3 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %3 limit %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        %4 = nl.distinct_filter %0, (%arg4) : !nl.chunk<!storage.node_id>
+        nl.limit_update %1, %4 : !nl.chunk<!storage.node_id>
+        nl.output(%4) limit %1 : !nl.chunk<!storage.node_id>
+      }
+    }
+    return
+  }
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -171,6 +171,19 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN DISTINCT a, a.score: two columns passed through, deduped on the
+// whole (node, score) row - no key attribute, since every column is part of the
+// dedup key.
+const char* const removeDuplicatesProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %da, %dscore = db.remove_duplicates(%a, %score) : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  db.output(%da, %dscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
 TEST_F(DBDialectTest, parsesCrossProductOfTwoScans) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
     ASSERT_TRUE(module);
@@ -580,6 +593,91 @@ TEST_F(DBDialectTest, verifierRejectsSortWithoutColumns) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(sort.getOperation())));
+}
+
+TEST_F(DBDialectTest, parsesRemoveDuplicates) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(removeDuplicatesProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::RemoveDuplicates distinct;
+    module.get().walk([&](mlir::db::RemoveDuplicates op) {
+        distinct = op;
+    });
+    ASSERT_TRUE(distinct);
+
+    // Two columns pass through as two results of the same types; the whole row is
+    // the dedup key, so there is no key attribute to read.
+    ASSERT_EQ(distinct.getColumns().size(), 2u);
+    ASSERT_EQ(distinct.getResults().size(), 2u);
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    EXPECT_EQ(distinct.getColumns()[0].getType(), nodeIDColumnType);
+    EXPECT_EQ(distinct.getResults()[0].getType(), nodeIDColumnType);
+}
+
+TEST_F(DBDialectTest, removeDuplicatesRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(removeDuplicatesProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.remove_duplicates printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+// Builds a db.remove_duplicates whose result count does not match its columns,
+// exercising the pass-through arity check on the programmatic builder path (the
+// parser path always derives the results from the printed functional type).
+TEST_F(DBDialectTest, verifierRejectsRemoveDuplicatesArityMismatch) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type colA = mlir::db::ColumnType::get(&_context);
+    const mlir::Type colB = mlir::db::ColumnType::get(&_context);
+
+    auto scanA = builder.create<mlir::db::ScanNodes>(loc, colA);
+
+    // One input column but two declared results: the pass-through arity is wrong.
+    auto distinct = builder.create<mlir::db::RemoveDuplicates>(loc,
+                                                               mlir::TypeRange {colA, colB},
+                                                               mlir::ValueRange {scanA.getResult()});
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(distinct.getOperation())));
+}
+
+// Builds a db.remove_duplicates with no columns. Its row set is read from the
+// first column during lowering, so the verifier rejects the empty case here rather
+// than leaving it to the lowering pass.
+TEST_F(DBDialectTest, verifierRejectsRemoveDuplicatesWithoutColumns) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    // No input columns and no results: nothing to deduplicate.
+    auto distinct = builder.create<mlir::db::RemoveDuplicates>(loc,
+                                                               mlir::TypeRange {},
+                                                               mlir::ValueRange {});
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(distinct.getOperation())));
 }
 
 }

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -731,6 +731,76 @@ std::string topKByScoreAscProgram(uint64_t count) {
              "}\n";
 }
 
+// MATCH (a)-[]->(b) RETURN DISTINCT b: one hop, then dedup the target column.
+// Several sources can point at the same target, so b has duplicates DISTINCT drops.
+const char* const removeDuplicatesTargetsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %ub = db.remove_duplicates(%b) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%ub) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[]->()-[]->(c) RETURN DISTINCT a, c: a two-hop with the origin `a`
+// carried alongside, deduped on the whole (a, c) pair. The diamond's two paths
+// 0->1->3 and 0->2->3 both yield (0, 3), so DISTINCT collapses them to one row.
+const char* const removeDuplicatesTwoHopProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %da, %dc = db.remove_duplicates(%a2, %c) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%da, %dc) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[]->(b) WITH DISTINCT a MATCH (a)-[]->(c) RETURN c: a mid-query
+// (chained) DISTINCT. The first hop's sources repeat once per out-edge; DISTINCT
+// collapses them to the unique sources, and the second hop fans out from each once
+// - fewer driver rows than the raw (duplicated) source column would give.
+const char* const removeDuplicatesChainedProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %da = db.remove_duplicates(%a1) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %a2, %e1, %et1, %c = db.get_out_edges(%da, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%c) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[]->(b) RETURN DISTINCT b LIMIT count: DISTINCT streams, so the LIMIT
+// bounds the producing loops through the ordinary early-exit - no top-K fusion.
+std::string removeDuplicatesLimitProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)\n"
+                       "  %ub = db.remove_duplicates(%b) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+                       "  %lb = db.limit(%ub) count ")
+           + std::to_string(count)
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%lb) : !db.column<!storage.node_id>\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN DISTINCT a, a.score: dedup on the (node, nullable score) pair,
+// exercising the nullable value column's key-append path (an int64 value or a null
+// tag) alongside the node ID. A node with no score serializes its null and still
+// round-trips.
+const char* const removeDuplicatesNodeScoreProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %da, %dscore = db.remove_duplicates(%a, %score) : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  db.output(%da, %dscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
 }
 
 class DBLoweringTest : public TuringTest {
@@ -2460,6 +2530,168 @@ TEST_F(DBLoweringTest, lowersTopKToBoundedSortBufferWithoutLimitOps) {
     ASSERT_TRUE(bufferOp);
     ASSERT_TRUE(bufferOp.getTopK().has_value());
     EXPECT_EQ(*bufferOp.getTopK(), 2u);
+}
+
+TEST_F(DBLoweringTest, removesDuplicateTargets) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond's out-edges point at targets [1, 2, 3, 3] (node 3 twice); DISTINCT
+    // drops the repeat, leaving the three distinct targets.
+    CollectingNodeSink sink;
+    runLoweredProgram(removeDuplicatesTargetsProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, removesDuplicateTargetsAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The two edges into node 3 land in different chunks at chunk size 2, so the
+    // dedup must span chunks - the seen-set is reset once at function scope, not
+    // per chunk.
+    CollectingNodeSink sink;
+    runLoweredProgram(removeDuplicatesTargetsProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, removesDuplicateTwoHopPairs) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Both two-hop paths 0->1->3 and 0->2->3 give the pair (0, 3), so DISTINCT over
+    // the carried origin and the two-hop target collapses them to a single row.
+    CollectingNodeSink sink;
+    runLoweredProgram(removeDuplicatesTwoHopProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{0, 3}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, removeDuplicatesChainedFansOutFromSurvivors) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The first hop's sources are [0, 0, 1, 2] (node 0 has out-degree two); DISTINCT
+    // collapses them to {0, 1, 2}, and the second hop fans out from those three:
+    // 0->1, 0->2, 1->3, 2->3 => c = [1, 2, 3, 3]. Without the dedup the duplicated 0
+    // would drive the second hop twice and emit six rows, so four rows proves the
+    // downstream traversal fans out from the deduped survivors.
+    CollectingNodeSink sink;
+    runLoweredProgram(removeDuplicatesChainedProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}, {3}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, removeDuplicatesLimitEmitsDistinctPrefix) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Three distinct targets exist ({1, 2, 3}); LIMIT 2 over the deduped stream
+    // emits exactly two, since the limit charges the deduped survivor count.
+    CountingSink sink;
+    const std::string program = removeDuplicatesLimitProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 2u);
+}
+
+TEST_F(DBLoweringTest, removeDuplicatesOnNodeAndScore) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Three nodes with scores 100, 200 and null (node 2 carries none). The
+    // (node, score) rows are all distinct, so every row survives - but each row's
+    // key is built from the nullable score column too, so this exercises the opt
+    // key-append path and the null serializing to its tag.
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(removeDuplicatesNodeScoreProgram, reader.getView(), sink);
+
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {
+        {0, 100}, {1, 200}, {2, std::nullopt}
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// DISTINCT ... LIMIT lowers to the streaming path, not a fused top-K: the nl keeps
+// its nl.distinct + nl.distinct_filter and a real nl.limit / nl.limit_update, with
+// no nl.sort_buffer, and the producing loops carry the limit handle so they
+// early-exit once the budget of distinct rows is spent.
+TEST_F(DBLoweringTest, lowersRemoveDuplicatesLimitToStreamingFilter) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = removeDuplicatesLimitProgram(2);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t distinctCount = 0;
+    size_t filterCount = 0;
+    size_t limitCount = 0;
+    size_t updateCount = 0;
+    size_t sortBufferCount = 0;
+    size_t forsWithLimit = 0;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::nl::Distinct>(operation)) {
+            distinctCount++;
+        } else if (mlir::isa<mlir::nl::DistinctFilter>(operation)) {
+            filterCount++;
+        } else if (mlir::isa<mlir::nl::Limit>(operation)) {
+            limitCount++;
+        } else if (mlir::isa<mlir::nl::LimitUpdate>(operation)) {
+            updateCount++;
+        } else if (mlir::isa<mlir::nl::SortBuffer>(operation)) {
+            sortBufferCount++;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        }
+    });
+
+    EXPECT_EQ(distinctCount, 1u);
+    EXPECT_EQ(filterCount, 1u);
+    EXPECT_EQ(limitCount, 1u);
+    EXPECT_EQ(updateCount, 1u);
+    EXPECT_EQ(sortBufferCount, 0u);
+    EXPECT_GE(forsWithLimit, 1u);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -170,6 +170,28 @@ TEST_F(NLDialectTest, verifierAcceptsSortChain) {
     EXPECT_EQ(sort.getResult().getType(), iteratorType);
 }
 
+// The distinct chain verifies: an nl.distinct producing the seen-set handle and an
+// nl.distinct_filter naming it, whose result mirrors the filtered column's chunk
+// type (results inferred, like nl.limit_truncate), feeding an nl.output.
+TEST_F(NLDialectTest, verifierAcceptsDistinctChain) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value handle = builder.create<mlir::nl::Distinct>(loc).getState();
+    mlir::nl::DistinctFilter filter = builder.create<mlir::nl::DistinctFilter>(loc, handle, mlir::ValueRange {chunk});
+    builder.create<mlir::nl::Output>(loc, filter.getResults(), mlir::Value(), mlir::Value());
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(filter.getState(), handle);
+    EXPECT_EQ(filter.getResult(0).getType(), chunk.getType());
+}
+
 // A folded nl.output carries the single handle of the truncate adjacent to it,
 // never both: an output with both a limit and a skip handle fails verification.
 TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -279,6 +279,25 @@ func.func @main() {
 }
 )mlir";
 
+// Scan all nodes, walk out-edges, and keep only the distinct targets. The seen-set
+// is created once at function scope by nl.distinct and the nl.distinct_filter runs
+// in the inner edge loop, so duplicate targets reached from different sources are
+// dropped globally, across chunk boundaries.
+constexpr const char* nlDistinctTargetsProgram = R"mlir(
+func.func @main() {
+  %set = nl.distinct
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      %db = nl.distinct_filter %set, (%b) : !nl.chunk<!storage.node_id>
+      nl.output(%db) : !nl.chunk<!storage.node_id>
+    }
+  }
+  func.return
+}
+)mlir";
+
 // Counts appendChunks calls and the total rows emitted, to prove a limited run
 // emits a clamped prefix (a partial final chunk) and stops the loop early.
 class CountingSink : public NLOutputSink {
@@ -950,6 +969,40 @@ TEST_F(NLExecutorTest, topKBoundedAccumulatorTrimsAcrossChunks) {
     ASSERT_EQ(sink.getColumns().size(), 1u);
     const std::vector<uint64_t> expected {5, 4};
     EXPECT_EQ(sink.getColumns()[0], expected);
+}
+
+TEST_F(NLExecutorTest, distinctFilterDropsDuplicateTargets) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond's edges point at targets [1, 2, 3, 3] (node 3 from two sources);
+    // the filter keeps each target once, so the distinct set is {1, 2, 3}.
+    CollectingNodeSink sink;
+    runProgram(nlDistinctTargetsProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, distinctFilterDedupsAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 feeds one target per step, so the two edges into node 3 arrive in
+    // separate steps; the seen-set persists across steps, so 3 is still emitted once.
+    CollectingNodeSink sink;
+    runProgram(nlDistinctTargetsProgram, reader.getView(), 1, sink);
+
+    ASSERT_EQ(sink.getColumns().size(), 1u);
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
+    EXPECT_EQ(rows, expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Adds a limit-aware, streaming DISTINCT (db.remove_duplicates lowering to a hoisted nl.distinct seen-set and an in-loop nl.distinct_filter) across the db and nl dialects.