### PR TITLE
Vector: use exact k-NN search instead of approximate LSH routing

### DIFF
--- a/test/vector/CMakeLists.txt
+++ b/test/vector/CMakeLists.txt
@@ -6,3 +6,4 @@ function(add_vector_tests exe_name cpp_file)
 endfunction()
 
 add_vector_tests(test_jsonimporter JsonImporterTest.cpp)
+add_vector_tests(test_vector_reload VectorReloadTest.cpp)

--- a/test/vector/VectorReloadTest.cpp
+++ b/test/vector/VectorReloadTest.cpp
@@ -1,0 +1,99 @@
+#include "TuringTest.h"
+
+#include <array>
+
+#include "VecLibAccessor.h"
+#include "VectorDatabase.h"
+#include "BatchVectorCreate.h"
+#include "VectorSearchQuery.h"
+#include "VectorSearchResult.h"
+
+using namespace vec;
+using namespace turing::test;
+
+class VectorReloadTest : public TuringTest {
+public:
+    void initialize() override {
+        TuringTest::initialize();
+        _rootDir = fs::Path {_outDir} / "vector_reload";
+
+        if (!_rootDir.exists()) {
+            ASSERT_TRUE(_rootDir.mkdir());
+        }
+    }
+
+protected:
+    fs::Path _rootDir;
+};
+
+// Exact vector search must still return results after the database is reloaded
+// from disk. Adding embeddings registers shard signatures on the router; those
+// signatures have to be persisted, otherwise an exact search after reload
+// iterates an empty signature set and returns nothing.
+TEST_F(VectorReloadTest, exactSearchAfterReload) {
+    constexpr Dimension dimension = 8;
+
+    const std::array<std::array<float, dimension>, 3> vectors {{
+        {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, // id 0
+        {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, // id 1
+        {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f}, // id 2
+    }};
+
+    const auto searchNearest = [&](VectorDatabase& db, int64_t& firstId, size_t& resultCount) {
+        VecLibAccessor accessor = db.getLibrary("reloadlib");
+        ASSERT_TRUE(accessor.isValid());
+
+        VectorSearchResult results;
+        VectorSearchQuery query(dimension);
+        query.setVector(vectors[1]);
+        query.setMaxResultCount(3);
+
+        ASSERT_TRUE(accessor.search(&query, &results));
+
+        resultCount = results.ids().size();
+        firstId = resultCount > 0 ? results.ids()[0] : -1;
+    };
+
+    // Populate the database and persist it to disk.
+    {
+        VectorDatabase db;
+        ASSERT_TRUE(db.init(_rootDir));
+
+        const auto libRes = db.createLibrary("reloadlib", dimension, DistanceMetric::EUCLIDEAN_DIST);
+        ASSERT_TRUE(libRes);
+
+        VecLibAccessor accessor = db.getLibrary("reloadlib");
+        ASSERT_TRUE(accessor.isValid());
+
+        BatchVectorCreate batch;
+        accessor.prepareCreateBatch(&batch);
+        for (size_t i = 0; i < vectors.size(); i++) {
+            batch.addPoint(static_cast<int64_t>(i), vectors[i]);
+        }
+
+        ASSERT_TRUE(accessor.addEmbeddings(&batch));
+
+        // Sanity check: exact search works before any reload.
+        int64_t firstId = -1;
+        size_t resultCount = 0;
+        searchNearest(db, firstId, resultCount);
+        ASSERT_GT(resultCount, 0u);
+        ASSERT_EQ(firstId, 1);
+    }
+
+    // Reload into a fresh instance (simulates a server restart) and search again.
+    {
+        VectorDatabase db;
+        ASSERT_TRUE(db.init(_rootDir));
+
+        int64_t firstId = -1;
+        size_t resultCount = 0;
+        searchNearest(db, firstId, resultCount);
+        ASSERT_GT(resultCount, 0u);
+        ASSERT_EQ(firstId, 1);
+    }
+}
+
+int main(int argc, char** argv) {
+    return turingTestMain(argc, argv);
+}

--- a/vector/LSHShardRouter.cpp
+++ b/vector/LSHShardRouter.cpp
@@ -57,7 +57,7 @@ LSHSignature LSHShardRouter::getSignature(std::span<const float> vector) const {
 void LSHShardRouter::getSearchSignatures(std::span<const float> vector, std::vector<LSHSignature>& signatures) const {
     bioassert(vector.size() == _dim, "LSHShardRouter: vector size must be equal to dimension");
     signatures.resize(_nbits + 1);
-    
+
     const LSHSignature sig = getSignature(vector);
 
     // Exact match

--- a/vector/LSHShardRouter.h
+++ b/vector/LSHShardRouter.h
@@ -27,6 +27,10 @@ public:
 
     LSHSignature getSignature(std::span<const float> vector) const;
 
+    // Approximate-search routing: the query's own shard signature plus its
+    // Hamming-distance-1 neighbours. Currently unused — VecLib::search probes
+    // every instantiated shard for exact results — but kept so approximate
+    // search can be re-enabled without reimplementing it.
     void getSearchSignatures(std::span<const float> vector,
                              std::vector<LSHSignature>& signatures) const;
 

--- a/vector/VecLib.cpp
+++ b/vector/VecLib.cpp
@@ -121,16 +121,17 @@ VectorResult<void> VecLib::search(const VectorSearchQuery* query, VectorSearchRe
     const std::span<const float> embeddings = query->embeddings();
     const size_t maxResultCount = query->resultCount();
 
-    std::vector<LSHSignature> searchSignatures;
-
-    // Compute signature
-    _shardRouter->getSearchSignatures(embeddings, searchSignatures);
-
     results->reset();
     results->setAscendingIsBetter(_metadata._metric == DistanceMetric::EUCLIDEAN_DIST);
 
     std::vector<float> distances(maxResultCount);
     std::vector<faiss::idx_t> indices(maxResultCount);
+
+    // Exact search: probe every shard that holds vectors instead of routing the
+    // query to an LSH neighbourhood. Each shard is a flat (brute-force) FAISS
+    // index and every vector lives in exactly one shard, so scanning all of them
+    // returns the true k nearest neighbours rather than an approximation.
+    const std::set<LSHSignature>& searchSignatures = _shardRouter->getInstantiatedShardSignatures();
 
     for (const LSHSignature& signature : searchSignatures) {
         const VecLibShardAccessor shard = _shardCache->getShard(_metadata, signature);

--- a/vector/VecLib.cpp
+++ b/vector/VecLib.cpp
@@ -114,6 +114,13 @@ VectorResult<void> VecLib::addEmbeddings(const BatchVectorCreate* batch) {
 
     _metadata._modifiedAt = Clock::now().time_since_epoch().count();
 
+    // Persist the router so the shard signatures just registered survive a restart;
+    // exact search iterates the instantiated signature set and would otherwise find
+    // nothing after reload.
+    if (auto res = _storage->persistShardRouter(*this); !res) {
+        return nonstd::make_unexpected(res.error());
+    }
+
     return {};
 }
 

--- a/vector/VectorStorageManager.cpp
+++ b/vector/VectorStorageManager.cpp
@@ -96,9 +96,9 @@ VectorResult<void> VectorStorageManager::createLibraryStorage(const VecLib& lib)
 }
 
 VectorResult<void> VectorStorageManager::persistShardRouter(const VecLib& lib) {
-    const auto* meta = lib.metadata();
-
     std::shared_lock lock(_mutex);
+
+    const auto* meta = lib.metadata();
 
     const auto it = _storages.find(meta->_id);
     if (it == _storages.end()) {

--- a/vector/VectorStorageManager.cpp
+++ b/vector/VectorStorageManager.cpp
@@ -95,6 +95,23 @@ VectorResult<void> VectorStorageManager::createLibraryStorage(const VecLib& lib)
     return {};
 }
 
+VectorResult<void> VectorStorageManager::persistShardRouter(const VecLib& lib) {
+    const auto* meta = lib.metadata();
+
+    std::shared_lock lock(_mutex);
+
+    const auto it = _storages.find(meta->_id);
+    if (it == _storages.end()) {
+        return VectorError::result(VectorErrorCode::LibraryDoesNotExist);
+    }
+
+    // Re-serialize the router so the shard signature set registered while adding
+    // embeddings survives a restart. createLibraryStorage() only writes the empty
+    // router at index-creation time; without this, an exact search after reload
+    // would iterate an empty signature set and return no results.
+    return it->second->_shardRouterWriter.write(lib.shardRouter());
+}
+
 bool VectorStorageManager::libraryExists(const VecLibID& libID) const {
     return getLibraryPath(libID).exists();
 }

--- a/vector/VectorStorageManager.h
+++ b/vector/VectorStorageManager.h
@@ -31,6 +31,7 @@ public:
     [[nodiscard]] static VectorResult<std::unique_ptr<VectorStorageManager>> create(const fs::Path& rootPath);
 
     [[nodiscard]] VectorResult<void> createLibraryStorage(const VecLib& lib);
+    [[nodiscard]] VectorResult<void> persistShardRouter(const VecLib& lib);
     [[nodiscard]] bool libraryExists(const VecLibID& libID) const;
     [[nodiscard]] VectorResult<void> deleteLibraryStorage(const VecLibID& libID);
 


### PR DESCRIPTION
I unplugged for now the approximate search implementation because it is way to coarse and gets very bad recall. The approximate implementation is kept to be revised soon.