### PR TITLE
MLIR: nested cross products, refreshed dialect samples/docs, and a sample-parse regress test

### DIFF
--- a/docs/subroutine_interpreter.md
+++ b/docs/subroutine_interpreter.md
@@ -10,14 +10,14 @@ without lowering to LLVM and without walking MLIR data structures at runtime.
 ```mlir
 func.func @two_hop() {
   %nodes = nl.scan_nodes()
-  nl.for %a in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
     %edges = nl.get_out_edges(%a, {})
     nl.for %srcs, %eids, %etypes, %b in %edges
-        : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
-      %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!nl.node_id>
+        : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!storage.node_id>
       nl.for %srcs2, %eids2, %etypes2, %c, %aFiltered in %hop
-          : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
-        nl.output(%aFiltered, %c) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+          : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%aFiltered, %c) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
       }
     }
   }

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -101,8 +101,8 @@ def GetNodeProperties : TuringOp<"get_node_properties", [Pure]> {
     traversal carries only node IDs; this op fetches the value behind `a.name`,
     one per node, into a new column:
 
-      %a    = db.scan_nodes() : !db.column<"a">
-      %name = db.get_node_properties(%a, "name") : (!db.column<"a">) -> !db.column<"a.name">
+      %a    = db.scan_nodes() : !db.column<!storage.node_id>
+      %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
 
     A node may not have the property, so missing values come back null and no
     node is dropped - the lowering uses the with-null property fetch. One op
@@ -138,11 +138,12 @@ def GetEdgeProperties : TuringOp<"get_edge_properties", [Pure]> {
     this op fetches the value behind `e.weight`, one per edge, with missing
     values null:
 
-      %weight = db.get_edge_properties(%eids, "weight") : (!db.column<"eids">) -> !db.column<"e.weight">
+      %weight = db.get_edge_properties(%eids, "weight") : (!db.column<!storage.edge_id>) -> !db.column<none>
 
-    A db.column is just a named column at this level, so node and edge columns
-    are indistinguishable in the type; the op chosen - node vs edge - selects
-    which side of the graph the property is read from.
+    The input column carries its element type - !storage.edge_id here - and the
+    op chosen (get_node_properties vs get_edge_properties) selects which side of
+    the graph the property is read from. The value column is left typed none: the
+    property's value type is only resolved against the schema during lowering.
   }];
 
   let arguments = (ins Column:$input_edges, StrAttr:$property);
@@ -168,11 +169,11 @@ def CrossProduct : TuringOp<"cross_product", [Pure]> {
     arguments, so the two factors share no SSA value.
 
       %a, %b = db.cross_product factor {
-        %x = db.scan_nodes() : !db.column<"a">
-        db.yield %x : !db.column<"a">
+        %x = db.scan_nodes() : !db.column<!storage.node_id>
+        db.yield %x : !db.column<!storage.node_id>
       } factor {
-        %y = db.scan_nodes() : !db.column<"b">
-        db.yield %y : !db.column<"b">
+        %y = db.scan_nodes() : !db.column<!storage.node_id>
+        db.yield %y : !db.column<!storage.node_id>
       }
 
     Because the factors are disconnected, which columns end up in the result
@@ -241,7 +242,7 @@ def Output : TuringOp<"output"> {
   let description = [{
       Sends a number of columns to output.
 
-      db.output(%a, %b, %c) : !db.column<a>, !db.column<b>, !db.column<c>
+      db.output(%a, %b, %c) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
 
     Variadic<Column> accepts any number of columns of any value. The op has no
     results and is deliberately not Pure: emitting the result is its whole
@@ -265,9 +266,9 @@ def Limit : TuringOp<"limit", [Pure]> {
     to the first N rows of the columns flowing into db.output, passing them
     through unchanged:
 
-      %a  = db.scan_nodes() : !db.column<"a">
-      %la = db.limit(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
-      db.output(%la) : !db.column<"a">
+      %a  = db.scan_nodes() : !db.column<!storage.node_id>
+      %la = db.limit(%a) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+      db.output(%la) : !db.column<!storage.node_id>
 
     It lowers to a hoisted nl.limit handle, an nl.limit_update in the innermost
     loop body, a `limit` operand on every nl.for in the nest, and a `limit`
@@ -301,9 +302,9 @@ def Skip : TuringOp<"skip", [Pure]> {
     The declarative counterpart of a Cypher RETURN ... SKIP M. Drops the first M
     rows of the columns flowing through it, passing the rest through unchanged:
 
-      %a  = db.scan_nodes() : !db.column<"a">
-      %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
-      db.output(%sa) : !db.column<"a">
+      %a  = db.scan_nodes() : !db.column<!storage.node_id>
+      %sa = db.skip(%a) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+      db.output(%sa) : !db.column<!storage.node_id>
   }];
 
   // The columns flow through unchanged; count is unsigned - a count of rows to
@@ -334,11 +335,11 @@ def Sort : TuringOp<"sort", [Pure]> {
     so that the key columns are sorted; every column moves as one row, so the
     projection stays row-aligned:
 
-      %a     = db.scan_nodes() : !db.column<"a">
-      %score = db.get_node_properties(%a, "score") : (!db.column<"a">) -> !db.column<"a.score">
+      %a     = db.scan_nodes() : !db.column<!storage.node_id>
+      %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
       %sa, %sscore = db.sort(%a, %score) keys [1] ascending [true]
-                       : (!db.column<"a">, !db.column<"a.score">) -> (!db.column<"a">, !db.column<"a.score">)
-      db.output(%sa, %sscore) : !db.column<"a">, !db.column<"a.score">
+                       : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+      db.output(%sa, %sscore) : !db.column<!storage.node_id>, !db.column<none>
 
     A row is sorted across several columns: `keys` is the list of column indices
     to sort by, most significant first (so `keys [1, 0]` sorts by column 1, ties
@@ -388,9 +389,9 @@ def RemoveDuplicates : TuringOp<"remove_duplicates", [Pure]> {
     nulls count as equal, as Cypher DISTINCT dedups nulls together. The columns
     pass through unchanged in count and type; only duplicate rows are removed:
 
-      %a  = db.scan_nodes() : !db.column<"a">
-      %da = db.remove_duplicates(%a) : (!db.column<"a">) -> !db.column<"a">
-      db.output(%da) : !db.column<"a">
+      %a  = db.scan_nodes() : !db.column<!storage.node_id>
+      %da = db.remove_duplicates(%a) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+      db.output(%da) : !db.column<!storage.node_id>
 
     Unlike db.sort it is not a pipeline breaker: it emits a row the moment it first
     sees it, keeping only a growing seen-set. It lowers to a hoisted nl.distinct

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -15,7 +15,7 @@ def ScanNodes : NLOp<"scan_nodes", [Pure, InferTypeOpAdaptor]> {
   let description = [{
     Imperative counterpart of db.scan_nodes. Each step of an enclosing
     nl.for fills one chunk of node IDs. The result type is always
-    !nl.iter<!nl.chunk<!nl.node_id>> and is inferred, not spelled out.
+    !nl.iter<!nl.chunk<!storage.node_id>> and is inferred, not spelled out.
   }];
   let results   = (outs NLIterator:$result);
   let assemblyFormat = "`(`operands`)` attr-dict";
@@ -40,7 +40,7 @@ def GetOutEdges : NLOp<"get_out_edges", [Pure, InferTypeOpAdaptor]> {
       %edges = nl.get_out_edges(%a, {})
       nl.for %srcs, %eids, %etypes, %b in %edges {
         // second hop b->c, carrying the `a` of this step (here %srcs)
-        %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!nl.node_id>
+        %hop = nl.get_out_edges(%b, {%srcs}) : !nl.chunk<!storage.node_id>
         nl.for %srcs2, %eids2, %etypes2, %c, %aFiltered in %hop { ... }
       }
 
@@ -131,14 +131,14 @@ def GetNodeProperties : NLOp<"get_node_properties", [Pure]> {
     into the current nl.for body.
 
     A node may not have the property, so the result is a nullable value chunk -
-    !nl.chunk<!nl.nullable<...>>, storage's ColumnOptVector. Missing values come
+    !nl.chunk<!storage.nullable<...>>, storage's ColumnOptVector. Missing values come
     back null; no row is dropped. The wrapped type is the concrete primitive the
     property resolved to during lowering.
 
       %weight = nl.get_property_type("weight")
       nl.for %nodes in %scan {
-        %values = nl.get_node_properties(%nodes, %weight) : !nl.chunk<!nl.nullable<f64>>
-        nl.output(%nodes, %values) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<f64>>
+        %values = nl.get_node_properties(%nodes, %weight) : !nl.chunk<!storage.nullable<f64>>
+        nl.output(%nodes, %values) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<f64>>
       }
   }];
 
@@ -181,7 +181,7 @@ def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
     Each step fills the next chunks of the iterator and binds them to the
     loop variables, one variable per chunk:
 
-    nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!nl.node_id>> {
+    nl.for %chunk in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
         ...
     }
 
@@ -190,7 +190,7 @@ def For : NLOp<"for", [SingleBlockImplicitTerminator<"Yield">]> {
     every nl.for in a LIMIT's nest carries the same handle and the break unwinds
     the whole nest:
 
-    nl.for %chunk in %nodes limit %h : !nl.iter<!nl.chunk<!nl.node_id>> {
+    nl.for %chunk in %nodes limit %h : !nl.iter<!nl.chunk<!storage.node_id>> {
         ...
     }
   }];
@@ -235,7 +235,7 @@ def CrossProduct : NLOp<"cross_product", [Pure, InferTypeOpAdaptor, AttrSizedOpe
     every outer row against every inner row.
 
       %a, %b = nl.cross_product {%a} {%b}
-                 : {!nl.chunk<!nl.node_id>} {!nl.chunk<!nl.node_id>}
+                 : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
 
     The two brace groups are the columns each factor contributes, in db.yield
     order; the op's results are the outer columns followed by the inner, each
@@ -250,7 +250,7 @@ def CrossProduct : NLOp<"cross_product", [Pure, InferTypeOpAdaptor, AttrSizedOpe
     would be wasted work. Absent, the whole N*M product is built.
 
       %a, %b = nl.cross_product {%a} {%b} limit %h
-                 : {!nl.chunk<!nl.node_id>} {!nl.chunk<!nl.node_id>}
+                 : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
   }];
 
   // The outer and inner column groups to cross, plus the optional limit handle.
@@ -288,8 +288,8 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     query result, one output column per chunk. The columns are typically loop
     variables, so each nl.for step emits one chunk per column:
 
-    nl.output(%targets) : !nl.chunk<!nl.node_id>
-    nl.output(%sources, %targets) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+    nl.output(%targets) : !nl.chunk<!storage.node_id>
+    nl.output(%sources, %targets) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
 
     Variadic<NLChunk> accepts any number of chunks of any element type. The op
     is deliberately not Pure: emitting output is its whole point, so it must
@@ -303,7 +303,7 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     output can read the budgeted prefix off the handle instead of copying it. It
     never mutates the budget - it only reads how many rows to emit:
 
-    nl.output(%targets) limit %h : !nl.chunk<!nl.node_id>
+    nl.output(%targets) limit %h : !nl.chunk<!storage.node_id>
 
     An optional `skip` operand carries an !nl.skip_state handle and is the skip
     sibling of the limit form: when present, output emits the surviving suffix
@@ -314,7 +314,7 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     path the suffix could not take through the sink before output learned an
     offset). Like the limit form it never mutates the counter:
 
-    nl.output(%targets) skip %h : !nl.chunk<!nl.node_id>
+    nl.output(%targets) skip %h : !nl.chunk<!storage.node_id>
   }];
 
   // Three variable-length operand groups - the columns, the optional limit and
@@ -403,7 +403,7 @@ def LimitTruncate : NLOp<"limit_truncate", [InferTypeOpAdaptor]> {
     awareness of its own. The columns pass through unchanged in type; only the row
     count is cut.
 
-      %a' = nl.limit_truncate %h, (%a) : !nl.chunk<!nl.node_id>
+      %a' = nl.limit_truncate %h, (%a) : !nl.chunk<!storage.node_id>
   }];
 
   // The limit handle whose emitThisStep sizes the copy, then the columns to cut.
@@ -488,7 +488,7 @@ def SkipTruncate : NLOp<"skip_truncate", [InferTypeOpAdaptor]> {
     survives only when the suffix feeds an inner sub-pipeline (a chained query)
     that reads from row zero and so needs the rows lifted to the front.
 
-      %a' = nl.skip_truncate %h, (%a) : !nl.chunk<!nl.node_id>
+      %a' = nl.skip_truncate %h, (%a) : !nl.chunk<!storage.node_id>
   }];
 
   // The skip handle whose offset/count size the copy, then the columns to cut.
@@ -562,7 +562,7 @@ def SortCollect : NLOp<"sort_collect", []> {
     handle, so that by the time the producing loop is exhausted the buffers hold
     every row. The columns are taken together so the buffers stay row-aligned.
 
-      nl.sort_collect %state, (%a, %score) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>
+      nl.sort_collect %state, (%a, %score) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<i64>>
   }];
 
   // The accumulator handle, then the columns to append. The column chunk types
@@ -592,9 +592,9 @@ def Sort : NLOp<"sort", [Pure]> {
     per column per step - the same chunk shape the buffers were collected with, so
     an enclosing nl.for binds one loop variable per column:
 
-      %sorted = nl.sort(%state) : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>>
+      %sorted = nl.sort(%state) : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<i64>>>
       nl.for %a, %score in %sorted : !nl.iter<...> {
-        nl.output(%a, %score) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.nullable<i64>>
+        nl.output(%a, %score) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<i64>>
       }
 
     The iterator chunk types match the collected columns, but cannot be inferred
@@ -643,7 +643,7 @@ def DistinctFilter : NLOp<"distinct_filter", [InferTypeOpAdaptor]> {
     DISTINCT awareness. And because it shrinks each chunk, a following nl.limit_update
     charges the deduped count, so a downstream LIMIT bounds the producing loop.
 
-      %da = nl.distinct_filter %s, (%a) : !nl.chunk<!nl.node_id>
+      %da = nl.distinct_filter %s, (%a) : !nl.chunk<!storage.node_id>
   }];
 
   let arguments = (ins NLDistinctStateHandle:$state, Variadic<NLChunk>:$columns);

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -119,7 +119,7 @@ def NLPropertyType : NLType<"PropertyType", "property_type"> {
 }
 
 // NLNodeIDChunk is a type *constraint*, not a new type: it restricts an op
-// operand to !nl.chunk<!nl.node_id> without defining anything new. Ops use it
+// operand to !nl.chunk<!storage.node_id> without defining anything new. Ops use it
 // in their (ins ...) clause where NLChunk would accept a chunk of anything.
 //
 // It is built from two tablegen pieces:
@@ -144,7 +144,7 @@ def NLNodeIDChunk : Type<
                   "::mlir::storage::NodeIDType::get($_builder.getContext()))">;
 
 // The edge-chunk counterpart of NLNodeIDChunk: constrains an operand to
-// !nl.chunk<!nl.edge_id> and carries a BuildableType recipe so an assembly
+// !nl.chunk<!storage.edge_id> and carries a BuildableType recipe so an assembly
 // format can omit the type. See NLNodeIDChunk above for the piece-by-piece
 // breakdown of Type<CPred, summary, cppClass> + BuildableType.
 def NLEdgeIDChunk : Type<

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -48,7 +48,7 @@ NLHandlerFunction selectPropertyFetchHandler(bool isNode, ValueType valueType) {
 // Reverse of DBLowering's valueTypeToElementType: recover the storage value
 // type baked into a nullable value chunk's element type. A cross product result
 // keeps its input chunk's element type, so a crossed property column carries the
-// same !nl.nullable<...> the fetch produced, and this maps it back to allocate
+// same !storage.nullable<...> the fetch produced, and this maps it back to allocate
 // the matching nullable value column and pick the broadcast.
 ValueType valueTypeFromElementType(mlir::Type elementType) {
     if (mlir::isa<storage::StringType>(elementType)) {
@@ -876,7 +876,7 @@ NLAggregateState* NLTranslator::aggregateStateFor(mlir::Value handle) const {
     return stateIt->second;
 }
 
-// An ID chunk allocates an ID column on its kind; a !nl.nullable<...> chunk
+// An ID chunk allocates an ID column on its kind; a !storage.nullable<...> chunk
 // allocates a ColumnOptVector on its value type. Mirrors addCrossColumn's split.
 Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
     const auto chunk = mlir::cast<nl::ChunkType>(chunkType);

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -198,7 +198,7 @@ private:
     NLAggregateState* aggregateStateFor(mlir::Value handle) const;
 
     // Pool-allocate a buffer/loop column matching a chunk type - an ID column for
-    // an ID chunk, a nullable value column for a !nl.nullable<...> chunk - and the
+    // an ID chunk, a nullable value column for a !storage.nullable<...> chunk - and the
     // append/gather/compare handler for that element type. The compare selector
     // throws for chunk types that have no order (an embedding key).
     Column* allocColumnForChunkType(mlir::Type chunkType);
@@ -208,7 +208,7 @@ private:
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
 
     // The non-null row count handler for a chunk type - the all-rows count for an
-    // ID chunk, the present-value count for a !nl.nullable<...> chunk. Used by
+    // ID chunk, the present-value count for a !storage.nullable<...> chunk. Used by
     // nl.count_update.
     static NLCountFunction selectCountForChunkType(mlir::Type chunkType);
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -398,6 +398,15 @@ void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
         _valueMap[dbResults[resultIndex]] = crossResults[resultIndex];
     }
+
+    // The crossed columns live in innerBody, so when this product is itself
+    // nested in a factor - e.g. the three-way MATCH (a), (b), (c), where a
+    // cross_product's factor is another cross_product - it stands in for that
+    // factor's innermost loop: the enclosing factor roots its next op (or a
+    // deeper product) there. Record it the way buildLoopForSource records a real
+    // loop, so lowerFactor sees a factor whose innermost "loop" is this product.
+    // At top level nothing reads _innermostLoopBody, so this is a no-op there.
+    _innermostLoopBody = innerBody;
 }
 
 mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -86,7 +86,10 @@ class GraphView;
 // loops nested inside the outer factor's innermost loop body, so the inner
 // factor re-runs once per outer chunk (a nested-loop join, bounded memory) -
 // bridged at the deepest point by an nl.cross_product that crosses the two
-// factors' yielded chunks just before db.output consumes them.
+// factors' yielded chunks just before db.output consumes them. A factor may
+// itself be a db.cross_product (the three-way MATCH (a), (b), (c)): the product
+// stands in for that factor's innermost loop, so the enclosing factor nests
+// under it and the two products compose into one deeper loop nest.
 //
 class DBLowering {
 public:
@@ -240,7 +243,7 @@ private:
     // top of the entry block (above every loop) and reused on later lookups
     mlir::Value getOrCreatePropertyTypeHandle(llvm::StringRef propertyName);
 
-    // The !nl.chunk<!nl.nullable<T>> a fetch of this property produces, with T
+    // The !nl.chunk<!storage.nullable<T>> a fetch of this property produces, with T
     // the value type the name resolves to in the schema
     mlir::Type propertyValueChunkType(llvm::StringRef propertyName);
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -50,6 +50,7 @@ add_subdirectory(load_parquet)
 add_subdirectory(history_on_change)
 add_subdirectory(reload_submit_edge)
 add_subdirectory(json_escape_properties)
+add_subdirectory(mlir_samples_parse)
 
 # write run_regress target
 # The script finds the wheel at runtime to avoid needing to re-run cmake after wheel build

--- a/regress/mlir_samples_parse/CMakeLists.txt
+++ b/regress/mlir_samples_parse/CMakeLists.txt
@@ -1,0 +1,1 @@
+regress_test(mlir_samples_parse run.sh)

--- a/regress/mlir_samples_parse/run.sh
+++ b/regress/mlir_samples_parse/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Parse every MLIR sample under samples/mlir with the `mlir` sample tool and
+# check the outcome. The file list is discovered at runtime, so dropping a new
+# .mlir sample in is covered automatically - there is nothing to edit here.
+#
+# Convention: a sample named invalid_*.mlir is a negative fixture and must be
+# rejected; every other sample must parse cleanly.
+
+set -u
+
+# The mlir sample tool is installed by turing_sample to $TURING_HOME/samples/mlir.
+# The sample sources are not installed, so they are read from the source tree,
+# which run_regress exports as $SOURCE_DIR. Both are overridable so the test can
+# be run standalone (outside the run_regress harness) for debugging.
+MLIR_TOOL="${MLIR_TOOL:-${TURING_HOME:-}/samples/mlir/mlir}"
+SAMPLES_DIR="${MLIR_SAMPLES_DIR:-${SOURCE_DIR:-}/samples/mlir}"
+
+if [[ ! -x "$MLIR_TOOL" ]]; then
+    echo "error: mlir sample tool not found at '$MLIR_TOOL'" >&2
+    exit 1
+fi
+if [[ ! -d "$SAMPLES_DIR" ]]; then
+    echo "error: sample directory not found at '$SAMPLES_DIR'" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+samples=("$SAMPLES_DIR"/*.mlir)
+if [[ ${#samples[@]} -eq 0 ]]; then
+    echo "error: no .mlir samples found in '$SAMPLES_DIR'" >&2
+    exit 1
+fi
+
+declare -i checked=0
+declare -a failures=()
+
+for f in "${samples[@]}"; do
+    name=$(basename "$f")
+    checked+=1
+
+    if "$MLIR_TOOL" "$f" >/dev/null 2>&1; then
+        parsed=1
+    else
+        parsed=0
+    fi
+
+    if [[ "$name" == invalid_* ]]; then
+        # Negative fixture: the tool must reject it.
+        if [[ $parsed -eq 1 ]]; then
+            echo "FAIL  $name (parsed, but an invalid_* fixture must be rejected)"
+            failures+=("$name")
+        else
+            echo "ok    $name (rejected as expected)"
+        fi
+    else
+        # Every other sample must parse.
+        if [[ $parsed -eq 1 ]]; then
+            echo "ok    $name"
+        else
+            echo "FAIL  $name (did not parse):"
+            "$MLIR_TOOL" "$f" 2>&1 | sed 's/^/        /' | head -5
+            failures+=("$name")
+        fi
+    fi
+done
+
+echo
+echo "=== mlir_samples_parse: checked $checked sample(s), ${#failures[@]} failure(s) ==="
+for t in "${failures[@]}"; do echo "  - $t"; done
+
+# Non-zero exit on any failure.
+[[ ${#failures[@]} -eq 0 ]]

--- a/regress/mlir_samples_parse/run.sh
+++ b/regress/mlir_samples_parse/run.sh
@@ -67,7 +67,11 @@ done
 
 echo
 echo "=== mlir_samples_parse: checked $checked sample(s), ${#failures[@]} failure(s) ==="
-for t in "${failures[@]}"; do echo "  - $t"; done
+# Guard the expansion: under `set -u`, macOS's bash 3.2 treats "${failures[@]}"
+# on an empty array as an unbound variable, so only expand it when non-empty.
+if [[ ${#failures[@]} -gt 0 ]]; then
+    for t in "${failures[@]}"; do echo "  - $t"; done
+fi
 
 # Non-zero exit on any failure.
 [[ ${#failures[@]} -eq 0 ]]

--- a/samples/mlir/limit.mlir
+++ b/samples/mlir/limit.mlir
@@ -6,11 +6,11 @@ module {
     // scan loop (so it stops once the budget is spent), an nl.limit_update that
     // charges each chunk against the budget, and an nl.limit_truncate that cuts
     // the chunk to the prefix the budget allows before nl.output emits it.
-    %a = db.scan_nodes() : !db.column<"a">
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %la = db.limit(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
+    %la = db.limit(%a) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
 
-    db.output(%la) : !db.column<"a">
+    db.output(%la) : !db.column<!storage.node_id>
 
     return
   }

--- a/samples/mlir/limit.nl.mlir
+++ b/samples/mlir/limit.nl.mlir
@@ -5,9 +5,9 @@ module {
   func.func @main() {
     %0 = nl.limit(3)
     %1 = nl.scan_nodes()
-    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
-      nl.limit_update %0, %arg0 : !nl.chunk<!nl.node_id>
-      nl.output(%arg0) limit %0 : !nl.chunk<!nl.node_id>
+    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.limit_update %0, %arg0 : !nl.chunk<!storage.node_id>
+      nl.output(%arg0) limit %0 : !nl.chunk<!storage.node_id>
     }
     return
   }

--- a/samples/mlir/limit_chained.mlir
+++ b/samples/mlir/limit_chained.mlir
@@ -9,13 +9,13 @@ module {
     // next db.get_out_edges, not db.output. db.limit lowers to an
     // nl.limit_truncate placed just before that inner traversal, handing it a
     // genuinely cut chunk so the downstream loop stays limit-oblivious.
-    %a = db.scan_nodes() : !db.column<"a">
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %la = db.limit(%a) count 2 : (!db.column<"a">) -> !db.column<"a">
+    %la = db.limit(%a) count 2 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
 
-    %a1, %e0, %et0, %b = db.get_out_edges(%la, {}) : (!db.column<"a">) -> (!db.column<"a1">, !db.column<"e0">, !db.column<"et0">, !db.column<"b">)
+    %a1, %e0, %et0, %b = db.get_out_edges(%la, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
 
-    db.output(%b) : !db.column<"b">
+    db.output(%b) : !db.column<!storage.node_id>
 
     return
   }

--- a/samples/mlir/limit_chained.nl.mlir
+++ b/samples/mlir/limit_chained.nl.mlir
@@ -5,12 +5,12 @@ module {
   func.func @main() {
     %0 = nl.limit(2)
     %1 = nl.scan_nodes()
-    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
-      nl.limit_update %0, %arg0 : !nl.chunk<!nl.node_id>
-      %2 = nl.limit_truncate %0, (%arg0) : !nl.chunk<!nl.node_id>
+    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.limit_update %0, %arg0 : !nl.chunk<!storage.node_id>
+      %2 = nl.limit_truncate %0, (%arg0) : !nl.chunk<!storage.node_id>
       %3 = nl.get_out_edges(%2, {})
-      nl.for %arg1, %arg2, %arg3, %arg4 in %3 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
-        nl.output(%arg4) : !nl.chunk<!nl.node_id>
+      nl.for %arg1, %arg2, %arg3, %arg4 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%arg4) : !nl.chunk<!storage.node_id>
       }
     }
     return

--- a/samples/mlir/limit_cross_product.mlir
+++ b/samples/mlir/limit_cross_product.mlir
@@ -8,16 +8,16 @@ module {
     // nl.limit_update charges that post-cross-product row count, and the
     // nl.limit_truncate cuts it to five before nl.output.
     %0:2 = db.cross_product factor {
-      %a = db.scan_nodes() : !db.column<"a">
-      db.yield %a : !db.column<"a">
+      %a = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %a : !db.column<!storage.node_id>
     } factor {
-      %b = db.scan_nodes() : !db.column<"b">
-      db.yield %b : !db.column<"b">
+      %b = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %b : !db.column<!storage.node_id>
     }
 
-    %la, %lb = db.limit(%0#0, %0#1) count 5 : (!db.column<"a">, !db.column<"b">) -> (!db.column<"a">, !db.column<"b">)
+    %la, %lb = db.limit(%0#0, %0#1) count 5 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
 
-    db.output(%la, %lb) : !db.column<"a">, !db.column<"b">
+    db.output(%la, %lb) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
 
     return
   }

--- a/samples/mlir/limit_cross_product.nl.mlir
+++ b/samples/mlir/limit_cross_product.nl.mlir
@@ -5,12 +5,12 @@ module {
   func.func @main() {
     %0 = nl.limit(5)
     %1 = nl.scan_nodes()
-    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
+    nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %2 = nl.scan_nodes()
-      nl.for %arg1 in %2 limit %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
-        %3:2 = nl.cross_product{%arg0} {%arg1} limit %0 : {!nl.chunk<!nl.node_id>} {!nl.chunk<!nl.node_id>}
-        nl.limit_update %0, %3#0 : !nl.chunk<!nl.node_id>
-        nl.output(%3#0, %3#1) limit %0 : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+      nl.for %arg1 in %2 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+        %3:2 = nl.cross_product{%arg0} {%arg1} limit %0 : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+        nl.limit_update %0, %3#0 : !nl.chunk<!storage.node_id>
+        nl.output(%3#0, %3#1) limit %0 : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
       }
     }
     return

--- a/samples/mlir/limit_two_stages.mlir
+++ b/samples/mlir/limit_two_stages.mlir
@@ -8,15 +8,15 @@ module {
     // clobber each other. The scan loop is shared by both limits' producing
     // nests; the outer (first, in program order) limit claims it, and the second
     // limit's nl.limit_truncate still caps the expansion independently.
-    %a = db.scan_nodes() : !db.column<"a">
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %la = db.limit(%a) count 2 : (!db.column<"a">) -> !db.column<"a">
+    %la = db.limit(%a) count 2 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
 
-    %a1, %e0, %et0, %b = db.get_out_edges(%la, {}) : (!db.column<"a">) -> (!db.column<"a1">, !db.column<"e0">, !db.column<"et0">, !db.column<"b">)
+    %a1, %e0, %et0, %b = db.get_out_edges(%la, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
 
-    %lb = db.limit(%b) count 3 : (!db.column<"b">) -> !db.column<"b">
+    %lb = db.limit(%b) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
 
-    db.output(%lb) : !db.column<"b">
+    db.output(%lb) : !db.column<!storage.node_id>
 
     return
   }

--- a/samples/mlir/limit_two_stages.nl.mlir
+++ b/samples/mlir/limit_two_stages.nl.mlir
@@ -6,13 +6,13 @@ module {
     %0 = nl.limit(2)
     %1 = nl.limit(3)
     %2 = nl.scan_nodes()
-    nl.for %arg0 in %2 limit %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
-      nl.limit_update %0, %arg0 : !nl.chunk<!nl.node_id>
-      %3 = nl.limit_truncate %0, (%arg0) : !nl.chunk<!nl.node_id>
+    nl.for %arg0 in %2 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.limit_update %0, %arg0 : !nl.chunk<!storage.node_id>
+      %3 = nl.limit_truncate %0, (%arg0) : !nl.chunk<!storage.node_id>
       %4 = nl.get_out_edges(%3, {})
-      nl.for %arg1, %arg2, %arg3, %arg4 in %4 limit %1 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
-        nl.limit_update %1, %arg4 : !nl.chunk<!nl.node_id>
-        nl.output(%arg4) limit %1 : !nl.chunk<!nl.node_id>
+      nl.for %arg1, %arg2, %arg3, %arg4 in %4 limit %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        nl.limit_update %1, %arg4 : !nl.chunk<!storage.node_id>
+        nl.output(%arg4) limit %1 : !nl.chunk<!storage.node_id>
       }
     }
     return

--- a/samples/mlir/nested_cross_product.mlir
+++ b/samples/mlir/nested_cross_product.mlir
@@ -1,0 +1,31 @@
+module {
+  func.func @main() {
+    // MATCH (a), (b), (c) RETURN a, b, c: a three-way cross product.
+    //
+    // The db dialect has no n-ary cross_product, so a third factor is expressed
+    // by nesting: the outer product's left factor is itself a db.cross_product
+    // crossing (a) with (b), and the outer product crosses that (a, b) pair with
+    // (c). Lowering nests the inner product's loops inside the outer product's,
+    // so the whole thing becomes one deeper loop nest - the inner nl.cross_product
+    // materializes the (a, b) pairs once per (a, b) chunk pair, and the outer
+    // nl.cross_product crosses that with each `c` chunk. The result is every
+    // (a, b, c) triple over the node set, N^3 rows.
+    %0:3 = db.cross_product factor {
+      %1:2 = db.cross_product factor {
+        %a = db.scan_nodes() : !db.column<!storage.node_id>
+        db.yield %a : !db.column<!storage.node_id>
+      } factor {
+        %b = db.scan_nodes() : !db.column<!storage.node_id>
+        db.yield %b : !db.column<!storage.node_id>
+      }
+      db.yield %1#0, %1#1 : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+    } factor {
+      %c = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %c : !db.column<!storage.node_id>
+    }
+
+    db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/nested_cross_product.nl.mlir
+++ b/samples/mlir/nested_cross_product.nl.mlir
@@ -1,0 +1,25 @@
+// Generated nl-dialect lowering of nested_cross_product.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered nested_cross_product.mlir
+// This is the DBLowering output; edit nested_cross_product.mlir, not this file.
+//
+// The three-way MATCH (a), (b), (c) becomes one loop nest: the inner
+// nl.cross_product crosses each `a` chunk with each `b` chunk into the (a, b)
+// pairs, the `c` scan then re-runs inside that, and the outer nl.cross_product
+// crosses the (a, b) pairs with each `c` chunk before nl.output.
+module {
+  func.func @main() {
+    %0 = nl.scan_nodes()
+    nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %1 = nl.scan_nodes()
+      nl.for %arg1 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+        %2:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+        %3 = nl.scan_nodes()
+        nl.for %arg2 in %3 : !nl.iter<!nl.chunk<!storage.node_id>> {
+          %4:3 = nl.cross_product{%2#0, %2#1} {%arg2} : {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+          nl.output(%4#0, %4#1, %4#2) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        }
+      }
+    }
+    return
+  }
+}

--- a/samples/mlir/node_properties.mlir
+++ b/samples/mlir/node_properties.mlir
@@ -7,11 +7,13 @@ module {
     // "name" must be a property that exists in the loaded graph (-graph): the
     // db -> nl lowering resolves the name against the schema and bakes its value
     // type into the result chunk. Swap it for a property your graph actually has.
-    %a = db.scan_nodes() : !db.column<none>
+    // The value column type is left as none in the db dialect - the concrete
+    // type is only known once the property name is resolved during lowering.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %name = db.get_node_properties(%a, "name") : (!db.column<none>) -> !db.column<none>
+    %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
 
-    db.output(%a, %name) : !db.column<none>, !db.column<none>
+    db.output(%a, %name) : !db.column<!storage.node_id>, !db.column<none>
 
     return
   }

--- a/samples/mlir/node_properties.nl.mlir
+++ b/samples/mlir/node_properties.nl.mlir
@@ -1,0 +1,19 @@
+// Generated nl-dialect lowering of node_properties.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered node_properties.mlir -graph <graph>
+// This is the DBLowering output; edit node_properties.mlir, not this file.
+//
+// Needs -graph: the value chunk element type is resolved from the "name"
+// property during lowering. In simpledb name is a String, so the fetch produces
+// a !storage.nullable<!storage.string> value chunk in place inside the scan
+// loop; the node IDs pass straight through, and both columns feed one nl.output.
+module {
+  func.func @main() {
+    %0 = nl.get_property_type("name")
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %2 = nl.get_node_properties(%arg0, %0) : !nl.chunk<!storage.nullable<!storage.string>>
+      nl.output(%arg0, %2) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+    }
+    return
+  }
+}

--- a/samples/mlir/sample.nl.mlir
+++ b/samples/mlir/sample.nl.mlir
@@ -4,12 +4,12 @@
 module {
   func.func @main() {
     %0 = nl.scan_nodes()
-    nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!nl.node_id>> {
+    nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %1 = nl.get_out_edges(%arg0, {})
-      nl.for %arg1, %arg2, %arg3, %arg4 in %1 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>> {
-        %2 = nl.get_out_edges(%arg4, {%arg1}) : !nl.chunk<!nl.node_id>
-        nl.for %arg5, %arg6, %arg7, %arg8, %arg9 in %2 : !nl.iter<!nl.chunk<!nl.node_id>, !nl.chunk<!nl.edge_id>, !nl.chunk<!nl.edge_type_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>> {
-          nl.output(%arg9, %arg5, %arg8) : !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>, !nl.chunk<!nl.node_id>
+      nl.for %arg1, %arg2, %arg3, %arg4 in %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        %2 = nl.get_out_edges(%arg4, {%arg1}) : !nl.chunk<!storage.node_id>
+        nl.for %arg5, %arg6, %arg7, %arg8, %arg9 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+          nl.output(%arg9, %arg5, %arg8) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
         }
       }
     }

--- a/samples/mlir/second.mlir
+++ b/samples/mlir/second.mlir
@@ -1,6 +1,6 @@
 module {
   func.func @second() {
-    %0 = db.scan_nodes() : !db.column<none>
+    %0 = db.scan_nodes() : !db.column<!storage.node_id>
     return
   }
 }

--- a/samples/mlir/skip.mlir
+++ b/samples/mlir/skip.mlir
@@ -10,11 +10,11 @@ module {
     // collapses it: nl.output carries the skip handle and emits the surviving
     // suffix in place at an offset (skipThisStep), with no copy at all - see the
     // generated lowering in skip.nl.mlir.
-    %a = db.scan_nodes() : !db.column<"a">
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
 
-    %sa = db.skip(%a) count 3 : (!db.column<"a">) -> !db.column<"a">
+    %sa = db.skip(%a) count 3 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
 
-    db.output(%sa) : !db.column<"a">
+    db.output(%sa) : !db.column<!storage.node_id>
 
     return
   }

--- a/samples/mlir/skip.nl.mlir
+++ b/samples/mlir/skip.nl.mlir
@@ -5,9 +5,9 @@ module {
   func.func @main() {
     %0 = nl.skip(3)
     %1 = nl.scan_nodes()
-    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!nl.node_id>> {
-      nl.skip_update %0, %arg0 : !nl.chunk<!nl.node_id>
-      nl.output(%arg0) skip %0 : !nl.chunk<!nl.node_id>
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      nl.skip_update %0, %arg0 : !nl.chunk<!storage.node_id>
+      nl.output(%arg0) skip %0 : !nl.chunk<!storage.node_id>
     }
     return
   }

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -13,6 +13,8 @@ endfunction()
 
 add_ir_tests(test_query_ir_nlexecutor NLExecutorTest.cpp)
 add_ir_tests(test_query_ir_dblowering DBLoweringTest.cpp)
+# The nested cross product execution tests run against the shared SimpleGraph fixture.
+target_link_libraries(test_query_ir_dblowering PRIVATE turing_db_examples_s)
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -100,6 +100,31 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a), (b), (c) RETURN a, b, c: a three-way product. The db dialect has no
+// n-ary cross_product; a third factor is expressed by nesting, so the outer
+// product's left factor is itself a db.cross_product crossing (a) with (b), and
+// the outer product crosses that pair with (c). The factor region holds another
+// db.cross_product - the op nests - and the outer product surfaces three columns.
+const char* const nestedCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %1:2 = db.cross_product factor {
+      %a = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %a : !db.column<!storage.node_id>
+    } factor {
+      %b = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %b : !db.column<!storage.node_id>
+    }
+    db.yield %1#0, %1#1 : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  } factor {
+    %c = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %c : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // MATCH (a), (b) RETURN a: the right factor surfaces no column, so its db.yield
 // is empty - which the verifier rejects, since a side's row count is read from
 // its first yielded column.
@@ -327,6 +352,60 @@ TEST_F(DBDialectTest, verifierRejectsResultsNotMatchingYields) {
         return mlir::success();
     });
     EXPECT_TRUE(mlir::failed(mlir::verify(product.getOperation())));
+}
+
+TEST_F(DBDialectTest, parsesNestedCrossProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(nestedCrossProductProgram);
+    ASSERT_TRUE(module);
+
+    // Two products in the module: the outer one and the inner one nested in its
+    // left factor.
+    llvm::SmallVector<mlir::db::CrossProduct, 2> products;
+    module.get().walk([&](mlir::db::CrossProduct op) {
+        products.push_back(op);
+    });
+    ASSERT_EQ(products.size(), 2u);
+
+    // The outer product surfaces three columns (a, b, c); the inner one two
+    // (a, b) - which tells the two apart independently of walk order.
+    mlir::db::CrossProduct outer;
+    mlir::db::CrossProduct inner;
+    for (mlir::db::CrossProduct product : products) {
+        if (product.getResults().size() == 3u) {
+            outer = product;
+        } else {
+            inner = product;
+        }
+    }
+    ASSERT_TRUE(outer);
+    ASSERT_TRUE(inner);
+
+    // The inner product sits inside the outer's left factor, so a factor region
+    // does hold another db.cross_product - the op nests.
+    EXPECT_EQ(inner->getParentOfType<mlir::db::CrossProduct>().getOperation(), outer.getOperation());
+
+    // All three of the outer product's columns are node ID columns.
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Operation::result_range outerResults = outer.getResults();
+    ASSERT_EQ(outerResults.size(), 3u);
+    for (const mlir::Value result : outerResults) {
+        EXPECT_EQ(result.getType(), nodeIDColumnType);
+    }
+}
+
+TEST_F(DBDialectTest, nestedCrossProductRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(nestedCrossProductProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing a nested product yields a module that still
+    // verifies, so the custom printer and parser are inverses through nesting.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
 TEST_F(DBDialectTest, parsesLimit) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -37,6 +37,8 @@
 #include "NLOps.h"
 #include "NLOutputSink.h"
 
+#include "SimpleGraph.h"
+
 #include "TuringTest.h"
 
 using namespace db;
@@ -485,6 +487,32 @@ func.func @main() {
     db.yield %b, %score : !db.column<!storage.node_id>, !db.column<none>
   }
   db.output(%0#0, %0#2) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+// MATCH (a), (b), (c) RETURN a, b, c: a three-way product. The db dialect has no
+// n-ary cross_product, so the third factor is expressed by nesting - the outer
+// product's left factor is itself a db.cross_product crossing (a) with (b), and
+// the outer product crosses that pair with (c). Lowering nests the inner
+// product's loops inside the outer product's, so the result is every (a, b, c)
+// triple over the node set, |nodes|^3 rows.
+constexpr const char* nestedCrossProductScansProgram = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %1:2 = db.cross_product factor {
+      %a = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %a : !db.column<!storage.node_id>
+    } factor {
+      %b = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %b : !db.column<!storage.node_id>
+    }
+    db.yield %1#0, %1#1 : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  } factor {
+    %c = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %c : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
   return
 }
 )mlir";
@@ -1090,6 +1118,22 @@ protected:
         interpreter.run();
     }
 
+    // Fills the node ID set of a graph by lowering and running MATCH (a) RETURN a,
+    // so a cross product's expected result is derived from the graph rather than
+    // from a hardcoded node count.
+    void collectNodeIDs(const GraphView& view, std::vector<uint64_t>& nodes) {
+        CollectingNodeSink scanSink;
+        runLoweredProgram(scanProgram, view, scanSink);
+
+        std::vector<std::vector<uint64_t>> scanRows;
+        scanSink.sortedRows(scanRows);
+
+        nodes.clear();
+        for (const std::vector<uint64_t>& row : scanRows) {
+            nodes.push_back(row.front());
+        }
+    }
+
     std::unique_ptr<JobSystem> _jobSystem;
 };
 
@@ -1346,6 +1390,74 @@ TEST_F(DBLoweringTest, executesCrossProductOfNodeProperty) {
     std::sort(expected.begin(), expected.end());
 
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesNestedCrossProductOnSimpleGraph) {
+    // MATCH (a), (b), (c) RETURN a, b, c on the shared simpledb graph: a
+    // three-way product the db dialect models as a cross_product whose left
+    // factor is itself a cross_product. Executed, it is the whole node set
+    // crossed with itself three times, so |nodes|^3 rows.
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> nodes;
+    collectNodeIDs(reader.getView(), nodes);
+    ASSERT_FALSE(nodes.empty());
+
+    // Every (a, b, c) triple over the node set.
+    std::vector<std::vector<uint64_t>> expected;
+    for (const uint64_t a : nodes) {
+        for (const uint64_t b : nodes) {
+            for (const uint64_t c : nodes) {
+                expected.push_back({a, b, c});
+            }
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    CollectingNodeSink sink;
+    runLoweredProgram(nestedCrossProductScansProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows.size(), nodes.size() * nodes.size() * nodes.size());
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesNestedCrossProductSpanningChunks) {
+    // The same three-way product on simpledb, but a small chunk splits each scan
+    // into several chunks, so the inner product re-runs once per (a, b) chunk
+    // pair and the outer product crosses that materialized result with each c
+    // chunk. The row set is unchanged - still every (a, b, c) triple.
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> nodes;
+    collectNodeIDs(reader.getView(), nodes);
+    ASSERT_FALSE(nodes.empty());
+
+    std::vector<std::vector<uint64_t>> expected;
+    for (const uint64_t a : nodes) {
+        for (const uint64_t b : nodes) {
+            for (const uint64_t c : nodes) {
+                expected.push_back({a, b, c});
+            }
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    CollectingNodeSink sink;
+    runLoweredProgram(nestedCrossProductScansProgram, reader.getView(), sink, /*chunkSize=*/3);
+
+    std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
 }


### PR DESCRIPTION
* Add test for nested db dialect cross product
* Fix lowering of nested cross product
* Update MLIR textual samples for new storage types dialect
* Add regress test script to automatically parse and check the MLIR sample files