### PR TITLE
MLIR: Implement constants

### DIFF
--- a/query/ir/dialect/db/CMakeLists.txt
+++ b/query/ir/dialect/db/CMakeLists.txt
@@ -22,7 +22,7 @@ set_source_files_properties(
   DBDialect.cpp
   DBOps.cpp
   DBTypes.cpp
-  PROPERTIES COMPILE_FLAGS "-Wno-uninitialized"
+  PROPERTIES COMPILE_FLAGS "-Wno-uninitialized -Wno-ambiguous-reversed-operator"
 )
 
 # Compiles .cpp files; needs the codegen first, hence the DEPENDS clause

--- a/query/ir/dialect/db/DBDialect.td
+++ b/query/ir/dialect/db/DBDialect.td
@@ -22,4 +22,9 @@ def DB : Dialect {
 class TuringOp<string mnemonic, list<Trait> traits = []>
     : Op<DB, mnemonic, traits>;
 
+// TODO: Not sure if this top-level, generic op is the best
+// way to do this. To revisit
+class BinaryOp<string mnemonic, list<Trait> traits =[]>
+    : TuringOp<mnemonic, traits>;
+
 #endif //TURINGDB_DIALECT

--- a/query/ir/dialect/db/DBDialect.td
+++ b/query/ir/dialect/db/DBDialect.td
@@ -22,12 +22,4 @@ def DB : Dialect {
 class TuringOp<string mnemonic, list<Trait> traits = []>
     : Op<DB, mnemonic, traits>;
 
-class UnaryOp<string mnemonic, list<Trait> traits = []>
-    : TuringOp<mnemonic, traits>;
-
-// TODO: Not sure if this top-level, generic op is the best
-// way to do this. To revisit
-class BinaryOp<string mnemonic, list<Trait> traits = []>
-    : TuringOp<mnemonic, traits>;
-
 #endif //TURINGDB_DIALECT

--- a/query/ir/dialect/db/DBDialect.td
+++ b/query/ir/dialect/db/DBDialect.td
@@ -22,9 +22,12 @@ def DB : Dialect {
 class TuringOp<string mnemonic, list<Trait> traits = []>
     : Op<DB, mnemonic, traits>;
 
+class UnaryOp<string mnemonic, list<Trait> traits = []>
+    : TuringOp<mnemonic, traits>;
+
 // TODO: Not sure if this top-level, generic op is the best
 // way to do this. To revisit
-class BinaryOp<string mnemonic, list<Trait> traits =[]>
+class BinaryOp<string mnemonic, list<Trait> traits = []>
     : TuringOp<mnemonic, traits>;
 
 #endif //TURINGDB_DIALECT

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -281,3 +281,17 @@ LogicalResult Sort::verify() {
 LogicalResult RemoveDuplicates::verify() {
     return verifyPassThrough(getOperation(), getColumns(), getResults());
 }
+
+// Allows inline declaration of a constant type
+LogicalResult ConstantOp::inferReturnTypes(MLIRContext* context,
+                                           std::optional<Location> location,
+                                           ValueRange operands, DictionaryAttr attributes,
+                                           PropertyRef properties,
+                                           RegionRange regions,
+                                           SmallVectorImpl<Type>& inferredReturnTypes) {
+    ConstantOpGenericAdaptor adaptor(operands, attributes, properties, regions);
+    const mlir::TypedAttr typedValue = mlir::cast<mlir::TypedAttr>(adaptor.getValue());
+    inferredReturnTypes.emplace_back(
+        mlir::db::ColumnType::get(context, typedValue.getType()));
+    return mlir::success();
+}

--- a/query/ir/dialect/db/DBOps.h
+++ b/query/ir/dialect/db/DBOps.h
@@ -7,6 +7,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #include "DBDialect.h"
 #include "DBTypes.h"

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -3,6 +3,8 @@
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 include "DBDialect.td"
 include "DBTypes.td"
@@ -605,12 +607,13 @@ def Min : AggregateOp<"min">;
 def Max : AggregateOp<"max">;
 def Avg : AggregateOp<"avg">;
 
-def ConstantOp : TuringOp<"constant", [Pure]> {
+def ConstantOp : TuringOp<"constant", [Pure, ConstantLike, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Produces a constant value in a column";
 
-  // FIXME: AnyType probably incorrect here
-  let arguments = (ins AnyType : $value);
+  let arguments = (ins TypedAttrInterface: $value);
   let results = (outs Column : $result);
+
+  let assemblyFormat = "`(` $value `)` attr-dict";
 }
 
 def AndOp : BinaryOp<"logical_and", [Pure]> {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -616,12 +616,21 @@ def ConstantOp : TuringOp<"constant", [Pure, ConstantLike, DeclareOpInterfaceMet
   let assemblyFormat = "`(` $value `)` attr-dict";
 }
 
-def AndOp : BinaryOp<"logical_and", [Pure]> {
-  let summary = "Performs row-wise logical AND on its two input columns";
+ class PredicateOp<string mnemonic, list<Trait> traits = []>
+    : TuringOp<mnemonic, traits>,
+      Arguments<(ins Column:$lhs, Column:$rhs)> {
+  let results = (outs ColumnBools:$result);
+  let assemblyFormat = "$lhs`,` $rhs attr-dict `:` functional-type(operands, results)";
 }
 
-def OrOp : BinaryOp<"logical_or", [Pure]> {
+def AndOp : PredicateOp<"and", [Pure]> {
+  let summary = "Performs row-wise logical AND on its two input columns";
+  let arguments = (ins ColumnBools : $lhs, ColumnBools : $rhs);
+}
+
+def OrOp : PredicateOp<"or", [Pure]> {
   let summary = "Performs row-wise logical OR on its two input columns";
+  let arguments = (ins ColumnBools : $lhs, ColumnBools : $rhs);
 }
 
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -616,21 +616,4 @@ def ConstantOp : TuringOp<"constant", [Pure, ConstantLike, DeclareOpInterfaceMet
   let assemblyFormat = "`(` $value `)` attr-dict";
 }
 
- class PredicateOp<string mnemonic, list<Trait> traits = []>
-    : TuringOp<mnemonic, traits>,
-      Arguments<(ins Column:$lhs, Column:$rhs)> {
-  let results = (outs ColumnBools:$result);
-  let assemblyFormat = "$lhs`,` $rhs attr-dict `:` functional-type(operands, results)";
-}
-
-def AndOp : PredicateOp<"and", [Pure]> {
-  let summary = "Performs row-wise logical AND on its two input columns";
-  let arguments = (ins ColumnBools : $lhs, ColumnBools : $rhs);
-}
-
-def OrOp : PredicateOp<"or", [Pure]> {
-  let summary = "Performs row-wise logical OR on its two input columns";
-  let arguments = (ins ColumnBools : $lhs, ColumnBools : $rhs);
-}
-
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -605,6 +605,14 @@ def Min : AggregateOp<"min">;
 def Max : AggregateOp<"max">;
 def Avg : AggregateOp<"avg">;
 
+def ConstantOp : TuringOp<"constant", [Pure]> {
+  let summary = "Produces a constant value in a column";
+
+  // FIXME: AnyType probably incorrect here
+  let arguments = (ins AnyType : $value);
+  let results = (outs Column : $result);
+}
+
 def AndOp : BinaryOp<"logical_and", [Pure]> {
   let summary = "Performs row-wise logical AND on its two input columns";
 }

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -605,4 +605,12 @@ def Min : AggregateOp<"min">;
 def Max : AggregateOp<"max">;
 def Avg : AggregateOp<"avg">;
 
+def AndOp : BinaryOp<"logical_and", [Pure]> {
+  let summary = "Performs row-wise logical AND on its two input columns";
+}
+
+def OrOp : BinaryOp<"logical_or", [Pure]> {
+  let summary = "Performs row-wise logical OR on its two input columns";
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/db/DBTypes.td
+++ b/query/ir/dialect/db/DBTypes.td
@@ -36,8 +36,12 @@ class ColumnOf<string cppType, string mnemonic> : Type<
             "  llvm::cast<::mlir::db::ColumnType>($_self).getType())">,
       "column<" # mnemonic # ">">;
 
+// ID Columns
 def ColumnNodeIDs : ColumnOf<"::mlir::storage::NodeIDType", "nodeid">;
 def ColumnEdgeIDs : ColumnOf<"::mlir::storage::EdgeIDType", "edgeid">;
 def ColumnEdgeTypes : ColumnOf<"::mlir::storage::EdgeTypeIDType", "edge_type_id">;
+
+// Property types
+def ColumnBools : ColumnOf<"::mlir::storage::BoolType", "bool">;
 
 #endif // TURINGDB_TYPES

--- a/query/ir/dialect/db/DBTypes.td
+++ b/query/ir/dialect/db/DBTypes.td
@@ -36,12 +36,8 @@ class ColumnOf<string cppType, string mnemonic> : Type<
             "  llvm::cast<::mlir::db::ColumnType>($_self).getType())">,
       "column<" # mnemonic # ">">;
 
-// ID Columns
 def ColumnNodeIDs : ColumnOf<"::mlir::storage::NodeIDType", "nodeid">;
 def ColumnEdgeIDs : ColumnOf<"::mlir::storage::EdgeIDType", "edgeid">;
 def ColumnEdgeTypes : ColumnOf<"::mlir::storage::EdgeTypeIDType", "edge_type_id">;
-
-// Property types
-def ColumnBools : ColumnOf<"::mlir::storage::BoolType", "bool">;
 
 #endif // TURINGDB_TYPES

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -149,6 +149,15 @@ LogicalResult CrossProduct::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+LogicalResult Constant::inferReturnTypes(MLIRContext* context,
+                                         std::optional<Location> location,
+                                         Constant::Adaptor adaptor,
+                                         SmallVectorImpl<Type>& inferredReturnTypes) {
+    const TypedAttr value = cast<TypedAttr>(adaptor.getValue());
+    inferredReturnTypes.push_back(ChunkType::get(context, value.getType()));
+    return success();
+}
+
 // A truncate passes its columns through unchanged - only the row count is cut -
 // so each result keeps its input column's chunk type.
 LogicalResult LimitTruncate::inferReturnTypes(MLIRContext* context,

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -436,16 +436,27 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     offset). Like the limit form it never mutates the counter:
 
     nl.output(%targets) skip %h : !nl.chunk<!storage.node_id>
+
+    An optional `cardinality` operand carries a representative chunk of the driving
+    relation (a node-ID loop variable). A projection of only constants - RETURN 5 -
+    has no per-row column to size the emission, yet its cardinality is the driving
+    relation's (projection preserves cardinality), so the output nests in the driving
+    loop and reads its row count from this chunk; the constants broadcast against it.
+    Absent for a per-row projection (its own columns size it) or a single-row emit.
+
+    nl.output(%c) cardinality %n : !nl.chunk<i64>
   }];
 
-  // Three variable-length operand groups - the columns, the optional limit and
-  // the optional skip - so the op carries operand-segment sizes to tell them
-  // apart, the same as nl.cross_product's column groups. A folded output carries
-  // at most one of limit/skip (the truncate adjacent to it); the two are not
-  // produced together (see DBLowering::foldSkipTruncatesIntoOutputs).
+  // Four variable-length operand groups - the columns, the optional limit, the
+  // optional skip and the optional cardinality driver - so the op carries
+  // operand-segment sizes to tell them apart, the same as nl.cross_product's column
+  // groups. A folded output carries at most one of limit/skip (the truncate adjacent
+  // to it); the two are not produced together (see foldSkipTruncatesIntoOutputs).
+  // cardinality's type is buildable (always a node-ID chunk) and so omitted.
   let arguments = (ins Variadic<NLChunk>:$columns,
                        Optional<NLLimitStateHandle>:$limit,
-                       Optional<NLSkipStateHandle>:$skip);
+                       Optional<NLSkipStateHandle>:$skip,
+                       Optional<NLNodeIDChunk>:$cardinality);
 
   // The chunk element types vary from call to call and - unlike the source
   // ops - cannot be inferred, so they are spelled after the colon. This keeps
@@ -457,7 +468,7 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   // `skip` keyword; both types are buildable and so omitted. Each optional group
   // has its own literal anchor, so the declarative parser tells them apart.
   let assemblyFormat = [{
-    `(` $columns `)` (`limit` $limit^)? (`skip` $skip^)? attr-dict `:` qualified(type($columns))
+    `(` $columns `)` (`limit` $limit^)? (`skip` $skip^)? (`cardinality` $cardinality^)? attr-dict `:` qualified(type($columns))
   }];
 
   // Enforce the "at most one of limit/skip" invariant the description promises:

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -3,6 +3,7 @@
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 include "NLDialect.td"
 include "NLTypes.td"
@@ -952,6 +953,19 @@ def AggregateResult : NLOp<"aggregate_result", []> {
   // producing nl.aggregate - the verifier enforces both. The result sibling of
   // AggregateUpdate's verifier.
   let hasVerifier = 1;
+}
+
+def Constant : NLOp<"constant", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Materialize a constant scalar as a single-row chunk";
+  let description = [{
+      Represents a ColumnVector<T> with a single row
+      %c = nl.constant(30 : i64) : !nl.chunk<i64>
+  }];
+
+  let arguments = (ins TypedAttrInterface:$value);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "`(` $value `)` attr-dict";
 }
 
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/storage/StorageTypes.td
+++ b/query/ir/dialect/storage/StorageTypes.td
@@ -35,6 +35,10 @@ def String : StorageType<"String", "string"> {
     }];
 }
 
+def Bool : StorageType<"Bool", "bool"> {
+    let summary = "TuringDB Boolean type";
+}
+
 def Embedding : StorageType<"Embedding", "embedding"> {
     let summary = "An embedding property value";
     let description = [{

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -762,6 +762,8 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     // A folded output carries at most one of limit/skip, so the two never combine.
     const NLLimitState* limit = output->getLimit();
     const NLSkipState* skip = output->getSkip();
+    // Column that defines the cardinality of the result
+    const Column* cardinality = output->getCardinality();
 
     size_t offset = 0;
     size_t rowCount = 0;
@@ -770,6 +772,8 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
         rowCount = skip->getEmitThisStep();
     } else if (limit) {
         rowCount = limit->getEmitThisStep();
+    } else if (cardinality) {
+        rowCount = cardinality->size();
     } else {
         // Logical row count, assumes all columns are either const or same dimension
         for (const Column* column : cols) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -771,7 +771,10 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     } else if (limit) {
         rowCount = limit->getEmitThisStep();
     } else {
-        rowCount = cols.front()->size();
+        // Logical row count, assumes all columns are either const or same dimension
+        for (const Column* column : cols) {
+            rowCount = std::max(rowCount, column->size());
+        }
     }
 
     context->getSink()->appendChunks(cols, offset, rowCount);

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1052,10 +1052,16 @@ public:
     NLSkipState* getSkip() const { return _skip; }
     void setSkip(NLSkipState* skip) { _skip = skip; }
 
+    const Column* getCardinality() const { return _cardinality; }
+
+    void setCardinality(const Column* cardinality) { _cardinality = cardinality; }
+
 private:
     std::vector<const Column*> _columns;
     NLLimitState* _limit {nullptr};
     NLSkipState* _skip {nullptr};
+    // Column which may define the cardinality of the output
+    const Column* _cardinality {nullptr};
 };
 
 class NLProgram {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -41,6 +41,17 @@ llvm::StringRef edgeTypeName(mlir::Value handle) {
     return handleOp.getName();
 }
 
+static bool isDefinedInOuterScope(mlir::Operation* definingOp, mlir::Block* outputBlock) {
+    mlir::Block* current = outputBlock;
+    while (mlir::Operation* parentOp = current->getParentOp()) {
+        current = parentOp->getBlock();
+        if (current == definingOp->getBlock()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // The with-null fetch handler for a property's value type, on the node side
 // when isNode is true and the edge side otherwise. Selecting it here keeps the
 // value-type dispatch with the rest of translation; the handler bodies live in
@@ -511,9 +522,11 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
         // produced in this same loop body; it is equally available to output.
         mlir::Operation* definingOp = column.getDefiningOp();
         const bool isProducedInThisBlock = definingOp && definingOp->getBlock() == outputBlock;
+        const bool isFromOuterScope = definingOp && isDefinedInOuterScope(definingOp, outputBlock);
 
-        if (!isInnermostLoopVariable && !isProducedInThisBlock) {
-            throw IRException("nl.output columns must belong to the innermost enclosing nl.for body");
+        if (!isInnermostLoopVariable && !isProducedInThisBlock && !isFromOuterScope) {
+            throw IRException("nl.output columns must belong to the innermost enclosing "
+                              "nl.for body or an outer scope");
         }
 
         outputData->addOutputColumn(getColumn(column));

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -5,6 +5,7 @@
 #include <spdlog/fmt/bundled/format.h>
 
 #include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Verifier.h"
 
@@ -83,6 +84,21 @@ ValueType valueTypeFromElementType(mlir::Type elementType) {
     }
 
     throw IRException("Unsupported nullable value chunk element type");
+}
+
+template <SupportedType T>
+typename T::Primitive constantValueAs(mlir::TypedAttr value) {
+    if constexpr (std::same_as<T, types::Int64>) {
+        return mlir::cast<mlir::IntegerAttr>(value).getInt();
+    } else if constexpr (std::same_as<T, types::UInt64>) {
+        return mlir::cast<mlir::IntegerAttr>(value).getValue().getZExtValue();
+    } else if constexpr (std::same_as<T, types::Double>) {
+        return mlir::cast<mlir::FloatAttr>(value).getValueAsDouble();
+    } else if constexpr (std::same_as<T, types::Bool>) {
+        return CustomBool(mlir::cast<mlir::IntegerAttr>(value).getInt() != 0);
+    } else { // string and embedding not yet supported
+        throw IRException("Unsupported constant value type");
+    }
 }
 
 // The runtime reduction the interpreter dispatches on, from the MLIR one the op
@@ -187,6 +203,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType, nl::GetEdgeType>(operation)) {
             // The handle carries only a name; a fetch/hop resolves it on consumption
+        } else if (mlir::isa<nl::GetPropertyType>(operation)) {
+            // The handle carries only a name; a fetch resolves it on consumption
+        } else if (nl::Constant constant = mlir::dyn_cast<nl::Constant>(operation)) {
+            translateConstant(constant);
         } else if (nl::GetNodeProperties getNodeProperties = mlir::dyn_cast<nl::GetNodeProperties>(operation)) {
             translatePropertyFetch(getNodeProperties.getInputNodes(),
                                    getNodeProperties.getPropertyType(),
@@ -443,6 +463,22 @@ void NLTranslator::translatePropertyFetch(mlir::Value inputValue,
 
     const NLHandlerFunction handler = selectPropertyFetchHandler(isNode, valueType);
     body->addStmt(NLFunctionDescriptor {handler, fetchData});
+}
+
+void NLTranslator::translateConstant(nl::Constant constant) {
+    const mlir::TypedAttr value = mlir::cast<mlir::TypedAttr>(constant.getValue());
+    const auto chunkType = mlir::cast<nl::ChunkType>(constant.getResult().getType());
+    const ValueType valueType = valueTypeFromElementType(chunkType.getElementType());
+
+    Column* column = nullptr;
+    const auto materialize = [&]<SupportedType T>() {
+        auto* typed = _memory->alloc<ColumnVector<typename T::Primitive>>();
+        typed->getRaw().assign(1, constantValueAs<T>(value));
+        column = typed;
+    };
+    ValueTypeDispatcher(valueType).execute(materialize);
+
+    _valueSlots[constant.getResult()] = column;
 }
 
 void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -9,6 +9,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Verifier.h"
 
+#include "columns/ColumnConst.h"
 #include "columns/ColumnOptVector.h"
 #include "metadata/GraphMetadata.h"
 #include "metadata/PropertyType.h"
@@ -472,11 +473,12 @@ void NLTranslator::translateConstant(nl::Constant constant) {
 
     Column* column = nullptr;
     const auto materialize = [&]<SupportedType T>() {
-        auto* typed = _memory->alloc<ColumnVector<typename T::Primitive>>();
-        typed->getRaw().assign(1, constantValueAs<T>(value));
+        auto* typed = _memory->alloc<ColumnConst<typename T::Primitive>>();
+        typed->set(constantValueAs<T>(value));
         column = typed;
     };
     ValueTypeDispatcher(valueType).execute(materialize);
+    bioassert(column, "Failed to allocate column.");
 
     _valueSlots[constant.getResult()] = column;
 }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -41,17 +41,6 @@ llvm::StringRef edgeTypeName(mlir::Value handle) {
     return handleOp.getName();
 }
 
-static bool isDefinedInOuterScope(mlir::Operation* definingOp, mlir::Block* outputBlock) {
-    mlir::Block* current = outputBlock;
-    while (mlir::Operation* parentOp = current->getParentOp()) {
-        current = parentOp->getBlock();
-        if (current == definingOp->getBlock()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 // The with-null fetch handler for a property's value type, on the node side
 // when isNode is true and the edge side otherwise. Selecting it here keeps the
 // value-type dispatch with the rest of translation; the handler bodies live in
@@ -516,6 +505,11 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
     NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
     outputData->setLimit(limitStateFor(output.getLimit()));
     outputData->setSkip(skipStateFor(output.getSkip()));
+
+    if (const mlir::Value cardinality = output.getCardinality()) {
+        outputData->setCardinality(getColumn(cardinality));
+    }
+
     for (const mlir::Value column : columns) {
         const auto columnArgument = mlir::dyn_cast<mlir::BlockArgument>(column);
         const bool isInnermostLoopVariable = columnArgument && columnArgument.getOwner() == outputBlock;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -204,8 +204,6 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType, nl::GetEdgeType>(operation)) {
             // The handle carries only a name; a fetch/hop resolves it on consumption
-        } else if (mlir::isa<nl::GetPropertyType>(operation)) {
-            // The handle carries only a name; a fetch resolves it on consumption
         } else if (nl::Constant constant = mlir::dyn_cast<nl::Constant>(operation)) {
             translateConstant(constant);
         } else if (nl::GetNodeProperties getNodeProperties = mlir::dyn_cast<nl::GetNodeProperties>(operation)) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -468,7 +468,8 @@ void NLTranslator::translatePropertyFetch(mlir::Value inputValue,
 
 void NLTranslator::translateConstant(nl::Constant constant) {
     const mlir::TypedAttr value = mlir::cast<mlir::TypedAttr>(constant.getValue());
-    const auto chunkType = mlir::cast<nl::ChunkType>(constant.getResult().getType());
+    const mlir::TypedValue<mlir::nl::ChunkType> res = constant.getResult();
+    const auto chunkType = mlir::cast<nl::ChunkType>(res.getType());
     const ValueType valueType = valueTypeFromElementType(chunkType.getElementType());
 
     Column* column = nullptr;
@@ -480,7 +481,7 @@ void NLTranslator::translateConstant(nl::Constant constant) {
     ValueTypeDispatcher(valueType).execute(materialize);
     bioassert(column, "Failed to allocate column.");
 
-    _valueSlots[constant.getResult()] = column;
+    _valueSlots[res] = column;
 }
 
 void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -505,10 +505,12 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
 
     // Output is either the per-step sink inside an nl.for body, or - for an
     // aggregate like COUNT that collapses to one row - a one-shot emit at function
-    // scope. Either way its columns must be bound in the output's own block, which
-    // the per-column check below enforces: a loop variable of this loop, or a chunk
-    // materialized in this block (a property fetch, or nl.count_result at function
-    // scope). A chunk from an outer or sibling loop fails that check.
+    // scope. Either way its per-row columns must be bound in the output's own block,
+    // which the per-column check below enforces: a loop variable of this loop, or a
+    // chunk materialized in this block (a property fetch, or nl.count_result at
+    // function scope). The sole cross-scope exception is a constant, which is
+    // loop-invariant and broadcasts; any other chunk from an outer or sibling loop
+    // fails the check.
     mlir::Block* outputBlock = output->getBlock();
 
     NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
@@ -522,11 +524,13 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
         // produced in this same loop body; it is equally available to output.
         mlir::Operation* definingOp = column.getDefiningOp();
         const bool isProducedInThisBlock = definingOp && definingOp->getBlock() == outputBlock;
-        const bool isFromOuterScope = definingOp && isDefinedInOuterScope(definingOp, outputBlock);
 
-        if (!isInnermostLoopVariable && !isProducedInThisBlock && !isFromOuterScope) {
-            throw IRException("nl.output columns must belong to the innermost enclosing "
-                              "nl.for body or an outer scope");
+        // Constants are invariant of any loop so they can be referenced anywhere
+        const bool isBroadcastConstant = definingOp && mlir::isa<nl::Constant>(definingOp);
+
+        if (!isInnermostLoopVariable && !isProducedInThisBlock && !isBroadcastConstant) {
+            throw IRException("nl.output columns must be a loop variable of the enclosing "
+                              "nl.for, produced in this block, or a constant");
         }
 
         outputData->addOutputColumn(getColumn(column));

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -247,6 +247,10 @@ private:
                                 mlir::Value resultValue,
                                 bool isNode,
                                 NLStmtContainer* body);
+
+    // Allocates singleton column for the constant and assigns MLIR value
+    void translateConstant(mlir::nl::Constant constant);
+
     void translateOutput(mlir::nl::Output output, NLStmtContainer* body);
 
     // Translate an nl.cross_product: allocate an output column per crossed

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -12,6 +12,7 @@
 #include "metadata/PropertyType.h"
 
 #include "IRException.h"
+#include "llvm/Support/Casting.h"
 
 using namespace db;
 
@@ -1002,7 +1003,9 @@ void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         // The preceding nl.limit_update still sets that count. Drop the old output
         // and the now-unused truncate.
         _builder.setInsertionPoint(output);
-        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), truncate.getState(), mlir::Value());
+        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(),
+                                    truncate.getState(), mlir::Value(),
+                                    output.getCardinality());
 
         output.erase();
         truncate.erase();
@@ -1063,7 +1066,8 @@ void DBLowering::foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         // preceding nl.skip_update still sets that offset and count. Drop the old
         // output and the now-unused truncate.
         _builder.setInsertionPoint(output);
-        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), mlir::Value(), truncate.getState());
+        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), mlir::Value(),
+                                    truncate.getState(), output.getCardinality());
 
         output.erase();
         truncate.erase();
@@ -1107,8 +1111,29 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
             break;
         }
     }
+
+    // Custom cardinality calculation for e.g. MATCH (n) RETURN 5
+    mlir::Value cardinality;
+    // Output would not normally be in a loop body, but toplevel
+    const bool returningNonLooped = anchorBlock == _entryBlock;
+    if (returningNonLooped && _innermostLoopBody) {
+        // but if we have all constants, then it need be moved to the inner most loop to
+        // match cardinality
+        const bool allConstants =
+            std::ranges::all_of(columns, [](const mlir::Value column) {
+                mlir::Operation* const definingOp = column.getDefiningOp();
+                return llvm::isa_and_nonnull<nl::Constant>(definingOp);
+            });
+
+        if (allConstants) {
+            anchorBlock = _innermostLoopBody;
+            cardinality = _innermostLoopBody->getArgument(0);
+        }
+    }
+
     setInsertionInto(anchorBlock);
-    _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value(), mlir::Value());
+    _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value(),
+                                mlir::Value(), cardinality);
 }
 
 void DBLowering::buildLoopForSource(mlir::Value iterator, mlir::Operation* dbOp) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -176,6 +176,7 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     _edgeTypes.clear();
     _rootBlock = _entryBlock;
     _innermostLoopBody = nullptr;
+    _innermostCardinality = mlir::Value();
     _limitHandles.clear();
     _loopLimitHandle.clear();
     _sortTopK.clear();
@@ -477,6 +478,9 @@ void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
     // loop, so lowerFactor sees a factor whose innermost "loop" is this product.
     // At top level nothing reads _innermostLoopBody, so this is a no-op there.
     _innermostLoopBody = innerBody;
+
+    // Cross prod result defines cardinality
+    _innermostCardinality = crossResults.front();
 }
 
 mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
@@ -486,8 +490,10 @@ mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
     // save and restore the caller's so nested or sibling products are unaffected.
     mlir::Block* const previousRoot = _rootBlock;
     mlir::Block* const previousInnermostLoopBody = _innermostLoopBody;
+    const mlir::Value previousInnermostCardinality = _innermostCardinality;
     _rootBlock = rootBlock;
     _innermostLoopBody = nullptr;
+    _innermostCardinality = mlir::Value();
 
     // A factor is one self-contained block ending in a db.yield. Lower each op
     // as at top level; the yield names the columns this factor contributes, so
@@ -517,6 +523,7 @@ mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
     mlir::Block* const innermostBody = _innermostLoopBody;
     _rootBlock = previousRoot;
     _innermostLoopBody = previousInnermostLoopBody;
+    _innermostCardinality = previousInnermostCardinality;
 
     return innermostBody;
 }
@@ -1127,7 +1134,7 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
 
         if (allConstants) {
             anchorBlock = _innermostLoopBody;
-            cardinality = _innermostLoopBody->getArgument(0);
+            cardinality = _innermostCardinality;
         }
     }
 
@@ -1154,6 +1161,7 @@ void DBLowering::buildLoopForSource(mlir::Value iterator, mlir::Operation* dbOp)
     // This is the innermost loop opened so far in the current factor (loops
     // nest in dataflow order), so a cross product nests at this body.
     _innermostLoopBody = loopBody;
+    _innermostCardinality = loopBody->getArguments().front();
 
     const mlir::ResultRange dbResults = dbOp->getResults();
     for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -279,6 +279,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerAggregate(max.getInput(), max.getResult(), storage::AggregateKind::Max);
     } else if (mlir::db::Avg avg = mlir::dyn_cast<mlir::db::Avg>(operation)) {
         lowerAggregate(avg.getInput(), avg.getResult(), storage::AggregateKind::Avg);
+    } else if (mlir::db::ConstantOp constant = mlir::dyn_cast<mlir::db::ConstantOp>(operation)) {
+        lowerConstant(constant);
     } else if (mlir::db::Output output = mlir::dyn_cast<mlir::db::Output>(operation)) {
         lowerOutput(output);
     } else if (mlir::isa<mlir::func::ReturnOp>(operation)) {
@@ -1066,6 +1068,14 @@ void DBLowering::foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         output.erase();
         truncate.erase();
     }
+}
+
+void DBLowering::lowerConstant(mlir::db::ConstantOp constant) {
+    // Constants are loop-invariant so hoist
+    _builder.setInsertionPointToStart(_entryBlock);
+
+    nl::Constant nlConstant = _builder.create<nl::Constant>(_builder.getUnknownLoc(), constant.getValue());
+    _valueMap[constant.getResult()] = nlConstant.getResult();
 }
 
 void DBLowering::lowerOutput(mlir::db::Output output) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1110,6 +1110,10 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
     // (e.g. a loop block), then set the anchor to be that block. Otherwise, we have no
     // loops, i.e. we are in a MATCH (n) RETURN 5 case, where the output can just be in
     // the entry block since it is independent of any loop (over n in this case).
+    // Getting the owner block of the returned column is sufficient because in nested
+    // loops, each Cypher variable is redefined each op due to the carry set implictly
+    // filtering. Otherwise we would need to check for the *deepest* block of all
+    // returned values.
     mlir::Block* anchorBlock = _entryBlock;
     for (const mlir::Value column : columns) {
         mlir::Block* const columnBlock = ownerBlock(column);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1094,7 +1094,20 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
     // budget-capped count. foldTruncatesIntoOutputs later rewrites the terminal
     // case - where the truncate feeds only this output - into nl.output ... limit,
     // dropping the copy.
-    setInsertionInto(ownerBlock(columns.front()));
+
+    // If there is a column which is produced by a block which is not the entry block
+    // (e.g. a loop block), then set the anchor to be that block. Otherwise, we have no
+    // loops, i.e. we are in a MATCH (n) RETURN 5 case, where the output can just be in
+    // the entry block since it is independent of any loop (over n in this case).
+    mlir::Block* anchorBlock = _entryBlock;
+    for (const mlir::Value column : columns) {
+        mlir::Block* const columnBlock = ownerBlock(column);
+        if (columnBlock != _entryBlock) {
+            anchorBlock = columnBlock;
+            break;
+        }
+    }
+    setInsertionInto(anchorBlock);
     _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value(), mlir::Value());
 }
 

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -134,6 +134,9 @@ private:
     // not left in the loop body - just a record of which block is innermost.
     mlir::Block* _innermostLoopBody {nullptr};
 
+    // Defines the cardinality of the innermost loop, used for projection
+    mlir::Value _innermostCardinality;
+
     // Each db.limit gets its own hoisted nl.limit handle - N independent budgets.
     // A pre-scan in lower() finds every db.limit before any loop is built, so the
     // handles exist first to be threaded into the loops as they are created. The

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -217,6 +217,9 @@ private:
     // one, so a string sum or an embedding min is rejected here.
     void lowerAggregate(mlir::Value input, mlir::Value result, mlir::storage::AggregateKind kind);
 
+    // Hoists an nl.constant to the top of the entry block
+    void lowerConstant(mlir::db::ConstantOp constant);
+
     void lowerOutput(mlir::db::Output output);
 
     // Lower one factor region of a db.cross_product into a loop nest rooted at

--- a/samples/mlir/constant.mlir
+++ b/samples/mlir/constant.mlir
@@ -1,0 +1,9 @@
+module {
+  func.func @main() {
+    %c = db.constant(30 : i64)
+
+    db.output(%c) : !db.column<i64>
+
+    return
+  }
+}

--- a/samples/mlir/constant.nl.mlir
+++ b/samples/mlir/constant.nl.mlir
@@ -1,0 +1,7 @@
+module {
+  func.func @main() {
+    %0 = nl.constant(30 : i64)
+    nl.output(%0) : !nl.chunk<i64>
+    return
+  }
+}

--- a/samples/mlir/constant_types.mlir
+++ b/samples/mlir/constant_types.mlir
@@ -1,0 +1,10 @@
+module {
+  func.func @main() {
+    %i = db.constant(30 : i64)
+    %u = db.constant(7 : ui64)
+    %f = db.constant(2.5 : f64)
+    %b = db.constant(true)
+    db.output(%i, %u, %f, %b) : !db.column<i64>, !db.column<ui64>, !db.column<f64>, !db.column<i1>
+    return
+  }
+}

--- a/samples/mlir/constant_types.nl.mlir
+++ b/samples/mlir/constant_types.nl.mlir
@@ -1,0 +1,10 @@
+module {
+  func.func @main() {
+    %0 = nl.constant(true)
+    %1 = nl.constant(2.500000e+00 : f64)
+    %2 = nl.constant(7 : ui64)
+    %3 = nl.constant(30 : i64)
+    nl.output(%3, %2, %1, %0) : !nl.chunk<i64>, !nl.chunk<ui64>, !nl.chunk<f64>, !nl.chunk<i1>
+    return
+  }
+}

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -314,6 +314,10 @@ private:
                    || printValueCell<std::string_view>(column, row)
                    || printEmbeddingCell(column, row)) {
             // Printed by the helper for whichever nullable value type matched
+        } else if (printPlainValueCell<int64_t>(column, row)
+                   || printPlainValueCell<double>(column, row)
+                   || printPlainBoolCell(column, row)) {
+            // A plain, non-null value column - the shape a db.constant lowers to
         } else {
             std::cout << "?";
         }
@@ -335,6 +339,32 @@ private:
             std::cout << "null";
         }
 
+        return true;
+    }
+
+    // Print one cell of a plain, non-null value column if it has element type T -
+    // the shape a db.constant lowers to (a ColumnVector, not the ColumnOptVector a
+    // property read produces); returns whether the column matched T.
+    template <typename T>
+    static bool printPlainValueCell(const Column* column, size_t row) {
+        const auto* values = dynamic_cast<const ColumnVector<T>*>(column);
+        if (!values) {
+            return false;
+        }
+
+        std::cout << (*values)[row];
+        return true;
+    }
+
+    // A plain bool constant column: CustomBool has no operator<<, so render it
+    // through its bool conversion, as true/false.
+    static bool printPlainBoolCell(const Column* column, size_t row) {
+        const auto* values = dynamic_cast<const ColumnVector<CustomBool>*>(column);
+        if (!values) {
+            return false;
+        }
+
+        std::cout << (static_cast<bool>((*values)[row]) ? "true" : "false");
         return true;
     }
 

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -38,6 +38,8 @@
 #include "versioning/Transaction.h"
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnEdgeTypes.h"
+#include "columns/ColumnConst.h"
+#include "columns/ColumnOptVector.h"
 
 #include "DBProgramGenerator.h"
 #include "StorageDialect.h"
@@ -314,10 +316,11 @@ private:
                    || printValueCell<std::string_view>(column, row)
                    || printEmbeddingCell(column, row)) {
             // Printed by the helper for whichever nullable value type matched
-        } else if (printPlainValueCell<int64_t>(column, row)
-                   || printPlainValueCell<double>(column, row)
-                   || printPlainBoolCell(column, row)) {
-            // A plain, non-null value column - the shape a db.constant lowers to
+        } else if (printConstValueCell<int64_t>(column, row)
+                   || printConstValueCell<uint64_t>(column, row)
+                   || printConstValueCell<double>(column, row)
+                   || printConstValueCell<CustomBool>(column, row)) {
+            // ColumnConst
         } else {
             std::cout << "?";
         }
@@ -342,29 +345,18 @@ private:
         return true;
     }
 
-    // Print one cell of a plain, non-null value column if it has element type T -
-    // the shape a db.constant lowers to (a ColumnVector, not the ColumnOptVector a
-    // property read produces); returns whether the column matched T.
     template <typename T>
-    static bool printPlainValueCell(const Column* column, size_t row) {
-        const auto* values = dynamic_cast<const ColumnVector<T>*>(column);
+    static bool printConstValueCell(const Column* column, size_t row) {
+        const auto* values = dynamic_cast<const ColumnConst<T>*>(column);
         if (!values) {
             return false;
         }
 
-        std::cout << (*values)[row];
-        return true;
-    }
-
-    // A plain bool constant column: CustomBool has no operator<<, so render it
-    // through its bool conversion, as true/false.
-    static bool printPlainBoolCell(const Column* column, size_t row) {
-        const auto* values = dynamic_cast<const ColumnVector<CustomBool>*>(column);
-        if (!values) {
-            return false;
+        if constexpr (std::is_same_v<T, CustomBool>) {
+            std::cout << (static_cast<bool>((*values)[row]) ? "true" : "false");
+        } else {
+            std::cout << (*values)[row];
         }
-
-        std::cout << (static_cast<bool>((*values)[row]) ? "true" : "false");
         return true;
     }
 

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -134,7 +134,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto outLoop = builder.create<mlir::nl::For>(loc, outEdges.getResult());
     mlir::Block* outLoopBody = outLoop.getBody();
     builder.setInsertionPointToStart(outLoopBody);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoopBody->getArgument(3)}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {outLoopBody->getArgument(3)}, mlir::Value(), mlir::Value(), mlir::Value());
 
     // In-edges of the same node chunk: send the source (predecessor) node IDs.
     // Same chunk order, so argument 0 is the sources column.
@@ -143,7 +143,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     auto inLoop = builder.create<mlir::nl::For>(loc, inEdges.getResult());
     mlir::Block* inLoopBody = inLoop.getBody();
     builder.setInsertionPointToStart(inLoopBody);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoopBody->getArgument(0)}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {inLoopBody->getArgument(0)}, mlir::Value(), mlir::Value(), mlir::Value());
 
     // MATCH (a)->(b)->(c): two out-edge hops where the second carries the `a`
     // of the current step. First hop a->b with an empty carry set; its loop
@@ -168,7 +168,7 @@ void addNestedLoopFunction(mlir::OpBuilder& builder, mlir::ModuleOp& module) {
     const mlir::Value bFiltered = secondHopLoopBody->getArgument(0);
     const mlir::Value cChunk = secondHopLoopBody->getArgument(3);
     const mlir::Value filteredA = secondHopLoopBody->getArgument(4);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {filteredA, bFiltered, cChunk}, mlir::Value(), mlir::Value(), mlir::Value());
 }
 
 // A disconnected pattern in the set-at-a-time db dialect: MATCH (a), (b)

--- a/samples/mlir/scan_return_constant.nl.mlir
+++ b/samples/mlir/scan_return_constant.nl.mlir
@@ -1,0 +1,8 @@
+func.func @main() {
+  %c = nl.constant(5 : i64)
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%c) cardinality %a : !nl.chunk<i64>
+  }
+  func.return
+}

--- a/samples/mlir/xprod_return_constant.mlir
+++ b/samples/mlir/xprod_return_constant.mlir
@@ -1,0 +1,12 @@
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %a : !db.column<!storage.node_id>
+  } factor {
+    %b = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %b : !db.column<!storage.node_id>
+  }
+  %c = db.constant(5 : i64)
+  db.output(%c) : !db.column<i64>
+  return
+}

--- a/samples/mlir/xprod_return_constant.nl.mlir
+++ b/samples/mlir/xprod_return_constant.nl.mlir
@@ -1,0 +1,12 @@
+func.func @main() {
+  %0 = nl.constant(5 : i64)
+  %1 = nl.scan_nodes()
+  nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %2 = nl.scan_nodes()
+    nl.for %arg1 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %3:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.output(%0) cardinality %3#0 : !nl.chunk<i64>
+    }
+  }
+  return
+}

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -410,6 +410,52 @@ private:
     bool _bool {false};
 };
 
+class CollectingNodeWithConstantSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* nodeIDs = static_cast<const ColumnNodeIDs*>(chunks[0]);
+        const auto* constant = static_cast<const ColumnConst<int64_t>*>(chunks[1]);
+
+        const auto& idRaw = nodeIDs->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.push_back({idRaw[rowIndex].getValue(), (*constant)[rowIndex]});
+        }
+    }
+
+    void sortedRows(std::vector<std::pair<uint64_t, int64_t>>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<std::pair<uint64_t, int64_t>> _rows;
+};
+
+class CollectingConstantWithNodeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* constant = static_cast<const ColumnConst<int64_t>*>(chunks[0]);
+        const auto* nodeIDs = static_cast<const ColumnNodeIDs*>(chunks[1]);
+
+        const auto& idRaw = nodeIDs->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.push_back({(*constant)[rowIndex], idRaw[rowIndex].getValue()});
+        }
+    }
+
+    void sortedRows(std::vector<std::pair<int64_t, uint64_t>>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<std::pair<int64_t, uint64_t>> _rows;
+};
+
 // RETURN 30, 7, 2.5, true: one constant of each supported value type projected
 // together as a single row.
 constexpr const char* allTypesConstantsProgram = R"mlir(
@@ -419,6 +465,24 @@ func.func @main() {
   %f = db.constant(2.5 : f64)
   %b = db.constant(true)
   db.output(%i, %u, %f, %b) : !db.column<i64>, !db.column<ui64>, !db.column<f64>, !db.column<i1>
+  return
+}
+)mlir";
+
+constexpr const char* scanThenConstantProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %c = db.constant(42 : i64)
+  db.output(%n, %c) : !db.column<!storage.node_id>, !db.column<i64>
+  return
+}
+)mlir";
+
+constexpr const char* constantThenScanProgram = R"mlir(
+func.func @main() {
+  %c = db.constant(42 : i64)
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  db.output(%c, %n) : !db.column<i64>, !db.column<!storage.node_id>
   return
 }
 )mlir";
@@ -1522,6 +1586,34 @@ TEST_F(DBLoweringTest, lowersConstantsOfAllSupportedTypes) {
     EXPECT_EQ(sink.getUint(), 7u);
     EXPECT_DOUBLE_EQ(sink.getDouble(), 2.5);
     EXPECT_TRUE(sink.getBool());
+}
+
+TEST_F(DBLoweringTest, lowersScanWithTrailingConstant) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeWithConstantSink sink;
+    runLoweredProgram(scanThenConstantProgram, reader.getView(), sink);
+
+    std::vector<std::pair<uint64_t, int64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::pair<uint64_t, int64_t>> expected {{0, 42}, {1, 42}, {2, 42}, {3, 42}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersScanWithLeadingConstant) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstantWithNodeSink sink;
+    runLoweredProgram(constantThenScanProgram, reader.getView(), sink);
+
+    std::vector<std::pair<int64_t, uint64_t>> rows;
+    sink.sortedRows(rows);
+    const std::vector<std::pair<int64_t, uint64_t>> expected {{42, 0}, {42, 1}, {42, 2}, {42, 3}};
+    EXPECT_EQ(rows, expected);
 }
 
 TEST_F(DBLoweringTest, lowersOneHopOutEdges) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -1759,6 +1759,7 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
     context.getOrLoadDialect<mlir::storage::Storage>();
     context.getOrLoadDialect<mlir::db::DB>();
     context.getOrLoadDialect<mlir::nl::NL>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
 
     const mlir::ParserConfig parserConfig(&context);
     mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(crossProductScansProgram, parserConfig);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -499,6 +499,44 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a), (b) RETURN 5
+constexpr const char* constantOverCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %a : !db.column<!storage.node_id>
+  } factor {
+    %b = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %b : !db.column<!storage.node_id>
+  }
+  %c = db.constant(5 : i64)
+  db.output(%c) : !db.column<i64>
+  return
+}
+)mlir";
+
+// MATCH (a), (b), (c) RETURN 5
+constexpr const char* constantOverNestedCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %1:2 = db.cross_product factor {
+      %a = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %a : !db.column<!storage.node_id>
+    } factor {
+      %b = db.scan_nodes() : !db.column<!storage.node_id>
+      db.yield %b : !db.column<!storage.node_id>
+    }
+    db.yield %1#0, %1#1 : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  } factor {
+    %c = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %c : !db.column<!storage.node_id>
+  }
+  %d = db.constant(5 : i64)
+  db.output(%d) : !db.column<i64>
+  return
+}
+)mlir";
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -1640,6 +1678,51 @@ TEST_F(DBLoweringTest, constantProjectionOverMatchHasRelationCardinality) {
     // four rows of 5 - not one. (Before the fix the output floated to function scope
     // and emitted a single row.)
     const std::vector<std::vector<int64_t>> expected {{5}, {5}, {5}, {5}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, constantProjectionOverCrossProductHasProductCardinality) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(constantOverCrossProductProgram, reader.getView(), sink);
+
+    // RETURN 5 over MATCH (a), (b) on the diamond's four nodes: the cross product
+    // is 4 x 4, so projection preserves that - 16 rows of 5. (Before the fix the
+    // witness was the inner factor's chunk, so it emitted only |b| = 4 rows.)
+    const std::vector<std::vector<int64_t>> expected(16, {5});
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, constantProjectionOverCrossProductSpanningChunks) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A chunk of three over four nodes splits each scan into two chunks, so the
+    // witness column is block-repeated afresh each step; the accumulated count must
+    // still be the full 16.
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(constantOverCrossProductProgram, reader.getView(), sink, /*chunkSize=*/3);
+
+    const std::vector<std::vector<int64_t>> expected(16, {5});
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, constantProjectionOverNestedCrossProductHasProductCardinality) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(constantOverNestedCrossProductProgram, reader.getView(), sink);
+
+    // RETURN 5 over MATCH (a), (b), (c): a 4 x 4 x 4 nested product, so 64 rows of
+    // 5 - the witness must follow the outer product's realized column through the
+    // nested lowering, not the innermost scan's chunk.
+    const std::vector<std::vector<int64_t>> expected(64, {5});
     EXPECT_EQ(sink.rows(), expected);
 }
 

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -15,6 +15,7 @@
 
 #include "Graph.h"
 #include "JobSystem.h"
+#include "columns/ColumnConst.h"
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnOptVector.h"
 #include "datapart/EdgeRecord.h"
@@ -315,6 +316,112 @@ public:
 private:
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> _rows;
 };
+
+// Collects constant result rows: each output column is a ColumnConst<T> - the
+// single broadcast value a db.constant lowers to - so a constant program emits
+// exactly one row, one value per column. Every column must be a ColumnConst<T>.
+template <typename T>
+class CollectingConstSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            std::vector<T> row;
+            for (const Column* chunk : chunks) {
+                const auto* values = dynamic_cast<const ColumnConst<T>*>(chunk);
+                ASSERT_NE(values, nullptr);
+                row.push_back((*values)[rowIndex]);
+            }
+            _rows.push_back(row);
+        }
+    }
+
+    const std::vector<std::vector<T>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<T>> _rows;
+};
+
+// RETURN 30: one constant projected straight to output. It touches no graph -
+// the constant is materialized at function scope and emitted as a single row.
+constexpr const char* singleConstantProgram = R"mlir(
+func.func @main() {
+  %c = db.constant(30 : i64)
+  db.output(%c) : !db.column<i64>
+  return
+}
+)mlir";
+
+// RETURN 10, 20, 30: several constants projected together as one row.
+constexpr const char* multipleConstantsProgram = R"mlir(
+func.func @main() {
+  %a = db.constant(10 : i64)
+  %b = db.constant(20 : i64)
+  %c = db.constant(30 : i64)
+  db.output(%a, %b, %c) : !db.column<i64>, !db.column<i64>, !db.column<i64>
+  return
+}
+)mlir";
+
+// RETURN 2.5: a single double constant, exercising the f64 value type.
+constexpr const char* doubleConstantProgram = R"mlir(
+func.func @main() {
+  %c = db.constant(2.5 : f64)
+  db.output(%c) : !db.column<f64>
+  return
+}
+)mlir";
+
+// Collects one row of the four supported constant value types, each a ColumnConst
+// of its primitive, in the fixed projection order (Int64, UInt64, Double, Bool).
+// String and embedding are not representable constants, so they are not covered.
+class CollectingAllTypesConstSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 4u);
+        ASSERT_EQ(rowCount, 1u);
+
+        const auto* ints = dynamic_cast<const ColumnConst<int64_t>*>(chunks[0]);
+        const auto* uints = dynamic_cast<const ColumnConst<uint64_t>*>(chunks[1]);
+        const auto* doubles = dynamic_cast<const ColumnConst<double>*>(chunks[2]);
+        const auto* bools = dynamic_cast<const ColumnConst<CustomBool>*>(chunks[3]);
+        ASSERT_NE(ints, nullptr);
+        ASSERT_NE(uints, nullptr);
+        ASSERT_NE(doubles, nullptr);
+        ASSERT_NE(bools, nullptr);
+
+        _seen = true;
+        _int = (*ints)[offset];
+        _uint = (*uints)[offset];
+        _double = (*doubles)[offset];
+        _bool = static_cast<bool>((*bools)[offset]);
+    }
+
+    bool seen() const { return _seen; }
+    int64_t getInt() const { return _int; }
+    uint64_t getUint() const { return _uint; }
+    double getDouble() const { return _double; }
+    bool getBool() const { return _bool; }
+
+private:
+    bool _seen {false};
+    int64_t _int {0};
+    uint64_t _uint {0};
+    double _double {0.0};
+    bool _bool {false};
+};
+
+// RETURN 30, 7, 2.5, true: one constant of each supported value type projected
+// together as a single row.
+constexpr const char* allTypesConstantsProgram = R"mlir(
+func.func @main() {
+  %i = db.constant(30 : i64)
+  %u = db.constant(7 : ui64)
+  %f = db.constant(2.5 : f64)
+  %b = db.constant(true)
+  db.output(%i, %u, %f, %b) : !db.column<i64>, !db.column<ui64>, !db.column<f64>, !db.column<i1>
+  return
+}
+)mlir";
 
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
@@ -1363,6 +1470,58 @@ TEST_F(DBLoweringTest, executesScanNodesByLabelUnknownIsEmpty) {
     std::vector<uint64_t> robots;
     collectScan(scanByLabelUnknownProgram, reader.getView(), robots);
     EXPECT_TRUE(robots.empty());
+}
+
+TEST_F(DBLoweringTest, lowersSingleConstant) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(singleConstantProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<int64_t>> expected {{30}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, lowersMultipleConstants) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(multipleConstantsProgram, reader.getView(), sink);
+
+    // One row of three constant columns, in projection order.
+    const std::vector<std::vector<int64_t>> expected {{10, 20, 30}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, lowersDoubleConstant) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<double> sink;
+    runLoweredProgram(doubleConstantProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<double>> expected {{2.5}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, lowersConstantsOfAllSupportedTypes) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingAllTypesConstSink sink;
+    runLoweredProgram(allTypesConstantsProgram, reader.getView(), sink);
+
+    ASSERT_TRUE(sink.seen());
+    EXPECT_EQ(sink.getInt(), 30);
+    EXPECT_EQ(sink.getUint(), 7u);
+    EXPECT_DOUBLE_EQ(sink.getDouble(), 2.5);
+    EXPECT_TRUE(sink.getBool());
 }
 
 TEST_F(DBLoweringTest, lowersOneHopOutEdges) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -487,6 +487,18 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n) RETURN 5: a constant projected over a scan, with no per-row column in
+// the projection. Projection preserves cardinality, so the result is one row of 5
+// per node - not a single row.
+constexpr const char* constantOverMatchProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %c = db.constant(5 : i64)
+  db.output(%c) : !db.column<i64>
+  return
+}
+)mlir";
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -1614,6 +1626,21 @@ TEST_F(DBLoweringTest, lowersScanWithLeadingConstant) {
     sink.sortedRows(rows);
     const std::vector<std::pair<int64_t, uint64_t>> expected {{42, 0}, {42, 1}, {42, 2}, {42, 3}};
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, constantProjectionOverMatchHasRelationCardinality) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(constantOverMatchProgram, reader.getView(), sink);
+
+    // RETURN 5 over the diamond's four nodes: projection preserves cardinality, so
+    // four rows of 5 - not one. (Before the fix the output floated to function scope
+    // and emitted a single row.)
+    const std::vector<std::vector<int64_t>> expected {{5}, {5}, {5}, {5}};
+    EXPECT_EQ(sink.rows(), expected);
 }
 
 TEST_F(DBLoweringTest, lowersOneHopOutEdges) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -55,7 +55,7 @@ TEST_F(NLDialectTest, verifierAcceptsLimitTruncate) {
     const mlir::Value handle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::LimitUpdate>(loc, handle, chunk);
     mlir::nl::LimitTruncate truncate = builder.create<mlir::nl::LimitTruncate>(loc, handle, mlir::ValueRange {chunk});
-    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -76,7 +76,7 @@ TEST_F(NLDialectTest, verifierAcceptsSkipTruncate) {
     const mlir::Value handle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::SkipUpdate>(loc, handle, chunk);
     mlir::nl::SkipTruncate truncate = builder.create<mlir::nl::SkipTruncate>(loc, handle, mlir::ValueRange {chunk});
-    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, truncate.getResults(), mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -93,7 +93,7 @@ TEST_F(NLDialectTest, verifierAcceptsOutput) {
     mlir::Block& entryBlock = function.getBody().front();
     const mlir::Value chunk = entryBlock.getArgument(0);
 
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -112,7 +112,7 @@ TEST_F(NLDialectTest, verifierAcceptsOutputWithLimit) {
 
     const mlir::Value handle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
     builder.create<mlir::nl::LimitUpdate>(loc, handle, chunk);
-    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, handle, mlir::Value());
+    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, handle, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -135,7 +135,7 @@ TEST_F(NLDialectTest, verifierAcceptsOutputWithSkip) {
     builder.create<mlir::nl::SkipUpdate>(loc, handle, chunk);
     // The skip handle goes in the third operand (no limit), so the columns, limit
     // and skip operand segments are all distinct.
-    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), handle);
+    mlir::nl::Output output = builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, mlir::Value(), handle, mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -184,7 +184,7 @@ TEST_F(NLDialectTest, verifierAcceptsDistinctChain) {
 
     const mlir::Value handle = builder.create<mlir::nl::Distinct>(loc).getState();
     mlir::nl::DistinctFilter filter = builder.create<mlir::nl::DistinctFilter>(loc, handle, mlir::ValueRange {chunk});
-    builder.create<mlir::nl::Output>(loc, filter.getResults(), mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, filter.getResults(), mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -213,7 +213,7 @@ TEST_F(NLDialectTest, verifierAcceptsCountChain) {
     const mlir::Type countChunkType = mlir::nl::ChunkType::get(&_context,
                                                                mlir::IntegerType::get(&_context, 64, mlir::IntegerType::Unsigned));
     mlir::nl::CountResult result = builder.create<mlir::nl::CountResult>(loc, countChunkType, handle);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -252,7 +252,7 @@ TEST_F(NLDialectTest, verifierAcceptsAggregateChain) {
     const mlir::Type resultChunkType = mlir::nl::ChunkType::get(&_context,
                                                                 mlir::storage::NullableType::get(&_context, int64Type));
     mlir::nl::AggregateResult result = builder.create<mlir::nl::AggregateResult>(loc, resultChunkType, handle, mlir::storage::AggregateKind::Sum);
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value());
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {result.getResult()}, mlir::Value(), mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -328,7 +328,7 @@ TEST_F(NLDialectTest, verifierRejectsOutputWithBothLimitAndSkip) {
 
     const mlir::Value limitHandle = builder.create<mlir::nl::Limit>(loc, /*count=*/3u).getState();
     const mlir::Value skipHandle = builder.create<mlir::nl::Skip>(loc, /*count=*/3u).getState();
-    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, limitHandle, skipHandle);
+    builder.create<mlir::nl::Output>(loc, mlir::ValueRange {chunk}, limitHandle, skipHandle, mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -289,6 +289,22 @@ func.func @main() {
 }
 )mlir";
 
+// Malformed (%score is of the wrong dimension in the output), should error
+constexpr const char* outerScopeOutputColumnProgram = R"mlir(
+func.func @main() {
+  %p = nl.get_property_type("score")
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %score = nl.get_node_properties(%a, %p) : !nl.chunk<!storage.nullable<i64>>
+    %edges = nl.get_out_edges(%a, {})
+    nl.for %srcs, %eids, %etypes, %b in %edges : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      nl.output(%score) : !nl.chunk<!storage.nullable<i64>>
+    }
+  }
+  func.return
+}
+)mlir";
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -902,6 +918,17 @@ TEST_F(NLExecutorTest, constantAllSupportedTypes) {
     EXPECT_EQ(sink.getUint(), 7u);
     EXPECT_DOUBLE_EQ(sink.getDouble(), 2.5);
     EXPECT_TRUE(sink.getBool());
+}
+
+TEST_F(NLExecutorTest, outputRejectsNonConstantOuterScopeColumn) {
+    auto graph = buildScoredGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingOptInt64Sink sink;
+    EXPECT_THROW(
+        runProgram(outerScopeOutputColumnProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink),
+        IRException);
 }
 
 TEST_F(NLExecutorTest, getNodeProperties) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -14,6 +14,7 @@
 
 #include "Graph.h"
 #include "JobSystem.h"
+#include "columns/ColumnConst.h"
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnOptVector.h"
 #include "iterators/ChunkConfig.h"
@@ -183,6 +184,110 @@ public:
 private:
     std::vector<std::optional<double>> _values;
 };
+
+// Collects constant result rows: each output column is a ColumnConst<T> - the
+// single broadcast value nl.constant materializes - so a constant program emits
+// exactly one row, one value per column. Every column must be a ColumnConst<T>.
+template <typename T>
+class CollectingConstSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            std::vector<T> row;
+            for (const Column* chunk : chunks) {
+                const auto* values = dynamic_cast<const ColumnConst<T>*>(chunk);
+                ASSERT_NE(values, nullptr);
+                row.push_back((*values)[rowIndex]);
+            }
+            _rows.push_back(row);
+        }
+    }
+
+    const std::vector<std::vector<T>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<T>> _rows;
+};
+
+// A single constant materialized at function scope and emitted as one row.
+constexpr const char* singleConstantProgram = R"mlir(
+func.func @main() {
+  %c = nl.constant(30 : i64)
+  nl.output(%c) : !nl.chunk<i64>
+  func.return
+}
+)mlir";
+
+// Several constants projected together as one row.
+constexpr const char* multipleConstantsProgram = R"mlir(
+func.func @main() {
+  %a = nl.constant(10 : i64)
+  %b = nl.constant(20 : i64)
+  %c = nl.constant(30 : i64)
+  nl.output(%a, %b, %c) : !nl.chunk<i64>, !nl.chunk<i64>, !nl.chunk<i64>
+  func.return
+}
+)mlir";
+
+// A single double constant, exercising the f64 value type.
+constexpr const char* doubleConstantProgram = R"mlir(
+func.func @main() {
+  %c = nl.constant(2.5 : f64)
+  nl.output(%c) : !nl.chunk<f64>
+  func.return
+}
+)mlir";
+
+// Collects one row of the four supported constant value types, each a ColumnConst
+// of its primitive, in the fixed projection order (Int64, UInt64, Double, Bool).
+// String and embedding are not representable constants, so they are not covered.
+class CollectingAllTypesConstSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 4u);
+        ASSERT_EQ(rowCount, 1u);
+
+        const auto* ints = dynamic_cast<const ColumnConst<int64_t>*>(chunks[0]);
+        const auto* uints = dynamic_cast<const ColumnConst<uint64_t>*>(chunks[1]);
+        const auto* doubles = dynamic_cast<const ColumnConst<double>*>(chunks[2]);
+        const auto* bools = dynamic_cast<const ColumnConst<CustomBool>*>(chunks[3]);
+        ASSERT_NE(ints, nullptr);
+        ASSERT_NE(uints, nullptr);
+        ASSERT_NE(doubles, nullptr);
+        ASSERT_NE(bools, nullptr);
+
+        _seen = true;
+        _int = (*ints)[offset];
+        _uint = (*uints)[offset];
+        _double = (*doubles)[offset];
+        _bool = static_cast<bool>((*bools)[offset]);
+    }
+
+    bool seen() const { return _seen; }
+    int64_t getInt() const { return _int; }
+    uint64_t getUint() const { return _uint; }
+    double getDouble() const { return _double; }
+    bool getBool() const { return _bool; }
+
+private:
+    bool _seen {false};
+    int64_t _int {0};
+    uint64_t _uint {0};
+    double _double {0.0};
+    bool _bool {false};
+};
+
+// One constant of each supported value type projected together as a single row.
+constexpr const char* allTypesConstantsProgram = R"mlir(
+func.func @main() {
+  %i = nl.constant(30 : i64)
+  %u = nl.constant(7 : ui64)
+  %f = nl.constant(2.5 : f64)
+  %b = nl.constant(true)
+  nl.output(%i, %u, %f, %b) : !nl.chunk<i64>, !nl.chunk<ui64>, !nl.chunk<f64>, !nl.chunk<i1>
+  func.return
+}
+)mlir";
 
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
@@ -745,6 +850,58 @@ TEST_F(NLExecutorTest, scanNodesOutput) {
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(NLExecutorTest, constantSingleValue) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runProgram(singleConstantProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<int64_t>> expected {{30}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(NLExecutorTest, constantMultipleValues) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runProgram(multipleConstantsProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // One row of three constant columns, in projection order.
+    const std::vector<std::vector<int64_t>> expected {{10, 20, 30}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(NLExecutorTest, constantDoubleValue) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<double> sink;
+    runProgram(doubleConstantProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<double>> expected {{2.5}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(NLExecutorTest, constantAllSupportedTypes) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingAllTypesConstSink sink;
+    runProgram(allTypesConstantsProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    ASSERT_TRUE(sink.seen());
+    EXPECT_EQ(sink.getInt(), 30);
+    EXPECT_EQ(sink.getUint(), 7u);
+    EXPECT_DOUBLE_EQ(sink.getDouble(), 2.5);
+    EXPECT_TRUE(sink.getBool());
 }
 
 TEST_F(NLExecutorTest, getNodeProperties) {

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -305,6 +305,20 @@ func.func @main() {
 }
 )mlir";
 
+// A constant projected over the scan (the lowered MATCH (n) RETURN 5). The output
+// carries the scan loop variable as an explicit cardinality driver, so it emits one
+// row of 5 per node - the constant broadcasts against the driver's row count.
+constexpr const char* constantOverMatchProgram = R"mlir(
+func.func @main() {
+  %c = nl.constant(5 : i64)
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%c) cardinality %a : !nl.chunk<i64>
+  }
+  func.return
+}
+)mlir";
+
 // Scan all nodes and output them
 constexpr const char* scanProgram = R"mlir(
 func.func @main() {
@@ -929,6 +943,20 @@ TEST_F(NLExecutorTest, outputRejectsNonConstantOuterScopeColumn) {
     EXPECT_THROW(
         runProgram(outerScopeOutputColumnProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink),
         IRException);
+}
+
+TEST_F(NLExecutorTest, outputBroadcastsConstantToCardinality) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runProgram(constantOverMatchProgram, reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    // The cardinality operand (the scan loop variable) sizes the emission to the
+    // node count, so the constant 5 is emitted once per node - four rows.
+    const std::vector<std::vector<int64_t>> expected {{5}, {5}, {5}, {5}};
+    EXPECT_EQ(sink.rows(), expected);
 }
 
 TEST_F(NLExecutorTest, getNodeProperties) {


### PR DESCRIPTION
Constant operations to produce a `ColumnConst` with a specific value. Lowered from DB, to NL, to execution. Tests for hardcoded MLIR programs.