### PR TITLE
Vector: yield score alongside ids from VECTOR SEARCH

### DIFF
--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -516,20 +516,24 @@ void ReadStmtAnalyzer::analyze(const VectorSearchStmt* stmt) {
 
     for (SymbolExpr* yieldItemExpr : *yieldItems) {
         const Symbol* yieldItem = yieldItemExpr->getSymbol();
+        const std::string_view yieldName = yieldItem->getName();
 
-        if (yieldItem->getName() != "ids") {
-            throwError(fmt::format("VECTOR SEARCH only supports YIELD ids, got '{}'",
-                                   yieldItem->getName()), stmt);
+        EvaluatedType yieldType = EvaluatedType::Invalid;
+        if (yieldName == "ids") {
+            yieldType = EvaluatedType::Integer;
+        } else if (yieldName == "score") {
+            yieldType = EvaluatedType::Double;
+        } else {
+            throwError(fmt::format("VECTOR SEARCH only supports YIELD ids and score, got '{}'",
+                                   yieldName), stmt);
         }
 
-        if (_ctxt->hasDecl(yieldItem->getName())) {
-            throwError(fmt::format("Variable '{}' already declared", yieldItem->getName()),
+        if (_ctxt->hasDecl(yieldName)) {
+            throwError(fmt::format("Variable '{}' already declared", yieldName),
                        yieldItemExpr);
         }
 
-        VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast,
-                                                       EvaluatedType::Integer,
-                                                       yieldItem->getName());
+        VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, yieldType, yieldName);
         yieldItemExpr->setDecl(decl);
         yieldItemExpr->setExprVarDecl(decl);
     }

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -1391,7 +1391,8 @@ PipelineValueOutputInterface& PipelineBuilder::addLoadEmbedding(std::string_view
 
 PipelineValuesOutputInterface& PipelineBuilder::addVectorSearch(std::string_view indexName,
                                                                 uint64_t k,
-                                                                const std::vector<float>& queryVector) {
+                                                                const std::vector<float>& queryVector,
+                                                                NamedColumn*& scoreColumn) {
     VectorSearchProcessor* proc = VectorSearchProcessor::create(_pipeline, indexName, k, queryVector);
 
     PipelineValuesOutputInterface& output = proc->outIds();
@@ -1400,6 +1401,10 @@ PipelineValuesOutputInterface& PipelineBuilder::addVectorSearch(std::string_view
     NamedColumn* idsCol = allocColumn<ColumnVector<types::Int64::Primitive>>(df);
     idsCol->rename("ids");
     output.setValues(idsCol);
+
+    scoreColumn = allocColumn<ColumnVector<types::Double::Primitive>>(df);
+    scoreColumn->rename("score");
+    proc->setScoreColumn(scoreColumn);
 
     _pendingOutput.setInterface(&output);
     return output;

--- a/query/pipeline/PipelineBuilder.h
+++ b/query/pipeline/PipelineBuilder.h
@@ -233,7 +233,8 @@ public:
                                                    std::string_view propertyName);
     PipelineValuesOutputInterface& addVectorSearch(std::string_view indexName,
                                                    uint64_t k,
-                                                   const std::vector<float>& queryVector);
+                                                   const std::vector<float>& queryVector,
+                                                   NamedColumn*& scoreColumn);
     PipelineValueOutputInterface& addDeleteVectorIndex(std::string_view indexName);
     PipelineValuesOutputInterface& addShowVectorIndexes();
 

--- a/query/pipeline/processors/VectorSearchProcessor.cpp
+++ b/query/pipeline/processors/VectorSearchProcessor.cpp
@@ -86,11 +86,14 @@ void VectorSearchProcessor::execute() {
     const std::span<const int64_t> ids = result.ids();
     colIds->getRaw().assign(ids.begin(), ids.end());
 
+    // There is a single metric column: the score. The search result reports it as
+    // a distance (squared L2 for EUCLID, inner product for cosine), which is the
+    // value we expose to the user as the per-result score.
     using ColumnDouble = ColumnVector<types::Double::Primitive>;
     ColumnDouble* scoreColumn = _scoreColumn->as<ColumnDouble>();
 
-    const std::span<const float> distances = result.distances();
-    scoreColumn->getRaw().assign(distances.begin(), distances.end());
+    const std::span<const float> scores = result.distances();
+    scoreColumn->getRaw().assign(scores.begin(), scores.end());
 
     _outIds.getPort()->writeData();
     finish();

--- a/query/pipeline/processors/VectorSearchProcessor.cpp
+++ b/query/pipeline/processors/VectorSearchProcessor.cpp
@@ -79,12 +79,18 @@ void VectorSearchProcessor::execute() {
             fmt::format("Vector search failed: {}", searchResult.error().fmtMessage()));
     }
 
-    // Output result IDs to column
+    // Output result IDs and scores to columns
     using ColumnInt = ColumnVector<types::Int64::Primitive>;
     ColumnInt* colIds = _outIds.getValues()->as<ColumnInt>();
 
     const std::span<const int64_t> ids = result.ids();
     colIds->getRaw().assign(ids.begin(), ids.end());
+
+    using ColumnDouble = ColumnVector<types::Double::Primitive>;
+    ColumnDouble* scoreColumn = _scoreColumn->as<ColumnDouble>();
+
+    const std::span<const float> distances = result.distances();
+    scoreColumn->getRaw().assign(distances.begin(), distances.end());
 
     _outIds.getPort()->writeData();
     finish();

--- a/query/pipeline/processors/VectorSearchProcessor.h
+++ b/query/pipeline/processors/VectorSearchProcessor.h
@@ -25,11 +25,14 @@ public:
 
     PipelineValuesOutputInterface& outIds() { return _outIds; }
 
+    void setScoreColumn(NamedColumn* scoreColumn) { _scoreColumn = scoreColumn; }
+
 protected:
     std::string_view _indexName;
     uint64_t _k {10};
     std::vector<float> _queryVector;
     PipelineValuesOutputInterface _outIds;
+    NamedColumn* _scoreColumn {nullptr};
 
     VectorSearchProcessor(std::string_view indexName,
                           uint64_t k,

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1758,16 +1758,22 @@ PipelineOutputInterface* PipelineGenerator::translateLoadEmbeddingNode(LoadEmbed
 }
 
 PipelineOutputInterface* PipelineGenerator::translateVectorSearchNode(VectorSearchNode* node) {
+    NamedColumn* scoreColumn = nullptr;
     PipelineValuesOutputInterface& output = _builder.addVectorSearch(
-        node->getIndexName(), node->getK(), node->getQueryVector());
+        node->getIndexName(), node->getK(), node->getQueryVector(), scoreColumn);
 
-    // Register the 'ids' column so RETURN can find it
+    // Register the 'ids' and 'score' columns so RETURN can find them
     const VarDecl* idsDecl = node->getIDsVarDecl();
     if (idsDecl) {
         NamedColumn* idsCol = output.getValues();
         if (idsCol) {
             _declToColumn[idsDecl] = idsCol->getTag();
         }
+    }
+
+    const VarDecl* scoreDecl = node->getScoreVarDecl();
+    if (scoreDecl) {
+        _declToColumn[scoreDecl] = scoreColumn->getTag();
     }
 
     return _builder.getPendingOutputInterface();

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -240,13 +240,19 @@ void ReadStmtGenerator::generateVectorSearchStmt(const VectorSearchStmt* stmt) {
         stmt->getK(),
         std::move(queryVector));
 
-    // Register the 'ids' variable for downstream use
+    // Register the yielded variables ('ids', 'score') for downstream use
     const YieldClause* yield = stmt->getYield();
     if (yield) {
         YieldItems* yieldItems = yield->getItems();
         for (SymbolExpr* yieldItemExpr : *yieldItems) {
             const VarDecl* decl = yieldItemExpr->getExprVarDecl();
-            node->setIDsVarDecl(decl);
+
+            if (yieldItemExpr->getSymbol()->getName() == "score") {
+                node->setScoreVarDecl(decl);
+            } else {
+                node->setIDsVarDecl(decl);
+            }
+
             _variables->setProducer(yieldItemExpr->getDecl(), node);
         }
     }

--- a/query/plan/nodes/VectorSearchNode.h
+++ b/query/plan/nodes/VectorSearchNode.h
@@ -30,11 +30,15 @@ public:
     void setIDsVarDecl(const VarDecl* decl) { _idsVarDecl = decl; }
     const VarDecl* getIDsVarDecl() const { return _idsVarDecl; }
 
+    void setScoreVarDecl(const VarDecl* decl) { _scoreVarDecl = decl; }
+    const VarDecl* getScoreVarDecl() const { return _scoreVarDecl; }
+
 private:
     std::string_view _indexName;
     uint64_t _k {10};
     std::vector<float> _queryVector;
     const VarDecl* _idsVarDecl {nullptr};
+    const VarDecl* _scoreVarDecl {nullptr};
 };
 
 }

--- a/test/query/queries/VectorQueriesTest.cpp
+++ b/test/query/queries/VectorQueriesTest.cpp
@@ -391,6 +391,84 @@ TEST_F(VectorQueriesTest, vectorSearchReturnsCorrectResults) {
     ASSERT_TRUE(executed);
 }
 
+TEST_F(VectorQueriesTest, vectorSearchYieldsScore) {
+    // Create a vector index with dimension 4
+    auto createRes = query("CREATE VECTOR INDEX score_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});
+    ASSERT_TRUE(createRes.isOk()) << "Create failed: " << createRes.getError();
+
+    // Define test vectors
+    std::vector<TestVector> testVectors = {
+        {1, {1.0f, 0.0f, 0.0f, 0.0f}},   // exact match with the query
+        {2, {0.0f, 1.0f, 0.0f, 0.0f}},   // far from the query
+        {3, {0.0f, 0.0f, 1.0f, 0.0f}},   // far from the query
+        {4, {0.9f, 0.1f, 0.0f, 0.0f}},   // close to the query
+        {5, {0.8f, 0.2f, 0.0f, 0.0f}},   // also close to the query
+    };
+
+    // Write vectors to CSV file in the data directory
+    std::string dataDir = _outDir + "/turing/data";
+    std::string vectorFile = dataDir + "/score_vectors.csv";
+    {
+        std::ofstream out(vectorFile);
+        for (const auto& vec : testVectors) {
+            out << vec._id;
+            for (float v : vec.values) {
+                out << "," << v;
+            }
+            out << "\n";
+        }
+    }
+
+    // Load vectors (path relative to data directory)
+    std::string loadQuery = "LOAD VECTOR FROM \"score_vectors.csv\" IN score_test";
+    auto loadRes = query(loadQuery, "default", [](const Dataframe*) {});
+    ASSERT_TRUE(loadRes.isOk()) << "Load failed: " << loadRes.getError();
+
+    // Define query vector and compute expected results
+    std::vector<float> queryVector = {1.0f, 0.0f, 0.0f, 0.0f};
+    const size_t k = 3;
+    std::vector<int64_t> expectedIds;
+    findKNearestNeighbors(expectedIds, testVectors, queryVector, k);
+
+    // Search and yield both the ids and their scores
+    bool executed = false;
+    const auto res = query("VECTOR SEARCH IN score_test FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids, score RETURN ids, score", "default", [&](const Dataframe* df) -> void {
+            ASSERT_TRUE(df != nullptr);
+            ASSERT_EQ(df->cols().size(), 2);
+            ASSERT_EQ(df->getLogicalRowCount(), k);
+
+            const auto& cols = df->cols();
+            ASSERT_EQ(cols.at(0)->getName(), "ids");
+            ASSERT_EQ(cols.at(1)->getName(), "score");
+
+            const auto* colIds = cols.at(0)->as<ColumnVector<types::Int64::Primitive>>();
+            const auto* colScores = cols.at(1)->as<ColumnVector<types::Double::Primitive>>();
+            ASSERT_TRUE(colIds != nullptr);
+            ASSERT_TRUE(colScores != nullptr);
+
+            // Verify each result row holds the expected neighbor with its squared
+            // euclidean distance to the query (faiss reports squared L2 for EUCLID)
+            for (size_t i = 0; i < k; ++i) {
+                ASSERT_EQ(colIds->at(i), expectedIds[i])
+                    << "Mismatch at position " << i << ": expected " << expectedIds[i]
+                    << ", got " << colIds->at(i);
+
+                const auto matchesId = [&](const TestVector& vec) { return vec._id == expectedIds[i]; };
+                const auto expectedVec = std::find_if(testVectors.begin(), testVectors.end(), matchesId);
+                ASSERT_TRUE(expectedVec != testVectors.end());
+
+                const float expectedScore = euclideanDistanceSquared(expectedVec->values, queryVector);
+                ASSERT_NEAR(colScores->at(i), expectedScore, 1e-5)
+                    << "Score mismatch at position " << i << " for id " << expectedIds[i];
+            }
+
+            executed = true;
+        });
+
+    ASSERT_TRUE(res.isOk()) << "Query failed: " << res.getError();
+    ASSERT_TRUE(executed);
+}
+
 TEST_F(VectorQueriesTest, vectorSearchWithDifferentK) {
     // Create a vector index
     auto createRes = query("CREATE VECTOR INDEX k_test WITH DIMENSION 4 METRIC EUCLID", "default", [](const Dataframe*) {});


### PR DESCRIPTION
Add a score to the VECTOR SEARCH query:
```
VECTOR SEARCH IN vdb FOR 3 (1.0, 0.0, 0.0, 0.0) YIELD ids, score RETURN ids, score
``` 
so that we can sort matches by similarity score