### PR TITLE
MLIR: add scan_edges operation to db and nl dialects

### DIFF
--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -92,6 +92,13 @@ LogicalResult verifyPassThrough(Operation* op,
 }
 
 // Ensures each variable has a numeric name
+void ScanEdges::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+    for (Value result : getResults()) {
+        setNameFn(result, "");
+    }
+}
+
+// Ensures each variable has a numeric name
 void GetOutEdges::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
     for (Value result : getResults()) {
         setNameFn(result, "");

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -58,6 +58,45 @@ def ScanNodesByLabel : TuringOp<"scan_nodes_by_label", [Pure]> {
 }
 
 /**
+* ScanEdges
+*/
+def ScanEdges : TuringOp<"scan_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Produce every edge in the graph as four row-aligned columns";
+
+  let description = [{
+    The edge counterpart of db.scan_nodes: where that produces every node, this
+    produces every edge, expanded into the same four row-aligned columns a hop
+    exposes - the source node, the edge, its type and the target node:
+
+      %srcs, %eids, %etypes, %tgts = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+
+    It reads no column and takes no input, so - like db.scan_nodes - it opens a
+    dataflow rather than consuming one. Unlike db.get_out_edges there is no source
+    node column to walk from and no carry set to filter: every edge is emitted
+    once. The four result chunks are the same shape and order db.get_out_edges
+    produces (sources, edge IDs, edge type IDs, targets), so a downstream op reads
+    them the same way. Scanning the graph is a deterministic read, so the op is
+    Pure.
+  }];
+
+  // No operands: a scan opens the dataflow. The four results are the source
+  // nodes, the edges, their types and the target nodes, in the same order
+  // db.get_out_edges produces them.
+  let results = (outs ColumnNodeIDs:$srcids,
+                      ColumnEdgeIDs:$eids,
+                      ColumnEdgeTypes:$etypes,
+                      ColumnNodeIDs:$tgtids);
+
+  // A source op has no meaningful operand arrow, so - like db.scan_nodes - the
+  // result types are spelled straight after the colon rather than through a
+  // functional-type; qualified(...) keeps the leading !db. on each.
+  let assemblyFormat = [{
+    `(`operands`)` attr-dict `:` qualified(type($srcids)) `,` qualified(type($eids)) `,`
+    qualified(type($etypes)) `,` qualified(type($tgtids))
+  }];
+}
+
+/**
 * GetOutEdges
 */
 def GetOutEdges : TuringOp<"get_out_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -91,6 +91,17 @@ LogicalResult ScanNodesByLabel::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// An edge scan produces the same four fixed edge chunks per step as an
+// out-edges fetch, but reads no input and carries nothing, so the iterator has
+// exactly those four chunks and no carried tail.
+LogicalResult ScanEdges::inferReturnTypes(MLIRContext* context,
+                                         std::optional<Location> location,
+                                         ScanEdges::Adaptor adaptor,
+                                         SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(getEdgeIteratorType(context, {}));
+    return success();
+}
+
 // An out-edges fetch produces one row of edge chunks per step, then one
 // filtered chunk per carried column, mirroring db.get_out_edges
 LogicalResult GetOutEdges::inferReturnTypes(MLIRContext* context,

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -47,6 +47,24 @@ def ScanNodesByLabel : NLOp<"scan_nodes_by_label", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* ScanEdges
+*/
+def ScanEdges : NLOp<"scan_edges", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Create a database iterator over all edges in the graph";
+  let description = [{
+    Imperative counterpart of db.scan_edges. Each step of an enclosing nl.for
+    fills one row of edge chunks - source node IDs, edge IDs, edge type IDs and
+    target node IDs - the same chunk shape nl.get_out_edges produces, so a loop
+    body written for a hop works unchanged over a full edge scan. Unlike
+    nl.get_out_edges it reads no input chunk and carries nothing: it opens the
+    dataflow. The result type is always the four-chunk edge iterator and is
+    inferred, not spelled out.
+  }];
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(`operands`)` attr-dict";
+}
+
+/**
 * GetOutEdges
 */
 def GetOutEdges : NLOp<"get_out_edges", [Pure, InferTypeOpAdaptor]> {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -10,6 +10,7 @@
 #include "iterators/GetOutEdgesIterator.h"
 #include "iterators/GetOutEdgesByTypeIterator.h"
 #include "iterators/GetPropertiesWithNullIterator.h"
+#include "iterators/ScanEdgesIterator.h"
 #include "iterators/ScanNodesIterator.h"
 #include "iterators/ScanNodesByLabelIterator.h"
 #include "columns/ColumnOptVector.h"
@@ -578,6 +579,45 @@ void NLExecutor::runScanNodesByLabelLoop(NLExecutionContext* context, NLFunction
         chunkWriter.fill(chunkSize);
 
         if (nodeIDs->empty()) {
+            return;
+        }
+
+        runBody(context, loopBody);
+    };
+
+    if (limit) {
+        while (chunkWriter.isValid() && limit->getRemaining() > 0) {
+            runIteration();
+        }
+    } else {
+        while (chunkWriter.isValid()) {
+            runIteration();
+        }
+    }
+}
+
+void NLExecutor::runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLScanEdgesLoopData* loopData = static_cast<NLScanEdgesLoopData*>(data);
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    ColumnNodeIDs* sources = loopData->getSources();
+    const size_t chunkSize = context->getChunkSize();
+
+    // A null limit leaves the loop unbounded; otherwise it stops once the budget
+    // is spent, exactly as in runScanNodesLoop.
+    const NLLimitState* limit = loopData->getLimit();
+
+    ScanEdgesChunkWriter chunkWriter(*context->getView());
+    chunkWriter.setSrcIDs(sources);
+    chunkWriter.setEdgeIDs(loopData->getEdgeIDs());
+    chunkWriter.setEdgeTypes(loopData->getEdgeTypes());
+    chunkWriter.setTgtIDs(loopData->getTargets());
+
+    const auto runIteration = [&]() {
+        chunkWriter.fill(chunkSize);
+
+        // The four columns are row-aligned, so the source column measures the
+        // step; an empty fill means the scan is drained and there is nothing to emit.
+        if (sources->empty()) {
             return;
         }
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -44,6 +44,7 @@ public:
 
     static void runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runScanNodesByLabelLoop(NLExecutionContext* context, NLFunctionData* data);
+    static void runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -212,6 +212,47 @@ private:
     bool _matchable {true};
 };
 
+// nl.scan_edges loop data: the edge sibling of NLScanLoopData. A source loop
+// (no input column, no carry set), so - unlike NLEdgeLoopData - it holds only
+// the four fixed output chunks a step fills (sources, edge IDs, edge type IDs,
+// targets), plus the limit and body a scan loop carries.
+class NLScanEdgesLoopData : public NLFunctionData {
+public:
+    NLScanEdgesLoopData(ColumnNodeIDs* sources,
+                        ColumnEdgeIDs* edgeIDs,
+                        ColumnEdgeTypes* edgeTypes,
+                        ColumnNodeIDs* targets)
+        : _sources(sources),
+        _edgeIDs(edgeIDs),
+        _edgeTypes(edgeTypes),
+        _targets(targets)
+    {
+    }
+
+    ColumnNodeIDs* getSources() const { return _sources; }
+    ColumnEdgeIDs* getEdgeIDs() const { return _edgeIDs; }
+    ColumnEdgeTypes* getEdgeTypes() const { return _edgeTypes; }
+    ColumnNodeIDs* getTargets() const { return _targets; }
+
+    // The governing limit counter, or null for an unbounded loop. The loop
+    // driver stops once it reaches zero.
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    // The four fixed chunks of an edge iterator step, in loop-variable order
+    ColumnNodeIDs* _sources {nullptr};
+    ColumnEdgeIDs* _edgeIDs {nullptr};
+    ColumnEdgeTypes* _edgeTypes {nullptr};
+    ColumnNodeIDs* _targets {nullptr};
+
+    NLLimitState* _limit {nullptr};
+    NLStmtContainer _stmts;
+};
+
 // nl.get_out_edges and nl.get_in_edges loop data
 // The state is the same for get_out_edges/get_in_edges
 class NLEdgeLoopData : public NLFunctionData {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -159,6 +159,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
                 config._labels.emplace_back(mlir::cast<mlir::StringAttr>(label).getValue());
             }
             _iteratorConfigs[scanNodesByLabel.getResult()] = config;
+        } else if (nl::ScanEdges scanEdges = mlir::dyn_cast<nl::ScanEdges>(operation)) {
+            _iteratorConfigs[scanEdges.getResult()] = IteratorConfig {IteratorKind::ScanEdges, {}, {}};
         } else if (nl::GetOutEdges getOutEdges = mlir::dyn_cast<nl::GetOutEdges>(operation)) {
             IteratorConfig config {IteratorKind::GetOutEdges, getOutEdges.getInputNodes(), {}};
             const mlir::OperandRange carriedColumns = getOutEdges.getColumnsToFilter();
@@ -264,6 +266,8 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         translateScanLoop(loopBody, limit, body);
     } else if (config._kind == IteratorKind::ScanNodesByLabel) {
         translateScanByLabelLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::ScanEdges) {
+        translateScanEdgesLoop(loopBody, limit, body);
     } else if (config._kind == IteratorKind::Sort) {
         // A sort emit loop is never limit-bounded: ORDER BY must see every row.
         translateSortLoop(config, loopBody, body);
@@ -316,6 +320,26 @@ void NLTranslator::translateScanByLabelLoop(const IteratorConfig& config,
     loopData->setLimit(limit);
 
     body->addStmt(NLFunctionDescriptor {&NLExecutor::runScanNodesByLabelLoop, loopData});
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+void NLTranslator::translateScanEdgesLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body) {
+    // For::verify guarantees one block argument per iterator chunk, and an edge
+    // scan iterator has exactly four chunks in the order getEdgeIteratorType
+    // establishes: sources, edge IDs, edge type IDs, targets.
+    ColumnNodeIDs* sources = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(0)));
+    ColumnEdgeIDs* edgeIDs = static_cast<ColumnEdgeIDs*>(allocColumn(loopBody.getArgument(1)));
+    ColumnEdgeTypes* edgeTypes = static_cast<ColumnEdgeTypes*>(allocColumn(loopBody.getArgument(2)));
+    ColumnNodeIDs* targets = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(3)));
+
+    NLScanEdgesLoopData* loopData = _program->allocFunctionData<NLScanEdgesLoopData>(sources,
+                                                                                     edgeIDs,
+                                                                                     edgeTypes,
+                                                                                     targets);
+    loopData->setLimit(limit);
+
+    body->addStmt(NLFunctionDescriptor {&NLExecutor::runScanEdgesLoop, loopData});
 
     translateBlock(loopBody, loopData->getStmts());
 }

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -29,6 +29,7 @@ private:
     enum class IteratorKind {
         ScanNodes,
         ScanNodesByLabel,
+        ScanEdges,
         GetOutEdges,
         GetInEdges,
         GetOutEdgesByType,
@@ -102,6 +103,13 @@ private:
                                   mlir::Block& loopBody,
                                   NLLimitState* limit,
                                   NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.scan_edges iterator: allocate the four
+    // fixed edge loop variables (sources, edge IDs, edge type IDs, targets) and
+    // record the edge-scan loop statement in body. The edge sibling of
+    // translateScanLoop - a source loop with no input chunk and no carry set.
+    void translateScanEdgesLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body);
+
     void translateEdgeLoop(const IteratorConfig& config,
                            mlir::Block& loopBody,
                            NLLimitState* limit,

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -247,6 +247,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerScanNodes(scanNodes);
     } else if (mlir::db::ScanNodesByLabel scanNodesByLabel = mlir::dyn_cast<mlir::db::ScanNodesByLabel>(operation)) {
         lowerScanNodesByLabel(scanNodesByLabel);
+    } else if (mlir::db::ScanEdges scanEdges = mlir::dyn_cast<mlir::db::ScanEdges>(operation)) {
+        lowerScanEdges(scanEdges);
     } else if (mlir::db::GetOutEdges getOutEdges = mlir::dyn_cast<mlir::db::GetOutEdges>(operation)) {
         lowerGetOutEdges(getOutEdges);
     } else if (mlir::db::GetInEdges getInEdges = mlir::dyn_cast<mlir::db::GetInEdges>(operation)) {
@@ -310,6 +312,17 @@ void DBLowering::lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLab
     nl::ScanNodesByLabel nodes = _builder.create<nl::ScanNodesByLabel>(_builder.getUnknownLoc(),
                                                                        scanNodesByLabel.getLabelsAttr());
     buildLoopForSource(nodes.getResult(), scanNodesByLabel.getOperation());
+}
+
+void DBLowering::lowerScanEdges(mlir::db::ScanEdges scanEdges) {
+    // The edge sibling of lowerScanNodes: a scan reads no column, so its loop
+    // sits at the top of the current root block. The nl.scan_edges iterator
+    // produces the four fixed edge chunks, which buildLoopForSource binds to the
+    // op's four results in order.
+    setInsertionInto(_rootBlock);
+
+    nl::ScanEdges edges = _builder.create<nl::ScanEdges>(_builder.getUnknownLoc());
+    buildLoopForSource(edges.getResult(), scanEdges.getOperation());
 }
 
 void DBLowering::lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges) {
@@ -923,6 +936,7 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
 
     const bool opensLoop = mlir::isa<mlir::db::ScanNodes,
                                      mlir::db::ScanNodesByLabel,
+                                     mlir::db::ScanEdges,
                                      mlir::db::GetOutEdges,
                                      mlir::db::GetInEdges,
                                      mlir::db::GetOutEdgesByType,

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -158,6 +158,7 @@ private:
     void lowerOperation(mlir::Operation& operation);
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLabel);
+    void lowerScanEdges(mlir::db::ScanEdges scanEdges);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetInEdges(mlir::db::GetInEdges getInEdges);
     void lowerGetOutEdgesByType(mlir::db::GetOutEdgesByType getOutEdgesByType);

--- a/samples/mlir/scan_edges.mlir
+++ b/samples/mlir/scan_edges.mlir
@@ -1,0 +1,31 @@
+module {
+  func.func @main() {
+    // Scan every edge, walk two out-hops from each edge's target, then read a
+    // property of the final node:
+    //
+    //   MATCH ()-[]->(t)-->(b)-->(c) RETURN c, c.name
+    //
+    // db.scan_edges opens the dataflow with the whole edge set - source node,
+    // edge, edge type and target node - the same four columns a hop exposes, so
+    // the two get_out_edges hops chain straight off the scan's target column.
+    // No carry set here: the sample keeps only the final node `c` and its
+    // property, so nothing earlier has to ride along.
+    %src, %e, %et, %t = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+
+    // First out-hop t->b, empty carry set. %h1src is `t`, %b its successor.
+    %h1src, %h1e, %h1et, %b = db.get_out_edges(%t, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Second out-hop b->c, empty carry set. %c is the node two hops past `t`.
+    %h2src, %h2e, %h2et, %c = db.get_out_edges(%b, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Read the "name" property of the final node `c`. A node that lacks it comes
+    // back null - none are dropped. "name" must exist in the loaded graph (-graph):
+    // the db -> nl lowering resolves the name against the schema and bakes its
+    // value type into the result chunk (in simpledb "name" is a String).
+    %name = db.get_node_properties(%c, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    db.output(%c, %name) : !db.column<!storage.node_id>, !db.column<none>
+
+    return
+  }
+}

--- a/samples/mlir/scan_edges.nl.mlir
+++ b/samples/mlir/scan_edges.nl.mlir
@@ -1,0 +1,34 @@
+// Generated nl-dialect lowering of scan_edges.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered scan_edges.mlir -graph <graph>
+// This is the DBLowering output; edit scan_edges.mlir, not this file.
+//
+// Needs -graph: the value chunk element type is resolved from the "name"
+// property during lowering (a String in simpledb). db.scan_edges lowers to an
+// nl.scan_edges source op whose nl.for binds the four edge chunks - source,
+// edge, edge type, target. The two out-hops nest inside, each an
+// nl.get_out_edges + nl.for off the previous step's target, and the property
+// fetch runs in the innermost body against the final node `c`, feeding one
+// nl.output.
+module {
+  func.func @main() {
+    %0 = nl.get_property_type("name")
+
+    // Edge scan: %arg0 is the source, %arg1 the edge, %arg2 the edge type,
+    // %arg3 the target `t` the first hop leaves from.
+    %1 = nl.scan_edges()
+    nl.for %arg0, %arg1, %arg2, %arg3 in %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      // First out-hop t->b, empty carry set. %arg4 is `t`, %arg7 is `b`.
+      %2 = nl.get_out_edges(%arg3, {})
+      nl.for %arg4, %arg5, %arg6, %arg7 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        // Second out-hop b->c, empty carry set. %arg8 is `b`, %arg11 is `c`.
+        %3 = nl.get_out_edges(%arg7, {})
+        nl.for %arg8, %arg9, %arg10, %arg11 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+          // Read c.name into a nullable string chunk and emit (c, c.name).
+          %4 = nl.get_node_properties(%arg11, %0) : !nl.chunk<!storage.nullable<!storage.string>>
+          nl.output(%arg11, %4) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+        }
+      }
+    }
+    return
+  }
+}

--- a/samples/mlir/scan_edges_edge_property.mlir
+++ b/samples/mlir/scan_edges_edge_property.mlir
@@ -1,0 +1,32 @@
+module {
+  func.func @main() {
+    // The edge-property sibling of scan_edges.mlir: same scan + two out-hops,
+    // but the property read is on the last hop's EDGE, not the final node:
+    //
+    //   MATCH ()-[]->(t)-->(b)-[r]->(c) RETURN r, r.duration
+    //
+    // db.scan_edges opens the dataflow with the whole edge set, the two
+    // get_out_edges hops chain off the target column, and the second hop's edge
+    // column %h2e feeds db.get_edge_properties - the edge counterpart of
+    // get_node_properties, reading from the edge side of the graph.
+    %src, %e, %et, %t = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+
+    // First out-hop t->b, empty carry set. %h1src is `t`, %b its successor.
+    %h1src, %h1e, %h1et, %b = db.get_out_edges(%t, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Second out-hop b->c, empty carry set. %h2e is the b->c edge `r`, %c the node.
+    %h2src, %h2e, %h2et, %c = db.get_out_edges(%b, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Read the "duration" property of the last hop's edge `r`. An edge that lacks
+    // it comes back null - none are dropped. "duration" must exist in the loaded
+    // graph (-graph): the db -> nl lowering resolves the name against the schema
+    // and bakes its value type into the result chunk (in simpledb "duration" is
+    // an Int64). The input is an edge ID column, so the op chosen is the edge-side
+    // db.get_edge_properties.
+    %dur = db.get_edge_properties(%h2e, "duration") : (!db.column<!storage.edge_id>) -> !db.column<none>
+
+    db.output(%h2e, %dur) : !db.column<!storage.edge_id>, !db.column<none>
+
+    return
+  }
+}

--- a/samples/mlir/scan_edges_edge_property.nl.mlir
+++ b/samples/mlir/scan_edges_edge_property.nl.mlir
@@ -1,0 +1,34 @@
+// Generated nl-dialect lowering of scan_edges_edge_property.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered scan_edges_edge_property.mlir -graph <graph>
+// This is the DBLowering output; edit scan_edges_edge_property.mlir, not this file.
+//
+// The edge-property sibling of scan_edges.nl.mlir: same nl.scan_edges + two
+// nl.get_out_edges hops, but the property fetch is nl.get_edge_properties on the
+// last hop's edge chunk (%arg9) rather than nl.get_node_properties on the node.
+// Needs -graph: the value chunk element type is resolved from the "duration"
+// property during lowering (an Int64 in simpledb), so the fetch produces a
+// !storage.nullable<i64> value chunk in the innermost loop, feeding one nl.output.
+module {
+  func.func @main() {
+    %0 = nl.get_property_type("duration")
+
+    // Edge scan: %arg0 is the source, %arg1 the edge, %arg2 the edge type,
+    // %arg3 the target `t` the first hop leaves from.
+    %1 = nl.scan_edges()
+    nl.for %arg0, %arg1, %arg2, %arg3 in %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      // First out-hop t->b, empty carry set. %arg4 is `t`, %arg7 is `b`.
+      %2 = nl.get_out_edges(%arg3, {})
+      nl.for %arg4, %arg5, %arg6, %arg7 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        // Second out-hop b->c, empty carry set. %arg9 is the b->c edge `r`,
+        // %arg11 is `c`.
+        %3 = nl.get_out_edges(%arg7, {})
+        nl.for %arg8, %arg9, %arg10, %arg11 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+          // Read r.duration into a nullable i64 chunk and emit (r, r.duration).
+          %4 = nl.get_edge_properties(%arg9, %0) : !nl.chunk<!storage.nullable<i64>>
+          nl.output(%arg9, %4) : !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.nullable<i64>>
+        }
+      }
+    }
+    return
+  }
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -883,6 +883,16 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH ()-[e]->() RETURN a, b: scan every edge, exposing the four edge columns
+// (source node, edge, edge type, target node); the output keeps the endpoints.
+const char* const scanEdgesProgram = R"mlir(
+func.func @main() {
+  %srcs, %eids, %etypes, %tgts = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 TEST_F(DBDialectTest, parsesScanNodesByLabel) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(scanByLabelProgram);
     ASSERT_TRUE(module);
@@ -966,6 +976,42 @@ TEST_F(DBDialectTest, edgesByTypeRoundTripThroughTextualForm) {
 
     // Printing then re-parsing yields a module that still verifies, so the
     // by-type edge op printers and parsers are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, parsesScanEdges) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(scanEdgesProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::ScanEdges scan;
+    module.get().walk([&](mlir::db::ScanEdges op) {
+        scan = op;
+    });
+    ASSERT_TRUE(scan);
+
+    // The four results are the source node, the edge, its type and the target
+    // node - the same shape and order db.get_out_edges exposes.
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Type edgeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::EdgeIDType::get(&_context));
+    const mlir::Type edgeTypeColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::EdgeTypeIDType::get(&_context));
+    EXPECT_EQ(scan.getSrcids().getType(), nodeIDColumnType);
+    EXPECT_EQ(scan.getEids().getType(), edgeIDColumnType);
+    EXPECT_EQ(scan.getEtypes().getType(), edgeTypeColumnType);
+    EXPECT_EQ(scan.getTgtids().getType(), nodeIDColumnType);
+}
+
+TEST_F(DBDialectTest, scanEdgesRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(scanEdgesProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.scan_edges printer and parser are inverses.
     std::string printed;
     llvm::raw_string_ostream stream(printed);
     module.get().print(stream);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -383,6 +383,17 @@ func.func @main() {
 }
 )mlir";
 
+// Scan every edge in the graph and output (source, target) pairs. Unlike the
+// one-hop program there is no scan_nodes then get_out_edges: db.scan_edges
+// yields the whole edge set directly, so the pairs are exactly the graph's edges.
+constexpr const char* scanEdgesProgram = R"mlir(
+func.func @main() {
+  %srcs, %eids, %etypes, %tgts = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // Two hops a->b->c carrying a through the second hop, outputting (a, c) pairs
 constexpr const char* twoHopProgram = R"mlir(
 func.func @main() {
@@ -1459,6 +1470,22 @@ TEST_F(DBLoweringTest, executesGetOutEdgesByTypeAcrossChunks) {
     runLoweredProgram(oneHopOutByTypeKnowsProgram, reader.getView(), sink, /*chunkSize=*/1);
 
     const std::vector<std::vector<uint64_t>> expected {{0, 1}, {1, 2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersScanEdges) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(scanEdgesProgram, reader.getView(), sink);
+
+    // db.scan_edges yields every edge, so the (source, target) pairs are exactly
+    // the diamond's four edges - the same set the one-hop out-edges program finds.
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}, {0, 2}, {1, 3}, {2, 3}};
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -435,4 +435,28 @@ TEST_F(NLDialectTest, getOutEdgesByTypeInfersEdgeIterator) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
 }
 
+// nl.scan_edges infers a four-chunk edge iterator - source node IDs, edge IDs,
+// edge type IDs and target node IDs - the same chunk shape nl.get_out_edges
+// produces, since a full edge scan opens the dataflow with no input or carry set.
+TEST_F(NLDialectTest, scanEdgesInfersEdgeIterator) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    mlir::nl::ScanEdges scan = builder.create<mlir::nl::ScanEdges>(loc);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    const mlir::Type nodeChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Type edgeChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::EdgeIDType::get(&_context));
+    const mlir::Type edgeTypeChunk = mlir::nl::ChunkType::get(&_context, mlir::storage::EdgeTypeIDType::get(&_context));
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {nodeChunk, edgeChunk, edgeTypeChunk, nodeChunk});
+
+    EXPECT_EQ(scan.getResult().getType(), iteratorType);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+}
+
 }


### PR DESCRIPTION
Implement a scan_edges operation in the db and nl dialects