### PR TITLE
MLIR: add branched two-hop sample with carry sets

### DIFF
--- a/samples/mlir/branch.mlir
+++ b/samples/mlir/branch.mlir
@@ -1,0 +1,35 @@
+module {
+  func.func @main() {
+    // MATCH (a)->(b)->(c), (b)->(d) RETURN a
+    //
+    // A nested two-hop chain a->b->c with a branch b->d hanging off `b`. The
+    // catch is the branch: it does NOT continue from the chain tip `c`, it
+    // reconnects to `b`. And because the query returns `a`, the `a` we emit must
+    // be the one filtered/replicated through *both* the chain and the branch -
+    // one row per full (a, b, c, d) match - so `a` has to ride the carry set all
+    // the way to the last hop. Returning the earlier `a` (%a2) instead of the
+    // branch-filtered `a` (%a3) is exactly what undercounts `a`.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    // First hop a->b, nothing carried yet so the carry set is `{}`.
+    // %src is `a`, %tgt is `b`.
+    %src, %e0, %et0, %tgt = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Second hop b->c, carrying `a` (%src) so it comes back as %a2, filtered to
+    // the `a` whose `b` has a successor `c`. %src1 is `b`, %tgt1 is `c`.
+    %src1, %e1, %et1, %tgt1, %a2 = db.get_out_edges(%tgt, {%src}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+
+    // Branch hop b->d. The input is %src1 - the `b` of the second hop, NOT its
+    // target `c` - so the branch leaves from `b`. The carry set is {%a2, %tgt1}:
+    // `a` (to return it) and `c` (to keep the earlier match bound). Each carried
+    // column comes back in carry-set order, so %a3 is `a` and %c1 is `c`, both
+    // replicated per branch edge - one row per (a, b, c, d). %src2 is `b`,
+    // %tgt2 is `d`.
+    %src2, %e2, %et2, %tgt2, %a3, %c1 = db.get_out_edges(%src1, {%a2, %tgt1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+
+    // RETURN a: the branch-filtered `a`, one row per full (a, b, c, d) match.
+    db.output(%a3) : !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/branch.nl.mlir
+++ b/samples/mlir/branch.nl.mlir
@@ -1,0 +1,34 @@
+// Generated nl-dialect lowering of branch.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered branch.mlir
+// This is the DBLowering output; edit branch.mlir, not this file.
+//
+// MATCH (a)->(b)->(c), (b)->(d) RETURN a. Three nested loops: the branch loop
+// nests inside the second hop's loop, because its input `b` (%arg5, the second
+// hop's srcids) is bound there - the branch leaves from `b`, not from the chain
+// tip `c`. `a` rides the carry set through both hops, so the emitted %arg14 is
+// filtered/replicated to one row per (a, b, c, d) match.
+module {
+  func.func @main() {
+    %0 = nl.scan_nodes()
+    nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      // First hop a->b, empty carry set. %arg1 is `a`, %arg4 is `b`.
+      %1 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        // Second hop b->c carrying `a` (%arg1). %arg5 is `b`, %arg8 is `c`,
+        // %arg9 is the carried `a`.
+        %2 = nl.get_out_edges(%arg4, {%arg1}) : !nl.chunk<!storage.node_id>
+        nl.for %arg5, %arg6, %arg7, %arg8, %arg9 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+          // Branch hop b->d. Input is %arg5 (the `b` of the second hop), carry
+          // set {%arg9, %arg8} = {a, c}. Carried columns come back in order, so
+          // %arg14 is `a` and %arg15 is `c`, replicated per branch edge.
+          %3 = nl.get_out_edges(%arg5, {%arg9, %arg8}) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+          nl.for %arg10, %arg11, %arg12, %arg13, %arg14, %arg15 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+            // RETURN a: the branch-filtered `a`, one row per (a, b, c, d).
+            nl.output(%arg14) : !nl.chunk<!storage.node_id>
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/test/query/ir/BranchTwoHopTest.cpp
+++ b/test/query/ir/BranchTwoHopTest.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <span>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "columns/ColumnIDs.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "SimpleGraph.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Accumulates every emitted node ID across all output chunks into one vector.
+// The branch program outputs a single node-ID column - the returned `a`.
+class CollectingNodeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        ASSERT_NE(nodeIDs, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _nodeIDs.push_back((*nodeIDs)[rowIndex].getValue());
+        }
+    }
+
+    const std::vector<uint64_t>& getNodeIDs() const { return _nodeIDs; }
+
+private:
+    std::vector<uint64_t> _nodeIDs;
+};
+
+// MATCH (a)->(b)->(c), (b)->(d) RETURN a. The branch off `b` reconnects to `b`
+// (%srcs2, the second hop's source), not to the chain tip `c`, and carries `a`
+// (and `c`) through, so the emitted %aBranch is filtered/replicated to one row
+// per full (a, b, c, d) match. Returning the second hop's `a` (%aCarried)
+// instead would drop the branch's x-d multiplicity and undercount `a`. This is
+// the lowered nl form of samples/mlir/branch.mlir (see samples/mlir/branch.nl.mlir).
+constexpr const char* branchTwoHopProgram = R"mlir(
+func.func @main() {
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!storage.node_id>
+      nl.for %srcs2, %eids2, %etypes2, %c, %aCarried in %hop : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        %branch = nl.get_out_edges(%srcs2, {%aCarried, %c}) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        nl.for %srcs3, %eids3, %etypes3, %d, %aBranch, %cBranch in %branch : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+          nl.output(%aBranch) : !nl.chunk<!storage.node_id>
+        }
+      }
+    }
+  }
+  func.return
+}
+)mlir";
+
+}
+
+class BranchTwoHopTest : public TuringTest {
+protected:
+    void runProgram(const char* programText, const GraphView& view, NLOutputSink& sink) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+    }
+};
+
+// MATCH (a)->(b)->(c), (b)->(d) RETURN a on the simpledb graph - the query and
+// graph on which the wrong `a` count was reported. Only three nodes are a valid
+// `b` (one with a predecessor `a` and at least one successor); `c` and `d` each
+// range over all of `b`'s successors independently:
+//   b = Remy (0):   a in {Adam (1), Ghosts (6)}, out-degree 4 -> 2 * 4 * 4 = 32
+//   b = Adam (1):   a = Remy (0),                 out-degree 3 -> 1 * 3 * 3 = 9
+//   b = Ghosts (6): a = Remy (0),                 out-degree 1 -> 1 * 1 * 1 = 1
+// so 42 rows of `a`: Remy x10 (9 via Adam + 1 via Ghosts), Adam x16, Ghosts x16.
+// Returning the second hop's `a` instead of the branch-filtered one drops the
+// x-d factor and undercounts to 12 - the bug this test guards against.
+TEST_F(BranchTwoHopTest, returnsBranchCarriedSourceCount) {
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runProgram(branchTwoHopProgram, reader.getView(), sink);
+
+    std::vector<uint64_t> nodeIDs = sink.getNodeIDs();
+    std::sort(nodeIDs.begin(), nodeIDs.end());
+
+    // Remy (0) x10, Adam (1) x16, Ghosts (6) x16, already in sorted order.
+    std::vector<uint64_t> expected;
+    expected.insert(expected.end(), 10, 0);
+    expected.insert(expected.end(), 16, 1);
+    expected.insert(expected.end(), 16, 6);
+
+    EXPECT_EQ(nodeIDs.size(), 42u);
+    EXPECT_EQ(nodeIDs, expected);
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -15,3 +15,7 @@ add_ir_tests(test_query_ir_nlexecutor NLExecutorTest.cpp)
 add_ir_tests(test_query_ir_dblowering DBLoweringTest.cpp)
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
+
+# The branch two-hop test runs against the shared SimpleGraph fixture.
+add_ir_tests(test_query_ir_branch_two_hop BranchTwoHopTest.cpp)
+target_link_libraries(test_query_ir_branch_two_hop PRIVATE turing_db_examples_s)


### PR DESCRIPTION
Adds a `db` and `nl` sample pair for 
```cypher
MATCH (a)->(b)->(c), (b)->(d) RETURN a
``` 
to pin down the carry-set handling behind wrong `a` counts on simpledb when compared to current pipeline.

* `branch.mlir` is the `db` form (scan + three `get_out_edges` hops) and `branch.nl.mlir` is its nested-loop lowering
* verified byte-for-byte against `mlir -dump-lowered branch.mlir`. 
* The branch hop takes `%src1` (the second hop's source = `b`), not `%tgt1` (=`c`), so it leaves from `b`, and it carries `a` through the carry set `{%a2, %tgt1}` — `RETURN a` must emit the branch-filtered `%a3`, not the pre-branch `%a2`.

Counts on simpledb: correct (`%a3`) = 42 rows; the bug (`%a2`) = 12. 42 = b=Remy (2 preds × 4 c × 4 d = 32) + b=Adam (1×3×3 = 9) + b=Ghosts (1×1×1 = 1). Returning `%a2` drops the branch's ×d multiplicity, which is the undercount to look for in the frontend's projection of the branch pattern.