### PR TITLE
MLIR: implement count across the db and nl dialects

### DIFF
--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -434,15 +434,6 @@ def Count : TuringOp<"count", [Pure]> {
       %a = db.scan_nodes() : !db.column<!storage.node_id>
       %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
       db.output(%n) : !db.column<i64>
-
-    Unlike the pass-through ops (db.limit, db.sort, db.remove_duplicates) it neither
-    keeps its input's arity nor its type: it takes one column and yields one integer
-    column, whatever the input column's type. Count is a pipeline breaker like
-    db.sort - the tally is known only once every row has been seen - so it lowers to
-    a hoisted nl.count counter, an nl.count_update in the producing loop body that
-    charges each chunk's non-null rows, and - after the loop - an nl.count_result
-    source iterator whose nl.for emits the single tally row. Counting a
-    deterministic read of the graph is itself deterministic, so the op is Pure.
   }];
 
   // One column in, one integer column out. The input and result types are

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -432,8 +432,8 @@ def Count : TuringOp<"count", [Pure]> {
     count(*) is expressed by counting such a column:
 
       %a = db.scan_nodes() : !db.column<!storage.node_id>
-      %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
-      db.output(%n) : !db.column<i64>
+      %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<ui64>
+      db.output(%n) : !db.column<ui64>
   }];
 
   // One column in, one integer column out. The input and result types are

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -419,4 +419,43 @@ def RemoveDuplicates : TuringOp<"remove_duplicates", [Pure]> {
   let hasVerifier = 1;
 }
 
+/**
+* Count
+*/
+def Count : TuringOp<"count", [Pure]> {
+  let summary = "Count the non-null rows of a column as a single-row result";
+  let description = [{
+    The declarative counterpart of a Cypher RETURN count(x). Consumes the whole
+    dataflow of one column and produces a single-row column holding how many of its
+    rows are non-null - matching Cypher, where count(x) counts the rows in which x
+    is not null. A never-null column (node IDs off a scan) counts every row, so
+    count(*) is expressed by counting such a column:
+
+      %a = db.scan_nodes() : !db.column<!storage.node_id>
+      %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
+      db.output(%n) : !db.column<i64>
+
+    Unlike the pass-through ops (db.limit, db.sort, db.remove_duplicates) it neither
+    keeps its input's arity nor its type: it takes one column and yields one integer
+    column, whatever the input column's type. Count is a pipeline breaker like
+    db.sort - the tally is known only once every row has been seen - so it lowers to
+    a hoisted nl.count counter, an nl.count_update in the producing loop body that
+    charges each chunk's non-null rows, and - after the loop - an nl.count_result
+    source iterator whose nl.for emits the single tally row. Counting a
+    deterministic read of the graph is itself deterministic, so the op is Pure.
+  }];
+
+  // One column in, one integer column out. The input and result types are
+  // unrelated (an integer count of any column), so - unlike the pass-through ops -
+  // there is nothing to cross-check and no verifier.
+  let arguments = (ins Column:$input);
+  let results   = (outs Column:$result);
+
+  // One operand and one result, so functional-type(operands, results) prints the
+  // `(!db.column<...>) -> !db.column<...>` form, the same as db.get_node_properties.
+  let assemblyFormat = [{
+    `(` $input `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -670,11 +670,6 @@ def Count : NLOp<"count", []> {
     Produces the !nl.count_state handle nl.count_update increments and
     nl.count_result reads. The result type is buildable and omitted.
 
-    Unlike nl.limit it never appears on an nl.for: a COUNT drives no loop
-    early-exit, since every row must be seen before the tally is final. But like
-    nl.sort_buffer it is a pipeline breaker - nl.count_result emits its row only
-    after the producing loop has filled the counter.
-
       %c = nl.count
   }];
 

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -704,31 +704,32 @@ def CountUpdate : NLOp<"count_update", []> {
 /**
 * CountResult
 */
-// Pure: given a filled counter it deterministically yields the same one-row
-// iterator, and it produces no side effect of its own - materializing the tally
-// row happens in the driving nl.for. Mirrors nl.sort: a source op whose nl.for
-// does the work.
-def CountResult : NLOp<"count_result", [Pure]> {
-  let summary = "Create a database iterator over the single result row of a count";
+// NOT Pure: it reads the handle's mutable tally (set by the nl.count_updates in
+// the producing loop), so it must run exactly where it sits - after that loop -
+// and must not be hoisted, CSE'd or eliminated. The count sibling of
+// nl.limit_truncate, which likewise reads mutable counter state.
+def CountResult : NLOp<"count_result", []> {
+  let summary = "Materialize the single result row of a count as a chunk";
   let description = [{
-    The source op for the emit phase of a COUNT, the count counterpart of nl.sort.
-    It consumes a filled nl.count_state and produces an iterator whose one and only
-    step yields a single-row chunk: the tally, as a nullable (always-present) i64.
-    An enclosing nl.for binds that one chunk and emits it once:
+    The emit step of a COUNT. It reads a filled nl.count_state and materializes the
+    tally directly as a single-row chunk - one unsigned i64. A count is a
+    non-negative number that is never null, so the chunk is a plain !nl.chunk<ui64>,
+    not a nullable value chunk.
 
-      %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
-      nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
-        nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
-      }
+    Unlike nl.sort it is not a source iterator: a COUNT collapses to exactly one
+    row, so there is nothing to iterate. It produces the chunk in place, at function
+    scope after the producing loop, and nl.output consumes it there - no emit loop:
 
-    The result chunk type is fixed (a nullable i64) but cannot be inferred from the
-    parameterless state handle, so it is spelled after the colon, the same as
-    nl.sort's iterator type. Placing nl.count_result after the producing loop
-    guarantees the counter is final by the time the driving loop first steps.
+      %r = nl.count_result(%c) : !nl.chunk<ui64>
+      nl.output(%r) : !nl.chunk<ui64>
+
+    The result chunk type is fixed (a ui64) but cannot be inferred from the
+    parameterless state handle, so it is spelled after the colon. Placing
+    nl.count_result after the producing loop guarantees the tally is final.
   }];
 
   let arguments = (ins NLCountStateHandle:$state);
-  let results   = (outs NLIterator:$result);
+  let results   = (outs NLChunk:$result);
 
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -656,4 +656,86 @@ def DistinctFilter : NLOp<"distinct_filter", [InferTypeOpAdaptor]> {
   let hasVerifier = 1;
 }
 
+/**
+* Count
+*/
+// NOT Pure: each nl.count is a distinct counter, so two must never be CSE'd into
+// one, and an unread one must not be DCE'd - resetting the tally is a side effect
+// (like nl.limit / nl.sort_buffer).
+def Count : NLOp<"count", []> {
+  let summary = "Create (and reset) a row-count accumulator, initialized to zero";
+  let description = [{
+    Sits at the top of the scope it governs - function scope for a top-level or
+    mid-query COUNT - where it zeroes the tally once per execution of that block.
+    Produces the !nl.count_state handle nl.count_update increments and
+    nl.count_result reads. The result type is buildable and omitted.
+
+    Unlike nl.limit it never appears on an nl.for: a COUNT drives no loop
+    early-exit, since every row must be seen before the tally is final. But like
+    nl.sort_buffer it is a pipeline breaker - nl.count_result emits its row only
+    after the producing loop has filled the counter.
+
+      %c = nl.count
+  }];
+
+  let results = (outs NLCountState:$state);
+  let assemblyFormat = "attr-dict";
+}
+
+/**
+* CountUpdate
+*/
+// NOT Pure: it increments the handle, so it must run exactly where it sits, once
+// per producing-loop step, and must not be hoisted, CSE'd or eliminated. The count
+// sibling of nl.limit_update / nl.sort_collect.
+def CountUpdate : NLOp<"count_update", []> {
+  let summary = "Charge this step's non-null rows against a count accumulator";
+  let description = [{
+    Runs in the producing loop body, once per step. Adds the number of non-null
+    rows of the current chunk to the tally - all rows of an ID chunk (IDs are never
+    null), or the present values of a nullable value chunk (Cypher count(x) counts
+    the rows in which x is not null). The sole counter mutator.
+
+      nl.count_update %c, %a : !nl.chunk<!storage.node_id>
+  }];
+
+  // The accumulator handle, then the column whose non-null rows are charged. The
+  // handle type is buildable and omitted; the column chunk type is spelled.
+  let arguments = (ins NLCountStateHandle:$state, NLChunk:$rows);
+
+  let assemblyFormat = "$state `,` $rows attr-dict `:` qualified(type($rows))";
+}
+
+/**
+* CountResult
+*/
+// Pure: given a filled counter it deterministically yields the same one-row
+// iterator, and it produces no side effect of its own - materializing the tally
+// row happens in the driving nl.for. Mirrors nl.sort: a source op whose nl.for
+// does the work.
+def CountResult : NLOp<"count_result", [Pure]> {
+  let summary = "Create a database iterator over the single result row of a count";
+  let description = [{
+    The source op for the emit phase of a COUNT, the count counterpart of nl.sort.
+    It consumes a filled nl.count_state and produces an iterator whose one and only
+    step yields a single-row chunk: the tally, as a nullable (always-present) i64.
+    An enclosing nl.for binds that one chunk and emits it once:
+
+      %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+      nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+        nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
+      }
+
+    The result chunk type is fixed (a nullable i64) but cannot be inferred from the
+    parameterless state handle, so it is spelled after the colon, the same as
+    nl.sort's iterator type. Placing nl.count_result after the producing loop
+    guarantees the counter is final by the time the driving loop first steps.
+  }];
+
+  let arguments = (ins NLCountStateHandle:$state);
+  let results   = (outs NLIterator:$result);
+
+  let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -59,6 +59,19 @@ def NLDistinctState : NLType<"DistinctState", "distinct_state"> {
     }];
 }
 
+def NLCountState : NLType<"CountState", "count_state"> {
+    let summary = "A row-count accumulator handle";
+    let description = [{
+        Stands for one COUNT's running tally. Produced by nl.count, incremented by
+        nl.count_update once per producing-loop step, and read by nl.count_result to
+        emit the single result row once the loop is exhausted. It is a handle, not a
+        chunk: it holds a count, not values. Modeled on !nl.limit_state, but it
+        counts up as rows are seen rather than down as a budget is spent - so, unlike
+        a limit, no nl.for names it (COUNT drives no early-exit; every row must be
+        seen before the tally is final).
+    }];
+}
+
 def NLChunk : NLType<"Chunk", "chunk"> {
     let summary = "A bounded batch of values";
     let description = "One column chunk filled by a single database iterator step";
@@ -166,5 +179,14 @@ def NLDistinctStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::DistinctStateType>($_self)">,
         "distinct state handle", "::mlir::nl::DistinctStateType">,
     BuildableType<"::mlir::nl::DistinctStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.count_state handle, the same way
+// NLSortStateHandle constrains the sort handle. The single concrete type - there
+// is only ever !nl.count_state - is what lets nl.count_update omit the handle's
+// type in its assembly, building it from this recipe instead.
+def NLCountStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::CountStateType>($_self)">,
+        "count state handle", "::mlir::nl::CountStateType">,
+    BuildableType<"::mlir::nl::CountStateType::get($_builder.getContext())">;
 
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -588,19 +588,17 @@ void NLExecutor::runCountUpdate(NLExecutionContext* context, NLFunctionData* dat
     update->getState()->add(count(update->getRows()));
 }
 
-void NLExecutor::runCountLoop(NLExecutionContext* context, NLFunctionData* data) {
-    NLCountLoopData* loopData = static_cast<NLCountLoopData*>(data);
+void NLExecutor::runCountResult(NLExecutionContext* context, NLFunctionData* data) {
+    const NLCountResultData* result = static_cast<NLCountResultData*>(data);
 
     // The aggregate collapses every counted row to a single result row: write the
-    // final tally into the loop variable as one present (never-null) int64. Runs
-    // after the producing loop, so the counter holds the whole dataflow's count.
-    const size_t count = loopData->getState()->getCount();
-    ColumnOptVector<int64_t>* output = static_cast<ColumnOptVector<int64_t>*>(loopData->getOutput());
-    std::vector<std::optional<int64_t>>& raw = output->getRaw();
-    raw.assign(1, std::optional<int64_t>(static_cast<int64_t>(count)));
-
-    // Emit that one row once (the body is the nl.output).
-    runBody(context, loopData->getStmts());
+    // final tally into the output chunk as one unsigned i64 (the !nl.chunk<ui64>
+    // count column). Runs after the producing loop, so the counter holds the whole
+    // dataflow's count; nl.output emits this chunk at function scope.
+    const size_t count = result->getState()->getCount();
+    ColumnVector<uint64_t>* output = static_cast<ColumnVector<uint64_t>*>(result->getOutput());
+    std::vector<uint64_t>& raw = output->getRaw();
+    raw.assign(1, static_cast<uint64_t>(count));
 }
 
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -223,6 +223,17 @@ void distinctKeyAppendOptColumn(const Column* column, size_t row, std::string& k
     distinctAppendValueBytes(key, *value);
 }
 
+// Count the present (non-null) values of a nullable value column - a
+// ColumnVector<std::optional<Primitive>> - so Cypher count(x) charges only the
+// rows in which x is not null.
+template <typename OptType>
+size_t countPresentColumn(const Column* column) {
+    const auto& raw = static_cast<const ColumnVector<OptType>*>(column)->getRaw();
+    return std::count_if(raw.begin(), raw.end(), [](const OptType& value) {
+        return value.has_value();
+    });
+}
+
 // Execute a get_out_edges/get_in_edges loop
 template <typename ChunkWriterType>
 void runEdgeLoopSteps(NLExecutionContext* context,
@@ -563,6 +574,35 @@ void NLExecutor::runDistinctFilter(NLExecutionContext* context, NLFunctionData* 
     }
 }
 
+void NLExecutor::runCountReset(NLExecutionContext* context, NLFunctionData* data) {
+    const NLCountResetData* reset = static_cast<NLCountResetData*>(data);
+    reset->getState()->reset();
+}
+
+void NLExecutor::runCountUpdate(NLExecutionContext* context, NLFunctionData* data) {
+    const NLCountUpdateData* update = static_cast<NLCountUpdateData*>(data);
+
+    // Charge this step's non-null rows: the handle returns all rows for an ID
+    // chunk, the present values for a nullable value chunk.
+    const NLCountFunction count = update->getCount();
+    update->getState()->add(count(update->getRows()));
+}
+
+void NLExecutor::runCountLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLCountLoopData* loopData = static_cast<NLCountLoopData*>(data);
+
+    // The aggregate collapses every counted row to a single result row: write the
+    // final tally into the loop variable as one present (never-null) int64. Runs
+    // after the producing loop, so the counter holds the whole dataflow's count.
+    const size_t count = loopData->getState()->getCount();
+    ColumnOptVector<int64_t>* output = static_cast<ColumnOptVector<int64_t>*>(loopData->getOutput());
+    std::vector<std::optional<int64_t>>& raw = output->getRaw();
+    raw.assign(1, std::optional<int64_t>(static_cast<int64_t>(count)));
+
+    // Emit that one row once (the body is the nl.output).
+    runBody(context, loopData->getStmts());
+}
+
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
@@ -774,6 +814,27 @@ NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) 
 
     bioassert(false, "Unhandled value type");
     return nullptr;
+}
+
+// An ID chunk (node/edge/edge-type IDs) has no null rows, so every row counts,
+// regardless of kind. The count sibling of selectKeyAppendFunction, but kind is
+// irrelevant here - the row count is just the column size.
+size_t NLExecutor::countAllRows(const Column* column) {
+    return column->size();
+}
+
+// Selected per column from its value type, so count(x) tallies only the rows in
+// which x is not null. Every value type has a present/absent flag, so - unlike
+// selectOptKeyAppendFunction - an embedding is fine: counting reads has_value(),
+// never the value's bytes.
+NLCountFunction NLExecutor::selectOptCountFunction(ValueType valueType) {
+    NLCountFunction count = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        count = &countPresentColumn<std::optional<typename T::Primitive>>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return count;
 }
 
 NLCompareFunction NLExecutor::selectCompareFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -99,9 +99,10 @@ public:
     // mutator.
     static void runCountUpdate(NLExecutionContext* context, NLFunctionData* data);
 
-    // The emit phase of a COUNT: materialize the final tally as a single present
-    // int64 row into the loop variable, then run the body (the nl.output) once.
-    static void runCountLoop(NLExecutionContext* context, NLFunctionData* data);
+    // The emit step of a COUNT: materialize the final tally as the output chunk's
+    // single unsigned i64 row. Runs once, after the producing loop; nl.output emits
+    // the chunk at function scope.
+    static void runCountResult(NLExecutionContext* context, NLFunctionData* data);
 
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -92,6 +92,17 @@ public:
     // gather the surviving rows into fresh output chunks. The sole seen-set mutator.
     static void runDistinctFilter(NLExecutionContext* context, NLFunctionData* data);
 
+    // Zero the tally of a COUNT; runs each time its block runs.
+    static void runCountReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Add this step's chunk's non-null row count to the tally. The sole tally
+    // mutator.
+    static void runCountUpdate(NLExecutionContext* context, NLFunctionData* data);
+
+    // The emit phase of a COUNT: materialize the final tally as a single present
+    // int64 row into the loop variable, then run the body (the nl.output) once.
+    static void runCountLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
@@ -133,6 +144,12 @@ public:
     // as a key (an embedding), which cannot be a DISTINCT key.
     static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
     static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
+
+    // Non-null row count for a COUNT. An ID chunk has no null rows, so countAllRows
+    // is its handle (the row count); a nullable value chunk of this value type
+    // counts only its present values. Used by nl.count_update.
+    static size_t countAllRows(const Column* column);
+    static NLCountFunction selectOptCountFunction(ValueType valueType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -776,6 +776,95 @@ private:
     std::string _key;
 };
 
+// Type of handle that returns how many rows of a column are non-null. One per
+// column kind / value type, selected during translation the same way the gather
+// and append families are. An ID column has no nulls, so its handle returns the
+// row count; a nullable value column's handle returns its present-value count.
+// This is what nl.count_update adds to the tally each step.
+using NLCountFunction = size_t (*)(const Column* column);
+
+// Runtime state of one COUNT: the running tally of non-null rows seen so far.
+// nl.count resets it (once at function scope for a top-level or mid-query COUNT),
+// nl.count_update is the sole incrementer, and nl.count_result reads the final
+// value to emit the single result row. The counting sibling of NLSortState: it
+// tallies rows as they arrive rather than accumulating them, so it holds only a
+// count, not the row values.
+class NLCountState {
+public:
+    // Zero the tally, so COUNT starts fresh. Runs each time nl.count's block runs
+    // (once at function scope for a top-level / mid-query COUNT).
+    void reset() { _count = 0; }
+
+    // Add this step's non-null row count to the tally. The sole mutator.
+    void add(size_t rows) { _count += rows; }
+
+    // The final tally, read once by nl.count_result after the producing loop.
+    size_t getCount() const { return _count; }
+
+private:
+    size_t _count {0};
+};
+
+// nl.count data: zeroes a tally each time the block it lives in runs - once at
+// function scope for a top-level COUNT. The count sibling of NLSortResetData.
+class NLCountResetData : public NLFunctionData {
+public:
+    NLCountResetData(NLCountState* state)
+        : _state(state)
+    {
+    }
+
+    NLCountState* getState() const { return _state; }
+
+private:
+    NLCountState* _state {nullptr};
+};
+
+// nl.count_update data: the tally to charge, the input chunk to measure, and the
+// count-of-non-null handle that measures it (all rows for an ID chunk, the present
+// values for a nullable value chunk). Runs once per producing-loop step.
+class NLCountUpdateData : public NLFunctionData {
+public:
+    NLCountUpdateData(NLCountState* state, const Column* rows, NLCountFunction count)
+        : _state(state),
+        _rows(rows),
+        _count(count)
+    {
+    }
+
+    NLCountState* getState() const { return _state; }
+    const Column* getRows() const { return _rows; }
+    NLCountFunction getCount() const { return _count; }
+
+private:
+    NLCountState* _state {nullptr};
+    const Column* _rows {nullptr};
+    NLCountFunction _count {nullptr};
+};
+
+// nl.for over nl.count_result data: the emit phase of a COUNT. Holds the tally and
+// the loop variable to fill with the single result row - a nullable (always-present)
+// i64 count column. Runs once, after the producing loop, so the tally is final.
+class NLCountLoopData : public NLFunctionData {
+public:
+    NLCountLoopData(NLCountState* state, Column* output)
+        : _state(state),
+        _output(output)
+    {
+    }
+
+    NLCountState* getState() const { return _state; }
+    Column* getOutput() const { return _output; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    NLCountState* _state {nullptr};
+    Column* _output {nullptr};
+    NLStmtContainer _stmts;
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:
@@ -860,6 +949,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one COUNT's runtime tally, owned by the program; the reset, update
+    // and emit statements that share it hold a borrowed pointer. The count sibling
+    // of allocSortState.
+    NLCountState* allocCountState() {
+        auto state = std::make_unique<NLCountState>();
+        NLCountState* statePtr = state.get();
+        _countStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -873,6 +972,7 @@ private:
     std::vector<std::unique_ptr<NLSkipState>> _skipStates;
     std::vector<std::unique_ptr<NLSortState>> _sortStates;
     std::vector<std::unique_ptr<NLDistinctState>> _distinctStates;
+    std::vector<std::unique_ptr<NLCountState>> _countStates;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -842,12 +842,14 @@ private:
     NLCountFunction _count {nullptr};
 };
 
-// nl.for over nl.count_result data: the emit phase of a COUNT. Holds the tally and
-// the loop variable to fill with the single result row - a nullable (always-present)
-// i64 count column. Runs once, after the producing loop, so the tally is final.
-class NLCountLoopData : public NLFunctionData {
+// nl.count_result data: the emit step of a COUNT. Holds the tally and the output
+// column to fill with the single result row - an unsigned i64 count column
+// (ColumnVector<uint64_t>). Runs once, after the producing loop, so the tally is
+// final; it materializes the chunk in place, with no body of its own (nl.output
+// consumes it at function scope).
+class NLCountResultData : public NLFunctionData {
 public:
-    NLCountLoopData(NLCountState* state, Column* output)
+    NLCountResultData(NLCountState* state, Column* output)
         : _state(state),
         _output(output)
     {
@@ -856,13 +858,9 @@ public:
     NLCountState* getState() const { return _state; }
     Column* getOutput() const { return _output; }
 
-    NLStmtContainer* getStmts() { return &_stmts; }
-    const NLStmtContainer* getStmts() const { return &_stmts; }
-
 private:
     NLCountState* _state {nullptr};
     Column* _output {nullptr};
-    NLStmtContainer _stmts;
 };
 
 // nl.output data

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -114,6 +114,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             _iteratorConfigs[getInEdges.getResult()] = config;
         } else if (nl::Sort sort = mlir::dyn_cast<nl::Sort>(operation)) {
             _iteratorConfigs[sort.getResult()] = IteratorConfig {IteratorKind::Sort, {}, {}, sortStateFor(sort.getState())};
+        } else if (nl::CountResult countResult = mlir::dyn_cast<nl::CountResult>(operation)) {
+            _iteratorConfigs[countResult.getResult()] = IteratorConfig {IteratorKind::Count, {}, {}, nullptr, countStateFor(countResult.getState())};
         } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType>(operation)) {
@@ -152,6 +154,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateDistinctState(distinct, body);
         } else if (nl::DistinctFilter distinctFilter = mlir::dyn_cast<nl::DistinctFilter>(operation)) {
             translateDistinctFilter(distinctFilter, body);
+        } else if (nl::Count count = mlir::dyn_cast<nl::Count>(operation)) {
+            translateCountState(count, body);
+        } else if (nl::CountUpdate countUpdate = mlir::dyn_cast<nl::CountUpdate>(operation)) {
+            translateCountUpdate(countUpdate, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -184,6 +190,9 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
     } else if (config._kind == IteratorKind::Sort) {
         // A sort emit loop is never limit-bounded: ORDER BY must see every row.
         translateSortLoop(config, loopBody, body);
+    } else if (config._kind == IteratorKind::Count) {
+        // A count emit loop yields the single tally row; it is never limit-bounded.
+        translateCountLoop(config, loopBody, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -701,6 +710,68 @@ NLDistinctState* NLTranslator::distinctStateFor(mlir::Value handle) const {
     return stateIt->second;
 }
 
+void NLTranslator::translateCountState(nl::Count count, NLStmtContainer* body) {
+    // Allocate the runtime tally and map the handle to it, so the update and the
+    // emit loop that name the handle share the same counter.
+    NLCountState* state = _program->allocCountState();
+    _countStates[count.getState()] = state;
+
+    // The reset zeroes the tally each time the block holding this nl.count runs:
+    // once at function scope for a top-level / mid-query COUNT.
+    NLCountResetData* resetData = _program->allocFunctionData<NLCountResetData>(state);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountReset, resetData});
+}
+
+void NLTranslator::translateCountUpdate(nl::CountUpdate update, NLStmtContainer* body) {
+    // The handle is a required operand, so countStateFor returns its tally or
+    // throws if it was not produced by an nl.count.
+    NLCountState* state = countStateFor(update.getState());
+
+    // Measure the chunk's non-null rows the way its type demands: all rows for an
+    // ID chunk, the present values for a nullable value chunk.
+    const mlir::Value rows = update.getRows();
+    const Column* input = getColumn(rows);
+    const NLCountFunction count = selectCountForChunkType(rows.getType());
+
+    NLCountUpdateData* data = _program->allocFunctionData<NLCountUpdateData>(state, input, count);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountUpdate, data});
+}
+
+void NLTranslator::translateCountLoop(const IteratorConfig& config,
+                                      mlir::Block& loopBody,
+                                      NLStmtContainer* body) {
+    NLCountState* state = config._countState;
+    if (!state) {
+        throw IRException("nl.count_result iterator must carry a count tally");
+    }
+
+    // The count iterator yields a single chunk - the one-row tally - so For::verify
+    // binds exactly one loop variable to it.
+    if (loopBody.getNumArguments() != 1) {
+        throw IRException("nl.count_result loop must bind exactly one variable");
+    }
+
+    // The loop variable is the nullable i64 count chunk runCountLoop fills with the
+    // single tally row.
+    const mlir::Value loopVariable = loopBody.getArgument(0);
+    Column* output = allocColumnForChunkType(loopVariable.getType());
+    _valueSlots[loopVariable] = output;
+
+    NLCountLoopData* loopData = _program->allocFunctionData<NLCountLoopData>(state, output);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountLoop, loopData});
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+NLCountState* NLTranslator::countStateFor(mlir::Value handle) const {
+    const auto stateIt = _countStates.find(handle);
+    if (stateIt == _countStates.end()) {
+        throw IRException("count handle must be produced by an nl.count");
+    }
+
+    return stateIt->second;
+}
+
 // An ID chunk allocates an ID column on its kind; a !nl.nullable<...> chunk
 // allocates a ColumnOptVector on its value type. Mirrors addCrossColumn's split.
 Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
@@ -761,6 +832,22 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     }
 
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
+}
+
+NLCountFunction NLTranslator::selectCountForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptCountFunction(valueType);
+    }
+
+    // A non-nullable chunk must be an ID chunk (node/edge/edge-type IDs), which has
+    // no null rows, so every row counts. chunkKindFromElementType rejects any other
+    // element type, so its result is discarded - it validates, nothing more.
+    chunkKindFromElementType(elementType);
+    return &NLExecutor::countAllRows;
 }
 
 void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -114,8 +114,6 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             _iteratorConfigs[getInEdges.getResult()] = config;
         } else if (nl::Sort sort = mlir::dyn_cast<nl::Sort>(operation)) {
             _iteratorConfigs[sort.getResult()] = IteratorConfig {IteratorKind::Sort, {}, {}, sortStateFor(sort.getState())};
-        } else if (nl::CountResult countResult = mlir::dyn_cast<nl::CountResult>(operation)) {
-            _iteratorConfigs[countResult.getResult()] = IteratorConfig {IteratorKind::Count, {}, {}, nullptr, countStateFor(countResult.getState())};
         } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType>(operation)) {
@@ -158,6 +156,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateCountState(count, body);
         } else if (nl::CountUpdate countUpdate = mlir::dyn_cast<nl::CountUpdate>(operation)) {
             translateCountUpdate(countUpdate, body);
+        } else if (nl::CountResult countResult = mlir::dyn_cast<nl::CountResult>(operation)) {
+            translateCountResult(countResult, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -190,9 +190,6 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
     } else if (config._kind == IteratorKind::Sort) {
         // A sort emit loop is never limit-bounded: ORDER BY must see every row.
         translateSortLoop(config, loopBody, body);
-    } else if (config._kind == IteratorKind::Count) {
-        // A count emit loop yields the single tally row; it is never limit-bounded.
-        translateCountLoop(config, loopBody, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -312,11 +309,12 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
         throw IRException("nl.output requires at least one column");
     }
 
-    if (!mlir::isa<nl::For>(output->getParentOp())) {
-        throw IRException("nl.output must appear inside an nl.for body");
-    }
-
-    // Check that the columns passed to output are all variables of the innermost loop
+    // Output is either the per-step sink inside an nl.for body, or - for an
+    // aggregate like COUNT that collapses to one row - a one-shot emit at function
+    // scope. Either way its columns must be bound in the output's own block, which
+    // the per-column check below enforces: a loop variable of this loop, or a chunk
+    // materialized in this block (a property fetch, or nl.count_result at function
+    // scope). A chunk from an outer or sibling loop fails that check.
     mlir::Block* outputBlock = output->getBlock();
 
     NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
@@ -737,30 +735,21 @@ void NLTranslator::translateCountUpdate(nl::CountUpdate update, NLStmtContainer*
     body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountUpdate, data});
 }
 
-void NLTranslator::translateCountLoop(const IteratorConfig& config,
-                                      mlir::Block& loopBody,
-                                      NLStmtContainer* body) {
-    NLCountState* state = config._countState;
-    if (!state) {
-        throw IRException("nl.count_result iterator must carry a count tally");
-    }
+void NLTranslator::translateCountResult(nl::CountResult result, NLStmtContainer* body) {
+    // The handle is a required operand, so countStateFor returns its tally or
+    // throws if it was not produced by an nl.count.
+    NLCountState* state = countStateFor(result.getState());
 
-    // The count iterator yields a single chunk - the one-row tally - so For::verify
-    // binds exactly one loop variable to it.
-    if (loopBody.getNumArguments() != 1) {
-        throw IRException("nl.count_result loop must bind exactly one variable");
-    }
+    // The result is the unsigned i64 count chunk (!nl.chunk<ui64>) runCountResult
+    // fills with the single tally row. It is the one non-nullable value chunk in the
+    // pipeline, so allocate its ColumnVector<uint64_t> directly - the shared
+    // allocColumnForChunkType only knows ID chunks and nullable value chunks.
+    ColumnVector<uint64_t>* output = _memory->alloc<ColumnVector<uint64_t>>();
+    output->reserve(_program->getChunkSize());
+    _valueSlots[result.getResult()] = output;
 
-    // The loop variable is the nullable i64 count chunk runCountLoop fills with the
-    // single tally row.
-    const mlir::Value loopVariable = loopBody.getArgument(0);
-    Column* output = allocColumnForChunkType(loopVariable.getType());
-    _valueSlots[loopVariable] = output;
-
-    NLCountLoopData* loopData = _program->allocFunctionData<NLCountLoopData>(state, output);
-    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountLoop, loopData});
-
-    translateBlock(loopBody, loopData->getStmts());
+    NLCountResultData* data = _program->allocFunctionData<NLCountResultData>(state, output);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runCountResult, data});
 }
 
 NLCountState* NLTranslator::countStateFor(mlir::Value handle) const {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -30,6 +30,7 @@ private:
         GetOutEdges,
         GetInEdges,
         Sort,
+        Count,
     };
 
     // Settings of the iterators passed to each for loop
@@ -40,6 +41,9 @@ private:
 
         // The accumulator a Sort iterator drains; null for the other kinds.
         NLSortState* _sortState {nullptr};
+
+        // The tally a Count iterator reads to emit its single row; null otherwise.
+        NLCountState* _countState {nullptr};
     };
 
     NLProgram* _program {nullptr};
@@ -63,6 +67,11 @@ private:
     // nl.distinct handle SSA value -> the runtime seen-set it produces, so the
     // nl.distinct_filter that names the handle finds the same set
     llvm::DenseMap<mlir::Value, NLDistinctState*> _distinctStates;
+
+    // nl.count handle SSA value -> the runtime tally it produces, so the
+    // nl.count_update and the nl.for over nl.count_result that name the handle find
+    // the same counter
+    llvm::DenseMap<mlir::Value, NLCountState*> _countStates;
 
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
     void translateFor(mlir::nl::For forLoop, NLStmtContainer* body);
@@ -149,6 +158,27 @@ private:
     // nl.distinct.
     NLDistinctState* distinctStateFor(mlir::Value handle) const;
 
+    // Translate an nl.count: allocate its runtime tally, map the handle to it, and
+    // record the reset statement (run each time the block runs)
+    void translateCountState(mlir::nl::Count count, NLStmtContainer* body);
+
+    // Translate an nl.count_update: look up the tally the handle names and record
+    // the charge of the chunk's non-null rows against it (all rows for an ID chunk,
+    // the present values for a nullable value chunk)
+    void translateCountUpdate(mlir::nl::CountUpdate update, NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.count_result iterator: allocate the single
+    // loop variable (a nullable i64 count chunk), map it, and record the emit-loop
+    // statement (materialize the tally as one present row, run the body once)
+    void translateCountLoop(const IteratorConfig& config,
+                            mlir::Block& loopBody,
+                            NLStmtContainer* body);
+
+    // The runtime tally a count handle names. The handle is a required operand of
+    // nl.count_update and nl.count_result, so this throws if it was not produced by
+    // an nl.count.
+    NLCountState* countStateFor(mlir::Value handle) const;
+
     // Pool-allocate a buffer/loop column matching a chunk type - an ID column for
     // an ID chunk, a nullable value column for a !nl.nullable<...> chunk - and the
     // append/gather/compare handler for that element type. The compare selector
@@ -158,6 +188,11 @@ private:
     static NLGatherFunction selectGatherForChunkType(mlir::Type chunkType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
+
+    // The non-null row count handler for a chunk type - the all-rows count for an
+    // ID chunk, the present-value count for a !nl.nullable<...> chunk. Used by
+    // nl.count_update.
+    static NLCountFunction selectCountForChunkType(mlir::Type chunkType);
 
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -30,7 +30,6 @@ private:
         GetOutEdges,
         GetInEdges,
         Sort,
-        Count,
     };
 
     // Settings of the iterators passed to each for loop
@@ -41,9 +40,6 @@ private:
 
         // The accumulator a Sort iterator drains; null for the other kinds.
         NLSortState* _sortState {nullptr};
-
-        // The tally a Count iterator reads to emit its single row; null otherwise.
-        NLCountState* _countState {nullptr};
     };
 
     NLProgram* _program {nullptr};
@@ -69,8 +65,7 @@ private:
     llvm::DenseMap<mlir::Value, NLDistinctState*> _distinctStates;
 
     // nl.count handle SSA value -> the runtime tally it produces, so the
-    // nl.count_update and the nl.for over nl.count_result that name the handle find
-    // the same counter
+    // nl.count_update and nl.count_result that name the handle find the same counter
     llvm::DenseMap<mlir::Value, NLCountState*> _countStates;
 
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
@@ -167,12 +162,10 @@ private:
     // the present values for a nullable value chunk)
     void translateCountUpdate(mlir::nl::CountUpdate update, NLStmtContainer* body);
 
-    // Translate the nl.for over an nl.count_result iterator: allocate the single
-    // loop variable (a nullable i64 count chunk), map it, and record the emit-loop
-    // statement (materialize the tally as one present row, run the body once)
-    void translateCountLoop(const IteratorConfig& config,
-                            mlir::Block& loopBody,
-                            NLStmtContainer* body);
+    // Translate an nl.count_result: look up the tally the handle names, allocate the
+    // unsigned i64 count chunk it produces, map the op result to it, and record the
+    // emit statement (materialize the final tally as the chunk's single row)
+    void translateCountResult(mlir::nl::CountResult result, NLStmtContainer* body);
 
     // The runtime tally a count handle names. The handle is a required operand of
     // nl.count_update and nl.count_result, so this throws if it was not produced by

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -215,6 +215,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerSort(sort);
     } else if (mlir::db::RemoveDuplicates distinct = mlir::dyn_cast<mlir::db::RemoveDuplicates>(operation)) {
         lowerRemoveDuplicates(distinct);
+    } else if (mlir::db::Count count = mlir::dyn_cast<mlir::db::Count>(operation)) {
+        lowerCount(count);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -665,6 +667,48 @@ void DBLowering::lowerRemoveDuplicates(mlir::db::RemoveDuplicates distinct) {
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
         _valueMap[dbResults[resultIndex]] = filteredChunks[resultIndex];
     }
+}
+
+void DBLowering::lowerCount(mlir::db::Count count) {
+    // The nl chunk the counted column lowered to; the update reads its per-step
+    // non-null row count.
+    const mlir::Value inputChunk = mapValue(count.getInput());
+
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // The tally is hoisted to the top of the entry block, above every loop, so it
+    // is reset once at function scope and dominates the update placed in the
+    // producing loop body and the emit that reads it after the loop. A correlated
+    // COUNT (reset per enclosing step) would hoist into its enclosing loop body
+    // instead - future work, as for the streaming limit.
+    _builder.setInsertionPointToStart(_entryBlock);
+    const mlir::Value state = _builder.create<nl::Count>(loc).getState();
+
+    // The update sits in the innermost producing loop body, where the counted
+    // column is bound (the same block db.output would emit from), and charges each
+    // step's non-null rows against the tally.
+    setInsertionInto(ownerBlock(inputChunk));
+    _builder.create<nl::CountUpdate>(loc, state, inputChunk);
+
+    // COUNT is a pipeline breaker: the tally is final only once every row has been
+    // seen. So - like db.sort - the result is emitted after the producing loop, by
+    // an nl.count_result source iterator and its nl.for, placed before the
+    // func.return. The iterator yields exactly one chunk: the single-row count as a
+    // nullable (always-present) i64, so nl.output stays inside a loop as it must.
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::Type elementType = _builder.getIntegerType(64);
+    const storage::NullableType nullableType = storage::NullableType::get(context, elementType);
+    const nl::ChunkType countChunkType = nl::ChunkType::get(context, nullableType);
+    const nl::IteratorType iteratorType = nl::IteratorType::get(context, {countChunkType});
+
+    setInsertionInto(_entryBlock);
+    nl::CountResult result = _builder.create<nl::CountResult>(loc, iteratorType, state);
+
+    // db.count's single result maps to the emit loop's single variable, so the
+    // db.output that follows lowers into the emit loop body reading the one-row
+    // count chunk. The emit loop is never limit-bounded (count.getOperation() opens
+    // no producing loop, so assignProducerLoops never attaches a handle to it).
+    buildLoopForSource(result.getResult(), count.getOperation());
 }
 
 void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -691,24 +691,23 @@ void DBLowering::lowerCount(mlir::db::Count count) {
     _builder.create<nl::CountUpdate>(loc, state, inputChunk);
 
     // COUNT is a pipeline breaker: the tally is final only once every row has been
-    // seen. So - like db.sort - the result is emitted after the producing loop, by
-    // an nl.count_result source iterator and its nl.for, placed before the
-    // func.return. The iterator yields exactly one chunk: the single-row count as a
-    // nullable (always-present) i64, so nl.output stays inside a loop as it must.
+    // seen. Since it collapses to exactly one row there is nothing to iterate, so -
+    // unlike db.sort - it opens no emit loop: nl.count_result materializes the tally
+    // chunk in place at function scope (after the producing loop, before the
+    // func.return), and db.output consumes it there. The chunk is the single-row
+    // count as an unsigned i64 (!nl.chunk<ui64>) - a non-negative tally that is
+    // never null, so no nullable wrapper.
     mlir::MLIRContext* const context = _builder.getContext();
-    const mlir::Type elementType = _builder.getIntegerType(64);
-    const storage::NullableType nullableType = storage::NullableType::get(context, elementType);
-    const nl::ChunkType countChunkType = nl::ChunkType::get(context, nullableType);
-    const nl::IteratorType iteratorType = nl::IteratorType::get(context, {countChunkType});
+    const mlir::Type countElementType = _builder.getIntegerType(64, /*isSigned=*/false);
+    const nl::ChunkType countChunkType = nl::ChunkType::get(context, countElementType);
 
     setInsertionInto(_entryBlock);
-    nl::CountResult result = _builder.create<nl::CountResult>(loc, iteratorType, state);
+    nl::CountResult result = _builder.create<nl::CountResult>(loc, countChunkType, state);
 
-    // db.count's single result maps to the emit loop's single variable, so the
-    // db.output that follows lowers into the emit loop body reading the one-row
-    // count chunk. The emit loop is never limit-bounded (count.getOperation() opens
-    // no producing loop, so assignProducerLoops never attaches a handle to it).
-    buildLoopForSource(result.getResult(), count.getOperation());
+    // db.count's result maps to that chunk, so the db.output that follows lowers
+    // into a function-scope nl.output reading it - the block that holds the chunk is
+    // the entry block, so lowerOutput places nl.output there.
+    _valueMap[count.getResult()] = result.getResult();
 }
 
 void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -58,12 +58,13 @@ class GraphView;
 //                                          nl.count_update in the producing loop
 //                                          body that charges each chunk's non-null
 //                                          rows, and - after the loop - an
-//                                          nl.count_result source iterator whose
-//                                          nl.for emits the single tally row. A
-//                                          pipeline breaker like db.sort (the count
-//                                          is final only once every row is seen), so
-//                                          it has an emit loop; but it collapses to
-//                                          one row rather than re-emitting the input
+//                                          nl.count_result that materializes the
+//                                          single tally row (an unsigned i64,
+//                                          !nl.chunk<ui64>) which a function-scope
+//                                          nl.output emits. A pipeline breaker like
+//                                          db.sort (the count is final only once
+//                                          every row is seen), but it collapses to
+//                                          one row, so it opens no emit loop
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -174,11 +175,11 @@ private:
 
     // Lower a db.count: hoist an nl.count tally to the top of the entry block,
     // place an nl.count_update in the innermost producing loop body to charge each
-    // chunk's non-null rows, then - after the producing loop - emit an
-    // nl.count_result source iterator and an nl.for over it that yields the single
-    // tally row (a nullable, always-present i64). db.count's result maps to that
-    // emit loop's variable, so the db.output that follows lowers into the emit loop
-    // body. A pipeline breaker like db.sort, but it collapses to one row.
+    // chunk's non-null rows, then - after the producing loop - an nl.count_result
+    // that materializes the single tally row (an unsigned i64, !nl.chunk<ui64>) at
+    // function scope. db.count's result maps to that chunk, so the db.output that
+    // follows lowers into a function-scope nl.output reading it. A pipeline breaker
+    // like db.sort, but it collapses to one row, so it opens no emit loop.
     void lowerCount(mlir::db::Count count);
 
     void lowerOutput(mlir::db::Output output);

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -54,6 +54,16 @@ class GraphView;
 //                                          the ordinary early-exit, and a chained
 //                                          WITH DISTINCT feeds the survivor chunks
 //                                          straight into the next traversal
+//   db.count                           ->  a hoisted nl.count tally, an
+//                                          nl.count_update in the producing loop
+//                                          body that charges each chunk's non-null
+//                                          rows, and - after the loop - an
+//                                          nl.count_result source iterator whose
+//                                          nl.for emits the single tally row. A
+//                                          pipeline breaker like db.sort (the count
+//                                          is final only once every row is seen), so
+//                                          it has an emit loop; but it collapses to
+//                                          one row rather than re-emitting the input
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -161,6 +171,15 @@ private:
     // db.limit over its results reaches the real producing loops through
     // assignProducerLoops' operand recursion and early-exits them.
     void lowerRemoveDuplicates(mlir::db::RemoveDuplicates distinct);
+
+    // Lower a db.count: hoist an nl.count tally to the top of the entry block,
+    // place an nl.count_update in the innermost producing loop body to charge each
+    // chunk's non-null rows, then - after the producing loop - emit an
+    // nl.count_result source iterator and an nl.for over it that yields the single
+    // tally row (a nullable, always-present i64). db.count's result maps to that
+    // emit loop's variable, so the db.output that follows lowers into the emit loop
+    // body. A pipeline breaker like db.sort, but it collapses to one row.
+    void lowerCount(mlir::db::Count count);
 
     void lowerOutput(mlir::db::Output output);
 

--- a/samples/mlir/count.mlir
+++ b/samples/mlir/count.mlir
@@ -6,13 +6,14 @@ module {
     //
     // db.count is a pipeline breaker like db.sort: it lowers to a hoisted nl.count
     // tally, an nl.count_update inside the scan loop that charges each chunk's
-    // rows, and - after the loop - an nl.count_result source iterator whose nl.for
-    // emits the single tally row (a nullable, always-present i64).
+    // rows, and - after the loop - an nl.count_result that materializes the single
+    // tally row as an unsigned i64 (!nl.chunk<ui64>), which a function-scope
+    // nl.output emits. It collapses to one row, so there is no emit loop.
     %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %count = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
+    %count = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<ui64>
 
-    db.output(%count) : !db.column<i64>
+    db.output(%count) : !db.column<ui64>
 
     return
   }

--- a/samples/mlir/count.mlir
+++ b/samples/mlir/count.mlir
@@ -1,0 +1,19 @@
+module {
+  func.func @main() {
+    // MATCH (a) RETURN count(a): scan every node and count them. count(a) counts
+    // the non-null values of its column; node IDs off a scan are never null, so
+    // this is the total node count - the way count(*) is expressed.
+    //
+    // db.count is a pipeline breaker like db.sort: it lowers to a hoisted nl.count
+    // tally, an nl.count_update inside the scan loop that charges each chunk's
+    // rows, and - after the loop - an nl.count_result source iterator whose nl.for
+    // emits the single tally row (a nullable, always-present i64).
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %count = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
+
+    db.output(%count) : !db.column<i64>
+
+    return
+  }
+}

--- a/samples/mlir/count.nl.mlir
+++ b/samples/mlir/count.nl.mlir
@@ -4,8 +4,9 @@
 //
 // db.count is a pipeline breaker like db.sort: a hoisted nl.count tally, an
 // nl.count_update inside the scan loop that charges each chunk's rows, and - after
-// the loop - an nl.count_result source iterator whose nl.for emits the single
-// tally row as a nullable (always-present) i64.
+// the loop - an nl.count_result that materializes the single tally row as an
+// unsigned i64 (!nl.chunk<ui64>), which a function-scope nl.output emits. It
+// collapses to one row, so there is no emit loop.
 module {
   func.func @main() {
     %0 = nl.count
@@ -13,10 +14,8 @@ module {
     nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
       nl.count_update %0, %arg0 : !nl.chunk<!storage.node_id>
     }
-    %2 = nl.count_result(%0) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
-    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
-      nl.output(%arg0) : !nl.chunk<!storage.nullable<i64>>
-    }
+    %2 = nl.count_result(%0) : !nl.chunk<ui64>
+    nl.output(%2) : !nl.chunk<ui64>
     return
   }
 }

--- a/samples/mlir/count.nl.mlir
+++ b/samples/mlir/count.nl.mlir
@@ -1,0 +1,22 @@
+// Generated nl-dialect lowering of count.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered count.mlir
+// This is the DBLowering output; edit count.mlir, not this file.
+//
+// db.count is a pipeline breaker like db.sort: a hoisted nl.count tally, an
+// nl.count_update inside the scan loop that charges each chunk's rows, and - after
+// the loop - an nl.count_result source iterator whose nl.for emits the single
+// tally row as a nullable (always-present) i64.
+module {
+  func.func @main() {
+    %0 = nl.count
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.count_update %0, %arg0 : !nl.chunk<!storage.node_id>
+    }
+    %2 = nl.count_result(%0) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+      nl.output(%arg0) : !nl.chunk<!storage.nullable<i64>>
+    }
+    return
+  }
+}

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -254,7 +254,8 @@ public:
 
 private:
     // Output chunks are node ID, edge ID and edge type ID chunks from traversals,
-    // or nullable value chunks (ColumnOptVector) from a property read
+    // nullable value chunks (ColumnOptVector) from a property read, or the
+    // non-nullable ColumnVector<uint64_t> a db.count emits
     static void printCell(const Column* column, size_t row) {
         if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
             std::cout << (*nodeIDs)[row].getValue();
@@ -262,6 +263,8 @@ private:
             std::cout << (*edgeIDs)[row].getValue();
         } else if (const auto* edgeTypes = dynamic_cast<const ColumnEdgeTypes*>(column)) {
             std::cout << (*edgeTypes)[row].getValue();
+        } else if (const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(column)) {
+            std::cout << (*counts)[row];
         } else if (printValueCell<int64_t>(column, row)
                    || printValueCell<uint64_t>(column, row)
                    || printValueCell<double>(column, row)

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -184,6 +184,18 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN count(a): one column in, one integer column out. Unlike the
+// pass-through ops, count changes both arity (only ever one result) and type (an
+// integer, whatever the input column's type).
+const char* const countProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
+  db.output(%n) : !db.column<i64>
+  return
+}
+)mlir";
+
 TEST_F(DBDialectTest, parsesCrossProductOfTwoScans) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
     ASSERT_TRUE(module);
@@ -678,6 +690,39 @@ TEST_F(DBDialectTest, verifierRejectsRemoveDuplicatesWithoutColumns) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(distinct.getOperation())));
+}
+
+TEST_F(DBDialectTest, parsesCount) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(countProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Count count;
+    module.get().walk([&](mlir::db::Count op) {
+        count = op;
+    });
+    ASSERT_TRUE(count);
+
+    // One column in, one integer column out - the input and result types are
+    // unrelated (a node ID column counted into an i64 column).
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Type intColumnType = mlir::db::ColumnType::get(&_context, mlir::IntegerType::get(&_context, 64));
+    EXPECT_EQ(count.getInput().getType(), nodeIDColumnType);
+    EXPECT_EQ(count.getResult().getType(), intColumnType);
+}
+
+TEST_F(DBDialectTest, countRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(countProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the db.count
+    // printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
 }

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -190,8 +190,8 @@ func.func @main() {
 const char* const countProgram = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
-  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
-  db.output(%n) : !db.column<i64>
+  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<ui64>
+  db.output(%n) : !db.column<ui64>
   return
 }
 )mlir";
@@ -703,11 +703,11 @@ TEST_F(DBDialectTest, parsesCount) {
     ASSERT_TRUE(count);
 
     // One column in, one integer column out - the input and result types are
-    // unrelated (a node ID column counted into an i64 column).
+    // unrelated (a node ID column counted into a ui64 column).
     const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
-    const mlir::Type intColumnType = mlir::db::ColumnType::get(&_context, mlir::IntegerType::get(&_context, 64));
+    const mlir::Type countColumnType = mlir::db::ColumnType::get(&_context, mlir::IntegerType::get(&_context, 64, mlir::IntegerType::Unsigned));
     EXPECT_EQ(count.getInput().getType(), nodeIDColumnType);
-    EXPECT_EQ(count.getResult().getType(), intColumnType);
+    EXPECT_EQ(count.getResult().getType(), countColumnType);
 }
 
 TEST_F(DBDialectTest, countRoundTripsThroughTextualForm) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -129,6 +129,29 @@ private:
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> _rows;
 };
 
+// Collects the single-row nullable-int64 result a COUNT emits: one chunk with one
+// present value. Captures every value seen, so a test can assert both that exactly
+// one row came out and what its tally is.
+class CollectingCountSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<int64_t>> _values;
+};
+
 // Collects (node ID, nullable string property) rows. The value column is a
 // !storage.nullable<!storage.string> chunk, storage's ColumnOptVector<string_view>.
 class CollectingNodeStringPropSink : public NLOutputSink {
@@ -797,6 +820,30 @@ func.func @main() {
   %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
   %da, %dscore = db.remove_duplicates(%a, %score) : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
   db.output(%da, %dscore) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN count(a): scan every node and count them. Node IDs are never
+// null, so this is the total node count.
+const char* const countNodesProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
+  db.output(%n) : !db.column<i64>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN count(a.score): count the non-null scores. A node without the
+// property reads null, and count(a.score) does not charge those - so the tally is
+// fewer than the node count.
+const char* const countScoresProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %n = db.count(%score) : (!db.column<none>) -> !db.column<i64>
+  db.output(%n) : !db.column<i64>
   return
 }
 )mlir";
@@ -2692,6 +2739,101 @@ TEST_F(DBLoweringTest, lowersRemoveDuplicatesLimitToStreamingFilter) {
     EXPECT_EQ(updateCount, 1u);
     EXPECT_EQ(sortBufferCount, 0u);
     EXPECT_GE(forsWithLimit, 1u);
+}
+
+TEST_F(DBLoweringTest, countsNodes) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond has four nodes, so db.count over the scanned node column emits a
+    // single row holding 4.
+    CollectingCountSink sink;
+    runLoweredProgram(countNodesProgram, reader.getView(), sink);
+
+    const std::vector<std::optional<int64_t>> expected {4};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, countsNodesAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // At chunk size 2 the four nodes span two scan chunks; the tally is reset once
+    // at function scope, not per chunk, so it still totals 4.
+    CollectingCountSink sink;
+    runLoweredProgram(countNodesProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::optional<int64_t>> expected {4};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, countsNonNullScores) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Three nodes carry scores 100, 200 and null (node 2 has none). count(a.score)
+    // charges only the present values, so the tally is 2, not 3 - the nullable
+    // value chunk's present-value count path.
+    CollectingCountSink sink;
+    runLoweredProgram(countScoresProgram, reader.getView(), sink);
+
+    const std::vector<std::optional<int64_t>> expected {2};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+// db.count lowers to the pipeline-breaker shape: a hoisted nl.count, a single
+// nl.count_update in the producing loop, and an nl.count_result emit loop after it -
+// two nl.for loops (the producing scan and the one-step emit), no nl.sort_buffer.
+TEST_F(DBLoweringTest, lowersCountToPipelineBreaker) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(countNodesProgram, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t countCount = 0;
+    size_t updateCount = 0;
+    size_t resultCount = 0;
+    size_t forCount = 0;
+    size_t sortBufferCount = 0;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::nl::Count>(operation)) {
+            countCount++;
+        } else if (mlir::isa<mlir::nl::CountUpdate>(operation)) {
+            updateCount++;
+        } else if (mlir::isa<mlir::nl::CountResult>(operation)) {
+            resultCount++;
+        } else if (mlir::isa<mlir::nl::For>(operation)) {
+            forCount++;
+        } else if (mlir::isa<mlir::nl::SortBuffer>(operation)) {
+            sortBufferCount++;
+        }
+    });
+
+    EXPECT_EQ(countCount, 1u);
+    EXPECT_EQ(updateCount, 1u);
+    EXPECT_EQ(resultCount, 1u);
+    EXPECT_EQ(forCount, 2u);
+    EXPECT_EQ(sortBufferCount, 0u);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -129,15 +129,15 @@ private:
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> _rows;
 };
 
-// Collects the single-row nullable-int64 result a COUNT emits: one chunk with one
-// present value. Captures every value seen, so a test can assert both that exactly
-// one row came out and what its tally is.
+// Collects the single-row unsigned-i64 result a COUNT emits: one non-nullable
+// !nl.chunk<ui64> with one row. Captures every value seen, so a test can assert
+// both that exactly one row came out and what its tally is.
 class CollectingCountSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
 
-        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        const auto* values = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[0]);
         ASSERT_NE(values, nullptr);
 
         const auto& raw = values->getRaw();
@@ -146,10 +146,10 @@ public:
         }
     }
 
-    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+    const std::vector<uint64_t>& getValues() const { return _values; }
 
 private:
-    std::vector<std::optional<int64_t>> _values;
+    std::vector<uint64_t> _values;
 };
 
 // Collects (node ID, nullable string property) rows. The value column is a
@@ -829,8 +829,8 @@ func.func @main() {
 const char* const countNodesProgram = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
-  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<i64>
-  db.output(%n) : !db.column<i64>
+  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<ui64>
+  db.output(%n) : !db.column<ui64>
   return
 }
 )mlir";
@@ -842,8 +842,8 @@ const char* const countScoresProgram = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %n = db.count(%score) : (!db.column<none>) -> !db.column<i64>
-  db.output(%n) : !db.column<i64>
+  %n = db.count(%score) : (!db.column<none>) -> !db.column<ui64>
+  db.output(%n) : !db.column<ui64>
   return
 }
 )mlir";
@@ -2751,7 +2751,7 @@ TEST_F(DBLoweringTest, countsNodes) {
     CollectingCountSink sink;
     runLoweredProgram(countNodesProgram, reader.getView(), sink);
 
-    const std::vector<std::optional<int64_t>> expected {4};
+    const std::vector<uint64_t> expected {4};
     EXPECT_EQ(sink.getValues(), expected);
 }
 
@@ -2765,7 +2765,7 @@ TEST_F(DBLoweringTest, countsNodesAcrossChunks) {
     CollectingCountSink sink;
     runLoweredProgram(countNodesProgram, reader.getView(), sink, /*chunkSize=*/2);
 
-    const std::vector<std::optional<int64_t>> expected {4};
+    const std::vector<uint64_t> expected {4};
     EXPECT_EQ(sink.getValues(), expected);
 }
 
@@ -2780,13 +2780,15 @@ TEST_F(DBLoweringTest, countsNonNullScores) {
     CollectingCountSink sink;
     runLoweredProgram(countScoresProgram, reader.getView(), sink);
 
-    const std::vector<std::optional<int64_t>> expected {2};
+    const std::vector<uint64_t> expected {2};
     EXPECT_EQ(sink.getValues(), expected);
 }
 
 // db.count lowers to the pipeline-breaker shape: a hoisted nl.count, a single
-// nl.count_update in the producing loop, and an nl.count_result emit loop after it -
-// two nl.for loops (the producing scan and the one-step emit), no nl.sort_buffer.
+// nl.count_update in the producing loop, and an nl.count_result after it that
+// materializes the tally chunk at function scope. Because count collapses to one
+// row it opens no emit loop, so there is exactly one nl.for (the producing scan)
+// and no nl.sort_buffer.
 TEST_F(DBLoweringTest, lowersCountToPipelineBreaker) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
@@ -2832,7 +2834,7 @@ TEST_F(DBLoweringTest, lowersCountToPipelineBreaker) {
     EXPECT_EQ(countCount, 1u);
     EXPECT_EQ(updateCount, 1u);
     EXPECT_EQ(resultCount, 1u);
-    EXPECT_EQ(forCount, 2u);
+    EXPECT_EQ(forCount, 1u);
     EXPECT_EQ(sortBufferCount, 0u);
 }
 

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -192,6 +192,33 @@ TEST_F(NLDialectTest, verifierAcceptsDistinctChain) {
     EXPECT_EQ(filter.getResult(0).getType(), chunk.getType());
 }
 
+// The count chain verifies: an nl.count producing the tally handle, an
+// nl.count_update charging the chunk against it, and an nl.count_result yielding a
+// single-chunk iterator over the nullable-i64 tally row, all naming the one handle.
+TEST_F(NLDialectTest, verifierAcceptsCountChain) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value chunk = entryBlock.getArgument(0);
+
+    const mlir::Value handle = builder.create<mlir::nl::Count>(loc).getState();
+    builder.create<mlir::nl::CountUpdate>(loc, handle, chunk);
+
+    // The count result iterator yields one chunk: the tally as a nullable i64.
+    const mlir::Type countChunkType = mlir::nl::ChunkType::get(&_context,
+                                                               mlir::storage::NullableType::get(&_context, mlir::IntegerType::get(&_context, 64)));
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {countChunkType});
+    mlir::nl::CountResult result = builder.create<mlir::nl::CountResult>(loc, iteratorType, handle);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(result.getState(), handle);
+    EXPECT_EQ(result.getResult().getType(), iteratorType);
+}
+
 // A folded nl.output carries the single handle of the truncate adjacent to it,
 // never both: an output with both a limit and a skip handle fails verification.
 TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -193,8 +193,9 @@ TEST_F(NLDialectTest, verifierAcceptsDistinctChain) {
 }
 
 // The count chain verifies: an nl.count producing the tally handle, an
-// nl.count_update charging the chunk against it, and an nl.count_result yielding a
-// single-chunk iterator over the nullable-i64 tally row, all naming the one handle.
+// nl.count_update charging the chunk against it, and an nl.count_result that
+// materializes the single ui64 tally chunk, emitted by a function-scope nl.output -
+// all naming the one handle.
 TEST_F(NLDialectTest, verifierAcceptsCountChain) {
     mlir::OpBuilder builder(&_context);
     const mlir::Location loc = builder.getUnknownLoc();
@@ -207,16 +208,17 @@ TEST_F(NLDialectTest, verifierAcceptsCountChain) {
     const mlir::Value handle = builder.create<mlir::nl::Count>(loc).getState();
     builder.create<mlir::nl::CountUpdate>(loc, handle, chunk);
 
-    // The count result iterator yields one chunk: the tally as a nullable i64.
+    // The count result is a single non-nullable unsigned-i64 chunk, emitted at
+    // function scope (no loop) since the count collapses to one row.
     const mlir::Type countChunkType = mlir::nl::ChunkType::get(&_context,
-                                                               mlir::storage::NullableType::get(&_context, mlir::IntegerType::get(&_context, 64)));
-    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {countChunkType});
-    mlir::nl::CountResult result = builder.create<mlir::nl::CountResult>(loc, iteratorType, handle);
+                                                               mlir::IntegerType::get(&_context, 64, mlir::IntegerType::Unsigned));
+    mlir::nl::CountResult result = builder.create<mlir::nl::CountResult>(loc, countChunkType, handle);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
     EXPECT_EQ(result.getState(), handle);
-    EXPECT_EQ(result.getResult().getType(), iteratorType);
+    EXPECT_EQ(result.getResult().getType(), countChunkType);
 }
 
 // A folded nl.output carries the single handle of the truncate adjacent to it,

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -116,15 +116,15 @@ private:
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> _rows;
 };
 
-// Collects the single-row nullable-int64 result a COUNT emits: one chunk with one
-// present value. Captures every value it sees, so a test can assert both that
-// exactly one row came out and what its tally is.
+// Collects the single-row unsigned-i64 result a COUNT emits: one non-nullable
+// !nl.chunk<ui64> with one row. Captures every value it sees, so a test can assert
+// both that exactly one row came out and what its tally is.
 class CollectingCountSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
 
-        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        const auto* values = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[0]);
         ASSERT_NE(values, nullptr);
 
         const auto& raw = values->getRaw();
@@ -133,10 +133,10 @@ public:
         }
     }
 
-    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+    const std::vector<uint64_t>& getValues() const { return _values; }
 
 private:
-    std::vector<std::optional<int64_t>> _values;
+    std::vector<uint64_t> _values;
 };
 
 // Scan all nodes and output them
@@ -323,8 +323,8 @@ func.func @main() {
 
 // Scan all nodes and count them. The tally is created once at function scope by
 // nl.count, incremented per scan chunk by nl.count_update, and - after the loop -
-// nl.count_result yields the single tally row that the second loop's nl.output
-// emits. Node IDs are never null, so this is the total node count.
+// nl.count_result materializes the single ui64 tally row that the function-scope
+// nl.output emits. Node IDs are never null, so this is the total node count.
 constexpr const char* nlCountNodesProgram = R"mlir(
 func.func @main() {
   %c = nl.count
@@ -332,10 +332,8 @@ func.func @main() {
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
     nl.count_update %c, %a : !nl.chunk<!storage.node_id>
   }
-  %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
-  nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
-    nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
-  }
+  %r = nl.count_result(%c) : !nl.chunk<ui64>
+  nl.output(%r) : !nl.chunk<ui64>
   func.return
 }
 )mlir";
@@ -352,10 +350,8 @@ func.func @main() {
     %values = nl.get_node_properties(%a, %score) : !nl.chunk<!storage.nullable<i64>>
     nl.count_update %c, %values : !nl.chunk<!storage.nullable<i64>>
   }
-  %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
-  nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
-    nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
-  }
+  %r = nl.count_result(%c) : !nl.chunk<ui64>
+  nl.output(%r) : !nl.chunk<ui64>
   func.return
 }
 )mlir";
@@ -1077,7 +1073,7 @@ TEST_F(NLExecutorTest, countsAllNodes) {
     CollectingCountSink sink;
     runProgram(nlCountNodesProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
 
-    const std::vector<std::optional<int64_t>> expected {4};
+    const std::vector<uint64_t> expected {4};
     EXPECT_EQ(sink.getValues(), expected);
 }
 
@@ -1092,7 +1088,7 @@ TEST_F(NLExecutorTest, countsAcrossChunks) {
     CollectingCountSink sink;
     runProgram(nlCountNodesProgram, reader.getView(), 1, sink);
 
-    const std::vector<std::optional<int64_t>> expected {4};
+    const std::vector<uint64_t> expected {4};
     EXPECT_EQ(sink.getValues(), expected);
 }
 
@@ -1106,7 +1102,7 @@ TEST_F(NLExecutorTest, countsOnlyNonNullValues) {
     CollectingCountSink sink;
     runProgram(nlCountScoresProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
 
-    const std::vector<std::optional<int64_t>> expected {2};
+    const std::vector<uint64_t> expected {2};
     EXPECT_EQ(sink.getValues(), expected);
 }
 

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -116,6 +116,29 @@ private:
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> _rows;
 };
 
+// Collects the single-row nullable-int64 result a COUNT emits: one chunk with one
+// present value. Captures every value it sees, so a test can assert both that
+// exactly one row came out and what its tally is.
+class CollectingCountSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<int64_t>> _values;
+};
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -293,6 +316,45 @@ func.func @main() {
       %db = nl.distinct_filter %set, (%b) : !nl.chunk<!storage.node_id>
       nl.output(%db) : !nl.chunk<!storage.node_id>
     }
+  }
+  func.return
+}
+)mlir";
+
+// Scan all nodes and count them. The tally is created once at function scope by
+// nl.count, incremented per scan chunk by nl.count_update, and - after the loop -
+// nl.count_result yields the single tally row that the second loop's nl.output
+// emits. Node IDs are never null, so this is the total node count.
+constexpr const char* nlCountNodesProgram = R"mlir(
+func.func @main() {
+  %c = nl.count
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.count_update %c, %a : !nl.chunk<!storage.node_id>
+  }
+  %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+  nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+    nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
+  }
+  func.return
+}
+)mlir";
+
+// Scan all nodes, read each one's "score", and count the non-null values -
+// Cypher count(a.score). A node without the property contributes a null value
+// that nl.count_update does not charge, so the tally is fewer than the node count.
+constexpr const char* nlCountScoresProgram = R"mlir(
+func.func @main() {
+  %score = nl.get_property_type("score")
+  %c = nl.count
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %values = nl.get_node_properties(%a, %score) : !nl.chunk<!storage.nullable<i64>>
+    nl.count_update %c, %values : !nl.chunk<!storage.nullable<i64>>
+  }
+  %r = nl.count_result(%c) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+  nl.for %n in %r : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+    nl.output(%n) : !nl.chunk<!storage.nullable<i64>>
   }
   func.return
 }
@@ -1003,6 +1065,49 @@ TEST_F(NLExecutorTest, distinctFilterDedupsAcrossChunks) {
     sink.sortedRows(rows);
     const std::vector<std::vector<uint64_t>> expected {{1}, {2}, {3}};
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, countsAllNodes) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond has four nodes; node IDs are never null, so the count is four,
+    // emitted as a single present int64 row.
+    CollectingCountSink sink;
+    runProgram(nlCountNodesProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {4};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, countsAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 feeds one node per step, so the tally is accumulated across four
+    // separate steps; nl.count is reset once at function scope, not per chunk, so
+    // the count is still four.
+    CollectingCountSink sink;
+    runProgram(nlCountNodesProgram, reader.getView(), 1, sink);
+
+    const std::vector<std::optional<int64_t>> expected {4};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, countsOnlyNonNullValues) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Three nodes carry scores 100, 200 and null (node 2 has none). count(a.score)
+    // charges only the present values, so the tally is two, not three.
+    CollectingCountSink sink;
+    runProgram(nlCountScoresProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {2};
+    EXPECT_EQ(sink.getValues(), expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Add db.count and its nl.count / nl.count_update / nl.count_result so a Cypher count(x) lowers to a hoisted counter and a per iteration update