### PR TITLE
MLIR: implement get out/in edges by type

### DIFF
--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -131,6 +131,86 @@ def GetInEdges : TuringOp<"get_in_edges", [Pure, DeclareOpInterfaceMethods<OpAsm
 }
 
 /**
+* GetOutEdgesByType
+*/
+def GetOutEdgesByType : TuringOp<"get_out_edges_by_type", [Pure]> {
+  let summary = "Fetch the out-edges of one edge type, filtering carried columns alongside";
+
+  let description = [{
+    The by-type sibling of get_out_edges. In `MATCH (a)-[:KNOWS]->(b)` only the
+    successors reached over a KNOWS edge count, so this walks each node's out-edges
+    but keeps only those of the named type - the plain get_out_edges narrowed by
+    the relationship type spelled in the query:
+
+      %s, %e, %t, %b = get_out_edges_by_type(%a, "KNOWS", {})
+      %c, %b2, %a2 = get_out_edges_by_type(%b, "LIKES", {%a})   // eids/etypes omitted
+
+    An edge carries exactly one type, so the filter is an equality on that type,
+    not a set match. `edge_type` is the type name spelled the same as in the query,
+    resolved against the graph schema; a name absent from the schema matches no
+    edge, so the hop yields no rows. `columns_to_filter` is the carry set, exactly
+    as on get_out_edges: each one comes back in `filtered_columns`, and the result
+    chunk shape - srcids, eids, etypes, tgtids - is identical, so a hop is
+    interchangeable with the unfiltered fetch.
+  }];
+
+  // `edge_type` is the symbolic relationship-type name. Being an attribute and
+  // not an SSA value, it is absent from `operands`; lowering hoists it into an
+  // nl.get_edge_type handle so the name is resolved once above the loops.
+  // `columns_to_filter` is the variadic carry set.
+  let arguments = (ins Column:$input_nodes, StrAttr:$edge_type, Variadic<Column>:$columns_to_filter);
+
+  // `filtered_columns`: one per carried column, after the four fixed results.
+  let results   = (outs ColumnNodeIDs:$srcids,
+                        ColumnEdgeIDs:$eids,
+                        ColumnEdgeTypes:$etypes,
+                        ColumnNodeIDs:$tgtids,
+                        Variadic<Column>:$filtered_columns);
+
+  // The type name prints inside the parens as `"KNOWS"`, between input_nodes and
+  // the brace-wrapped carry set; MLIR elides it from attr-dict because the format
+  // already names it. functional-type spells only the operand and result types.
+  let assemblyFormat = [{
+    `(` $input_nodes `,` $edge_type `,` `{` $columns_to_filter `}` `)` attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+
+/**
+* GetInEdgesByType
+*/
+def GetInEdgesByType : TuringOp<"get_in_edges_by_type", [Pure]> {
+  let summary = "Fetch the in-edges of one edge type, filtering carried columns alongside";
+
+  let description = [{
+    The reverse-direction sibling of get_out_edges_by_type: where that keeps a
+    node's out-edges of the named type, this keeps its in-edges of that type. In
+    `MATCH (a)<-[:KNOWS]-(b)` only the predecessors reached over a KNOWS edge
+    count:
+
+      %s, %e, %t, %b = get_in_edges_by_type(%a, "KNOWS", {})
+
+    The result chunk shape - srcids, eids, etypes, tgtids - and the
+    `columns_to_filter` carry set match get_out_edges_by_type, so the two are
+    interchangeable in a hop; `edge_type` is resolved the same way and an absent
+    name yields no rows.
+  }];
+
+  let arguments = (ins Column:$input_nodes, StrAttr:$edge_type, Variadic<Column>:$columns_to_filter);
+
+  let results   = (outs ColumnNodeIDs:$srcids,
+                        ColumnEdgeIDs:$eids,
+                        ColumnEdgeTypes:$etypes,
+                        ColumnNodeIDs:$tgtids,
+                        Variadic<Column>:$filtered_columns);
+
+  let assemblyFormat = [{
+    `(` $input_nodes `,` $edge_type `,` `{` $columns_to_filter `}` `)` attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+
+/**
 * GetNodeProperties
 */
 def GetNodeProperties : TuringOp<"get_node_properties", [Pure]> {

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -111,6 +111,26 @@ LogicalResult GetInEdges::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// Filtering out-edges by type narrows only the rows, never their shape, so a
+// by-type fetch produces the same iterator as GetOutEdges - the edge type name is
+// a filter, not a result type.
+LogicalResult GetOutEdgesByType::inferReturnTypes(MLIRContext* context,
+                                                  std::optional<Location> location,
+                                                  GetOutEdgesByType::Adaptor adaptor,
+                                                  SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(getEdgeIteratorType(context, adaptor.getColumnsToFilter()));
+    return success();
+}
+
+// The in-edge by-type sibling: same iterator shape as GetInEdges, narrowed by type.
+LogicalResult GetInEdgesByType::inferReturnTypes(MLIRContext* context,
+                                                 std::optional<Location> location,
+                                                 GetInEdgesByType::Adaptor adaptor,
+                                                 SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(getEdgeIteratorType(context, adaptor.getColumnsToFilter()));
+    return success();
+}
+
 // A cross product yields one chunk per crossed column - the outer columns
 // followed by the inner - each keeping its input chunk's element type, since
 // the broadcast only changes the row count, not the element kind.

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -117,6 +117,73 @@ def GetInEdges : NLOp<"get_in_edges", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* GetOutEdgesByType
+*/
+def GetOutEdgesByType : NLOp<"get_out_edges_by_type", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Create a database iterator over the out-edges of one edge type of a chunk of nodes";
+  let description = [{
+    Imperative counterpart of db.get_out_edges_by_type. It fills the same row of
+    chunks as nl.get_out_edges - source node IDs, edge IDs, edge type IDs and
+    target node IDs, then one filtered chunk per carried column - but keeps only
+    the out-edges whose type is `edge_type`:
+
+      %knows = nl.get_edge_type("KNOWS")
+      %likes = nl.get_edge_type("LIKES")
+      %edges = nl.get_out_edges_by_type(%a, %knows, {})
+      nl.for %srcs, %eids, %etypes, %b in %edges {
+        %hop = nl.get_out_edges_by_type(%b, %likes, {%srcs}) : !nl.chunk<!storage.node_id>
+        ...
+      }
+
+    `edge_type` is an !nl.edge_type handle produced by nl.get_edge_type, not a name
+    on the op: the name is resolved once above the loops, so a hop nested in a loop
+    reuses the resolved handle rather than looking the name up per step (the same
+    split as nl.get_property_type and the property fetches). Filtering by type
+    narrows only the rows, never their shape, so the result iterator type is
+    identical to nl.get_out_edges' and is inferred; only the carried chunk types
+    are spelled out, after the colon.
+  }];
+
+  // `edge_type` is the resolved handle from nl.get_edge_type. The carry set is
+  // NLChunk, not NLNodeIDChunk, so chunks of any element type can be carried,
+  // exactly as on nl.get_out_edges.
+  let arguments = (ins NLNodeIDChunk:$input_nodes, NLEdgeTypeHandle:$edge_type, Variadic<NLChunk>:$columns_to_filter);
+  let results   = (outs NLIterator:$result);
+
+  // The handle prints as %h inside the parens after input_nodes; its type is
+  // buildable and so omitted, as nl.get_node_properties omits its property handle
+  // type. As on nl.get_out_edges, only the carried chunk types are spelled, in the
+  // optional group that drops the colon when the carry set is empty.
+  let assemblyFormat = [{
+    `(` $input_nodes `,` $edge_type `,` `{` $columns_to_filter `}` `)` attr-dict
+    ( `:` qualified(type($columns_to_filter))^ )?
+  }];
+}
+
+/**
+* GetInEdgesByType
+*/
+def GetInEdgesByType : NLOp<"get_in_edges_by_type", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Create a database iterator over the in-edges of one edge type of a chunk of nodes";
+  let description = [{
+    The reverse-direction sibling of nl.get_out_edges_by_type and the by-type
+    sibling of nl.get_in_edges: it fills the same chunk shape as in-edges but keeps
+    only the in-edges whose type is `edge_type`. The carry set and the result
+    iterator type match nl.get_out_edges_by_type, so the two are interchangeable in
+    a loop; `edge_type` is the same nl.get_edge_type handle and an unresolved type
+    yields no chunk.
+  }];
+
+  let arguments = (ins NLNodeIDChunk:$input_nodes, NLEdgeTypeHandle:$edge_type, Variadic<NLChunk>:$columns_to_filter);
+  let results   = (outs NLIterator:$result);
+
+  let assemblyFormat = [{
+    `(` $input_nodes `,` $edge_type `,` `{` $columns_to_filter `}` `)` attr-dict
+    ( `:` qualified(type($columns_to_filter))^ )?
+  }];
+}
+
+/**
 * GetPropertyType
 */
 def GetPropertyType : NLOp<"get_property_type", [Pure]> {
@@ -139,6 +206,34 @@ def GetPropertyType : NLOp<"get_property_type", [Pure]> {
   // The property name, the same `name`/`weight` spelled in the query.
   let arguments = (ins StrAttr:$name);
   let results   = (outs NLPropertyType:$result);
+
+  // No operands and a constant result type, so nothing is printed after the name.
+  let assemblyFormat = "`(` $name `)` attr-dict";
+}
+
+/**
+* GetEdgeType
+*/
+def GetEdgeType : NLOp<"get_edge_type", [Pure]> {
+  let summary = "Resolve an edge type name to an edge type handle, once, ahead of the loops";
+  let description = [{
+    The edge sibling of nl.get_property_type. Looks the relationship-type name up
+    in the graph schema and yields an !nl.edge_type handle for its storage
+    EdgeTypeID. It takes no chunk, so it sits at function scope above the loop
+    nest: a query resolves each name once here and feeds the handle to every
+    get_out_edges_by_type / get_in_edges_by_type hop, instead of resolving the name
+    per step when the hop is nested in a loop.
+
+      %knows = nl.get_edge_type("KNOWS")
+
+    The result is always !nl.edge_type. That type is parameterless and so
+    buildable, so the assembly omits it. Pure, so it can be hoisted and shared
+    across the loops below it.
+  }];
+
+  // The edge type name, the same `KNOWS` spelled in the query.
+  let arguments = (ins StrAttr:$name);
+  let results   = (outs NLEdgeType:$result);
 
   // No operands and a constant result type, so nothing is printed after the name.
   let assemblyFormat = "`(` $name `)` attr-dict";

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -118,6 +118,18 @@ def NLPropertyType : NLType<"PropertyType", "property_type"> {
     }];
 }
 
+def NLEdgeType : NLType<"EdgeType", "edge_type"> {
+    let summary = "A resolved edge type handle";
+    let description = [{
+        The edge sibling of !nl.property_type. Stands for one relationship type of
+        the graph - storage's EdgeTypeID - once its name has been resolved.
+        Produced by nl.get_edge_type ahead of the loops and consumed by the by-type
+        edge hops, so the name is looked up once rather than per step when a hop is
+        nested in a loop. It is not a chunk element type: it names an edge type, it
+        does not hold values.
+    }];
+}
+
 // NLNodeIDChunk is a type *constraint*, not a new type: it restricts an op
 // operand to !nl.chunk<!storage.node_id> without defining anything new. Ops use it
 // in their (ins ...) clause where NLChunk would accept a chunk of anything.
@@ -162,6 +174,15 @@ def NLPropertyTypeHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::PropertyTypeType>($_self)">,
         "property type handle", "::mlir::nl::PropertyTypeType">,
     BuildableType<"::mlir::nl::PropertyTypeType::get($_builder.getContext())">;
+
+// Constrains an operand to a resolved !nl.edge_type handle, the edge sibling of
+// NLPropertyTypeHandle. The single concrete type - there is only ever
+// !nl.edge_type - lets the by-type edge hops omit the handle's type in their
+// assembly format, building it from this recipe instead.
+def NLEdgeTypeHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::EdgeTypeType>($_self)">,
+        "edge type handle", "::mlir::nl::EdgeTypeType">,
+    BuildableType<"::mlir::nl::EdgeTypeType::get($_builder.getContext())">;
 
 // Constrains an operand to an !nl.limit_state handle, the same way
 // NLPropertyTypeHandle constrains the property handle. The single concrete type

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -6,7 +6,9 @@
 #include <type_traits>
 
 #include "iterators/GetInEdgesIterator.h"
+#include "iterators/GetInEdgesByTypeIterator.h"
 #include "iterators/GetOutEdgesIterator.h"
+#include "iterators/GetOutEdgesByTypeIterator.h"
 #include "iterators/GetPropertiesWithNullIterator.h"
 #include "iterators/ScanNodesIterator.h"
 #include "iterators/ScanNodesByLabelIterator.h"
@@ -619,6 +621,42 @@ void NLExecutor::runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* 
     }
 
     GetInEdgesChunkWriter chunkWriter(*context->getView(), inputNodeIDs);
+    chunkWriter.setIndices(loopData->getIndices());
+    chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
+    chunkWriter.setEdgeTypes(loopData->getEdgeTypes());
+    chunkWriter.setSrcIDs(loopData->getSources());
+
+    runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getTargets());
+}
+
+void NLExecutor::runGetOutEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLEdgeByTypeLoopData* loopData = static_cast<NLEdgeByTypeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
+
+    // An edge type absent from the schema matches no edge, and an empty input has
+    // no edges to walk: either way the loop body never runs.
+    if (!loopData->isMatchable() || inputNodeIDs->empty()) {
+        return;
+    }
+
+    GetOutEdgesByTypeChunkWriter chunkWriter(*context->getView(), inputNodeIDs, loopData->getEdgeType());
+    chunkWriter.setIndices(loopData->getIndices());
+    chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
+    chunkWriter.setEdgeTypes(loopData->getEdgeTypes());
+    chunkWriter.setTgtIDs(loopData->getTargets());
+
+    runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getSources());
+}
+
+void NLExecutor::runGetInEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLEdgeByTypeLoopData* loopData = static_cast<NLEdgeByTypeLoopData*>(data);
+    const ColumnNodeIDs* inputNodeIDs = loopData->getInput();
+
+    if (!loopData->isMatchable() || inputNodeIDs->empty()) {
+        return;
+    }
+
+    GetInEdgesByTypeChunkWriter chunkWriter(*context->getView(), inputNodeIDs, loopData->getEdgeType());
     chunkWriter.setIndices(loopData->getIndices());
     chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
     chunkWriter.setEdgeTypes(loopData->getEdgeTypes());

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -46,6 +46,13 @@ public:
     static void runScanNodesByLabelLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
+
+    // The by-type edge hops: like runGetOutEdgesLoop / runGetInEdgesLoop, but the
+    // chunk writer keeps only the edges of the loop data's resolved edge type. An
+    // unmatchable type (a name absent from the schema) emits nothing.
+    static void runGetOutEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runGetInEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runCrossProduct(NLExecutionContext* context, NLFunctionData* data);
 
     // Reset a limit counter to its budget; runs each time its block runs.

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -271,6 +271,35 @@ private:
     ColumnVector<size_t> _indices;
 };
 
+// nl.get_out_edges_by_type / nl.get_in_edges_by_type loop data: an edge hop
+// restricted to one edge type. Reuses the plain edge hop's chunks, limit, carry
+// set and body; adds the resolved EdgeTypeID the Get{Out,In}EdgesByTypeChunkWriter
+// filters by. _matchable is false when the type name was absent from the schema,
+// so no edge can match and the loop emits no row - the edge sibling of
+// NLScanByLabelLoopData.
+class NLEdgeByTypeLoopData : public NLEdgeLoopData {
+public:
+    NLEdgeByTypeLoopData(const ColumnNodeIDs* input,
+                         ColumnNodeIDs* sources,
+                         ColumnEdgeIDs* edgeIDs,
+                         ColumnEdgeTypes* edgeTypes,
+                         ColumnNodeIDs* targets,
+                         EdgeTypeID edgeType,
+                         bool matchable)
+        : NLEdgeLoopData(input, sources, edgeIDs, edgeTypes, targets),
+        _edgeType(edgeType),
+        _matchable(matchable)
+    {
+    }
+
+    EdgeTypeID getEdgeType() const { return _edgeType; }
+    bool isMatchable() const { return _matchable; }
+
+private:
+    EdgeTypeID _edgeType;
+    bool _matchable {true};
+};
+
 // nl.get_node_properties / nl.get_edge_properties data: a with-null property
 // read that maps the input ID column to a nullable value column, one value per
 // input row (missing values are null, no row dropped). The node-vs-edge ID type

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -26,6 +26,19 @@ namespace storage = mlir::storage;
 
 namespace {
 
+// The edge type name carried by the nl.get_edge_type handle a by-type hop's
+// edge_type operand names. The name lives on the handle op, not the hop, so it is
+// resolved once above the loops; a hop reads it back through its operand here (the
+// same way translatePropertyFetch reads a property name off nl.get_property_type).
+llvm::StringRef edgeTypeName(mlir::Value handle) {
+    nl::GetEdgeType handleOp = handle.getDefiningOp<nl::GetEdgeType>();
+    if (!handleOp) {
+        throw IRException("edge_type operand must come from nl.get_edge_type");
+    }
+
+    return handleOp.getName();
+}
+
 // The with-null fetch handler for a property's value type, on the node side
 // when isNode is true and the edge side otherwise. Selecting it here keeps the
 // value-type dispatch with the rest of translation; the handler bodies live in
@@ -156,12 +169,24 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             const mlir::OperandRange carriedColumns = getInEdges.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
             _iteratorConfigs[getInEdges.getResult()] = config;
+        } else if (nl::GetOutEdgesByType getOutEdgesByType = mlir::dyn_cast<nl::GetOutEdgesByType>(operation)) {
+            IteratorConfig config {IteratorKind::GetOutEdgesByType, getOutEdgesByType.getInputNodes(), {}};
+            const mlir::OperandRange carriedColumns = getOutEdgesByType.getColumnsToFilter();
+            config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
+            config._edgeType = edgeTypeName(getOutEdgesByType.getEdgeType()).str();
+            _iteratorConfigs[getOutEdgesByType.getResult()] = config;
+        } else if (nl::GetInEdgesByType getInEdgesByType = mlir::dyn_cast<nl::GetInEdgesByType>(operation)) {
+            IteratorConfig config {IteratorKind::GetInEdgesByType, getInEdgesByType.getInputNodes(), {}};
+            const mlir::OperandRange carriedColumns = getInEdgesByType.getColumnsToFilter();
+            config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
+            config._edgeType = edgeTypeName(getInEdgesByType.getEdgeType()).str();
+            _iteratorConfigs[getInEdgesByType.getResult()] = config;
         } else if (nl::Sort sort = mlir::dyn_cast<nl::Sort>(operation)) {
             _iteratorConfigs[sort.getResult()] = IteratorConfig {IteratorKind::Sort, {}, {}, sortStateFor(sort.getState())};
         } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
-        } else if (mlir::isa<nl::GetPropertyType>(operation)) {
-            // The handle carries only a name; a fetch resolves it on consumption
+        } else if (mlir::isa<nl::GetPropertyType, nl::GetEdgeType>(operation)) {
+            // The handle carries only a name; a fetch/hop resolves it on consumption
         } else if (nl::GetNodeProperties getNodeProperties = mlir::dyn_cast<nl::GetNodeProperties>(operation)) {
             translatePropertyFetch(getNodeProperties.getInputNodes(),
                                    getNodeProperties.getPropertyType(),
@@ -309,11 +334,36 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
 
     const ColumnNodeIDs* inputNodeIDs = static_cast<const ColumnNodeIDs*>(getColumn(config._inputNodes));
 
-    NLEdgeLoopData* loopData = _program->allocFunctionData<NLEdgeLoopData>(inputNodeIDs,
-                                                                           sources,
-                                                                           edgeIDs,
-                                                                           edgeTypes,
-                                                                           targets);
+    const bool byType = config._kind == IteratorKind::GetOutEdgesByType
+                        || config._kind == IteratorKind::GetInEdgesByType;
+
+    // A by-type hop carries the resolved edge type in an NLEdgeByTypeLoopData; a
+    // plain hop uses the base NLEdgeLoopData. The shared driver below (reserve,
+    // carried columns, body) works through the base pointer either way.
+    NLEdgeLoopData* loopData = nullptr;
+    if (byType) {
+        // Resolve the edge type name against the schema, exactly as
+        // translateScanByLabelLoop resolves its labels. A name absent from the
+        // schema matches no edge, so the loop is marked unmatchable and emits
+        // nothing rather than filtering against a bogus type.
+        const std::optional<EdgeTypeID> edgeTypeID = _view->metadata().edgeTypes().get(config._edgeType);
+        const bool matchable = edgeTypeID.has_value();
+        const EdgeTypeID resolvedType = matchable ? *edgeTypeID : EdgeTypeID();
+
+        loopData = _program->allocFunctionData<NLEdgeByTypeLoopData>(inputNodeIDs,
+                                                                     sources,
+                                                                     edgeIDs,
+                                                                     edgeTypes,
+                                                                     targets,
+                                                                     resolvedType,
+                                                                     matchable);
+    } else {
+        loopData = _program->allocFunctionData<NLEdgeLoopData>(inputNodeIDs,
+                                                               sources,
+                                                               edgeIDs,
+                                                               edgeTypes,
+                                                               targets);
+    }
     loopData->setLimit(limit);
 
     // Reserve scratch indices column
@@ -346,9 +396,16 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
         loopData->addCarriedColumn(carriedColumn);
     }
 
-    const bool isOutEdges = config._kind == IteratorKind::GetOutEdges;
-    const NLHandlerFunction handler = isOutEdges ? &NLExecutor::runGetOutEdgesLoop
-                                                 : &NLExecutor::runGetInEdgesLoop;
+    NLHandlerFunction handler = nullptr;
+    if (config._kind == IteratorKind::GetOutEdges) {
+        handler = &NLExecutor::runGetOutEdgesLoop;
+    } else if (config._kind == IteratorKind::GetInEdges) {
+        handler = &NLExecutor::runGetInEdgesLoop;
+    } else if (config._kind == IteratorKind::GetOutEdgesByType) {
+        handler = &NLExecutor::runGetOutEdgesByTypeLoop;
+    } else {
+        handler = &NLExecutor::runGetInEdgesByTypeLoop;
+    }
     body->addStmt(NLFunctionDescriptor {handler, loopData});
 
     translateBlock(loopBody, loopData->getStmts());

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -173,13 +173,13 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             IteratorConfig config {IteratorKind::GetOutEdgesByType, getOutEdgesByType.getInputNodes(), {}};
             const mlir::OperandRange carriedColumns = getOutEdgesByType.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
-            config._edgeType = edgeTypeName(getOutEdgesByType.getEdgeType()).str();
+            config._edgeType = edgeTypeName(getOutEdgesByType.getEdgeType());
             _iteratorConfigs[getOutEdgesByType.getResult()] = config;
         } else if (nl::GetInEdgesByType getInEdgesByType = mlir::dyn_cast<nl::GetInEdgesByType>(operation)) {
             IteratorConfig config {IteratorKind::GetInEdgesByType, getInEdgesByType.getInputNodes(), {}};
             const mlir::OperandRange carriedColumns = getInEdgesByType.getColumnsToFilter();
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
-            config._edgeType = edgeTypeName(getInEdgesByType.getEdgeType()).str();
+            config._edgeType = edgeTypeName(getInEdgesByType.getEdgeType());
             _iteratorConfigs[getInEdgesByType.getResult()] = config;
         } else if (nl::Sort sort = mlir::dyn_cast<nl::Sort>(operation)) {
             _iteratorConfigs[sort.getResult()] = IteratorConfig {IteratorKind::Sort, {}, {}, sortStateFor(sort.getState())};

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -52,9 +52,11 @@ private:
         llvm::SmallVector<llvm::StringRef, 4> _labels;
 
         // The edge type name a GetOutEdgesByType / GetInEdgesByType iterator
-        // filters by; empty for the other kinds. Resolved to an EdgeTypeID when
-        // the loop is translated.
-        std::string _edgeType;
+        // filters by; empty for the other kinds. Like _labels, a view into the
+        // op's interned StringAttr storage, which the MLIRContext keeps alive for
+        // the whole translation; resolved to an EdgeTypeID when the loop is
+        // translated.
+        llvm::StringRef _edgeType;
     };
 
     NLProgram* _program {nullptr};

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -31,6 +31,8 @@ private:
         ScanNodesByLabel,
         GetOutEdges,
         GetInEdges,
+        GetOutEdgesByType,
+        GetInEdgesByType,
         Sort,
     };
 
@@ -48,6 +50,11 @@ private:
         // which the MLIRContext keeps alive for the whole translation; they are
         // resolved to a LabelSet as soon as the loop is translated.
         llvm::SmallVector<llvm::StringRef, 4> _labels;
+
+        // The edge type name a GetOutEdgesByType / GetInEdgesByType iterator
+        // filters by; empty for the other kinds. Resolved to an EdgeTypeID when
+        // the loop is translated.
+        std::string _edgeType;
     };
 
     NLProgram* _program {nullptr};

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -172,6 +172,7 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     // in the entry block; a cross product retargets the root per factor.
     _valueMap.clear();
     _propertyTypes.clear();
+    _edgeTypes.clear();
     _rootBlock = _entryBlock;
     _innermostLoopBody = nullptr;
     _limitHandles.clear();
@@ -250,6 +251,10 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerGetOutEdges(getOutEdges);
     } else if (mlir::db::GetInEdges getInEdges = mlir::dyn_cast<mlir::db::GetInEdges>(operation)) {
         lowerGetInEdges(getInEdges);
+    } else if (mlir::db::GetOutEdgesByType getOutEdgesByType = mlir::dyn_cast<mlir::db::GetOutEdgesByType>(operation)) {
+        lowerGetOutEdgesByType(getOutEdgesByType);
+    } else if (mlir::db::GetInEdgesByType getInEdgesByType = mlir::dyn_cast<mlir::db::GetInEdgesByType>(operation)) {
+        lowerGetInEdgesByType(getInEdgesByType);
     } else if (mlir::db::GetNodeProperties getNodeProperties = mlir::dyn_cast<mlir::db::GetNodeProperties>(operation)) {
         lowerGetNodeProperties(getNodeProperties);
     } else if (mlir::db::GetEdgeProperties getEdgeProperties = mlir::dyn_cast<mlir::db::GetEdgeProperties>(operation)) {
@@ -342,6 +347,53 @@ void DBLowering::lowerGetInEdges(mlir::db::GetInEdges getInEdges) {
     // carried chunk - is inferred from the operands.
     nl::GetInEdges edges = _builder.create<nl::GetInEdges>(_builder.getUnknownLoc(), inputChunk, carriedChunks);
     buildLoopForSource(edges.getResult(), getInEdges.getOperation());
+}
+
+void DBLowering::lowerGetOutEdgesByType(mlir::db::GetOutEdgesByType getOutEdgesByType) {
+    // The by-type sibling of lowerGetOutEdges: identical shape, plus the edge type.
+    // The name is hoisted into an nl.get_edge_type handle at the top of the entry
+    // block, so it is resolved once above the loops rather than carried on the hop
+    // (the same split lowerGetNodeProperties uses for a property name). The handle
+    // is created before the loop's insertion point is set below.
+    const mlir::Value inputChunk = mapValue(getOutEdgesByType.getInputNodes());
+    const mlir::Value edgeTypeHandle = getOrCreateEdgeTypeHandle(getOutEdgesByType.getEdgeType());
+
+    llvm::SmallVector<mlir::Value, 4> carriedChunks;
+    for (const mlir::Value carriedColumn : getOutEdgesByType.getColumnsToFilter()) {
+        carriedChunks.push_back(mapValue(carriedColumn));
+    }
+
+    setInsertionInto(ownerBlock(inputChunk));
+
+    // The result iterator type - the four fixed edge chunks plus one per carried
+    // chunk - is inferred from the operands, exactly as for get_out_edges.
+    nl::GetOutEdgesByType edges = _builder.create<nl::GetOutEdgesByType>(_builder.getUnknownLoc(),
+                                                                         inputChunk,
+                                                                         edgeTypeHandle,
+                                                                         carriedChunks);
+    buildLoopForSource(edges.getResult(), getOutEdgesByType.getOperation());
+}
+
+void DBLowering::lowerGetInEdgesByType(mlir::db::GetInEdgesByType getInEdgesByType) {
+    // The predecessor counterpart of lowerGetOutEdgesByType: same shape, reverse
+    // direction, edge type hoisted into the same nl.get_edge_type handle.
+    const mlir::Value inputChunk = mapValue(getInEdgesByType.getInputNodes());
+    const mlir::Value edgeTypeHandle = getOrCreateEdgeTypeHandle(getInEdgesByType.getEdgeType());
+
+    llvm::SmallVector<mlir::Value, 4> carriedChunks;
+    for (const mlir::Value carriedColumn : getInEdgesByType.getColumnsToFilter()) {
+        carriedChunks.push_back(mapValue(carriedColumn));
+    }
+
+    setInsertionInto(ownerBlock(inputChunk));
+
+    // The result iterator type - the four fixed edge chunks plus one per carried
+    // chunk - is inferred from the operands, exactly as for get_in_edges.
+    nl::GetInEdgesByType edges = _builder.create<nl::GetInEdgesByType>(_builder.getUnknownLoc(),
+                                                                       inputChunk,
+                                                                       edgeTypeHandle,
+                                                                       carriedChunks);
+    buildLoopForSource(edges.getResult(), getInEdgesByType.getOperation());
 }
 
 void DBLowering::lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties) {
@@ -480,6 +532,25 @@ mlir::Value DBLowering::getOrCreatePropertyTypeHandle(llvm::StringRef propertyNa
                                                                         _builder.getStringAttr(propertyName));
     const mlir::Value handle = handleOp.getResult();
     _propertyTypes[propertyName] = handle;
+
+    return handle;
+}
+
+mlir::Value DBLowering::getOrCreateEdgeTypeHandle(llvm::StringRef edgeTypeName) {
+    // The edge sibling of getOrCreatePropertyTypeHandle: dedup per name and hoist
+    // the handle to the top of the entry block, above every loop, so a by-type hop
+    // nested in a loop reuses one resolved handle rather than re-carrying the name.
+    const auto existing = _edgeTypes.find(edgeTypeName);
+    if (existing != _edgeTypes.end()) {
+        return existing->second;
+    }
+
+    _builder.setInsertionPointToStart(_entryBlock);
+
+    nl::GetEdgeType handleOp = _builder.create<nl::GetEdgeType>(_builder.getUnknownLoc(),
+                                                               _builder.getStringAttr(edgeTypeName));
+    const mlir::Value handle = handleOp.getResult();
+    _edgeTypes[edgeTypeName] = handle;
 
     return handle;
 }
@@ -850,7 +921,12 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
         return;
     }
 
-    const bool opensLoop = mlir::isa<mlir::db::ScanNodes, mlir::db::ScanNodesByLabel, mlir::db::GetOutEdges, mlir::db::GetInEdges>(definingOp);
+    const bool opensLoop = mlir::isa<mlir::db::ScanNodes,
+                                     mlir::db::ScanNodesByLabel,
+                                     mlir::db::GetOutEdges,
+                                     mlir::db::GetInEdges,
+                                     mlir::db::GetOutEdgesByType,
+                                     mlir::db::GetInEdgesByType>(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
     // The first limit, in program order, to claim a producer wins, so a loop

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -112,6 +112,11 @@ private:
     // resolved once and shared by every fetch that reads it
     llvm::StringMap<mlir::Value> _propertyTypes;
 
+    // Edge type name -> the hoisted nl.get_edge_type handle, so a name is resolved
+    // once and shared by every by-type edge hop that reads it (the edge sibling of
+    // _propertyTypes)
+    llvm::StringMap<mlir::Value> _edgeTypes;
+
     // Entry block of the nl function being built
     mlir::Block* _entryBlock {nullptr};
 
@@ -155,6 +160,8 @@ private:
     void lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLabel);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetInEdges(mlir::db::GetInEdges getInEdges);
+    void lowerGetOutEdgesByType(mlir::db::GetOutEdgesByType getOutEdgesByType);
+    void lowerGetInEdgesByType(mlir::db::GetInEdgesByType getInEdgesByType);
     void lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties);
     void lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgeProperties);
     void lowerCrossProduct(mlir::db::CrossProduct product);
@@ -243,6 +250,11 @@ private:
     // The nl.get_property_type handle for a property name, inserted once at the
     // top of the entry block (above every loop) and reused on later lookups
     mlir::Value getOrCreatePropertyTypeHandle(llvm::StringRef propertyName);
+
+    // The nl.get_edge_type handle for an edge type name, inserted once at the top
+    // of the entry block (above every loop) and reused on later lookups - the edge
+    // sibling of getOrCreatePropertyTypeHandle
+    mlir::Value getOrCreateEdgeTypeHandle(llvm::StringRef edgeTypeName);
 
     // The !nl.chunk<!storage.nullable<T>> a fetch of this property produces, with T
     // the value type the name resolves to in the schema

--- a/samples/mlir/edges_by_type.mlir
+++ b/samples/mlir/edges_by_type.mlir
@@ -1,20 +1,10 @@
 module {
   func.func @main() {
-    // MATCH (a)-[:KNOWS_WELL]->(b): scan `a`, then one out-edge hop that keeps
-    // only the KNOWS_WELL edges. get_out_edges_by_type is the plain get_out_edges
-    // narrowed by the relationship type spelled in the query - an edge carries
-    // exactly one type, so the filter is an equality on that type.
-    //
-    // The type name is resolved against the loaded graph's schema (-graph) at
-    // execution, the same way scan_nodes_by_label resolves its labels. A name no
-    // edge was ever created with matches nothing, so the hop yields no rows. Swap
-    // "KNOWS_WELL" for an edge type your graph actually has.
     %a = db.scan_nodes() : !db.column<!storage.node_id>
 
     %s, %e, %et, %b = db.get_out_edges_by_type(%a, "KNOWS_WELL", {})
         : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
 
-    // Project the (a, b) pairs linked by a KNOWS_WELL edge.
     db.output(%s, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
 
     return

--- a/samples/mlir/edges_by_type.mlir
+++ b/samples/mlir/edges_by_type.mlir
@@ -1,0 +1,22 @@
+module {
+  func.func @main() {
+    // MATCH (a)-[:KNOWS_WELL]->(b): scan `a`, then one out-edge hop that keeps
+    // only the KNOWS_WELL edges. get_out_edges_by_type is the plain get_out_edges
+    // narrowed by the relationship type spelled in the query - an edge carries
+    // exactly one type, so the filter is an equality on that type.
+    //
+    // The type name is resolved against the loaded graph's schema (-graph) at
+    // execution, the same way scan_nodes_by_label resolves its labels. A name no
+    // edge was ever created with matches nothing, so the hop yields no rows. Swap
+    // "KNOWS_WELL" for an edge type your graph actually has.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %s, %e, %et, %b = db.get_out_edges_by_type(%a, "KNOWS_WELL", {})
+        : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Project the (a, b) pairs linked by a KNOWS_WELL edge.
+    db.output(%s, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+
+    return
+  }
+}

--- a/samples/mlir/edges_by_type.nl.mlir
+++ b/samples/mlir/edges_by_type.nl.mlir
@@ -1,13 +1,3 @@
-// Generated nl-dialect lowering of edges_by_type.mlir (db dialect).
-// Reproduce with: mlir -dump-lowered edges_by_type.mlir
-// This is the DBLowering output; edit edges_by_type.mlir, not this file.
-//
-// The edge type name is not carried on the hop: lowering hoists it into one
-// nl.get_edge_type handle at the top of the function (deduped per name), above
-// every loop, and the hop takes that handle. So a hop nested in a loop resolves
-// its type once rather than per step - the same split as nl.get_property_type and
-// the property fetches. The name is resolved to an EdgeTypeID only at execution,
-// so no -graph is needed to lower.
 module {
   func.func @main() {
     %0 = nl.get_edge_type("KNOWS_WELL")

--- a/samples/mlir/edges_by_type.nl.mlir
+++ b/samples/mlir/edges_by_type.nl.mlir
@@ -1,0 +1,23 @@
+// Generated nl-dialect lowering of edges_by_type.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered edges_by_type.mlir
+// This is the DBLowering output; edit edges_by_type.mlir, not this file.
+//
+// The edge type name is not carried on the hop: lowering hoists it into one
+// nl.get_edge_type handle at the top of the function (deduped per name), above
+// every loop, and the hop takes that handle. So a hop nested in a loop resolves
+// its type once rather than per step - the same split as nl.get_property_type and
+// the property fetches. The name is resolved to an EdgeTypeID only at execution,
+// so no -graph is needed to lower.
+module {
+  func.func @main() {
+    %0 = nl.get_edge_type("KNOWS_WELL")
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %2 = nl.get_out_edges_by_type(%arg0, %0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%arg1, %arg4) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      }
+    }
+    return
+  }
+}

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -29,9 +29,11 @@ set(storage_sources
         reader/GraphReader.cpp
 
         iterators/GetInEdgesIterator.cpp
+        iterators/GetInEdgesByTypeIterator.cpp
         iterators/GetPropertiesIterator.cpp
         iterators/GetPropertiesWithNullIterator.cpp
         iterators/GetOutEdgesIterator.cpp
+        iterators/GetOutEdgesByTypeIterator.cpp
         iterators/GetEdgesIterator.cpp
         iterators/GetNodeViewsIterator.cpp
         iterators/PartIterator.cpp

--- a/storage/iterators/GetInEdgesByTypeIterator.cpp
+++ b/storage/iterators/GetInEdgesByTypeIterator.cpp
@@ -5,7 +5,7 @@
 #include "columns/ColumnIDs.h"
 #include "IteratorUtils.h"
 
-namespace db {
+using namespace db;
 
 GetInEdgesByTypeChunkWriter::GetInEdgesByTypeChunkWriter(const GraphView& view,
                                                          const ColumnNodeIDs* inputNodeIDs,
@@ -114,6 +114,4 @@ void GetInEdgesByTypeChunkWriter::fill(size_t maxCount) {
     if (_view.tombstones().hasEdges()) {
         filterTombstones();
     }
-}
-
 }

--- a/storage/iterators/GetInEdgesByTypeIterator.cpp
+++ b/storage/iterators/GetInEdgesByTypeIterator.cpp
@@ -1,0 +1,119 @@
+#include "GetInEdgesByTypeIterator.h"
+
+#include <iterator>
+
+#include "columns/ColumnIDs.h"
+#include "IteratorUtils.h"
+
+namespace db {
+
+GetInEdgesByTypeChunkWriter::GetInEdgesByTypeChunkWriter(const GraphView& view,
+                                                         const ColumnNodeIDs* inputNodeIDs,
+                                                         EdgeTypeID edgeType)
+    : GetInEdgesIterator(view, inputNodeIDs),
+    _edgeType(edgeType),
+    _filter(view.tombstones())
+{
+}
+
+void GetInEdgesByTypeChunkWriter::filterTombstones() {
+    // Base column of this ChunkWriter is _edgeIDs
+    _filter.populateRanges(_edgeIDs);
+
+    _filter.filter(_indices);
+    _filter.filter(_edgeIDs);
+
+    if (_srcs) {
+        _filter.filter(_srcs);
+    }
+    if (_types) {
+        _filter.filter(_types);
+    }
+
+    _filter.reset();
+}
+
+static constexpr size_t NColumns = 3;
+static constexpr size_t NCombinations = 1 << NColumns;
+
+void GetInEdgesByTypeChunkWriter::fill(size_t maxCount) {
+    size_t remainingToMax = maxCount;
+    static constexpr auto bools = generateArray<NColumns, NCombinations>();
+    static constexpr auto masks = generateBitmasks<NColumns, NCombinations>();
+
+    // The filtered chunk is at most maxCount rows, so reserving once keeps the
+    // per-edge push_back below from reallocating as it appends.
+    _indices->clear();
+    _indices->reserve(maxCount);
+
+    if (_edgeIDs) {
+        _edgeIDs->clear();
+        _edgeIDs->reserve(maxCount);
+    }
+    if (_srcs) {
+        _srcs->clear();
+        _srcs->reserve(maxCount);
+    }
+    if (_types) {
+        _types->clear();
+        _types->reserve(maxCount);
+    }
+
+    // The by-type in-edge fill mirrors GetOutEdgesByTypeChunkWriter::fill: the
+    // edges of the requested type are scattered through a node's in-edge span, so
+    // we walk it edge by edge and push only the matches straight into the output
+    // columns, with no intermediate unfiltered chunk. For an in-edge the neighbour
+    // (_otherID) is the source. The bitmask dispatch lifts the "is this column
+    // wired up?" test out of the per-edge loop.
+    const auto fill = [&]<std::array<bool, NColumns> conditions>() {
+        while (isValid() && remainingToMax > 0) {
+            const size_t index = std::distance(_inputNodeIDs->cbegin(), _nodeIt);
+
+            // Append this node's remaining in-edges of the requested type until
+            // the span is exhausted or the row budget runs out.
+            while (_edgeIt != _edges.end() && remainingToMax > 0) {
+                if (_edgeIt->_edgeTypeID == _edgeType) {
+                    _indices->push_back(index);
+
+                    if constexpr (conditions[0]) {
+                        _edgeIDs->push_back(_edgeIt->_edgeID);
+                    }
+                    if constexpr (conditions[1]) {
+                        _srcs->push_back(_edgeIt->_otherID);
+                    }
+                    if constexpr (conditions[2]) {
+                        _types->push_back(_edgeIt->_edgeTypeID);
+                    }
+
+                    remainingToMax--;
+                }
+
+                _edgeIt++;
+            }
+
+            // Span exhausted: advance to the next node (or datapart) that has
+            // edges. Otherwise we stopped mid-span on the row budget, so _edgeIt
+            // stays put and the next fill() resumes from the same edge.
+            if (_edgeIt == _edges.end()) {
+                nextValid();
+            }
+        }
+    };
+
+    switch (bitmask::create(_edgeIDs, _srcs, _types)) {
+        CASE(0);
+        CASE(1);
+        CASE(2);
+        CASE(3);
+        CASE(4);
+        CASE(5);
+        CASE(6);
+        CASE(7);
+    }
+
+    if (_view.tombstones().hasEdges()) {
+        filterTombstones();
+    }
+}
+
+}

--- a/storage/iterators/GetInEdgesByTypeIterator.h
+++ b/storage/iterators/GetInEdgesByTypeIterator.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "GetInEdgesIterator.h"
+
+#include "ID.h"
+
+namespace db {
+
+// The predecessor counterpart of GetOutEdgesByTypeChunkWriter: a
+// GetInEdgesChunkWriter restricted to the in-edges of one edge type, modelling the
+// MATCH (a)<-[:TYPE]-(b) hop. It reuses GetInEdgesIterator's datapart and node-span
+// navigation unchanged - only fill() differs: it walks each node's in-edge span
+// edge by edge and writes only the records whose _edgeTypeID matches straight into
+// the output columns, so the by-type filter costs no extra copy over the plain
+// fetch.
+class GetInEdgesByTypeChunkWriter : public GetInEdgesIterator {
+public:
+    GetInEdgesByTypeChunkWriter() = delete;
+    GetInEdgesByTypeChunkWriter(const GraphView& view,
+                                const ColumnNodeIDs* inputNodeIDs,
+                                EdgeTypeID edgeType);
+
+    void fill(size_t maxCount);
+
+    void setInputNodeIDs(const ColumnNodeIDs* inputNodeIDs) { _inputNodeIDs = inputNodeIDs; }
+    void setIndices(ColumnVector<size_t>* indices) { _indices = indices; }
+    void setEdgeIDs(ColumnEdgeIDs* edgeIDs) { _edgeIDs = edgeIDs; }
+    void setSrcIDs(ColumnNodeIDs* srcs) { _srcs = srcs; }
+    void setEdgeTypes(ColumnEdgeTypes* types) { _types = types; }
+
+private:
+    // The single edge type kept; every other type is skipped during fill().
+    EdgeTypeID _edgeType;
+
+    ColumnVector<size_t>* _indices {nullptr};
+    ColumnEdgeIDs* _edgeIDs {nullptr};
+    ColumnNodeIDs* _srcs {nullptr};
+    ColumnEdgeTypes* _types {nullptr};
+
+    TombstoneFilter _filter;
+
+    void filterTombstones();
+};
+
+static_assert(NonRootChunkWriter<GetInEdgesByTypeChunkWriter>);
+static_assert(EdgeIDsChunkWriter<GetInEdgesByTypeChunkWriter>);
+static_assert(SrcIDsChunkWriter<GetInEdgesByTypeChunkWriter>);
+static_assert(EdgeTypesChunkWriter<GetInEdgesByTypeChunkWriter>);
+
+}

--- a/storage/iterators/GetInEdgesByTypeIterator.h
+++ b/storage/iterators/GetInEdgesByTypeIterator.h
@@ -6,13 +6,6 @@
 
 namespace db {
 
-// The predecessor counterpart of GetOutEdgesByTypeChunkWriter: a
-// GetInEdgesChunkWriter restricted to the in-edges of one edge type, modelling the
-// MATCH (a)<-[:TYPE]-(b) hop. It reuses GetInEdgesIterator's datapart and node-span
-// navigation unchanged - only fill() differs: it walks each node's in-edge span
-// edge by edge and writes only the records whose _edgeTypeID matches straight into
-// the output columns, so the by-type filter costs no extra copy over the plain
-// fetch.
 class GetInEdgesByTypeChunkWriter : public GetInEdgesIterator {
 public:
     GetInEdgesByTypeChunkWriter() = delete;
@@ -29,7 +22,6 @@ public:
     void setEdgeTypes(ColumnEdgeTypes* types) { _types = types; }
 
 private:
-    // The single edge type kept; every other type is skipped during fill().
     EdgeTypeID _edgeType;
 
     ColumnVector<size_t>* _indices {nullptr};

--- a/storage/iterators/GetOutEdgesByTypeIterator.cpp
+++ b/storage/iterators/GetOutEdgesByTypeIterator.cpp
@@ -5,7 +5,7 @@
 #include "columns/ColumnIDs.h"
 #include "IteratorUtils.h"
 
-namespace db {
+using namespace db;
 
 GetOutEdgesByTypeChunkWriter::GetOutEdgesByTypeChunkWriter(const GraphView& view,
                                                            const ColumnNodeIDs* inputNodeIDs,
@@ -117,6 +117,4 @@ void GetOutEdgesByTypeChunkWriter::fill(size_t maxCount) {
     if (_view.tombstones().hasEdges()) {
         filterTombstones();
     }
-}
-
 }

--- a/storage/iterators/GetOutEdgesByTypeIterator.cpp
+++ b/storage/iterators/GetOutEdgesByTypeIterator.cpp
@@ -1,0 +1,122 @@
+#include "GetOutEdgesByTypeIterator.h"
+
+#include <iterator>
+
+#include "columns/ColumnIDs.h"
+#include "IteratorUtils.h"
+
+namespace db {
+
+GetOutEdgesByTypeChunkWriter::GetOutEdgesByTypeChunkWriter(const GraphView& view,
+                                                           const ColumnNodeIDs* inputNodeIDs,
+                                                           EdgeTypeID edgeType)
+    : GetOutEdgesIterator(view, inputNodeIDs),
+    _edgeType(edgeType),
+    _filter(view.tombstones())
+{
+}
+
+void GetOutEdgesByTypeChunkWriter::filterTombstones() {
+    // Base column of this ChunkWriter is _edgeIDs
+    _filter.populateRanges(_edgeIDs);
+
+    _filter.filter(_edgeIDs);
+    _filter.filter(_indices);
+
+    if (_tgts) {
+        _filter.filter(_tgts);
+    }
+    if (_types) {
+        _filter.filter(_types);
+    }
+
+    _filter.reset();
+}
+
+static constexpr size_t NColumns = 3;
+static constexpr size_t NCombinations = 1 << NColumns;
+
+void GetOutEdgesByTypeChunkWriter::fill(size_t maxCount) {
+    size_t remainingToMax = maxCount;
+    static constexpr auto bools = generateArray<NColumns, NCombinations>();
+    static constexpr auto masks = generateBitmasks<NColumns, NCombinations>();
+
+    // The filtered chunk is at most maxCount rows, so reserving once keeps the
+    // per-edge push_back below from reallocating as it appends.
+    _indices->clear();
+    _indices->reserve(maxCount);
+
+    if (_edgeIDs) {
+        _edgeIDs->clear();
+        _edgeIDs->reserve(maxCount);
+    }
+    if (_tgts) {
+        _tgts->clear();
+        _tgts->reserve(maxCount);
+    }
+    if (_types) {
+        _types->clear();
+        _types->reserve(maxCount);
+    }
+
+    // Filtering by edge type breaks the contiguous-range fill the unfiltered
+    // GetOutEdgesChunkWriter uses: a node's edges of the requested type are
+    // scattered through its edge span, not a sub-range of it, so there is no run
+    // to std::generate over. We walk the span edge by edge and push only the
+    // matches - directly into the output columns, with no intermediate unfiltered
+    // chunk. The bitmask dispatch (as in GetOutEdgesChunkWriter::fill) lifts the
+    // "is this column wired up?" test out of the per-edge loop: one template
+    // instantiation per column combination, selected once by the switch below.
+    const auto fill = [&]<std::array<bool, NColumns> conditions>() {
+        while (isValid() && remainingToMax > 0) {
+            const size_t index = std::distance(_inputNodeIDs->cbegin(), _nodeIt);
+
+            // Append this node's remaining edges of the requested type until the
+            // span is exhausted or the row budget runs out.
+            while (_edgeIt != _edges.end() && remainingToMax > 0) {
+                if (_edgeIt->_edgeTypeID == _edgeType) {
+                    _indices->push_back(index);
+
+                    if constexpr (conditions[0]) {
+                        _edgeIDs->push_back(_edgeIt->_edgeID);
+                    }
+                    if constexpr (conditions[1]) {
+                        _tgts->push_back(_edgeIt->_otherID);
+                    }
+                    if constexpr (conditions[2]) {
+                        _types->push_back(_edgeIt->_edgeTypeID);
+                    }
+
+                    remainingToMax--;
+                }
+
+                _edgeIt++;
+            }
+
+            // Span exhausted: advance to the next node (or datapart) that has
+            // edges. Otherwise we stopped mid-span on the row budget, so _edgeIt
+            // stays put and the next fill() resumes from the same edge.
+            if (_edgeIt == _edges.end()) {
+                nextValid();
+            }
+        }
+    };
+
+    switch (bitmask::create(_edgeIDs, _tgts, _types)) {
+        CASE(0);
+        CASE(1);
+        CASE(2);
+        CASE(3);
+        CASE(4);
+        CASE(5);
+        CASE(6);
+        CASE(7);
+    }
+
+    // Base column is _edgeIDs: only need to check if there are edge tombstones
+    if (_view.tombstones().hasEdges()) {
+        filterTombstones();
+    }
+}
+
+}

--- a/storage/iterators/GetOutEdgesByTypeIterator.h
+++ b/storage/iterators/GetOutEdgesByTypeIterator.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "GetOutEdgesIterator.h"
+
+#include "ID.h"
+
+namespace db {
+
+// A GetOutEdgesChunkWriter restricted to the out-edges of one edge type, modelling
+// the MATCH (a)-[:TYPE]->(b) hop. It reuses GetOutEdgesIterator's datapart and
+// node-span navigation unchanged - only fill() differs: it walks each node's edge
+// span edge by edge and writes only the records whose _edgeTypeID matches straight
+// into the output columns. No unfiltered chunk is materialized and then filtered,
+// so the by-type filter costs no extra copy over the plain fetch.
+class GetOutEdgesByTypeChunkWriter : public GetOutEdgesIterator {
+public:
+    GetOutEdgesByTypeChunkWriter() = delete;
+    GetOutEdgesByTypeChunkWriter(const GraphView& view,
+                                 const ColumnNodeIDs* inputNodeIDs,
+                                 EdgeTypeID edgeType);
+
+    void fill(size_t maxCount);
+
+    void setInputNodeIDs(const ColumnNodeIDs* inputNodeIDs) { _inputNodeIDs = inputNodeIDs; }
+    void setIndices(ColumnVector<size_t>* indices) { _indices = indices; }
+    void setEdgeIDs(ColumnEdgeIDs* edgeIDs) { _edgeIDs = edgeIDs; }
+    void setTgtIDs(ColumnNodeIDs* tgts) { _tgts = tgts; }
+    void setEdgeTypes(ColumnEdgeTypes* types) { _types = types; }
+
+private:
+    // The single edge type kept; every other type is skipped during fill().
+    EdgeTypeID _edgeType;
+
+    ColumnVector<size_t>* _indices {nullptr};
+    ColumnEdgeIDs* _edgeIDs {nullptr};
+    ColumnNodeIDs* _tgts {nullptr};
+    ColumnEdgeTypes* _types {nullptr};
+
+    TombstoneFilter _filter;
+
+    void filterTombstones();
+};
+
+static_assert(NonRootChunkWriter<GetOutEdgesByTypeChunkWriter>);
+static_assert(EdgeIDsChunkWriter<GetOutEdgesByTypeChunkWriter>);
+static_assert(TgtIDsChunkWriter<GetOutEdgesByTypeChunkWriter>);
+static_assert(EdgeTypesChunkWriter<GetOutEdgesByTypeChunkWriter>);
+
+}

--- a/storage/iterators/GetOutEdgesByTypeIterator.h
+++ b/storage/iterators/GetOutEdgesByTypeIterator.h
@@ -6,12 +6,6 @@
 
 namespace db {
 
-// A GetOutEdgesChunkWriter restricted to the out-edges of one edge type, modelling
-// the MATCH (a)-[:TYPE]->(b) hop. It reuses GetOutEdgesIterator's datapart and
-// node-span navigation unchanged - only fill() differs: it walks each node's edge
-// span edge by edge and writes only the records whose _edgeTypeID matches straight
-// into the output columns. No unfiltered chunk is materialized and then filtered,
-// so the by-type filter costs no extra copy over the plain fetch.
 class GetOutEdgesByTypeChunkWriter : public GetOutEdgesIterator {
 public:
     GetOutEdgesByTypeChunkWriter() = delete;
@@ -28,7 +22,6 @@ public:
     void setEdgeTypes(ColumnEdgeTypes* types) { _types = types; }
 
 private:
-    // The single edge type kept; every other type is skipped during fill().
     EdgeTypeID _edgeType;
 
     ColumnVector<size_t>* _indices {nullptr};

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -926,4 +926,53 @@ TEST_F(DBDialectTest, verifierRejectsScanNodesByLabelWithoutLabels) {
     EXPECT_FALSE(module);
 }
 
+// MATCH (a)-[:KNOWS]->(b)<-[:LIKES]-(c): one by-type out-edge hop and one by-type
+// in-edge hop, so both ops' assembly formats (the type name inside the parens)
+// are exercised.
+const char* const edgesByTypeProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s0, %e0, %et0, %b = db.get_out_edges_by_type(%a, "KNOWS", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s1, %e1, %et1, %c = db.get_in_edges_by_type(%b, "LIKES", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%s0, %c) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(DBDialectTest, parsesGetEdgesByType) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(edgesByTypeProgram);
+    ASSERT_TRUE(module);
+
+    // The type name spelled inside each op's parens comes back on the edge_type
+    // attribute.
+    mlir::db::GetOutEdgesByType outByType;
+    module.get().walk([&](mlir::db::GetOutEdgesByType op) {
+        outByType = op;
+    });
+    ASSERT_TRUE(outByType);
+    EXPECT_EQ(outByType.getEdgeType(), "KNOWS");
+
+    mlir::db::GetInEdgesByType inByType;
+    module.get().walk([&](mlir::db::GetInEdgesByType op) {
+        inByType = op;
+    });
+    ASSERT_TRUE(inByType);
+    EXPECT_EQ(inByType.getEdgeType(), "LIKES");
+}
+
+TEST_F(DBDialectTest, edgesByTypeRoundTripThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(edgesByTypeProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // by-type edge op printers and parsers are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
 }

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -408,6 +408,51 @@ func.func @main() {
 }
 )mlir";
 
+// One hop along the out-edges of a single edge type, outputting (source, target)
+// pairs. Only the KNOWS edges survive - the rest are filtered in the chunk
+// writer - so this is a strict subset of the unfiltered oneHopOutProgram.
+constexpr const char* oneHopOutByTypeKnowsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_out_edges_by_type(%a, "KNOWS", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The LIKES sibling of oneHopOutByTypeKnowsProgram: the complementary edge set.
+constexpr const char* oneHopOutByTypeLikesProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_out_edges_by_type(%a, "LIKES", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A by-type hop naming an edge type the graph never created: the type resolves
+// to nothing, so the hop matches no edge and emits no row.
+constexpr const char* oneHopOutByTypeUnknownProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_out_edges_by_type(%a, "ROBOTS", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The in-edge by-type mirror: the same KNOWS edge set, discovered walking
+// predecessors. The writer fills the source side and the target is gathered from
+// the input, so the (source, target) pairs match the out-edge KNOWS hop.
+constexpr const char* oneHopInByTypeKnowsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %b = db.get_in_edges_by_type(%a, "KNOWS", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %b) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // Scan all nodes and output each node with its "score" property, which some
 // nodes lack (those come back null, none are dropped)
 constexpr const char* nodePropertiesProgram = R"mlir(
@@ -1019,6 +1064,40 @@ protected:
         return graph;
     }
 
+    // Four nodes (one label set, so IDs follow insertion order) linked by two
+    // edge types: KNOWS on 0->1 and 1->2, LIKES on 0->2 and 2->3. Each type is a
+    // strict subset of all four out-edges and the two types partition them, so a
+    // by-type hop must return exactly its own edges and the two together the whole
+    // out-edge set.
+    std::unique_ptr<Graph> buildTypedEdgeGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        metadata.getOrCreateLabel("0");
+        const EdgeTypeID knowsID = metadata.getOrCreateEdgeType("KNOWS");
+        const EdgeTypeID likesID = metadata.getOrCreateEdgeType("LIKES");
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const NodeID node0 = builder.addNode(labelset);
+        const NodeID node1 = builder.addNode(labelset);
+        const NodeID node2 = builder.addNode(labelset);
+        const NodeID node3 = builder.addNode(labelset);
+
+        builder.addEdge(knowsID, node0, node1);
+        builder.addEdge(likesID, node0, node2);
+        builder.addEdge(knowsID, node1, node2);
+        builder.addEdge(likesID, node2, node3);
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
     // A second datapart with nodes 4, 5 and the edge 4 -> 5, growing the node
     // count past the top-K trim threshold in the trims-across-chunks test.
     void addSecondPart(Graph& graph) {
@@ -1309,6 +1388,77 @@ TEST_F(DBLoweringTest, lowersOneHopInEdges) {
     runLoweredProgram(oneHopInProgram, reader.getView(), sink);
 
     const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesGetOutEdgesByType) {
+    auto graph = buildTypedEdgeGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView& view = reader.getView();
+
+    // KNOWS is 0->1 and 1->2; LIKES is 0->2 and 2->3. Each hop returns exactly
+    // its own edges, and the two together are the whole out-edge set.
+    CollectingNodeSink knowsSink;
+    runLoweredProgram(oneHopOutByTypeKnowsProgram, view, knowsSink);
+    std::vector<std::vector<uint64_t>> knowsRows;
+    knowsSink.sortedRows(knowsRows);
+    const std::vector<std::vector<uint64_t>> knowsExpected {{0, 1}, {1, 2}};
+    EXPECT_EQ(knowsRows, knowsExpected);
+
+    CollectingNodeSink likesSink;
+    runLoweredProgram(oneHopOutByTypeLikesProgram, view, likesSink);
+    std::vector<std::vector<uint64_t>> likesRows;
+    likesSink.sortedRows(likesRows);
+    const std::vector<std::vector<uint64_t>> likesExpected {{0, 2}, {2, 3}};
+    EXPECT_EQ(likesRows, likesExpected);
+}
+
+TEST_F(DBLoweringTest, executesGetInEdgesByType) {
+    auto graph = buildTypedEdgeGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The KNOWS edges discovered walking predecessors are the same (source,
+    // target) pairs as the out-edge KNOWS hop.
+    CollectingNodeSink sink;
+    runLoweredProgram(oneHopInByTypeKnowsProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {1, 2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, getOutEdgesByTypeUnknownIsEmpty) {
+    auto graph = buildTypedEdgeGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // "ROBOTS" was never created, so no edge carries it: the hop yields no rows.
+    CollectingNodeSink sink;
+    runLoweredProgram(oneHopOutByTypeUnknownProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_TRUE(rows.empty());
+}
+
+TEST_F(DBLoweringTest, executesGetOutEdgesByTypeAcrossChunks) {
+    auto graph = buildTypedEdgeGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 1 forces the writer to fill at most one matching edge per step, so
+    // it must stop mid-span on the row budget (node 0 carries KNOWS then LIKES) and
+    // resume from the same edge on the next fill without re-emitting or skipping a
+    // match. The KNOWS result must still be exactly the two KNOWS edges.
+    CollectingNodeSink sink;
+    runLoweredProgram(oneHopOutByTypeKnowsProgram, reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {1, 2}};
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -403,4 +403,36 @@ TEST_F(NLDialectTest, scanNodesByLabelInfersNodeIDIterator) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
 }
 
+// nl.get_out_edges_by_type infers the same four-chunk edge iterator as
+// nl.get_out_edges - sources, edge IDs, edge type IDs, targets - since the edge
+// type filters rows, not columns. The type is a resolved nl.get_edge_type handle,
+// not a name on the op.
+TEST_F(NLDialectTest, getOutEdgesByTypeInfersEdgeIterator) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    mlir::func::FuncOp function = buildOneChunkFunction(builder, *module);
+    mlir::Block& entryBlock = function.getBody().front();
+    const mlir::Value nodes = entryBlock.getArgument(0);
+
+    mlir::nl::GetEdgeType handle = builder.create<mlir::nl::GetEdgeType>(loc, builder.getStringAttr("KNOWS"));
+    mlir::nl::GetOutEdgesByType edges = builder.create<mlir::nl::GetOutEdgesByType>(loc,
+                                                                                   nodes,
+                                                                                   handle.getResult(),
+                                                                                   mlir::ValueRange {});
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    const mlir::Type nodeChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Type edgeIDChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::EdgeIDType::get(&_context));
+    const mlir::Type edgeTypeIDChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::EdgeTypeIDType::get(&_context));
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {nodeChunk, edgeIDChunk, edgeTypeIDChunk, nodeChunk});
+
+    EXPECT_EQ(edges.getResult().getType(), iteratorType);
+    // The hop's edge_type operand is the get_edge_type handle, which carries the name.
+    EXPECT_EQ(edges.getEdgeType(), handle.getResult());
+    EXPECT_EQ(handle.getName(), "KNOWS");
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+}
+
 }

--- a/test/storage/CMakeLists.txt
+++ b/test/storage/CMakeLists.txt
@@ -26,6 +26,7 @@ add_storage_tests(test_storage_graphwriter GraphWriterTest.cpp)
 
 add_storage_tests(test_storage_iterator iterators/IteratorsTest.cpp)
 add_storage_tests(test_storage_scan_nodes_iterator iterators/ScanNodesIteratorTest.cpp)
+add_storage_tests(test_storage_get_edges_by_type_iterator iterators/GetEdgesByTypeIteratorTest.cpp)
 add_storage_tests(test_storage_metadatarebaser versioning/MetadataRebaserTest.cpp)
 add_storage_tests(test_storage_datapartmerger versioning/DatapartMergerTest.cpp)
 

--- a/test/storage/iterators/GetEdgesByTypeIteratorTest.cpp
+++ b/test/storage/iterators/GetEdgesByTypeIteratorTest.cpp
@@ -1,0 +1,416 @@
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "TuringTest.h"
+
+#include "Graph.h"
+#include "columns/ColumnEdgeTypes.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+#include "iterators/GetInEdgesByTypeIterator.h"
+#include "iterators/GetInEdgesIterator.h"
+#include "iterators/GetOutEdgesByTypeIterator.h"
+#include "iterators/GetOutEdgesIterator.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+#include "FileUtils.h"
+#include "JobSystem.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// One emitted (input-index, edge) row, flattened to raw values so the rows sort
+// and compare without depending on the ID types' operators.
+struct CollectedEdge {
+    size_t _index {0};
+    uint64_t _edgeID {0};
+    uint64_t _neighbour {0};
+    uint64_t _type {0};
+};
+
+// Drive a by-type out-edge writer over the whole input, gathering one row per
+// emitted edge. maxCount is the per-fill row budget: a small value exercises the
+// mid-span resume path across successive fill() calls.
+void collectOutEdgesByType(const GraphReader& reader,
+                           const ColumnNodeIDs* input,
+                           EdgeTypeID edgeType,
+                           size_t maxCount,
+                           std::vector<CollectedEdge>& out) {
+    ColumnVector<size_t> indices;
+    ColumnEdgeIDs edgeIDs;
+    ColumnNodeIDs targets;
+    ColumnEdgeTypes types;
+
+    GetOutEdgesByTypeChunkWriter writer(reader.getView(), input, edgeType);
+    writer.setIndices(&indices);
+    writer.setEdgeIDs(&edgeIDs);
+    writer.setTgtIDs(&targets);
+    writer.setEdgeTypes(&types);
+
+    out.clear();
+    while (writer.isValid()) {
+        writer.fill(maxCount);
+
+        for (size_t i = 0; i < indices.size(); i++) {
+            out.push_back({indices[i], edgeIDs[i].getValue(), targets[i].getValue(), types[i].getValue()});
+        }
+    }
+}
+
+// As collectOutEdgesByType, but for in-edges: the neighbour is the source.
+void collectInEdgesByType(const GraphReader& reader,
+                          const ColumnNodeIDs* input,
+                          EdgeTypeID edgeType,
+                          size_t maxCount,
+                          std::vector<CollectedEdge>& out) {
+    ColumnVector<size_t> indices;
+    ColumnEdgeIDs edgeIDs;
+    ColumnNodeIDs sources;
+    ColumnEdgeTypes types;
+
+    GetInEdgesByTypeChunkWriter writer(reader.getView(), input, edgeType);
+    writer.setIndices(&indices);
+    writer.setEdgeIDs(&edgeIDs);
+    writer.setSrcIDs(&sources);
+    writer.setEdgeTypes(&types);
+
+    out.clear();
+    while (writer.isValid()) {
+        writer.fill(maxCount);
+
+        for (size_t i = 0; i < indices.size(); i++) {
+            out.push_back({indices[i], edgeIDs[i].getValue(), sources[i].getValue(), types[i].getValue()});
+        }
+    }
+}
+
+// Gather every out-edge of the input via the unfiltered writer - ground truth
+// that the by-type writer is compared against once filtered to a single type.
+void collectAllOutEdges(const GraphReader& reader,
+                        const ColumnNodeIDs* input,
+                        std::vector<CollectedEdge>& out) {
+    ColumnVector<size_t> indices;
+    ColumnEdgeIDs edgeIDs;
+    ColumnNodeIDs targets;
+    ColumnEdgeTypes types;
+
+    GetOutEdgesChunkWriter writer(reader.getView(), input);
+    writer.setIndices(&indices);
+    writer.setEdgeIDs(&edgeIDs);
+    writer.setTgtIDs(&targets);
+    writer.setEdgeTypes(&types);
+
+    out.clear();
+    while (writer.isValid()) {
+        writer.fill(ChunkConfig::CHUNK_SIZE);
+
+        for (size_t i = 0; i < indices.size(); i++) {
+            out.push_back({indices[i], edgeIDs[i].getValue(), targets[i].getValue(), types[i].getValue()});
+        }
+    }
+}
+
+// Gather every in-edge of the input via the unfiltered writer.
+void collectAllInEdges(const GraphReader& reader,
+                       const ColumnNodeIDs* input,
+                       std::vector<CollectedEdge>& out) {
+    ColumnVector<size_t> indices;
+    ColumnEdgeIDs edgeIDs;
+    ColumnNodeIDs sources;
+    ColumnEdgeTypes types;
+
+    GetInEdgesChunkWriter writer(reader.getView(), input);
+    writer.setIndices(&indices);
+    writer.setEdgeIDs(&edgeIDs);
+    writer.setSrcIDs(&sources);
+    writer.setEdgeTypes(&types);
+
+    out.clear();
+    while (writer.isValid()) {
+        writer.fill(ChunkConfig::CHUNK_SIZE);
+
+        for (size_t i = 0; i < indices.size(); i++) {
+            out.push_back({indices[i], edgeIDs[i].getValue(), sources[i].getValue(), types[i].getValue()});
+        }
+    }
+}
+
+// Keep only the rows whose edge type matches, preserving order.
+void filterByType(const std::vector<CollectedEdge>& all,
+                  EdgeTypeID edgeType,
+                  std::vector<CollectedEdge>& out) {
+    out.clear();
+    for (const CollectedEdge& edge : all) {
+        if (edge._type == edgeType.getValue()) {
+            out.push_back(edge);
+        }
+    }
+}
+
+// The by-type writer and the filtered unfiltered writer walk nodes and edge
+// spans in the same order, so the two row sequences must be identical.
+void expectSameRows(const std::vector<CollectedEdge>& expected,
+                    const std::vector<CollectedEdge>& actual) {
+    ASSERT_EQ(expected.size(), actual.size());
+
+    for (size_t i = 0; i < expected.size(); i++) {
+        EXPECT_EQ(expected[i]._index, actual[i]._index);
+        EXPECT_EQ(expected[i]._edgeID, actual[i]._edgeID);
+        EXPECT_EQ(expected[i]._neighbour, actual[i]._neighbour);
+        EXPECT_EQ(expected[i]._type, actual[i]._type);
+    }
+}
+
+// Compare rows by (index, neighbour) as an order-independent multiset, so a test
+// can pin the emitted content without hard-coding the edge-span traversal order.
+void expectSameContent(std::vector<std::pair<size_t, uint64_t>> expected,
+                       const std::vector<CollectedEdge>& actual) {
+    std::vector<std::pair<size_t, uint64_t>> actualPairs;
+    for (const CollectedEdge& edge : actual) {
+        actualPairs.emplace_back(edge._index, edge._neighbour);
+    }
+
+    std::sort(expected.begin(), expected.end());
+    std::sort(actualPairs.begin(), actualPairs.end());
+
+    EXPECT_EQ(expected, actualPairs);
+}
+
+}
+
+class GetEdgesByTypeIteratorTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+        _graph = Graph::create();
+
+        auto change = _graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        const LabelID person = metadata.getOrCreateLabel("Person");
+        const LabelSet labelset = LabelSet::fromList({person});
+
+        _knows = metadata.getOrCreateEdgeType("KNOWS");
+        _likes = metadata.getOrCreateEdgeType("LIKES");
+        _worksAt = metadata.getOrCreateEdgeType("WORKS_AT");
+
+        // Registered but never attached to an edge: an existing type that matches
+        // nothing.
+        _follows = metadata.getOrCreateEdgeType("FOLLOWS");
+
+        // Single datapart, so the temporary IDs 0..5 are also the final node IDs.
+        for (size_t i = 0; i < 6; i++) {
+            builder.addNode(labelset);
+        }
+
+        // A mix of types per source node, and both directions per node, so that
+        // filtering has something to keep and something to drop at every node.
+        builder.addEdge(_knows, 0, 1);
+        builder.addEdge(_likes, 0, 2);
+        builder.addEdge(_knows, 0, 3);
+        builder.addEdge(_likes, 1, 2);
+        builder.addEdge(_worksAt, 2, 3);
+        builder.addEdge(_knows, 4, 5);
+        builder.addEdge(_likes, 4, 0);
+        builder.addEdge(_knows, 5, 0);
+        builder.addEdge(_worksAt, 5, 1);
+
+        const auto res = change->access().submit(*_jobSystem);
+        if (!res) {
+            spdlog::error("Failed to submit change: {}", res.error().fmtMessage());
+        }
+        ASSERT_TRUE(res);
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    std::unique_ptr<db::JobSystem> _jobSystem;
+    std::unique_ptr<Graph> _graph = nullptr;
+
+    EdgeTypeID _knows;
+    EdgeTypeID _likes;
+    EdgeTypeID _worksAt;
+    EdgeTypeID _follows;
+
+    FileUtils::Path _logPath;
+};
+
+// For every registered edge type, the out-edges the by-type writer emits must
+// equal the unfiltered out-edges filtered down to that type.
+TEST_F(GetEdgesByTypeIteratorTest, outEdgesByTypeMatchFilteredUnfiltered) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    std::vector<CollectedEdge> allEdges;
+    collectAllOutEdges(reader, &input, allEdges);
+
+    for (const EdgeTypeID edgeType : {_knows, _likes, _worksAt, _follows}) {
+        std::vector<CollectedEdge> expected;
+        filterByType(allEdges, edgeType, expected);
+
+        std::vector<CollectedEdge> actual;
+        collectOutEdgesByType(reader, &input, edgeType, ChunkConfig::CHUNK_SIZE, actual);
+
+        expectSameRows(expected, actual);
+    }
+}
+
+// Same equivalence for in-edges.
+TEST_F(GetEdgesByTypeIteratorTest, inEdgesByTypeMatchFilteredUnfiltered) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    std::vector<CollectedEdge> allEdges;
+    collectAllInEdges(reader, &input, allEdges);
+
+    for (const EdgeTypeID edgeType : {_knows, _likes, _worksAt, _follows}) {
+        std::vector<CollectedEdge> expected;
+        filterByType(allEdges, edgeType, expected);
+
+        std::vector<CollectedEdge> actual;
+        collectInEdgesByType(reader, &input, edgeType, ChunkConfig::CHUNK_SIZE, actual);
+
+        expectSameRows(expected, actual);
+    }
+}
+
+// Hand-derived expected content, so the differential tests above cannot be fooled
+// by a matching bug in the unfiltered writer.
+TEST_F(GetEdgesByTypeIteratorTest, outEdgesByTypeExplicit) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    {
+        // KNOWS: 0->1, 0->3, 4->5, 5->0 as (input index, target).
+        std::vector<CollectedEdge> knows;
+        collectOutEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, knows);
+        expectSameContent({{0, 1}, {0, 3}, {4, 5}, {5, 0}}, knows);
+    }
+
+    {
+        // LIKES: 0->2, 1->2, 4->0.
+        std::vector<CollectedEdge> likes;
+        collectOutEdgesByType(reader, &input, _likes, ChunkConfig::CHUNK_SIZE, likes);
+        expectSameContent({{0, 2}, {1, 2}, {4, 0}}, likes);
+    }
+
+    {
+        // WORKS_AT: 2->3, 5->1.
+        std::vector<CollectedEdge> worksAt;
+        collectOutEdgesByType(reader, &input, _worksAt, ChunkConfig::CHUNK_SIZE, worksAt);
+        expectSameContent({{2, 3}, {5, 1}}, worksAt);
+    }
+}
+
+TEST_F(GetEdgesByTypeIteratorTest, inEdgesByTypeExplicit) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    // KNOWS in-edges, neighbour is the source: node 0<-5, node 1<-0, node 3<-0,
+    // node 5<-4, expressed as (input index, source).
+    std::vector<CollectedEdge> knows;
+    collectInEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, knows);
+    expectSameContent({{0, 5}, {1, 0}, {3, 0}, {5, 4}}, knows);
+}
+
+// An edge type present in the schema but on no edge yields nothing, in either
+// direction. This is the storage-level counterpart of the interpreter's
+// unknown-type short-circuit.
+TEST_F(GetEdgesByTypeIteratorTest, absentEdgeTypeYieldsNoRows) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    std::vector<CollectedEdge> outRows;
+    collectOutEdgesByType(reader, &input, _follows, ChunkConfig::CHUNK_SIZE, outRows);
+    EXPECT_TRUE(outRows.empty());
+
+    std::vector<CollectedEdge> inRows;
+    collectInEdgesByType(reader, &input, _follows, ChunkConfig::CHUNK_SIZE, inRows);
+    EXPECT_TRUE(inRows.empty());
+}
+
+// The emitted index is relative to the input column, not the node ID: node 4 sits
+// at input index 1 here, so its edges must be tagged 1.
+TEST_F(GetEdgesByTypeIteratorTest, indexIsRelativeToInput) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 4};
+
+    std::vector<CollectedEdge> knows;
+    collectOutEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, knows);
+
+    // node 0 (index 0): 0->1, 0->3 ; node 4 (index 1): 4->5.
+    expectSameContent({{0, 1}, {0, 3}, {1, 5}}, knows);
+
+    // Still consistent with the unfiltered writer on this reduced input.
+    std::vector<CollectedEdge> allEdges;
+    collectAllOutEdges(reader, &input, allEdges);
+    std::vector<CollectedEdge> expected;
+    filterByType(allEdges, _knows, expected);
+    expectSameRows(expected, knows);
+}
+
+// A tight row budget must not change the result: the writer resumes mid-span
+// across fills and still produces exactly the full-budget rows, in order.
+TEST_F(GetEdgesByTypeIteratorTest, respectsRowBudgetAcrossFills) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input = {0, 1, 2, 3, 4, 5};
+
+    std::vector<CollectedEdge> wholeChunk;
+    collectOutEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, wholeChunk);
+
+    for (const size_t budget : {size_t {1}, size_t {2}, size_t {3}}) {
+        std::vector<CollectedEdge> chunked;
+        collectOutEdgesByType(reader, &input, _knows, budget, chunked);
+        expectSameRows(wholeChunk, chunked);
+    }
+
+    std::vector<CollectedEdge> wholeChunkIn;
+    collectInEdgesByType(reader, &input, _likes, ChunkConfig::CHUNK_SIZE, wholeChunkIn);
+
+    for (const size_t budget : {size_t {1}, size_t {2}}) {
+        std::vector<CollectedEdge> chunked;
+        collectInEdgesByType(reader, &input, _likes, budget, chunked);
+        expectSameRows(wholeChunkIn, chunked);
+    }
+}
+
+TEST_F(GetEdgesByTypeIteratorTest, emptyInputYieldsNoRows) {
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const ColumnNodeIDs input;
+
+    std::vector<CollectedEdge> outRows;
+    collectOutEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, outRows);
+    EXPECT_TRUE(outRows.empty());
+
+    std::vector<CollectedEdge> inRows;
+    collectInEdgesByType(reader, &input, _knows, ChunkConfig::CHUNK_SIZE, inRows);
+    EXPECT_TRUE(inRows.empty());
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv, [] {
+        testing::GTEST_FLAG(repeat) = 1;
+    });
+}


### PR DESCRIPTION
Add db/nl get_out_edges_by_type and get_in_edges_by_type with chunk writers that filter edges by type on the spot, without materializing an unfiltered chunk first.