### PR TITLE
Add CrossProduct generation for DBProgramGenerator

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -131,7 +131,7 @@ void DBProgramGenerator::addEdgeTraversal(const VariableDependency* src,
     llvm::SmallVector<mlir::Value> operands {input};
     llvm::SmallVector<mlir::Type> results {srcs, eids, etypes, tgts};
     for (const VariableDependency* var : carrySet) {
-        // source variable is expliclty filtered by the edge op
+        // source variable is explicitly filtered by the edge op
         if (var == src) {
             continue;
         }
@@ -424,8 +424,8 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
 void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponent>& components,
                                                   mlir::Block* targetBlock,
                                                   llvm::SmallVectorImpl<mlir::Value>& results) {
-    const size_t count = components.size();
-    bioassert(count >= 2, "Cross product cascade needs at least two components");
+    const size_t numComponents = components.size();
+    bioassert(numComponents >= 2, "Cross product cascade needs at least two components");
 
     const mlir::Location loc = _opBuilder.getUnknownLoc();
 
@@ -433,23 +433,32 @@ void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponen
 
     mlir::Block* pendingYieldBlock = nullptr;
 
-    for (size_t i = 0; i + 1 < count; i++) {
+    // Fold over all components, applying a CrossProduct between them
+    // comp1 x (comp2 x (comp3 x ...))
+    for (size_t i = 0; i + 1 < numComponents; i++) {
+        // Component i crossed with the cross of all subsequent component js
+        // The result of this cross is result of i x i + 1 x i + 2 x ... x j
         llvm::SmallVector<mlir::Type> resultTypes;
-        for (size_t j = i; j < count; j++) {
+        for (size_t j = i; j < numComponents; j++) {
             for (const mlir::Value column : components[j]._columns) {
                 resultTypes.push_back(column.getType());
             }
         }
 
+        // Starts as main block, then updated to the RHS of the previous factor
         _opBuilder.setInsertionPointToEnd(currentTarget);
+        // Create a cross for i x j
         auto crossProduct = _opBuilder.create<mlir::db::CrossProduct>(loc, resultTypes);
 
         mlir::Block* const leftBlock = &crossProduct.getLeftFactor().front();
         mlir::Block* const rightBlock = &crossProduct.getRightFactor().front();
 
+        // Component i occupies the LHS of this cross prod
         moveComponentToFactor(components[i], leftBlock);
 
         const mlir::ResultRange crossResults = crossProduct.getResults();
+        // There is no pending yield iff we have a single cross product between 2
+        // components
         if (pendingYieldBlock) {
             _opBuilder.setInsertionPointToEnd(pendingYieldBlock);
             _opBuilder.create<mlir::db::Yield>(loc, mlir::ValueRange {crossResults});
@@ -457,10 +466,12 @@ void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponen
             results.assign(crossResults.begin(), crossResults.end());
         }
 
-        const bool lastPair = i + 2 == count;
+        // If this is the final cross prod, move this component to the right hand side
+        const bool lastPair = i + 2 == numComponents;
         if (lastPair) {
             moveComponentToFactor(components[i + 1], rightBlock);
         } else {
+            // Otherwise the next component will be assigned to the right block
             currentTarget = rightBlock;
             pendingYieldBlock = rightBlock;
         }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1,14 +1,17 @@
 #include "DBProgramGenerator.h"
 
 #include <algorithm>
+#include <memory>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Region.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
@@ -195,18 +198,13 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
         return;
     }
 
+    // Main block is saved so we can splice into it after generation
+    mlir::Block* const mainBlock = _opBuilder->getInsertionBlock();
+
     std::unordered_set<const VariableDependency*> defined;
 
-    struct Frame {
-        const VariableDependency* _var {nullptr};
-        const DependencyEdge* _predEdge {nullptr};
-        const DependencyEdge* _predPredEdge {nullptr};
-    };
-
-    std::vector<Frame> stack;
-
-    // Forms the "carried set" for each connected component
-    std::vector<const VariableDependency*> carriedSet;
+    // Connected components
+    std::vector<TranslatedComponent> components;
 
     // TODO: Use nodes at ends of diameter
     for (const VariableDependency& root : _vdg.vars()) {
@@ -228,126 +226,256 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
             continue;
         }
 
-        addScanNodes(&root);
-        defined.insert(&root);
+        TranslatedComponent& component = components.emplace_back();
+        component._region = std::make_unique<mlir::Region>();
 
-        carriedSet.clear();
+        mlir::Block* const scratch = new mlir::Block();
+        component._region->push_back(scratch);
+        _opBuilder->setInsertionPointToStart(scratch);
 
-        // DFS from this root
-        stack.emplace_back(&root, nullptr);
-        while (!stack.empty()) {
-            const auto [var, pred, predPred] = stack.back();
-            stack.pop_back();
+        translateComponent(&root, defined, component._vars);
 
-            const auto seenOrMeta = [&defined](const DependencyEdge* e) {
-                return !e->isMetaEdge() || defined.contains(e->src());
-            };
-            const bool canTraverse = std::ranges::all_of(var->incoming(), seenOrMeta);
-
-            // If we cannot traverse now, we will find another path to this node
-            if (!canTraverse) {
-                continue;
-            }
-
-            // Have we found a (source, edge, target) triple yet on this traversal?
-            const bool haveTriple = pred && predPred;
-
-            for (const DependencyEdge* e : var->edges()) {
-                const VariableDependency* other = e->src() == var ? e->tgt() : e->src();
-                if (defined.contains(other)) {
-                    continue;
-                }
-
-                if (haveTriple) {
-                    // We have discovered a full (src, edge, tgt) triple, set the next
-                    // elements on the stack to only have (src, edge) and await tgt
-                    stack.emplace_back(other, e, nullptr);
-                } else {
-                    // We have not yet discovered a full (src, edge, tgt) triple, but the
-                    // next elements on stack will have such a triple (with @ref pred)
-                    stack.emplace_back(other, e, pred);
-                }
-            }
-
-            // Only translate when we have a full triple
-            if (!haveTriple) {
-                defined.insert(var); // Mark as defined to avoid retraversal
-                continue;
-            }
-
-            // The order we encountered the nodes may not be source, edge, target, it may
-            // be target, edge, source. Determine a definitive order, irrespective of
-            // traversal
-            const DependencyEdge* edgeVarProd = producesEdgeVar(pred) ? pred : predPred;
-            const DependencyEdge* nodeVarProd = producesNodeVar(pred) ? pred : predPred;
-            bioassert(producesEdgeVar(edgeVarProd), "No edge producer");
-            bioassert(producesNodeVar(nodeVarProd), "No node producer");
-
-            // Only one of either source or target should be defined. Determine which end
-            // of the triple is defined
-            const bool edgeSrcDefined = defined.contains(edgeVarProd->src());
-            const bool nodeTgtDefined = defined.contains(nodeVarProd->tgt());
-            bioassert(edgeSrcDefined ^ nodeTgtDefined, "Ambiguous definition");
-            bioassert(edgeSrcDefined || nodeTgtDefined, "No defined start");
-
-            VariableDependency* src = nullptr;
-            VariableDependency* edge = nullptr;
-            VariableDependency* tgt = nullptr;
-
-            // Orientate the operation such that the source operand is defined
-            if (edgeSrcDefined) {
-                src = edgeVarProd->src();
-                edge = edgeVarProd->tgt();
-                tgt = nodeVarProd->tgt();
-            } else /* (nodeTgtDefined) */ {
-                src = nodeVarProd->tgt();
-                edge = nodeVarProd->src();
-                tgt = edgeVarProd->src();
-            }
-
-            // We may walk an edge backwards compared to the cypher pattern. In such a
-            // case we emit the opposite traversal.
-            const EdgeMetadata::EdgeType prodType = edgeVarProd->data().type();
-            const EdgeMetadata::EdgeType logicalDir =
-                edgeSrcDefined ? prodType : reverseEdge(prodType);
-
-            switch (logicalDir) {
-                case EdgeMetadata::EdgeType::GET_OUT_EDGES:
-                    addGetOutEdges(src, edge, tgt, carriedSet);
-                break;
-
-                case EdgeMetadata::EdgeType::GET_IN_EDGES:
-                    addGetInEdges(src, edge, tgt, carriedSet);
-                break;
-
-                case EdgeMetadata::EdgeType::MERGE:
-                    throw TuringException("MERGE edges not yet supported.");
-                break;
-
-                case EdgeMetadata::EdgeType::GET_EDGES:
-                    throw TuringException("Undirected edges not yet supported.");
-                break;
-
-                case EdgeMetadata::EdgeType::GET_EDGE_TGT:
-                case EdgeMetadata::EdgeType::GET_EDGE_SRC:
-                    throw FatalException(fmt::format("Attempted to translate {}",
-                                                     EdgeTypeName::value(logicalDir)));
-                break;
-
-                case EdgeMetadata::EdgeType::_SIZE:
-                    throw FatalException("Attempted to translate invalid edge.");
-                break;
-            }
-
-            defined.insert(src);
-            defined.insert(edge);
-            defined.insert(tgt);
-
-            carriedSet.push_back(src);
-            carriedSet.push_back(edge);
-            carriedSet.push_back(tgt);
+        for (const VariableDependency* var : component._vars) {
+            bioassert(_varMap.contains(var), "Component var {} not registered", var->getName());
+            component._columns.push_back(_varMap[var].back());
         }
     }
+
+    if (components.empty()) {
+        return;
+    }
+
+    // Single connected component, no need to X prod any islands
+    if (components.size() == 1) {
+        TranslatedComponent& comp = components.front();
+
+        const auto& reg = comp._region;
+        bioassert(reg->hasOneBlock(), "Connected component region did not have 1 block");
+
+        // Get the ops for this connected component
+        mlir::Block& block = reg->front();
+        mlir::Block::OpListType& ops = block.getOperations();
+
+        // Get the block for main
+        const auto mainEnd = mainBlock->end();
+        mlir::Block::OpListType& mainOps = mainBlock->getOperations();
+
+        // Splice the ops for this component into the end of main
+        mainOps.splice(mainEnd, ops);
+
+        _opBuilder->setInsertionPointToEnd(mainBlock);
+        return;
+    }
+
+    llvm::SmallVector<mlir::Value> results;
+    buildCrossProductCascade(components, mainBlock, results);
+
+    size_t resultIndex = 0;
+    for (const TranslatedComponent& component : components) {
+        for (const VariableDependency* var : component._vars) {
+            registerValue(var, results[resultIndex]);
+            resultIndex++;
+        }
+    }
+
+    _opBuilder->setInsertionPointToEnd(mainBlock);
+}
+
+void DBProgramGenerator::translateComponent(const VariableDependency* root,
+                                            std::unordered_set<const VariableDependency*>& defined,
+                                            std::vector<const VariableDependency*>& outVars) {
+    struct Frame {
+        const VariableDependency* _var {nullptr};
+        const DependencyEdge* _predEdge {nullptr};
+        const DependencyEdge* _predPredEdge {nullptr};
+    };
+
+    // Makes var an output on first encounter
+    const auto markDefined = [&](const VariableDependency* var) {
+        if (defined.insert(var).second) {
+            outVars.push_back(var);
+        }
+    };
+
+    addScanNodes(root);
+    markDefined(root);
+
+    // Forms the "carried set" for this connected component
+    std::vector<const VariableDependency*> carriedSet;
+
+    std::vector<Frame> stack;
+
+    // DFS from this root
+    stack.emplace_back(root, nullptr);
+    while (!stack.empty()) {
+        const auto [var, pred, predPred] = stack.back();
+        stack.pop_back();
+
+        const auto seenOrMeta = [&defined](const DependencyEdge* e) {
+            return !e->isMetaEdge() || defined.contains(e->src());
+        };
+        const bool canTraverse = std::ranges::all_of(var->incoming(), seenOrMeta);
+
+        // If we cannot traverse now, we will find another path to this node
+        if (!canTraverse) {
+            continue;
+        }
+
+        // Have we found a (source, edge, target) triple yet on this traversal?
+        const bool haveTriple = pred && predPred;
+
+        for (const DependencyEdge* e : var->edges()) {
+            const VariableDependency* other = e->src() == var ? e->tgt() : e->src();
+            if (defined.contains(other)) {
+                continue;
+            }
+
+            if (haveTriple) {
+                // We have discovered a full (src, edge, tgt) triple, set the next
+                // elements on the stack to only have (src, edge) and await tgt
+                stack.emplace_back(other, e, nullptr);
+            } else {
+                // We have not yet discovered a full (src, edge, tgt) triple, but the
+                // next elements on stack will have such a triple (with @ref pred)
+                stack.emplace_back(other, e, pred);
+            }
+        }
+
+        // Only translate when we have a full triple
+        if (!haveTriple) {
+            markDefined(var); // Mark as defined to avoid retraversal
+            continue;
+        }
+
+        // The order we encountered the nodes may not be source, edge, target, it may
+        // be target, edge, source. Determine a definitive order, irrespective of
+        // traversal
+        const DependencyEdge* edgeVarProd = producesEdgeVar(pred) ? pred : predPred;
+        const DependencyEdge* nodeVarProd = producesNodeVar(pred) ? pred : predPred;
+        bioassert(producesEdgeVar(edgeVarProd), "No edge producer");
+        bioassert(producesNodeVar(nodeVarProd), "No node producer");
+
+        // Only one of either source or target should be defined. Determine which end
+        // of the triple is defined
+        const bool edgeSrcDefined = defined.contains(edgeVarProd->src());
+        const bool nodeTgtDefined = defined.contains(nodeVarProd->tgt());
+        bioassert(edgeSrcDefined ^ nodeTgtDefined, "Ambiguous definition");
+        bioassert(edgeSrcDefined || nodeTgtDefined, "No defined start");
+
+        VariableDependency* src = nullptr;
+        VariableDependency* edge = nullptr;
+        VariableDependency* tgt = nullptr;
+
+        // Orientate the operation such that the source operand is defined
+        if (edgeSrcDefined) {
+            src = edgeVarProd->src();
+            edge = edgeVarProd->tgt();
+            tgt = nodeVarProd->tgt();
+        } else /* (nodeTgtDefined) */ {
+            src = nodeVarProd->tgt();
+            edge = nodeVarProd->src();
+            tgt = edgeVarProd->src();
+        }
+
+        const EdgeMetadata::EdgeType edgeType = edgeVarProd->data().type();
+        switch (edgeType) {
+            case EdgeMetadata::EdgeType::GET_OUT_EDGES:
+                addGetOutEdges(src, edge, tgt, carriedSet);
+            break;
+
+            case EdgeMetadata::EdgeType::GET_IN_EDGES:
+                addGetInEdges(src, edge, tgt, carriedSet);
+            break;
+
+            case EdgeMetadata::EdgeType::MERGE:
+                throw TuringException("MERGE edges not yet supported.");
+            break;
+
+            case EdgeMetadata::EdgeType::GET_EDGES:
+                throw TuringException("Undirected edges not yet supported.");
+            break;
+
+            case EdgeMetadata::EdgeType::GET_EDGE_TGT:
+            case EdgeMetadata::EdgeType::GET_EDGE_SRC:
+                throw FatalException(fmt::format("Attempted to translate {}",
+                                                 EdgeTypeName::value(edgeType)));
+            break;
+
+            case EdgeMetadata::EdgeType::_SIZE:
+                throw FatalException("Attempted to translate invalid edge.");
+            break;
+        }
+
+        markDefined(src);
+        markDefined(edge);
+        markDefined(tgt);
+
+        carriedSet.push_back(src);
+        carriedSet.push_back(edge);
+        carriedSet.push_back(tgt);
+    }
+}
+
+void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponent>& components,
+                                                  mlir::Block* targetBlock,
+                                                  llvm::SmallVectorImpl<mlir::Value>& results) {
+    const size_t count = components.size();
+    bioassert(count >= 2, "Cross product cascade needs at least two components");
+
+    const mlir::Location loc = _opBuilder->getUnknownLoc();
+
+    mlir::Block* currentTarget = targetBlock;
+
+    mlir::Block* pendingYieldBlock = nullptr;
+
+    for (size_t i = 0; i + 1 < count; i++) {
+        llvm::SmallVector<mlir::Type> resultTypes;
+        for (size_t j = i; j < count; j++) {
+            for (const mlir::Value column : components[j]._columns) {
+                resultTypes.push_back(column.getType());
+            }
+        }
+
+        _opBuilder->setInsertionPointToEnd(currentTarget);
+        auto crossProduct = _opBuilder->create<mlir::db::CrossProduct>(loc, resultTypes);
+
+        mlir::Block* const leftBlock = &crossProduct.getLeftFactor().front();
+        mlir::Block* const rightBlock = &crossProduct.getRightFactor().front();
+
+        moveComponentToFactor(components[i], leftBlock);
+
+        const mlir::ResultRange crossResults = crossProduct.getResults();
+        if (pendingYieldBlock) {
+            _opBuilder->setInsertionPointToEnd(pendingYieldBlock);
+            _opBuilder->create<mlir::db::Yield>(loc, mlir::ValueRange {crossResults});
+        } else {
+            results.assign(crossResults.begin(), crossResults.end());
+        }
+
+        const bool lastPair = i + 2 == count;
+        if (lastPair) {
+            moveComponentToFactor(components[i + 1], rightBlock);
+        } else {
+            currentTarget = rightBlock;
+            pendingYieldBlock = rightBlock;
+        }
+    }
+}
+
+void DBProgramGenerator::moveComponentToFactor(TranslatedComponent& component, mlir::Block* factorBlock) {
+    // Insertion point into the factor
+    auto factorEnd = factorBlock->end();
+
+    auto& compReg = component._region;
+    mlir::Block& compBlock = compReg->front();
+    // Operations to insert
+    mlir::Block::OpListType& compOps = compBlock.getOperations();
+
+    factorBlock->getOperations().splice(factorEnd, compOps);
+
+    _opBuilder->setInsertionPointToEnd(factorBlock);
+    const mlir::Location loc = _opBuilder->getUnknownLoc();
+    _opBuilder->create<mlir::db::Yield>(loc, mlir::ValueRange {component._columns});
 }
 
 void DBProgramGenerator::generateOutput(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -4,8 +4,6 @@
 #include <memory>
 #include <string_view>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Block.h"
@@ -201,7 +199,7 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
     // Main block is saved so we can splice into it after generation
     mlir::Block* const mainBlock = _opBuilder.getInsertionBlock();
 
-    std::unordered_set<const VariableDependency*> defined;
+    DefinedVars defined;
 
     // Connected components
     std::vector<TranslatedComponent> components;
@@ -282,7 +280,7 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
 }
 
 void DBProgramGenerator::translateComponent(const VariableDependency* root,
-                                            std::unordered_set<const VariableDependency*>& defined,
+                                            DefinedVars& defined,
                                             std::vector<const VariableDependency*>& outVars) {
     struct Frame {
         const VariableDependency* _var {nullptr};

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -90,6 +90,16 @@ DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
 DBProgramGenerator::~DBProgramGenerator() {
 }
 
+DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
+    : _module(mainModule),
+    _mlirCtxt(_module->getContext()),
+    _opBuilder(_module->getBodyRegion())
+{
+}
+
+DBProgramGenerator::~DBProgramGenerator() {
+}
+
 mlir::db::ColumnType DBProgramGenerator::allocColumnType(mlir::Type type) {
     return mlir::db::ColumnType::get(_mlirCtxt, type);
 }
@@ -199,7 +209,7 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
     }
 
     // Main block is saved so we can splice into it after generation
-    mlir::Block* const mainBlock = _opBuilder->getInsertionBlock();
+    mlir::Block* const mainBlock = _opBuilder.getInsertionBlock();
 
     std::unordered_set<const VariableDependency*> defined;
 
@@ -230,8 +240,8 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
         component._region = std::make_unique<mlir::Region>();
 
         mlir::Block* const scratch = new mlir::Block();
-        component._region->push_back(scratch);
-        _opBuilder->setInsertionPointToStart(scratch);
+        component._region->push_back(scratch); // Region destructor frees scratch
+        _opBuilder.setInsertionPointToStart(scratch);
 
         translateComponent(&root, defined, component._vars);
 
@@ -263,7 +273,7 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
         // Splice the ops for this component into the end of main
         mainOps.splice(mainEnd, ops);
 
-        _opBuilder->setInsertionPointToEnd(mainBlock);
+        _opBuilder.setInsertionPointToEnd(mainBlock);
         return;
     }
 
@@ -278,7 +288,7 @@ void DBProgramGenerator::generateTraversal(const CypherAST* ast) {
         }
     }
 
-    _opBuilder->setInsertionPointToEnd(mainBlock);
+    _opBuilder.setInsertionPointToEnd(mainBlock);
 }
 
 void DBProgramGenerator::translateComponent(const VariableDependency* root,
@@ -422,7 +432,7 @@ void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponen
     const size_t count = components.size();
     bioassert(count >= 2, "Cross product cascade needs at least two components");
 
-    const mlir::Location loc = _opBuilder->getUnknownLoc();
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
 
     mlir::Block* currentTarget = targetBlock;
 
@@ -436,8 +446,8 @@ void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponen
             }
         }
 
-        _opBuilder->setInsertionPointToEnd(currentTarget);
-        auto crossProduct = _opBuilder->create<mlir::db::CrossProduct>(loc, resultTypes);
+        _opBuilder.setInsertionPointToEnd(currentTarget);
+        auto crossProduct = _opBuilder.create<mlir::db::CrossProduct>(loc, resultTypes);
 
         mlir::Block* const leftBlock = &crossProduct.getLeftFactor().front();
         mlir::Block* const rightBlock = &crossProduct.getRightFactor().front();
@@ -446,8 +456,8 @@ void DBProgramGenerator::buildCrossProductCascade(std::vector<TranslatedComponen
 
         const mlir::ResultRange crossResults = crossProduct.getResults();
         if (pendingYieldBlock) {
-            _opBuilder->setInsertionPointToEnd(pendingYieldBlock);
-            _opBuilder->create<mlir::db::Yield>(loc, mlir::ValueRange {crossResults});
+            _opBuilder.setInsertionPointToEnd(pendingYieldBlock);
+            _opBuilder.create<mlir::db::Yield>(loc, mlir::ValueRange {crossResults});
         } else {
             results.assign(crossResults.begin(), crossResults.end());
         }
@@ -473,9 +483,9 @@ void DBProgramGenerator::moveComponentToFactor(TranslatedComponent& component, m
 
     factorBlock->getOperations().splice(factorEnd, compOps);
 
-    _opBuilder->setInsertionPointToEnd(factorBlock);
-    const mlir::Location loc = _opBuilder->getUnknownLoc();
-    _opBuilder->create<mlir::db::Yield>(loc, mlir::ValueRange {component._columns});
+    _opBuilder.setInsertionPointToEnd(factorBlock);
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    _opBuilder.create<mlir::db::Yield>(loc, mlir::ValueRange {component._columns});
 }
 
 void DBProgramGenerator::generateOutput(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -90,16 +90,6 @@ DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
 DBProgramGenerator::~DBProgramGenerator() {
 }
 
-DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
-    : _module(mainModule),
-    _mlirCtxt(_module->getContext()),
-    _opBuilder(_module->getBodyRegion())
-{
-}
-
-DBProgramGenerator::~DBProgramGenerator() {
-}
-
 mlir::db::ColumnType DBProgramGenerator::allocColumnType(mlir::Type type) {
     return mlir::db::ColumnType::get(_mlirCtxt, type);
 }
@@ -387,8 +377,13 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
             tgt = edgeVarProd->src();
         }
 
-        const EdgeMetadata::EdgeType edgeType = edgeVarProd->data().type();
-        switch (edgeType) {
+        // We may walk an edge backwards compared to the cypher pattern. In such a
+        // case we emit the opposite traversal.
+        const EdgeMetadata::EdgeType prodType = edgeVarProd->data().type();
+        const EdgeMetadata::EdgeType logicalDir =
+            edgeSrcDefined ? prodType : reverseEdge(prodType);
+
+        switch (logicalDir) {
             case EdgeMetadata::EdgeType::GET_OUT_EDGES:
                 addGetOutEdges(src, edge, tgt, carriedSet);
             break;
@@ -408,7 +403,7 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
             case EdgeMetadata::EdgeType::GET_EDGE_TGT:
             case EdgeMetadata::EdgeType::GET_EDGE_SRC:
                 throw FatalException(fmt::format("Attempted to translate {}",
-                                                 EdgeTypeName::value(edgeType)));
+                                                 EdgeTypeName::value(logicalDir)));
             break;
 
             case EdgeMetadata::EdgeType::_SIZE:

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -42,7 +42,7 @@ private:
     mlir::MLIRContext* _mlirCtxt {nullptr};
     mlir::OpBuilder _opBuilder;
 
-    // Maps a Cypher variable to all of its MLIR variable uses, in order of appearence
+    // Maps a Cypher variable to all of its MLIR variable defs, in order of appearance
     VariableIdentityMap _varMap;
 
     VariableDependencyGraph _vdg;
@@ -55,7 +55,7 @@ private:
 
     void generateTraversal(const CypherAST* ast);
 
-    // Translate a connectected component of @ref _vdg, fills @param outVars
+    // Translate a connected component of @ref _vdg, fills @param outVars
     void translateComponent(const VariableDependency* root,
                             std::unordered_set<const VariableDependency*>& defined,
                             std::vector<const VariableDependency*>& outVars);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 
@@ -14,12 +17,15 @@
 namespace mlir {
 class ModuleOp;
 class OpBuilder;
+class Block;
+class Region;
 }
 
 namespace db {
 
 class CypherAST;
 class VariableDependency;
+class DependencyEdge;
 
 class DBProgramGenerator {
 public:
@@ -41,7 +47,27 @@ private:
 
     VariableDependencyGraph _vdg;
 
+    struct TranslatedComponent {
+        std::unique_ptr<mlir::Region> _region;
+        std::vector<const VariableDependency*> _vars;
+        llvm::SmallVector<mlir::Value> _columns;
+    };
+
     void generateTraversal(const CypherAST* ast);
+
+    // Translate a connectected component of @ref _vdg, fills @param outVars
+    void translateComponent(const VariableDependency* root,
+                            std::unordered_set<const VariableDependency*>& defined,
+                            std::vector<const VariableDependency*>& outVars);
+
+    // Converts an arbitrary number of connected components into a cascading nest of
+    // CrossProducts
+    void buildCrossProductCascade(std::vector<TranslatedComponent>& components,
+                                  mlir::Block* targetBlock,
+                                  llvm::SmallVectorImpl<mlir::Value>& results);
+
+    // Moves a translated connected component into a CrossProduct factor
+    void moveComponentToFactor(TranslatedComponent& component, mlir::Block* factorBlock);
 
     void generateOutput(const CypherAST* ast);
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -31,6 +31,7 @@ class DBProgramGenerator {
 public:
     using VariableIdentities = std::vector<mlir::TypedValue<mlir::Type>>;
     using VariableIdentityMap = std::unordered_map<const VariableDependency*, VariableIdentities>;
+    using DefinedVars = std::unordered_set<const VariableDependency*>;
 
     explicit DBProgramGenerator(mlir::ModuleOp* mainModule);
     ~DBProgramGenerator();

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -21,6 +21,7 @@ add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 # The branch two-hop test runs against the shared SimpleGraph fixture.
 add_ir_tests(test_query_ir_branch_two_hop BranchTwoHopTest.cpp)
 target_link_libraries(test_query_ir_branch_two_hop PRIVATE turing_db_examples_s)
+
 add_turing_test(test_query_ir_equivalence EquivalenceTest.cpp)
 target_link_libraries(test_query_ir_equivalence PRIVATE
         turing_db_s

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -262,4 +262,5 @@ TEST_F(EquivalenceTest, trees) {
     expectEquivalent("MATCH (b)-->(a), (c)-->(a) RETURN c");
     // Disabled due to suspected v2 bug
     // expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
+    expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
 }

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -264,3 +264,16 @@ TEST_F(EquivalenceTest, trees) {
     // expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
     expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
 }
+
+TEST_F(EquivalenceTest, crossProd) {
+    expectEquivalent("MATCH (a), (b) RETURN a");
+    expectEquivalent("MATCH (a), (b) RETURN b");
+    expectEquivalent("MATCH (a), (b) RETURN a, b");
+
+    expectEquivalent("MATCH (a), (b), (c) RETURN b");
+    expectEquivalent("MATCH (a), (b), (c) RETURN a, b, c");
+
+    expectEquivalent("MATCH (a)-->(d), (b), (c) RETURN a, b, c, d");
+
+    expectEquivalent("MATCH (a)-->(d), (b)-->(e), (c)-->(f) RETURN a, b, c, d, e, f");
+}

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -206,10 +206,10 @@ protected:
 
         EXPECT_FALSE(pipelineRows.empty()) << "Expected non-empty result for query: " << query;
 
-        ASSERT_EQ(pipelineRows.size(), irRows.size());
+        ASSERT_EQ(pipelineRows.size(), irRows.size()) << "Size mismatch for " << query;
 
         for (auto [plRow, irRow] : rv::zip(pipelineRows, irRows)) {
-            EXPECT_EQ(plRow, irRow);
+            EXPECT_EQ(plRow, irRow) << "Row mismatch for " << query;
         }
     }
 
@@ -262,7 +262,6 @@ TEST_F(EquivalenceTest, trees) {
     expectEquivalent("MATCH (b)-->(a), (c)-->(a) RETURN c");
     // Disabled due to suspected v2 bug
     // expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
-    expectEquivalent("MATCH (a)-->(b)-->(c), (b)-->(e) RETURN a");
 }
 
 TEST_F(EquivalenceTest, crossProd) {


### PR DESCRIPTION
The VDG traversal now explores connected components, and combines them with cascading cross products to unify islands