### PR TITLE
MLIR: sum/min/max/avg aggregate ops for the db and nl dialects

### DIFF
--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -449,4 +449,39 @@ def Count : TuringOp<"count", [Pure]> {
   }];
 }
 
+/**
+* Aggregates: Sum / Min / Max / Avg
+*/
+// The value-reducing counterparts of db.count. Each consumes the whole dataflow of
+// one property column and produces a single-row column holding the reduction.
+// Cypher aggregates ignore nulls, so they reduce only the non-null rows.
+//
+// Unlike count(*), which tallies rows regardless of value and so accepts an ID
+// column, these reduce the values themselves, so the input must be a property
+// value column. The result value type follows Cypher and is resolved during
+// lowering: sum and min/max keep the input's type, avg is always a float, and the
+// result is null when no non-null row was seen (except sum, which is 0). Like
+// db.count the input and result types are unrelated, so there is no verifier.
+//
+// One op per reduction, the way db.count is its own op: the op name is the
+// aggregate, so no kind attribute is needed and each reads like `db.sum(%x)`. They
+// share this base since only the name differs.
+class AggregateOp<string mnemonic> : TuringOp<mnemonic, [Pure]> {
+  let summary = "Reduce a column of property values to a single-row result";
+
+  let arguments = (ins Column:$input);
+  let results   = (outs Column:$result);
+
+  // One operand and one result, so functional-type(operands, results) prints the
+  // `(!db.column<...>) -> !db.column<...>` form, the same as db.count.
+  let assemblyFormat = [{
+    `(` $input `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def Sum : AggregateOp<"sum">;
+def Min : AggregateOp<"min">;
+def Max : AggregateOp<"max">;
+def Avg : AggregateOp<"avg">;
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -26,6 +26,31 @@ Type getEdgeTypeIDChunkType(MLIRContext* context) {
     return ChunkType::get(context, storage::EdgeTypeIDType::get(context));
 }
 
+// The value type an aggregate reduces: the T in a !nl.chunk<!storage.nullable<T>>.
+// Aggregates fold property values, so an update's input and a result's output are
+// always such chunks. Returns a null Type for anything else (an ID chunk, say), so
+// the caller can reject it.
+Type aggregateValueType(Type chunkType) {
+    const auto chunk = dyn_cast<ChunkType>(chunkType);
+    if (!chunk) {
+        return Type();
+    }
+
+    const auto nullable = dyn_cast<storage::NullableType>(chunk.getElementType());
+    if (!nullable) {
+        return Type();
+    }
+
+    return nullable.getValueType();
+}
+
+// The nl.aggregate that produced this state handle, or a null op if the handle is
+// not the result of one (a block argument, say). nl.aggregate_update /
+// nl.aggregate_result use it to reconcile their kind with the accumulator's reset.
+Aggregate producingAggregate(Value state) {
+    return state.getDefiningOp<Aggregate>();
+}
+
 // Out- and in-edge fetches expose the same row of chunks - source node IDs,
 // edge IDs, edge type IDs and target node IDs - followed by one filtered chunk
 // per carried column, so a loop body written for one direction works unchanged
@@ -334,6 +359,88 @@ LogicalResult For::verify() {
 LogicalResult Output::verify() {
     if (getLimit() && getSkip()) {
         return emitOpError("carries both a limit and a skip handle; a folded output takes at most one");
+    }
+
+    return success();
+}
+
+// avg accumulates a running sum as f64, so its accumulator state must be an f64;
+// sum/min/max accumulate in the value's own type, so any value element type is
+// fine here (the update and result ops check the input/output against it).
+LogicalResult Aggregate::verify() {
+    if (getKind() == storage::AggregateKind::Avg) {
+        const auto stateType = cast<AggregateStateType>(getState().getType());
+        if (!isa<Float64Type>(stateType.getElementType())) {
+            return emitOpError("avg must produce an f64 accumulator state");
+        }
+    }
+
+    return success();
+}
+
+// The fold handler is selected from this op's kind and the input's value type, and
+// it reads the accumulator as its own type; the accumulator was reset by the
+// producing nl.aggregate's kind. Reconcile all three so a mismatch is rejected
+// rather than folding into a wrongly-typed or wrongly-initialized accumulator.
+LogicalResult AggregateUpdate::verify() {
+    const storage::AggregateKind kind = getKind();
+
+    // The input is a property value chunk; its value type is what the fold reads.
+    const Type inputValueType = aggregateValueType(getRows().getType());
+    if (!inputValueType) {
+        return emitOpError("input must be a nullable value chunk (a property column)");
+    }
+
+    // avg folds any numeric input into an f64 accumulator; sum/min/max fold into an
+    // accumulator of the input's own value type.
+    const Type accumulatorType = cast<AggregateStateType>(getState().getType()).getElementType();
+    if (kind == storage::AggregateKind::Avg) {
+        if (!isa<Float64Type>(accumulatorType)) {
+            return emitOpError("avg must fold into an f64 accumulator state");
+        }
+    } else if (inputValueType != accumulatorType) {
+        return emitOpError("sum/min/max must fold into an accumulator of the input's value type");
+    }
+
+    // The accumulator's reset depends on the producer's kind (a present zero for
+    // sum/avg, null for min/max), so a differing kind here folds into the wrong one.
+    if (Aggregate producer = producingAggregate(getState())) {
+        if (producer.getKind() != kind) {
+            return emitOpError("kind must match the nl.aggregate that produced the state");
+        }
+    }
+
+    return success();
+}
+
+// The result sibling of AggregateUpdate::verify: the emit handler copies the
+// accumulator into the result (or divides by the count for avg), both read as the
+// result's value type, so the result must be a nullable value chunk whose value
+// type matches the reduction, and the kind must match the producer.
+LogicalResult AggregateResult::verify() {
+    const storage::AggregateKind kind = getKind();
+
+    const Type resultValueType = aggregateValueType(getResult().getType());
+    if (!resultValueType) {
+        return emitOpError("result must be a nullable value chunk");
+    }
+
+    // avg emits an f64 result from an f64 accumulator; sum/min/max emit a result of
+    // the accumulator's own value type.
+    const Type accumulatorType = cast<AggregateStateType>(getState().getType()).getElementType();
+    if (kind == storage::AggregateKind::Avg) {
+        const bool bothF64 = isa<Float64Type>(accumulatorType) && isa<Float64Type>(resultValueType);
+        if (!bothF64) {
+            return emitOpError("avg must emit an f64 result from an f64 accumulator state");
+        }
+    } else if (resultValueType != accumulatorType) {
+        return emitOpError("sum/min/max must emit a result of the accumulator's value type");
+    }
+
+    if (Aggregate producer = producingAggregate(getState())) {
+        if (producer.getKind() != kind) {
+            return emitOpError("kind must match the nl.aggregate that produced the state");
+        }
     }
 
     return success();

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -734,4 +734,104 @@ def CountResult : NLOp<"count_result", []> {
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }
 
+/**
+* Aggregate
+*/
+// NOT Pure: the value-reducing sibling of nl.count. Each nl.aggregate is a
+// distinct accumulator, so two must never be CSE'd into one, and an unread one
+// must not be DCE'd - resetting the accumulator is a side effect.
+def Aggregate : NLOp<"aggregate", []> {
+  let summary = "Create (and reset) a value-aggregate accumulator";
+  let description = [{
+    The value-reducing counterpart of nl.count. Sits at the top of the scope it
+    governs, where it resets the accumulator once per execution of that block, and
+    produces the !nl.aggregate_state handle nl.aggregate_update folds into and
+    nl.aggregate_result reads. `$kind` selects the reduction (sum/min/max/avg); the
+    state type carries the accumulator element type, so the result type is spelled.
+
+      %s = nl.aggregate sum : !nl.aggregate_state<i64>
+  }];
+
+  let arguments = (ins AggregateKind:$kind);
+  let results   = (outs NLAggregateState:$state);
+  let assemblyFormat = "$kind attr-dict `:` qualified(type($state))";
+
+  // avg accumulates a running sum as f64, so its accumulator state must be f64;
+  // the other kinds accumulate in the value's own type.
+  let hasVerifier = 1;
+}
+
+/**
+* AggregateUpdate
+*/
+// NOT Pure: it folds the chunk into the handle, so it must run exactly where it
+// sits, once per producing-loop step. The value sibling of nl.count_update.
+def AggregateUpdate : NLOp<"aggregate_update", []> {
+  let summary = "Fold this step's non-null rows into a value-aggregate accumulator";
+  let description = [{
+    Runs in the producing loop body, once per step. Reduces the present (non-null)
+    values of the current nullable value chunk into the accumulator - adding them
+    (sum/avg) or keeping the extreme (min/max) - matching Cypher, where these
+    aggregates ignore null rows. The sole accumulator mutator.
+
+      nl.aggregate_update sum %s, %v : !nl.aggregate_state<i64>, !nl.chunk<!storage.nullable<i64>>
+
+    The input is always a nullable value chunk (a property fetch); its value type
+    need not match the accumulator's - an avg of an i64 column folds into an f64
+    accumulator, so both types are spelled after the colon.
+  }];
+
+  let arguments = (ins NLAggregateState:$state, NLChunk:$rows, AggregateKind:$kind);
+
+  let assemblyFormat = [{
+    $kind $state `,` $rows attr-dict `:` qualified(type($state)) `,` qualified(type($rows))
+  }];
+
+  // The fold handler is picked from this op's kind but the accumulator was reset by
+  // the producing nl.aggregate's kind, and the handler reads the accumulator as its
+  // own value type - so a kind that disagrees with the producer, an input that is
+  // not a nullable value chunk, or a state element type that does not match the
+  // reduction would fold into a wrongly-typed or wrongly-initialized accumulator.
+  // The verifier reconciles all three so such IR is rejected rather than crashing.
+  let hasVerifier = 1;
+}
+
+/**
+* AggregateResult
+*/
+// NOT Pure: it reads the handle's mutable accumulator (set by the
+// nl.aggregate_updates in the producing loop), so it must run exactly where it
+// sits - after that loop. The value sibling of nl.count_result.
+def AggregateResult : NLOp<"aggregate_result", []> {
+  let summary = "Materialize the single result row of a value-aggregate as a chunk";
+  let description = [{
+    The emit step of a SUM/MIN/MAX/AVG. It reads a filled nl.aggregate_state and
+    materializes the reduced value directly as a single-row nullable value chunk.
+    Unlike count, an aggregate can be null (min/max/avg of no non-null row), so the
+    result is a nullable value chunk, not a plain chunk; sum is never null (0 for an
+    empty input) but rides the same nullable representation for uniformity.
+
+      %r = nl.aggregate_result sum (%s) : !nl.aggregate_state<i64> -> !nl.chunk<!storage.nullable<i64>>
+      nl.output(%r) : !nl.chunk<!storage.nullable<i64>>
+
+    Like nl.count_result it is not a source iterator: an aggregate collapses to one
+    row, so it produces the chunk in place at function scope after the producing
+    loop, and nl.output consumes it there - no emit loop.
+  }];
+
+  let arguments = (ins NLAggregateState:$state, AggregateKind:$kind);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = [{
+    $kind `(` $state `)` attr-dict `:` qualified(type($state)) `->` qualified(type($result))
+  }];
+
+  // The emit handler copies the accumulator into the result (or divides for avg),
+  // both read as the result's value type, so the result must be a nullable value
+  // chunk whose value type matches the reduction, and the kind must match the
+  // producing nl.aggregate - the verifier enforces both. The result sibling of
+  // AggregateUpdate's verifier.
+  let hasVerifier = 1;
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -72,6 +72,27 @@ def NLCountState : NLType<"CountState", "count_state"> {
     }];
 }
 
+def NLAggregateState : NLType<"AggregateState", "aggregate_state"> {
+    let summary = "A value-aggregate accumulator handle";
+    let description = [{
+        Stands for one SUM/MIN/MAX/AVG's running accumulator. Produced by
+        nl.aggregate, folded into by nl.aggregate_update once per producing-loop
+        step, and read by nl.aggregate_result to emit the single result row once the
+        loop is exhausted. The value-reducing sibling of !nl.count_state: where a
+        count holds only a tally, this holds the reduced value, so it is parameterized
+        by the accumulator's element type (the resolved property primitive - f64 for
+        an avg, the input type otherwise). Like a count it drives no early-exit; every
+        row must be seen before the accumulator is final, so no nl.for names it.
+    }];
+
+    // The accumulator's element type, baked during lowering. avg accumulates as
+    // f64; sum/min/max accumulate in the input's own type. It is spelled in the
+    // assembly of the ops naming the handle, since - unlike the parameterless
+    // state handles - there is no single concrete type to build.
+    let parameters = (ins "::mlir::Type":$elementType);
+    let assemblyFormat = "`<` $elementType `>`";
+}
+
 def NLChunk : NLType<"Chunk", "chunk"> {
     let summary = "A bounded batch of values";
     let description = "One column chunk filled by a single database iterator step";

--- a/query/ir/dialect/storage/CMakeLists.txt
+++ b/query/ir/dialect/storage/CMakeLists.txt
@@ -7,6 +7,10 @@ set(LLVM_TARGET_DEFINITIONS StorageTypes.td)
 mlir_tablegen(StorageTypes.h.inc     -gen-typedef-decls -dialect storage  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
 mlir_tablegen(StorageTypes.cpp.inc   -gen-typedef-defs  -dialect storage  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
 
+set(LLVM_TARGET_DEFINITIONS StorageEnums.td)
+mlir_tablegen(StorageEnums.h.inc     -gen-enum-decls    EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+mlir_tablegen(StorageEnums.cpp.inc   -gen-enum-defs     EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+
 add_public_tablegen_target(StorageDialectIncGen)
 
 set_source_files_properties(

--- a/query/ir/dialect/storage/StorageEnums.h
+++ b/query/ir/dialect/storage/StorageEnums.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpImplementation.h"
+
+#include "StorageEnums.h.inc"

--- a/query/ir/dialect/storage/StorageEnums.td
+++ b/query/ir/dialect/storage/StorageEnums.td
@@ -1,0 +1,24 @@
+#ifndef STORAGE_ENUMS
+#define STORAGE_ENUMS
+
+include "mlir/IR/EnumAttr.td"
+
+// The reduction an aggregate applies to a column of property values. It is used
+// by the nl dialect (the three nl.aggregate ops carry it) and set by the lowering
+// from each db aggregate op (db.sum / db.min / db.max / db.avg), so it lives in
+// the storage dialect the way the value/nullable types do, rather than being
+// defined in a single dialect.
+//
+// COUNT is deliberately not a case here: it tallies rows regardless of value and
+// has its own op family (db.count, nl.count*). These four all reduce the values
+// themselves and share the create/update/result shape, so one enum drives them.
+def AggregateKind : I64EnumAttr<"AggregateKind", "A property-value aggregate", [
+    I64EnumAttrCase<"Sum", 0, "sum">,
+    I64EnumAttrCase<"Min", 1, "min">,
+    I64EnumAttrCase<"Max", 2, "max">,
+    I64EnumAttrCase<"Avg", 3, "avg">,
+]> {
+    let cppNamespace = "::mlir::storage";
+}
+
+#endif // STORAGE_ENUMS

--- a/query/ir/dialect/storage/StorageTypes.cpp
+++ b/query/ir/dialect/storage/StorageTypes.cpp
@@ -8,6 +8,8 @@
 
 using namespace mlir::storage;
 
+#include "StorageEnums.cpp.inc"
+
 #define GET_TYPEDEF_CLASSES
 #include "StorageTypes.cpp.inc"
 

--- a/query/ir/dialect/storage/StorageTypes.h
+++ b/query/ir/dialect/storage/StorageTypes.h
@@ -2,5 +2,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 
+#include "StorageEnums.h"
+
 #define GET_TYPEDEF_CLASSES
 #include "StorageTypes.h.inc"

--- a/query/ir/dialect/storage/StorageTypes.td
+++ b/query/ir/dialect/storage/StorageTypes.td
@@ -4,6 +4,7 @@
 include "mlir/IR/AttrTypeBase.td"
 
 include "StorageDialect.td"
+include "StorageEnums.td"
 
 class StorageType<string name, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<Storage, name, traits> {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -234,6 +234,219 @@ size_t countPresentColumn(const Column* column) {
     });
 }
 
+// Reset a sum/avg accumulator to a present zero (its identity): a running sum
+// starts at zero and stays present regardless of nulls, so an empty input sums
+// to zero, matching Cypher.
+template <typename Primitive>
+void aggregateResetZero(NLAggregateState* state) {
+    auto* accumulator = static_cast<ColumnOptVector<Primitive>*>(state->getAccumulator());
+    accumulator->getRaw().assign(1, std::optional<Primitive>(Primitive {}));
+    state->setCount(0);
+}
+
+// Reset a min/max accumulator to null: with no non-null row seen yet there is no
+// extreme, and an all-null (or empty) input reduces to null, matching Cypher.
+template <typename Primitive>
+void aggregateResetNull(NLAggregateState* state) {
+    auto* accumulator = static_cast<ColumnOptVector<Primitive>*>(state->getAccumulator());
+    accumulator->getRaw().assign(1, std::nullopt);
+    state->setCount(0);
+}
+
+// Add two aggregate values with defined overflow. A signed integer sum wraps in
+// two's complement (matching Cypher's Java-long integer sum) rather than invoking
+// C++ signed-overflow undefined behavior; unsigned integers already wrap by the
+// language, and doubles use the built-in +.
+template <typename Primitive>
+Primitive numericAdd(Primitive accumulator, Primitive value) {
+    if constexpr (std::is_integral_v<Primitive> && std::is_signed_v<Primitive>) {
+        using Unsigned = std::make_unsigned_t<Primitive>;
+        return static_cast<Primitive>(static_cast<Unsigned>(accumulator) + static_cast<Unsigned>(value));
+    } else {
+        return accumulator + value;
+    }
+}
+
+// Fold a chunk's present values into a sum accumulator (same primitive as the
+// input). The accumulator is always present, so read-modify-write its one row.
+template <typename Primitive>
+void aggregateUpdateSum(NLAggregateState* state, const Column* input) {
+    auto* accumulator = static_cast<ColumnOptVector<Primitive>*>(state->getAccumulator());
+    std::optional<Primitive>& current = accumulator->getRaw().front();
+    const auto& inputRaw = static_cast<const ColumnOptVector<Primitive>*>(input)->getRaw();
+
+    Primitive running = current.value();
+    for (const std::optional<Primitive>& value : inputRaw) {
+        if (value.has_value()) {
+            running = numericAdd(running, *value);
+        }
+    }
+
+    current = running;
+}
+
+// Fold a chunk's present values into a min (IsMax false) or max (IsMax true)
+// accumulator. The first present value seeds the accumulator; later values
+// replace it when more extreme. Nulls are skipped, so an all-null input leaves
+// the accumulator null.
+template <typename Primitive, bool IsMax>
+void aggregateUpdateMinMax(NLAggregateState* state, const Column* input) {
+    auto* accumulator = static_cast<ColumnOptVector<Primitive>*>(state->getAccumulator());
+    std::optional<Primitive>& current = accumulator->getRaw().front();
+    const auto& inputRaw = static_cast<const ColumnOptVector<Primitive>*>(input)->getRaw();
+
+    for (const std::optional<Primitive>& value : inputRaw) {
+        if (!value.has_value()) {
+            continue;
+        }
+
+        if (!current.has_value()) {
+            current = *value;
+        } else if constexpr (IsMax) {
+            if (*current < *value) {
+                current = *value;
+            }
+        } else {
+            if (*value < *current) {
+                current = *value;
+            }
+        }
+    }
+}
+
+// Fold a chunk's present values into an avg accumulator: a running f64 sum plus a
+// count of the non-null rows (the input primitive is widened to f64). avg divides
+// the two at the emit step, so both are accumulated here.
+template <typename Primitive>
+void aggregateUpdateAvg(NLAggregateState* state, const Column* input) {
+    auto* accumulator = static_cast<ColumnOptVector<double>*>(state->getAccumulator());
+    std::optional<double>& current = accumulator->getRaw().front();
+    const auto& inputRaw = static_cast<const ColumnOptVector<Primitive>*>(input)->getRaw();
+
+    double running = current.value();
+    size_t seen = 0;
+    for (const std::optional<Primitive>& value : inputRaw) {
+        if (value.has_value()) {
+            running += static_cast<double>(*value);
+            seen++;
+        }
+    }
+
+    current = running;
+    state->addCount(seen);
+}
+
+// Emit a sum/min/max result: the accumulator already holds the reduced value in
+// the result's own type, so copy its single row into the output (a present sum,
+// or the extreme / null for min/max).
+template <typename Primitive>
+void aggregateResultCopy(const NLAggregateState* state, Column* output) {
+    const auto* accumulator = static_cast<const ColumnOptVector<Primitive>*>(state->getAccumulator());
+    auto* typedOutput = static_cast<ColumnOptVector<Primitive>*>(output);
+    typedOutput->getRaw().assign(1, accumulator->getRaw().front());
+}
+
+// Emit an avg result: divide the running f64 sum by the non-null count. With no
+// non-null row the average is null (division is undefined), matching Cypher.
+void aggregateResultAvg(const NLAggregateState* state, Column* output) {
+    const auto* accumulator = static_cast<const ColumnOptVector<double>*>(state->getAccumulator());
+    auto* typedOutput = static_cast<ColumnOptVector<double>*>(output);
+    std::vector<std::optional<double>>& outputRaw = typedOutput->getRaw();
+    const size_t count = state->getCount();
+
+    if (count == 0) {
+        outputRaw.assign(1, std::nullopt);
+    } else {
+        const double average = accumulator->getRaw().front().value() / static_cast<double>(count);
+        outputRaw.assign(1, std::optional<double>(average));
+    }
+}
+
+// The fold handler for a sum over a column of this value type. sum adds the
+// values, so only a numeric column is valid - a string or bool sum is rejected
+// (which also keeps aggregateUpdateSum from being instantiated for a type whose
+// operator+= would not compile).
+NLAggregateUpdateFunction selectSumUpdate(ValueType inputType) {
+    switch (inputType) {
+        case ValueType::Int64:
+            return &aggregateUpdateSum<types::Int64::Primitive>;
+        break;
+
+        case ValueType::UInt64:
+            return &aggregateUpdateSum<types::UInt64::Primitive>;
+        break;
+
+        case ValueType::Double:
+            return &aggregateUpdateSum<types::Double::Primitive>;
+        break;
+
+        default:
+            throw IRException("sum requires a numeric column");
+        break;
+    }
+
+    return nullptr;
+}
+
+// The fold handler for an avg over a column of this value type. avg widens each
+// value to f64, so - like sum - only a numeric column is valid.
+NLAggregateUpdateFunction selectAvgUpdate(ValueType inputType) {
+    switch (inputType) {
+        case ValueType::Int64:
+            return &aggregateUpdateAvg<types::Int64::Primitive>;
+        break;
+
+        case ValueType::UInt64:
+            return &aggregateUpdateAvg<types::UInt64::Primitive>;
+        break;
+
+        case ValueType::Double:
+            return &aggregateUpdateAvg<types::Double::Primitive>;
+        break;
+
+        default:
+            throw IRException("avg requires a numeric column");
+        break;
+    }
+
+    return nullptr;
+}
+
+// The fold handler for a min (IsMax false) or max (IsMax true) over a column of
+// this value type. min/max order the values, so any orderable type is valid -
+// numbers, bools and strings - but an embedding has no order (its < would not
+// compile), so it is rejected.
+template <bool IsMax>
+NLAggregateUpdateFunction selectMinMaxUpdate(ValueType inputType) {
+    switch (inputType) {
+        case ValueType::Int64:
+            return &aggregateUpdateMinMax<types::Int64::Primitive, IsMax>;
+        break;
+
+        case ValueType::UInt64:
+            return &aggregateUpdateMinMax<types::UInt64::Primitive, IsMax>;
+        break;
+
+        case ValueType::Double:
+            return &aggregateUpdateMinMax<types::Double::Primitive, IsMax>;
+        break;
+
+        case ValueType::Bool:
+            return &aggregateUpdateMinMax<types::Bool::Primitive, IsMax>;
+        break;
+
+        case ValueType::String:
+            return &aggregateUpdateMinMax<types::String::Primitive, IsMax>;
+        break;
+
+        default:
+            throw IRException("min/max requires an orderable column");
+        break;
+    }
+
+    return nullptr;
+}
+
 // Execute a get_out_edges/get_in_edges loop
 template <typename ChunkWriterType>
 void runEdgeLoopSteps(NLExecutionContext* context,
@@ -601,6 +814,29 @@ void NLExecutor::runCountResult(NLExecutionContext* context, NLFunctionData* dat
     raw.assign(1, static_cast<uint64_t>(count));
 }
 
+void NLExecutor::runAggregateReset(NLExecutionContext* context, NLFunctionData* data) {
+    const NLAggregateResetData* reset = static_cast<NLAggregateResetData*>(data);
+    reset->getReset()(reset->getState());
+}
+
+void NLExecutor::runAggregateUpdate(NLExecutionContext* context, NLFunctionData* data) {
+    const NLAggregateUpdateData* update = static_cast<NLAggregateUpdateData*>(data);
+
+    // Fold this step's non-null values into the accumulator the way its kind and
+    // value type demand (add for sum/avg, keep the extreme for min/max).
+    update->getUpdate()(update->getState(), update->getInput());
+}
+
+void NLExecutor::runAggregateResult(NLExecutionContext* context, NLFunctionData* data) {
+    const NLAggregateResultData* result = static_cast<NLAggregateResultData*>(data);
+
+    // The aggregate collapses every folded row to a single result row: write the
+    // reduced value into the output chunk's one nullable row. Runs after the
+    // producing loop, so the accumulator holds the whole dataflow's reduction;
+    // nl.output emits this chunk at function scope.
+    result->getResult()(result->getState(), result->getOutput());
+}
+
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
@@ -833,6 +1069,64 @@ NLCountFunction NLExecutor::selectOptCountFunction(ValueType valueType) {
     ValueTypeDispatcher(valueType).execute(select);
 
     return count;
+}
+
+NLAggregateResetFunction NLExecutor::selectAggregateReset(AggregateKind kind, ValueType accumulatorType) {
+    // sum/avg reset to a present zero (their identity); min/max reset to null. Both
+    // resets compile for any value type and lowering has already validated the
+    // kind / type pairing (and the update selector re-checks it), so a single
+    // dispatch over the accumulator type suffices here.
+    const bool resetsToZero = (kind == AggregateKind::Sum || kind == AggregateKind::Avg);
+
+    NLAggregateResetFunction reset = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        reset = resetsToZero ? &aggregateResetZero<typename T::Primitive>
+                             : &aggregateResetNull<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(accumulatorType).execute(select);
+
+    return reset;
+}
+
+NLAggregateUpdateFunction NLExecutor::selectAggregateUpdate(AggregateKind kind, ValueType inputType) {
+    switch (kind) {
+        case AggregateKind::Sum:
+            return selectSumUpdate(inputType);
+        break;
+
+        case AggregateKind::Avg:
+            return selectAvgUpdate(inputType);
+        break;
+
+        case AggregateKind::Min:
+            return selectMinMaxUpdate</*IsMax=*/false>(inputType);
+        break;
+
+        case AggregateKind::Max:
+            return selectMinMaxUpdate</*IsMax=*/true>(inputType);
+        break;
+    }
+
+    bioassert(false, "Unhandled aggregate kind");
+    return nullptr;
+}
+
+NLAggregateResultFunction NLExecutor::selectAggregateResult(AggregateKind kind, ValueType resultType) {
+    if (kind == AggregateKind::Avg) {
+        // avg always emits an f64 (the running sum divided by the count), whatever
+        // the input type was.
+        return &aggregateResultAvg;
+    }
+
+    // sum/min/max hold the reduced value in the result's own type, so the emit is a
+    // copy of the accumulator's single row - valid for any value type.
+    NLAggregateResultFunction result = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        result = &aggregateResultCopy<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(resultType).execute(select);
+
+    return result;
 }
 
 NLCompareFunction NLExecutor::selectCompareFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -104,6 +104,18 @@ public:
     // the chunk at function scope.
     static void runCountResult(NLExecutionContext* context, NLFunctionData* data);
 
+    // Re-initialize an aggregate accumulator; runs each time its block runs.
+    static void runAggregateReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Fold this step's chunk's non-null values into the accumulator. The sole
+    // accumulator mutator.
+    static void runAggregateUpdate(NLExecutionContext* context, NLFunctionData* data);
+
+    // The emit step of an aggregate: materialize the reduced value as the output
+    // chunk's single nullable value row. Runs once, after the producing loop;
+    // nl.output emits the chunk at function scope.
+    static void runAggregateResult(NLExecutionContext* context, NLFunctionData* data);
+
     static void runOutput(NLExecutionContext* context, NLFunctionData* data);
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
@@ -151,6 +163,14 @@ public:
     // counts only its present values. Used by nl.count_update.
     static size_t countAllRows(const Column* column);
     static NLCountFunction selectOptCountFunction(ValueType valueType);
+
+    // The reset / fold / emit handlers for one aggregate, selected from the
+    // reduction and a value type (the accumulator's for reset/result, the input's
+    // for update). Throw for a value type the reduction cannot handle: sum/avg need
+    // a numeric type, min/max an orderable one. Used by the nl.aggregate ops.
+    static NLAggregateResetFunction selectAggregateReset(AggregateKind kind, ValueType accumulatorType);
+    static NLAggregateUpdateFunction selectAggregateUpdate(AggregateKind kind, ValueType inputType);
+    static NLAggregateResultFunction selectAggregateResult(AggregateKind kind, ValueType resultType);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -863,6 +863,116 @@ private:
     Column* _output {nullptr};
 };
 
+// The reduction one nl.aggregate applies. The runtime counterpart of the MLIR
+// storage::AggregateKind: the translator maps the op's kind onto this, and it -
+// with the column value type - selects the reset/update/result handlers below.
+enum class AggregateKind {
+    Sum,
+    Min,
+    Max,
+    Avg,
+};
+
+// Runtime state of one SUM/MIN/MAX/AVG: the running accumulator. The value
+// sibling of NLCountState - where a count holds a tally, this holds the reduced
+// value in a single-row nullable value column (owned elsewhere; a borrowed
+// pointer here), plus a count of the non-null rows folded in (only avg divides by
+// it). nl.aggregate resets it, nl.aggregate_update is the sole folder, and
+// nl.aggregate_result reads it to emit the single result row. The accumulator's
+// element type is fixed by the handlers, so the state itself is type-erased.
+class NLAggregateState {
+public:
+    // The single-row accumulator column (a ColumnOptVector of the accumulator's
+    // primitive), reset by the reset handler and folded into by the update handler.
+    Column* getAccumulator() const { return _accumulator; }
+    void setAccumulator(Column* accumulator) { _accumulator = accumulator; }
+
+    // The number of non-null rows folded in so far, used only by avg.
+    size_t getCount() const { return _count; }
+    void setCount(size_t count) { _count = count; }
+    void addCount(size_t count) { _count += count; }
+
+private:
+    Column* _accumulator {nullptr};
+    size_t _count {0};
+};
+
+// Handlers of one aggregate, selected during translation from the reduction and
+// the column value type (as the count / gather / append families are), so the
+// per-type fan-out lives in one place. Reset re-initializes the accumulator (a
+// present zero for sum/avg, null for min/max) and zeroes the count; update folds
+// a chunk's non-null values into the accumulator; result writes the single
+// reduced row into the output column.
+using NLAggregateResetFunction = void (*)(NLAggregateState* state);
+using NLAggregateUpdateFunction = void (*)(NLAggregateState* state, const Column* input);
+using NLAggregateResultFunction = void (*)(const NLAggregateState* state, Column* output);
+
+// nl.aggregate data: re-initializes an accumulator each time the block it lives in
+// runs - once at function scope for a top-level aggregate. The value sibling of
+// NLCountResetData; the reset handler knows the accumulator's type and kind.
+class NLAggregateResetData : public NLFunctionData {
+public:
+    NLAggregateResetData(NLAggregateState* state, NLAggregateResetFunction reset)
+        : _state(state),
+        _reset(reset)
+    {
+    }
+
+    NLAggregateState* getState() const { return _state; }
+    NLAggregateResetFunction getReset() const { return _reset; }
+
+private:
+    NLAggregateState* _state {nullptr};
+    NLAggregateResetFunction _reset {nullptr};
+};
+
+// nl.aggregate_update data: the accumulator to fold into, the input chunk to
+// reduce, and the fold handler that reduces it (selected from the kind and the
+// input value type). Runs once per producing-loop step. The value sibling of
+// NLCountUpdateData.
+class NLAggregateUpdateData : public NLFunctionData {
+public:
+    NLAggregateUpdateData(NLAggregateState* state, const Column* input, NLAggregateUpdateFunction update)
+        : _state(state),
+        _input(input),
+        _update(update)
+    {
+    }
+
+    NLAggregateState* getState() const { return _state; }
+    const Column* getInput() const { return _input; }
+    NLAggregateUpdateFunction getUpdate() const { return _update; }
+
+private:
+    NLAggregateState* _state {nullptr};
+    const Column* _input {nullptr};
+    NLAggregateUpdateFunction _update {nullptr};
+};
+
+// nl.aggregate_result data: the emit step of an aggregate. Holds the accumulator,
+// the output column to fill with the single result row (a nullable value column),
+// and the emit handler (a copy for sum/min/max, a divide-by-count for avg). Runs
+// once, after the producing loop, so the accumulator is final. The value sibling
+// of NLCountResultData.
+class NLAggregateResultData : public NLFunctionData {
+public:
+    NLAggregateResultData(NLAggregateState* state, Column* output, NLAggregateResultFunction result)
+        : _state(state),
+        _output(output),
+        _result(result)
+    {
+    }
+
+    NLAggregateState* getState() const { return _state; }
+    Column* getOutput() const { return _output; }
+    NLAggregateResultFunction getResult() const { return _result; }
+
+private:
+    NLAggregateState* _state {nullptr};
+    Column* _output {nullptr};
+    NLAggregateResultFunction _result {nullptr};
+};
+
 // nl.output data
 class NLOutputData : public NLFunctionData {
 public:
@@ -957,6 +1067,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one aggregate's runtime accumulator, owned by the program; the
+    // reset, update and emit statements that share it hold a borrowed pointer. The
+    // value sibling of allocCountState.
+    NLAggregateState* allocAggregateState() {
+        auto state = std::make_unique<NLAggregateState>();
+        NLAggregateState* statePtr = state.get();
+        _aggregateStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -971,6 +1091,7 @@ private:
     std::vector<std::unique_ptr<NLSortState>> _sortStates;
     std::vector<std::unique_ptr<NLDistinctState>> _distinctStates;
     std::vector<std::unique_ptr<NLCountState>> _countStates;
+    std::vector<std::unique_ptr<NLAggregateState>> _aggregateStates;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -816,7 +816,7 @@ void NLTranslator::translateAggregateState(nl::Aggregate aggregate, NLStmtContai
     // nullable value column the reduction folds into.
     const auto stateType = mlir::cast<nl::AggregateStateType>(aggregate.getState().getType());
     const ValueType accumulatorType = valueTypeFromElementType(stateType.getElementType());
-    Column* accumulator = allocOptColumnForValueType(accumulatorType);
+    Column* accumulator = allocSingleRowOptColumnForValueType(accumulatorType);
     state->setAccumulator(accumulator);
 
     // The reset re-initializes the accumulator each time the block holding this
@@ -1071,15 +1071,26 @@ Column* NLTranslator::allocColumnForKind(NLChunkKind kind) {
 // allocation-free. The value type was baked into the chunk during lowering and
 // re-resolved from the schema here.
 Column* NLTranslator::allocOptColumnForValueType(ValueType valueType) {
-    const size_t chunkSize = _program->getChunkSize();
+    // Per-step loop columns reserve a full chunk so execution stays
+    // allocation-free.
+    return allocOptColumn(valueType, _program->getChunkSize());
+}
 
-    // Allocate a ColumnOptVector for the value type's primitive, reserving a
-    // full chunk so execution stays allocation-free; ValueTypeDispatcher maps
-    // the runtime value type to that compile-time primitive.
+Column* NLTranslator::allocSingleRowOptColumnForValueType(ValueType valueType) {
+    // The aggregate accumulator only ever holds one row (reset assign(1, ...),
+    // update rewrites .front()), so reserve a single element rather than a chunk
+    // it would never fill.
+    return allocOptColumn(valueType, 1);
+}
+
+Column* NLTranslator::allocOptColumn(ValueType valueType, size_t reserveSize) {
+    // Allocate a ColumnOptVector for the value type's primitive, reserving
+    // reserveSize optionals up front; ValueTypeDispatcher maps the runtime value
+    // type to that compile-time primitive.
     Column* column = nullptr;
     const auto allocate = [&]<SupportedType T>() {
         ColumnOptVector<typename T::Primitive>* typed = _memory->alloc<ColumnOptVector<typename T::Primitive>>();
-        typed->reserve(chunkSize);
+        typed->reserve(reserveSize);
         column = typed;
     };
     ValueTypeDispatcher(valueType).execute(allocate);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -72,6 +72,44 @@ ValueType valueTypeFromElementType(mlir::Type elementType) {
     throw IRException("Unsupported nullable value chunk element type");
 }
 
+// The runtime reduction the interpreter dispatches on, from the MLIR one the op
+// carries. The two enums are kept separate so the runtime (NLProgram / NLExecutor)
+// stays free of the MLIR dialect headers; this is the one place they meet.
+AggregateKind toRuntimeAggregateKind(storage::AggregateKind kind) {
+    switch (kind) {
+        case storage::AggregateKind::Sum:
+            return AggregateKind::Sum;
+        break;
+
+        case storage::AggregateKind::Min:
+            return AggregateKind::Min;
+        break;
+
+        case storage::AggregateKind::Max:
+            return AggregateKind::Max;
+        break;
+
+        case storage::AggregateKind::Avg:
+            return AggregateKind::Avg;
+        break;
+    }
+
+    throw IRException("Unhandled aggregate kind");
+}
+
+// The value type wrapped by a nullable value chunk (!nl.chunk<!storage.nullable<T>>).
+// An aggregate reduces property values, so its input and result are always such
+// chunks; a chunk that is not a nullable value chunk (an ID chunk) is rejected.
+ValueType nullableChunkValueType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const auto nullableType = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
+    if (!nullableType) {
+        throw IRException("aggregate requires a nullable value chunk");
+    }
+
+    return valueTypeFromElementType(nullableType.getValueType());
+}
+
 }
 
 NLTranslator::NLTranslator(NLProgram* program, LocalMemory* memory, const GraphView* view)
@@ -158,6 +196,12 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateCountUpdate(countUpdate, body);
         } else if (nl::CountResult countResult = mlir::dyn_cast<nl::CountResult>(operation)) {
             translateCountResult(countResult, body);
+        } else if (nl::Aggregate aggregate = mlir::dyn_cast<nl::Aggregate>(operation)) {
+            translateAggregateState(aggregate, body);
+        } else if (nl::AggregateUpdate aggregateUpdate = mlir::dyn_cast<nl::AggregateUpdate>(operation)) {
+            translateAggregateUpdate(aggregateUpdate, body);
+        } else if (nl::AggregateResult aggregateResult = mlir::dyn_cast<nl::AggregateResult>(operation)) {
+            translateAggregateResult(aggregateResult, body);
         } else if (nl::Output output = mlir::dyn_cast<nl::Output>(operation)) {
             translateOutput(output, body);
         } else if (mlir::isa<nl::Yield, mlir::func::ReturnOp>(operation)) {
@@ -756,6 +800,77 @@ NLCountState* NLTranslator::countStateFor(mlir::Value handle) const {
     const auto stateIt = _countStates.find(handle);
     if (stateIt == _countStates.end()) {
         throw IRException("count handle must be produced by an nl.count");
+    }
+
+    return stateIt->second;
+}
+
+void NLTranslator::translateAggregateState(nl::Aggregate aggregate, NLStmtContainer* body) {
+    // Allocate the runtime accumulator and map the handle to it, so the update and
+    // the emit that name the handle share the same accumulator.
+    NLAggregateState* state = _program->allocAggregateState();
+    _aggregateStates[aggregate.getState()] = state;
+
+    // The state handle's element type is the accumulator's value type (f64 for an
+    // avg, the input type otherwise), baked during lowering. Allocate the single-row
+    // nullable value column the reduction folds into.
+    const auto stateType = mlir::cast<nl::AggregateStateType>(aggregate.getState().getType());
+    const ValueType accumulatorType = valueTypeFromElementType(stateType.getElementType());
+    Column* accumulator = allocOptColumnForValueType(accumulatorType);
+    state->setAccumulator(accumulator);
+
+    // The reset re-initializes the accumulator each time the block holding this
+    // nl.aggregate runs (once at function scope for a top-level aggregate): a present
+    // zero for sum/avg, null for min/max.
+    const AggregateKind kind = toRuntimeAggregateKind(aggregate.getKind());
+    const NLAggregateResetFunction reset = NLExecutor::selectAggregateReset(kind, accumulatorType);
+
+    NLAggregateResetData* resetData = _program->allocFunctionData<NLAggregateResetData>(state, reset);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runAggregateReset, resetData});
+}
+
+void NLTranslator::translateAggregateUpdate(nl::AggregateUpdate update, NLStmtContainer* body) {
+    // The handle is a required operand, so aggregateStateFor returns its accumulator
+    // or throws if it was not produced by an nl.aggregate.
+    NLAggregateState* state = aggregateStateFor(update.getState());
+
+    // Fold the chunk's non-null values the way its kind and value type demand. The
+    // input value type may differ from the accumulator's (an avg of i64 folds into
+    // an f64 accumulator), so the handler is selected from the input type here.
+    const mlir::Value rows = update.getRows();
+    const Column* input = getColumn(rows);
+    const AggregateKind kind = toRuntimeAggregateKind(update.getKind());
+    const ValueType inputType = nullableChunkValueType(rows.getType());
+    const NLAggregateUpdateFunction fold = NLExecutor::selectAggregateUpdate(kind, inputType);
+
+    NLAggregateUpdateData* data = _program->allocFunctionData<NLAggregateUpdateData>(state, input, fold);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runAggregateUpdate, data});
+}
+
+void NLTranslator::translateAggregateResult(nl::AggregateResult result, NLStmtContainer* body) {
+    // The handle is a required operand, so aggregateStateFor returns its accumulator
+    // or throws if it was not produced by an nl.aggregate.
+    NLAggregateState* state = aggregateStateFor(result.getState());
+
+    // The result is a single-row nullable value chunk runAggregateResult fills with
+    // the reduced value. Allocate its ColumnOptVector on the result value type and
+    // map the op result to it.
+    const mlir::Value resultChunk = result.getResult();
+    const ValueType resultType = nullableChunkValueType(resultChunk.getType());
+    Column* output = allocOptColumnForValueType(resultType);
+    _valueSlots[resultChunk] = output;
+
+    const AggregateKind kind = toRuntimeAggregateKind(result.getKind());
+    const NLAggregateResultFunction emit = NLExecutor::selectAggregateResult(kind, resultType);
+
+    NLAggregateResultData* data = _program->allocFunctionData<NLAggregateResultData>(state, output, emit);
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runAggregateResult, data});
+}
+
+NLAggregateState* NLTranslator::aggregateStateFor(mlir::Value handle) const {
+    const auto stateIt = _aggregateStates.find(handle);
+    if (stateIt == _aggregateStates.end()) {
+        throw IRException("aggregate handle must be produced by an nl.aggregate");
     }
 
     return stateIt->second;

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -250,7 +250,15 @@ private:
 
     Column* allocColumn(mlir::Value chunkValue);
     Column* allocColumnForKind(NLChunkKind kind);
+
+    // Allocate a nullable value column for the value type's primitive. The
+    // per-step variant reserves a full chunk so the loop body stays
+    // allocation-free; the single-row variant reserves one element for an
+    // accumulator that never grows past its one row.
     Column* allocOptColumnForValueType(ValueType valueType);
+    Column* allocSingleRowOptColumnForValueType(ValueType valueType);
+    Column* allocOptColumn(ValueType valueType, size_t reserveSize);
+
     Column* getColumn(mlir::Value chunkValue) const;
     static NLChunkKind getChunkKind(mlir::Type chunkType);
     static NLChunkKind chunkKindFromElementType(mlir::Type elementType);

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -68,6 +68,11 @@ private:
     // nl.count_update and nl.count_result that name the handle find the same counter
     llvm::DenseMap<mlir::Value, NLCountState*> _countStates;
 
+    // nl.aggregate handle SSA value -> the runtime accumulator it produces, so the
+    // nl.aggregate_update and nl.aggregate_result that name the handle find the same
+    // accumulator
+    llvm::DenseMap<mlir::Value, NLAggregateState*> _aggregateStates;
+
     void translateBlock(mlir::Block& block, NLStmtContainer* body);
     void translateFor(mlir::nl::For forLoop, NLStmtContainer* body);
     void translateScanLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body);
@@ -171,6 +176,26 @@ private:
     // nl.count_update and nl.count_result, so this throws if it was not produced by
     // an nl.count.
     NLCountState* countStateFor(mlir::Value handle) const;
+
+    // Translate an nl.aggregate: allocate its runtime accumulator (a single-row
+    // nullable value column of the state handle's element type), map the handle to
+    // it, and record the reset statement (run each time the block runs)
+    void translateAggregateState(mlir::nl::Aggregate aggregate, NLStmtContainer* body);
+
+    // Translate an nl.aggregate_update: look up the accumulator the handle names and
+    // record the fold of the chunk's non-null values into it (selected from the
+    // reduction and the input value type)
+    void translateAggregateUpdate(mlir::nl::AggregateUpdate update, NLStmtContainer* body);
+
+    // Translate an nl.aggregate_result: look up the accumulator the handle names,
+    // allocate the single-row nullable value chunk it produces, map the op result to
+    // it, and record the emit statement (materialize the reduced value)
+    void translateAggregateResult(mlir::nl::AggregateResult result, NLStmtContainer* body);
+
+    // The runtime accumulator an aggregate handle names. The handle is a required
+    // operand of nl.aggregate_update and nl.aggregate_result, so this throws if it
+    // was not produced by an nl.aggregate.
+    NLAggregateState* aggregateStateFor(mlir::Value handle) const;
 
     // Pool-allocate a buffer/loop column matching a chunk type - an ID column for
     // an ID chunk, a nullable value column for a !nl.nullable<...> chunk - and the

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -74,28 +74,31 @@ mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
     const bool isString = mlir::isa<storage::StringType>(inputElement);
 
     switch (kind) {
-        case storage::AggregateKind::Sum:
+        case storage::AggregateKind::Sum: {
             if (!isNumeric) {
                 throw IRException("db.sum requires a numeric column");
             }
             return inputElement;
+        }
         break;
 
-        case storage::AggregateKind::Avg:
+        case storage::AggregateKind::Avg: {
             if (!isNumeric) {
                 throw IRException("db.avg requires a numeric column");
             }
             return builder.getF64Type();
+        }
         break;
 
         case storage::AggregateKind::Min:
-        case storage::AggregateKind::Max:
+        case storage::AggregateKind::Max: {
             // min/max order the values, so anything with a natural order is fine -
             // numbers, strings and bools - but an embedding has none.
             if (!isNumeric && !isString && !isBool) {
                 throw IRException("db.min/db.max requires an orderable column");
             }
             return inputElement;
+        }
         break;
     }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -58,6 +58,50 @@ mlir::Type valueTypeToElementType(mlir::OpBuilder& builder, ValueType valueType)
     throw IRException("Unhandled property value type");
 }
 
+// The accumulator (and result) element type of an aggregate over a column whose
+// nullable value chunk wraps inputElement. avg always reduces to an f64; sum,
+// min and max keep the input's own type. Throws for a value type the reduction
+// cannot handle: sum/avg need a numeric column, min/max an orderable one (so a
+// string sum, a bool sum or an embedding min is rejected, matching Cypher).
+mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
+                                      storage::AggregateKind kind,
+                                      mlir::Type inputElement) {
+    const bool isFloat = mlir::isa<mlir::Float64Type>(inputElement);
+    const auto integerType = mlir::dyn_cast<mlir::IntegerType>(inputElement);
+    const bool isBool = integerType && integerType.getWidth() == 1;
+    const bool isInteger = integerType && !isBool;
+    const bool isNumeric = isFloat || isInteger;
+    const bool isString = mlir::isa<storage::StringType>(inputElement);
+
+    switch (kind) {
+        case storage::AggregateKind::Sum:
+            if (!isNumeric) {
+                throw IRException("db.sum requires a numeric column");
+            }
+            return inputElement;
+        break;
+
+        case storage::AggregateKind::Avg:
+            if (!isNumeric) {
+                throw IRException("db.avg requires a numeric column");
+            }
+            return builder.getF64Type();
+        break;
+
+        case storage::AggregateKind::Min:
+        case storage::AggregateKind::Max:
+            // min/max order the values, so anything with a natural order is fine -
+            // numbers, strings and bools - but an embedding has none.
+            if (!isNumeric && !isString && !isBool) {
+                throw IRException("db.min/db.max requires an orderable column");
+            }
+            return inputElement;
+        break;
+    }
+
+    throw IRException("Unhandled aggregate kind");
+}
+
 // The single nl.output that solely consumes every result in the range, or a null
 // op if any result has more than one use, a non-nl.output user, or a different
 // output than its siblings. Read the direction as "one shared output user => the
@@ -217,6 +261,14 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerRemoveDuplicates(distinct);
     } else if (mlir::db::Count count = mlir::dyn_cast<mlir::db::Count>(operation)) {
         lowerCount(count);
+    } else if (mlir::db::Sum sum = mlir::dyn_cast<mlir::db::Sum>(operation)) {
+        lowerAggregate(sum.getInput(), sum.getResult(), storage::AggregateKind::Sum);
+    } else if (mlir::db::Min min = mlir::dyn_cast<mlir::db::Min>(operation)) {
+        lowerAggregate(min.getInput(), min.getResult(), storage::AggregateKind::Min);
+    } else if (mlir::db::Max max = mlir::dyn_cast<mlir::db::Max>(operation)) {
+        lowerAggregate(max.getInput(), max.getResult(), storage::AggregateKind::Max);
+    } else if (mlir::db::Avg avg = mlir::dyn_cast<mlir::db::Avg>(operation)) {
+        lowerAggregate(avg.getInput(), avg.getResult(), storage::AggregateKind::Avg);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -708,6 +760,58 @@ void DBLowering::lowerCount(mlir::db::Count count) {
     // into a function-scope nl.output reading it - the block that holds the chunk is
     // the entry block, so lowerOutput places nl.output there.
     _valueMap[count.getResult()] = result.getResult();
+}
+
+void DBLowering::lowerAggregate(mlir::Value input, mlir::Value result, storage::AggregateKind kind) {
+    // The nl chunk the aggregated column lowered to; the update folds its per-step
+    // non-null values into the accumulator.
+    const mlir::Value inputChunk = mapValue(input);
+
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // The input must be a property value column - a nullable value chunk - since
+    // these reduce the values themselves (unlike count(*), which tallies IDs). An
+    // ID chunk has no value to reduce, so reject it here.
+    const nl::ChunkType inputChunkType = mlir::cast<nl::ChunkType>(inputChunk.getType());
+    const auto inputNullable = mlir::dyn_cast<storage::NullableType>(inputChunkType.getElementType());
+    if (!inputNullable) {
+        throw IRException("db aggregate requires a property value column");
+    }
+
+    // The accumulator (and result) element type: avg widens to f64, the rest keep
+    // the input type. This also validates the reduction against the value type.
+    const mlir::Type resultElement = aggregateResultElementType(_builder, kind, inputNullable.getValueType());
+
+    // The accumulator is hoisted to the top of the entry block, above every loop,
+    // so it is reset once at function scope and dominates the update in the
+    // producing loop body and the emit that reads it after the loop. The count
+    // sibling; a correlated aggregate (reset per enclosing step) would hoist into
+    // its enclosing loop body instead - future work, as for the streaming limit.
+    _builder.setInsertionPointToStart(_entryBlock);
+    const nl::AggregateStateType stateType = nl::AggregateStateType::get(context, resultElement);
+    const mlir::Value state = _builder.create<nl::Aggregate>(loc, stateType, kind).getState();
+
+    // The update sits in the innermost producing loop body, where the aggregated
+    // column is bound (the same block db.output would emit from), and folds each
+    // step's non-null values into the accumulator.
+    setInsertionInto(ownerBlock(inputChunk));
+    _builder.create<nl::AggregateUpdate>(loc, state, inputChunk, kind);
+
+    // Like db.count, an aggregate is a pipeline breaker that collapses to one row,
+    // so it opens no emit loop: nl.aggregate_result materializes the reduced value
+    // in place at function scope (after the producing loop, before the func.return).
+    // The result is a single-row nullable value chunk - an aggregate can be null
+    // (min/max/avg of no non-null row), and sum rides the same representation.
+    const storage::NullableType resultNullable = storage::NullableType::get(context, resultElement);
+    const nl::ChunkType resultChunkType = nl::ChunkType::get(context, resultNullable);
+
+    setInsertionInto(_entryBlock);
+    nl::AggregateResult aggregateResult = _builder.create<nl::AggregateResult>(loc, resultChunkType, state, kind);
+
+    // The db aggregate's result maps to that chunk, so the db.output that follows
+    // lowers into a function-scope nl.output reading it, exactly as db.count does.
+    _valueMap[result] = aggregateResult.getResult();
 }
 
 void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -65,6 +65,17 @@ class GraphView;
 //                                          db.sort (the count is final only once
 //                                          every row is seen), but it collapses to
 //                                          one row, so it opens no emit loop
+//   db.sum / db.min / db.max / db.avg  ->  the value-reducing siblings of db.count: a
+//                                          hoisted nl.aggregate accumulator, an
+//                                          nl.aggregate_update in the producing loop
+//                                          body that folds each chunk's non-null
+//                                          values, and - after the loop - an
+//                                          nl.aggregate_result that materializes the
+//                                          single reduced row (a nullable value chunk)
+//                                          which a function-scope nl.output emits.
+//                                          Same pipeline-breaker, one-row shape as
+//                                          db.count; one db op per reduction, each
+//                                          carrying its nl.aggregate kind
 //
 // db.get_node_properties / db.get_edge_properties resolve their property name
 // against the graph schema here (hence the GraphView): the name is hoisted into
@@ -181,6 +192,19 @@ private:
     // follows lowers into a function-scope nl.output reading it. A pipeline breaker
     // like db.sort, but it collapses to one row, so it opens no emit loop.
     void lowerCount(mlir::db::Count count);
+
+    // Lower a db.sum / db.min / db.max / db.avg: the value-reducing siblings of
+    // lowerCount. The db op names the reduction (`kind`); the input and result SSA
+    // values are the column being reduced and the single-row result. Hoist an
+    // nl.aggregate accumulator to the top of the entry block, place an
+    // nl.aggregate_update in the innermost producing loop body to fold each chunk's
+    // non-null values, then - after the loop - an nl.aggregate_result that
+    // materializes the single reduced row as a nullable value chunk at function
+    // scope. The db result maps to that chunk. The accumulator element type (and thus
+    // the result value type) follows Cypher: avg widens to f64, sum/min/max keep the
+    // input's value type; sum/avg require a numeric column and min/max an orderable
+    // one, so a string sum or an embedding min is rejected here.
+    void lowerAggregate(mlir::Value input, mlir::Value result, mlir::storage::AggregateKind kind);
 
     void lowerOutput(mlir::db::Output output);
 

--- a/samples/mlir/aggregate.mlir
+++ b/samples/mlir/aggregate.mlir
@@ -1,0 +1,29 @@
+module {
+  func.func @main() {
+    // MATCH (a) RETURN sum(a.score): scan every node, read its "score", and reduce
+    // the non-null values to a single row. Each reduction is its own op - db.sum,
+    // db.min, db.max, db.avg - the way count(*) is db.count.
+    //
+    // Like db.count, they are pipeline breakers: each lowers to a hoisted
+    // nl.aggregate accumulator, an nl.aggregate_update inside the scan loop that
+    // folds each chunk's non-null values, and - after the loop - an
+    // nl.aggregate_result that materializes the single reduced row as a nullable
+    // value chunk, which a function-scope nl.output emits. It collapses to one row,
+    // so there is no emit loop.
+    //
+    // Cypher aggregates ignore nulls. sum and min/max keep the input's value type;
+    // avg always widens to a float. sum/avg need a numeric column, min/max an
+    // orderable one. The property value type is resolved during the db -> nl
+    // lowering (hence -graph), so the result chunk element type is baked from it -
+    // swap "score" for a property your graph actually has.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %total = db.sum(%score) : (!db.column<none>) -> !db.column<none>
+
+    db.output(%total) : !db.column<none>
+
+    return
+  }
+}

--- a/samples/mlir/aggregate.nl.mlir
+++ b/samples/mlir/aggregate.nl.mlir
@@ -1,0 +1,29 @@
+// Generated nl-dialect lowering of aggregate.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered aggregate.mlir -graph <graph>
+// This is the DBLowering output; edit aggregate.mlir, not this file.
+//
+// db.sum - like db.min/db.max/db.avg - is a pipeline breaker like db.count: a
+// hoisted nl.aggregate accumulator, an nl.aggregate_update inside the scan loop
+// that folds each chunk's non-null values, and - after the loop - an
+// nl.aggregate_result that materializes the single reduced row as a nullable value
+// chunk, which a function-scope nl.output emits. It collapses to one row, so there
+// is no emit loop.
+//
+// Unlike the other lowered samples this one needs -graph: the result element type
+// is resolved from the "score" property during lowering. score is Int64, so sum
+// keeps it and the chunk is !storage.nullable<i64>; an avg would widen to
+// !storage.nullable<f64>.
+module {
+  func.func @main() {
+    %0 = nl.aggregate sum : !nl.aggregate_state<i64>
+    %1 = nl.get_property_type("score")
+    %2 = nl.scan_nodes()
+    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %4 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<i64>>
+      nl.aggregate_update sum %0, %4 : !nl.aggregate_state<i64>, !nl.chunk<!storage.nullable<i64>>
+    }
+    %3 = nl.aggregate_result sum(%0) : !nl.aggregate_state<i64> -> !nl.chunk<!storage.nullable<i64>>
+    nl.output(%3) : !nl.chunk<!storage.nullable<i64>>
+    return
+  }
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -17,6 +17,10 @@
 
 namespace {
 
+// Defined below with the other program strings; declared here so the fixture's
+// checkAggregateOp helper (an inline member) can name it.
+std::string aggregateProgram(const char* op);
+
 // A context with just the dialects a db-dialect program needs: db for the query
 // ops and func for the enclosing function.
 class DBDialectTest : public ::testing::Test {
@@ -46,6 +50,35 @@ protected:
         });
 
         return product;
+    }
+
+    // Parses one aggregate op program (db.sum / db.min / db.max / db.avg), asserts
+    // the op is present with the spelled input/result column types, and that printing
+    // it and re-parsing still verifies (the printer and parser are inverses). One
+    // typed helper covers all four ops, which differ only in their name.
+    template <typename OpType>
+    void checkAggregateOp(const char* op) {
+        const mlir::OwningOpRef<mlir::ModuleOp> module = parse(aggregateProgram(op).c_str());
+        ASSERT_TRUE(module) << op;
+
+        OpType aggregate;
+        module.get().walk([&](OpType found) {
+            aggregate = found;
+        });
+        ASSERT_TRUE(aggregate) << op;
+
+        // One property column in, one reduced column out - the two spelled i64 columns.
+        const mlir::Type int64ColumnType = mlir::db::ColumnType::get(&_context, mlir::IntegerType::get(&_context, 64));
+        EXPECT_EQ(aggregate.getInput().getType(), int64ColumnType) << op;
+        EXPECT_EQ(aggregate.getResult().getType(), int64ColumnType) << op;
+
+        std::string printed;
+        llvm::raw_string_ostream stream(printed);
+        module.get().print(stream);
+
+        const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+        ASSERT_TRUE(reparsed) << op;
+        EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed))) << op;
     }
 
     mlir::MLIRContext _context;
@@ -195,6 +228,23 @@ func.func @main() {
   return
 }
 )mlir";
+
+// MATCH (a) RETURN sum(a.score): a property column reduced to a single-row result.
+// Each reduction is its own op - db.sum / db.min / db.max / db.avg - the way count(*)
+// is db.count. Like db.count they change arity and type, so the input and result
+// types are unrelated; only the op name differs, which lets one program string cover
+// all four ops.
+std::string aggregateProgram(const char* op) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %s = db.get_node_properties(%a, \"score\") : (!db.column<!storage.node_id>) -> !db.column<i64>\n"
+                       "  %r = db.")
+           + op
+           + "(%s) : (!db.column<i64>) -> !db.column<i64>\n"
+             "  db.output(%r) : !db.column<i64>\n"
+             "  return\n"
+             "}\n";
+}
 
 TEST_F(DBDialectTest, parsesCrossProductOfTwoScans) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductProgram);
@@ -723,6 +773,16 @@ TEST_F(DBDialectTest, countRoundTripsThroughTextualForm) {
     const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
     ASSERT_TRUE(reparsed);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, parsesAndRoundTripsAggregateOps) {
+    // Each aggregate is its own op - db.sum / db.min / db.max / db.avg - so each
+    // parses to its own type, exposes the spelled input/result columns, and survives
+    // a print/re-parse round trip.
+    checkAggregateOp<mlir::db::Sum>("sum");
+    checkAggregateOp<mlir::db::Min>("min");
+    checkAggregateOp<mlir::db::Max>("max");
+    checkAggregateOp<mlir::db::Avg>("avg");
 }
 
 }

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -152,6 +152,50 @@ private:
     std::vector<uint64_t> _values;
 };
 
+// Collects the single-row nullable int64 result a SUM/MIN/MAX over an Int64 column
+// emits: one !nl.chunk<!storage.nullable<i64>> with one row (present or null).
+class CollectingOptInt64Sink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<int64_t>> _values;
+};
+
+// Collects the single-row nullable double result an AVG emits: one
+// !nl.chunk<!storage.nullable<f64>> with one row.
+class CollectingOptDoubleSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<double>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<double>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<double>> _values;
+};
+
 // Collects (node ID, nullable string property) rows. The value column is a
 // !storage.nullable<!storage.string> chunk, storage's ColumnOptVector<string_view>.
 class CollectingNodeStringPropSink : public NLOutputSink {
@@ -847,6 +891,23 @@ func.func @main() {
   return
 }
 )mlir";
+
+// MATCH (a) RETURN <agg>(a.score): reduce the non-null scores with the given
+// aggregate op (db.sum / db.min / db.max / db.avg). The db result value type is
+// resolved during lowering (the property is Int64, so sum/min/max stay Int64 and
+// avg widens to f64), so the db column types are left as none - the same way the
+// property column is spelled.
+std::string aggregateScoreProgram(const char* op) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+                       "  %r = db.")
+           + op
+           + "(%score) : (!db.column<none>) -> !db.column<none>\n"
+             "  db.output(%r) : !db.column<none>\n"
+             "  return\n"
+             "}\n";
+}
 
 }
 
@@ -2832,6 +2893,119 @@ TEST_F(DBLoweringTest, lowersCountToPipelineBreaker) {
     });
 
     EXPECT_EQ(countCount, 1u);
+    EXPECT_EQ(updateCount, 1u);
+    EXPECT_EQ(resultCount, 1u);
+    EXPECT_EQ(forCount, 1u);
+    EXPECT_EQ(sortBufferCount, 0u);
+}
+
+TEST_F(DBLoweringTest, sumsScores) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Scores 100, 200 and null: sum(a.score) adds the present values to 300 (the
+    // null is ignored), through the full db -> nl lowering.
+    CollectingOptInt64Sink sink;
+    runLoweredProgram(aggregateScoreProgram("sum").c_str(), reader.getView(), sink);
+
+    const std::vector<std::optional<int64_t>> expected {300};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, minsAndMaxsScores) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // min/max(a.score) over 100, 200, null are the smallest and largest present
+    // values.
+    CollectingOptInt64Sink minSink;
+    runLoweredProgram(aggregateScoreProgram("min").c_str(), reader.getView(), minSink);
+    EXPECT_EQ(minSink.getValues(), (std::vector<std::optional<int64_t>> {100}));
+
+    CollectingOptInt64Sink maxSink;
+    runLoweredProgram(aggregateScoreProgram("max").c_str(), reader.getView(), maxSink);
+    EXPECT_EQ(maxSink.getValues(), (std::vector<std::optional<int64_t>> {200}));
+}
+
+TEST_F(DBLoweringTest, averagesScores) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // avg(a.score) divides the sum of the present values (300) by their count (2),
+    // widening to f64, so the single result row is a present 150.0.
+    CollectingOptDoubleSink sink;
+    runLoweredProgram(aggregateScoreProgram("avg").c_str(), reader.getView(), sink);
+
+    const std::vector<std::optional<double>> expected {150.0};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, averagesScoresAcrossChunks) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // At chunk size 1 the scores span three scan chunks; the accumulator is reset
+    // once at function scope, not per chunk, so avg still totals 150.0.
+    CollectingOptDoubleSink sink;
+    runLoweredProgram(aggregateScoreProgram("avg").c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::optional<double>> expected {150.0};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+// A db aggregate op lowers to the pipeline-breaker shape, the same as db.count: a
+// hoisted nl.aggregate, a single nl.aggregate_update in the producing loop, and an
+// nl.aggregate_result after it that materializes the reduced chunk at function
+// scope. It collapses to one row, so there is exactly one nl.for (the producing
+// scan) and no nl.sort_buffer.
+TEST_F(DBLoweringTest, lowersAggregateToPipelineBreaker) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = aggregateScoreProgram("sum");
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t aggregateCount = 0;
+    size_t updateCount = 0;
+    size_t resultCount = 0;
+    size_t forCount = 0;
+    size_t sortBufferCount = 0;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::nl::Aggregate>(operation)) {
+            aggregateCount++;
+        } else if (mlir::isa<mlir::nl::AggregateUpdate>(operation)) {
+            updateCount++;
+        } else if (mlir::isa<mlir::nl::AggregateResult>(operation)) {
+            resultCount++;
+        } else if (mlir::isa<mlir::nl::For>(operation)) {
+            forCount++;
+        } else if (mlir::isa<mlir::nl::SortBuffer>(operation)) {
+            sortBufferCount++;
+        }
+    });
+
+    EXPECT_EQ(aggregateCount, 1u);
     EXPECT_EQ(updateCount, 1u);
     EXPECT_EQ(resultCount, 1u);
     EXPECT_EQ(forCount, 1u);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -156,6 +156,8 @@ private:
 // emits: one !nl.chunk<!storage.nullable<i64>> with one row (present or null).
 class CollectingOptInt64Sink : public NLOutputSink {
 public:
+    using OptInt64Values = std::vector<std::optional<int64_t>>;
+
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
 
@@ -168,16 +170,18 @@ public:
         }
     }
 
-    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+    const OptInt64Values& getValues() const { return _values; }
 
 private:
-    std::vector<std::optional<int64_t>> _values;
+    OptInt64Values _values;
 };
 
 // Collects the single-row nullable double result an AVG emits: one
 // !nl.chunk<!storage.nullable<f64>> with one row.
 class CollectingOptDoubleSink : public NLOutputSink {
 public:
+    using OptDoubleValues = std::vector<std::optional<double>>;
+
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
 
@@ -190,10 +194,10 @@ public:
         }
     }
 
-    const std::vector<std::optional<double>>& getValues() const { return _values; }
+    const OptDoubleValues& getValues() const { return _values; }
 
 private:
-    std::vector<std::optional<double>> _values;
+    OptDoubleValues _values;
 };
 
 // Collects (node ID, nullable string property) rows. The value column is a

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -221,6 +221,100 @@ TEST_F(NLDialectTest, verifierAcceptsCountChain) {
     EXPECT_EQ(result.getResult().getType(), countChunkType);
 }
 
+// The aggregate chain verifies: an nl.aggregate producing the accumulator handle,
+// an nl.aggregate_update folding the value chunk into it, and an nl.aggregate_result
+// that materializes the single reduced chunk, emitted by a function-scope nl.output -
+// all naming the one handle and carrying the same reduction. The value sibling of
+// the count-chain test.
+TEST_F(NLDialectTest, verifierAcceptsAggregateChain) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+
+    // A function whose entry block takes one nullable-int64 value chunk - the
+    // property column an aggregate folds (unlike count, an aggregate reduces values,
+    // so its input is a value chunk, not an ID chunk).
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type valueChunkType = mlir::nl::ChunkType::get(&_context,
+                                                               mlir::storage::NullableType::get(&_context, int64Type));
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {valueChunkType}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+    const mlir::Value chunk = function.getBody().front().getArgument(0);
+
+    // sum over an i64 column: the accumulator (state) and the result are both nullable
+    // int64, so the state carries the i64 element type.
+    const mlir::nl::AggregateStateType stateType = mlir::nl::AggregateStateType::get(&_context, int64Type);
+    const mlir::Value handle = builder.create<mlir::nl::Aggregate>(loc, stateType, mlir::storage::AggregateKind::Sum).getState();
+    builder.create<mlir::nl::AggregateUpdate>(loc, handle, chunk, mlir::storage::AggregateKind::Sum);
+
+    const mlir::Type resultChunkType = mlir::nl::ChunkType::get(&_context,
+                                                                mlir::storage::NullableType::get(&_context, int64Type));
+    mlir::nl::AggregateResult result = builder.create<mlir::nl::AggregateResult>(loc, resultChunkType, handle, mlir::storage::AggregateKind::Sum);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value());
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+    EXPECT_EQ(result.getState(), handle);
+    EXPECT_EQ(result.getResult().getType(), resultChunkType);
+    EXPECT_EQ(result.getKind(), mlir::storage::AggregateKind::Sum);
+}
+
+// The update's fold handler is picked from its own kind, but the accumulator was
+// reset by the producing nl.aggregate's kind - so a differing kind folds into a
+// wrongly-initialized accumulator (a min-reset null read as a present sum, which
+// crashes at runtime). The verifier must reject the mismatch before execution.
+TEST_F(NLDialectTest, verifierRejectsMismatchedAggregateKind) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type valueChunkType = mlir::nl::ChunkType::get(&_context,
+                                                               mlir::storage::NullableType::get(&_context, int64Type));
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {valueChunkType}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+    const mlir::Value chunk = function.getBody().front().getArgument(0);
+
+    // Reset for a sum, but fold as a min against the same handle.
+    const mlir::nl::AggregateStateType stateType = mlir::nl::AggregateStateType::get(&_context, int64Type);
+    const mlir::Value handle = builder.create<mlir::nl::Aggregate>(loc, stateType, mlir::storage::AggregateKind::Sum).getState();
+    builder.create<mlir::nl::AggregateUpdate>(loc, handle, chunk, mlir::storage::AggregateKind::Min);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    // Swallow the verifier's diagnostic so the deliberate failure does not print.
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(function)));
+}
+
+// avg accumulates a running sum as f64, so an nl.aggregate avg whose state is not an
+// f64 accumulator (here an i64) would type-confuse the avg handler at runtime; the
+// verifier rejects it at the source op.
+TEST_F(NLDialectTest, verifierRejectsAvgWithNonFloatState) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::nl::AggregateStateType i64State = mlir::nl::AggregateStateType::get(&_context, int64Type);
+    builder.create<mlir::nl::Aggregate>(loc, i64State, mlir::storage::AggregateKind::Avg);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(function)));
+}
+
 // A folded nl.output carries the single handle of the truncate adjacent to it,
 // never both: an output with both a limit and a skip handle fails verification.
 TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -139,6 +139,51 @@ private:
     std::vector<uint64_t> _values;
 };
 
+// Collects the single-row nullable int64 result a SUM/MIN/MAX over an Int64
+// column emits: one !nl.chunk<!storage.nullable<i64>> with one row. Captures the
+// value (present or null), so a test can assert both the arity and the reduction.
+class CollectingOptInt64Sink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<int64_t>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<int64_t>> _values;
+};
+
+// Collects the single-row nullable double result an AVG emits: one
+// !nl.chunk<!storage.nullable<f64>> with one row.
+class CollectingOptDoubleSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<double>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::optional<double>>& getValues() const { return _values; }
+
+private:
+    std::vector<std::optional<double>> _values;
+};
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -356,6 +401,51 @@ func.func @main() {
 }
 )mlir";
 
+// Scan all nodes, read each one's "score", and reduce the non-null values with
+// the given aggregate - Cypher sum/min/max(a.score). The accumulator is created
+// once at function scope, folded per scan chunk by nl.aggregate_update, and - after
+// the loop - nl.aggregate_result materializes the single reduced row that the
+// function-scope nl.output emits. A null value (node 2 has no score) is ignored.
+// sum/min/max keep the Int64 type, so the state and result are !nl...<i64>.
+std::string nlIntAggregateScoresProgram(const char* kind) {
+    return std::string("func.func @main() {\n"
+                       "  %score = nl.get_property_type(\"score\")\n"
+                       "  %s = nl.aggregate ")
+           + kind
+           + " : !nl.aggregate_state<i64>\n"
+             "  %nodes = nl.scan_nodes()\n"
+             "  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {\n"
+             "    %values = nl.get_node_properties(%a, %score) : !nl.chunk<!storage.nullable<i64>>\n"
+             "    nl.aggregate_update "
+           + kind
+           + " %s, %values : !nl.aggregate_state<i64>, !nl.chunk<!storage.nullable<i64>>\n"
+             "  }\n"
+             "  %r = nl.aggregate_result "
+           + kind
+           + " (%s) : !nl.aggregate_state<i64> -> !nl.chunk<!storage.nullable<i64>>\n"
+             "  nl.output(%r) : !nl.chunk<!storage.nullable<i64>>\n"
+             "  func.return\n"
+             "}\n";
+}
+
+// avg(a.score): the same shape, but avg accumulates in f64 (the running sum) and
+// divides by the non-null count, so the state and result are !nl...<f64> while the
+// input chunk stays the Int64 property column.
+constexpr const char* nlAvgScoresProgram = R"mlir(
+func.func @main() {
+  %score = nl.get_property_type("score")
+  %s = nl.aggregate avg : !nl.aggregate_state<f64>
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %values = nl.get_node_properties(%a, %score) : !nl.chunk<!storage.nullable<i64>>
+    nl.aggregate_update avg %s, %values : !nl.aggregate_state<f64>, !nl.chunk<!storage.nullable<i64>>
+  }
+  %r = nl.aggregate_result avg (%s) : !nl.aggregate_state<f64> -> !nl.chunk<!storage.nullable<f64>>
+  nl.output(%r) : !nl.chunk<!storage.nullable<f64>>
+  func.return
+}
+)mlir";
+
 // Counts appendChunks calls and the total rows emitted, to prove a limited run
 // emits a clamped prefix (a partial final chunk) and stops the loop early.
 class CountingSink : public NLOutputSink {
@@ -559,6 +649,33 @@ protected:
         builder.addNodeProperty<types::Int64>(nodeA, scoreID, 100);
         builder.addNodeProperty<types::Int64>(nodeB, scoreID, 200);
         // nodeC has no "score" property, so a property read returns null for it
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
+    // Two nodes with a "score" Int64 property declared in the schema but assigned to
+    // neither, so every score read is null. Exercises the aggregate identity/empty
+    // branches: sum of no non-null value is a present zero, min/max/avg are null. The
+    // property is still in the schema, so nl.get_property_type("score") resolves.
+    std::unique_ptr<Graph> buildAllNullScoredGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        metadata.getOrCreateLabel("0");
+        metadata.getOrCreateEdgeType("0");
+        metadata.getOrCreatePropertyType("score", ValueType::Int64);
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        builder.addNode(labelset);
+        builder.addNode(labelset);
+        // No node carries a "score", so every property read returns null
 
         const auto submitResult = change->access().submit(*_jobSystem);
         EXPECT_TRUE(submitResult);
@@ -1103,6 +1220,119 @@ TEST_F(NLExecutorTest, countsOnlyNonNullValues) {
     runProgram(nlCountScoresProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
 
     const std::vector<uint64_t> expected {2};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, sumsNonNullValues) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Scores 100, 200 and null: sum(a.score) adds the present values, so the single
+    // result row is a present 300 (the null is ignored).
+    CollectingOptInt64Sink sink;
+    runProgram(nlIntAggregateScoresProgram("sum").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {300};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, minOfNonNullValues) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // min(a.score) over 100, 200, null is the smallest present value, 100.
+    CollectingOptInt64Sink sink;
+    runProgram(nlIntAggregateScoresProgram("min").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {100};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, maxOfNonNullValues) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // max(a.score) over 100, 200, null is the largest present value, 200.
+    CollectingOptInt64Sink sink;
+    runProgram(nlIntAggregateScoresProgram("max").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {200};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, avgOfNonNullValues) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // avg(a.score) divides the sum of the present values (300) by their count (2),
+    // ignoring the null, so the single result row is a present 150.0.
+    CollectingOptDoubleSink sink;
+    runProgram(nlAvgScoresProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<double>> expected {150.0};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, sumsAcrossChunks) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 folds one node per step, so the accumulator is grown across
+    // several steps; nl.aggregate resets it once at function scope, not per chunk,
+    // so the sum is still 300.
+    CollectingOptInt64Sink sink;
+    runProgram(nlIntAggregateScoresProgram("sum").c_str(), reader.getView(), 1, sink);
+
+    const std::vector<std::optional<int64_t>> expected {300};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, sumOfAllNullIsZero) {
+    auto graph = buildAllNullScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // No node carries a score, so sum folds no value: it stays at its identity, a
+    // present 0 (Cypher's sum of an all-null/empty input is 0, never null).
+    CollectingOptInt64Sink sink;
+    runProgram(nlIntAggregateScoresProgram("sum").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<int64_t>> expected {0};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(NLExecutorTest, minMaxOfAllNullIsNull) {
+    auto graph = buildAllNullScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // With no non-null value, min/max never seed their accumulator, so each emits a
+    // single null row (Cypher's min/max of an all-null/empty input is null).
+    CollectingOptInt64Sink minSink;
+    runProgram(nlIntAggregateScoresProgram("min").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, minSink);
+    EXPECT_EQ(minSink.getValues(), (std::vector<std::optional<int64_t>> {std::nullopt}));
+
+    CollectingOptInt64Sink maxSink;
+    runProgram(nlIntAggregateScoresProgram("max").c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, maxSink);
+    EXPECT_EQ(maxSink.getValues(), (std::vector<std::optional<int64_t>> {std::nullopt}));
+}
+
+TEST_F(NLExecutorTest, avgOfAllNullIsNull) {
+    auto graph = buildAllNullScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The non-null count is zero, so avg divides nothing and emits a single null row
+    // (Cypher's avg of an all-null/empty input is null, not 0).
+    CollectingOptDoubleSink sink;
+    runProgram(nlAvgScoresProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::optional<double>> expected {std::nullopt};
     EXPECT_EQ(sink.getValues(), expected);
 }
 


### PR DESCRIPTION
Adds db.sum/db.min/db.max/db.avg and the parameterized nl.aggregate/aggregate_update/aggregate_result family they lower to, with the null-aware interpreter, dialect verifiers, and unit tests.