### PR TITLE
MLIR: Implement inline node and edge property filters

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -590,6 +590,12 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
         return;
     }
 
+    // Reused across iterations
+    std::vector<const Expr*> constraintExprs;
+    llvm::SmallVector<mlir::Value> columnsToFilter;
+    llvm::SmallVector<const VariableDependency*> orderedVars;
+    llvm::SmallVector<mlir::Type> resultTypes;
+
     for (const Stmt* stmt : stmtsContainer->stmts()) {
         if (stmt->getKind() != Stmt::Kind::MATCH) {
             continue;
@@ -601,7 +607,7 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
         // Collect all property constraint expressions from every entity pattern
         // in this MATCH. Each EntityPropertyConstraint._expr is a synthesized
         // equality BinaryExpr (e.g. n.name = "Alice") produced by the analyzer.
-        std::vector<const Expr*> constraintExprs;
+        constraintExprs.clear();
 
         for (const PatternElement* element : pattern->elements()) {
             const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
@@ -650,8 +656,8 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             }
         }
 
-        llvm::SmallVector<mlir::Value> columnsToFilter;
-        llvm::SmallVector<const VariableDependency*> orderedVars;
+        columnsToFilter.clear();
+        orderedVars.clear();
         for (auto& [var, values] : _varMap) {
             columnsToFilter.push_back(values.back());
             orderedVars.push_back(var);
@@ -661,13 +667,15 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             continue;
         }
 
-        llvm::SmallVector<mlir::Type> resultTypes;
+        resultTypes.clear();
         for (const mlir::Value column : columnsToFilter) {
             resultTypes.push_back(column.getType());
         }
 
-        auto filterOp = _opBuilder.create<mlir::db::FilterOp>(
-            loc, resultTypes, combinedPredicate, columnsToFilter);
+        auto filterOp = _opBuilder.create<mlir::db::FilterOp>(loc,
+                                                              resultTypes,
+                                                              combinedPredicate,
+                                                              columnsToFilter);
 
         for (size_t index = 0; index < orderedVars.size(); index++) {
             const VariableDependency* var = orderedVars[index];

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -30,10 +30,12 @@
 
 #include "CypherAST.h"
 #include "Pattern.h"
+#include "PatternElement.h"
 #include "Projection.h"
 #include "QueryCommand.h"
 #include "SinglePartQuery.h"
 #include "WhereClause.h"
+#include "decl/PatternData.h"
 #include "decl/VarDecl.h"
 #include "Literal.h"
 #include "expr/BinaryExpr.h"
@@ -195,6 +197,7 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
     }
 
     generateTraversal(ast);
+    generatePropertyConstraints(ast);
     generateFilters(ast);
     generateOutput(ast);
 
@@ -567,6 +570,110 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
 
     const mlir::Location loc = _opBuilder.getUnknownLoc();
     _opBuilder.create<mlir::db::Output>(loc, mlir::ValueRange{outputted});
+}
+
+void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
+    const CypherAST::QueryCommands& queries = ast->queries();
+    if (queries.size() != 1) {
+        throw TuringException("Multiple queries not yet supported.");
+    }
+
+    const QueryCommand* query = queries.front();
+
+    const SinglePartQuery* sglPart = dynamic_cast<const SinglePartQuery*>(query);
+    if (!sglPart) {
+        return;
+    }
+
+    const StmtContainer* stmtsContainer = sglPart->getReadStmts();
+    if (!stmtsContainer) {
+        return;
+    }
+
+    for (const Stmt* stmt : stmtsContainer->stmts()) {
+        if (stmt->getKind() != Stmt::Kind::MATCH) {
+            continue;
+        }
+
+        const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
+        const Pattern* pattern = matchStmt->getPattern();
+
+        // Collect all property constraint expressions from every entity pattern
+        // in this MATCH. Each EntityPropertyConstraint._expr is a synthesized
+        // equality BinaryExpr (e.g. n.name = "Alice") produced by the analyzer.
+        std::vector<const Expr*> constraintExprs;
+
+        for (const PatternElement* element : pattern->elements()) {
+            const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
+            const NodePatternData* rootData = rootNode->getData();
+
+            if (rootData) {
+                for (const EntityPropertyConstraint& constraint : rootData->exprConstraints()) {
+                    constraintExprs.push_back(constraint._expr);
+                }
+            }
+
+            for (auto [edgePattern, nodePattern] : element->getElementChain()) {
+                const EdgePatternData* edgeData = edgePattern->getData();
+                if (edgeData) {
+                    for (const EntityPropertyConstraint& constraint : edgeData->exprConstraints()) {
+                        constraintExprs.push_back(constraint._expr);
+                    }
+                }
+
+                const NodePatternData* nodeData = nodePattern->getData();
+                if (nodeData) {
+                    for (const EntityPropertyConstraint& constraint : nodeData->exprConstraints()) {
+                        constraintExprs.push_back(constraint._expr);
+                    }
+                }
+            }
+        }
+
+        if (constraintExprs.empty()) {
+            continue;
+        }
+
+        const mlir::Location loc = _opBuilder.getUnknownLoc();
+        const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+
+        // Fold left on all expressions, combining with AND
+        mlir::Value combinedPredicate;
+        for (const Expr* constraintExpr : constraintExprs) {
+            translateExpr(constraintExpr);
+            const mlir::Value predicate = _exprMap.at(constraintExpr);
+
+            if (!combinedPredicate) {
+                combinedPredicate = predicate;
+            } else {
+                combinedPredicate = _opBuilder.create<mlir::db::AndOp>(loc, boolType, combinedPredicate, predicate).getResult();
+            }
+        }
+
+        llvm::SmallVector<mlir::Value> columnsToFilter;
+        llvm::SmallVector<const VariableDependency*> orderedVars;
+        for (auto& [var, values] : _varMap) {
+            columnsToFilter.push_back(values.back());
+            orderedVars.push_back(var);
+        }
+
+        if (columnsToFilter.empty()) {
+            continue;
+        }
+
+        llvm::SmallVector<mlir::Type> resultTypes;
+        for (const mlir::Value column : columnsToFilter) {
+            resultTypes.push_back(column.getType());
+        }
+
+        auto filterOp = _opBuilder.create<mlir::db::FilterOp>(
+            loc, resultTypes, combinedPredicate, columnsToFilter);
+
+        for (size_t index = 0; index < orderedVars.size(); index++) {
+            const VariableDependency* var = orderedVars[index];
+            _varMap.at(var).push_back(filterOp.getResult(index));
+        }
+    }
 }
 
 void DBProgramGenerator::generateFilters(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -81,6 +81,7 @@ private:
 
     void generateOutput(const CypherAST* ast);
 
+    void generatePropertyConstraints(const CypherAST* ast);
     void generateFilters(const CypherAST* ast);
 
     void translateExpr(const Expr* expr);

--- a/samples/mlir/complex_predicates.mlir
+++ b/samples/mlir/complex_predicates.mlir
@@ -1,0 +1,27 @@
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %17 = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %17 : !db.column<!storage.node_id>
+  } factor {
+    %17 = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %17 : !db.column<!storage.node_id>
+  }
+  %1 = db.get_node_properties(%0#0, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.constant("Cyrus" : !storage.string)
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %4 = db.get_node_properties(%0#1, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %5 = db.get_node_properties(%0#0, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %6 = db.eq %4, %5 : (!db.column<none>, !db.column<none>) -> !db.column<!storage.bool>
+  %7 = db.and %3, %6 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %8 = db.get_node_properties(%0#1, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %9 = db.constant(32 : i64)
+  %10 = db.eq %8, %9 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %11 = db.and %7, %10 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %12:2 = db.filter(%11, {%0#1, %0#0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %13 = db.get_node_properties(%12#1, "isFrench") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %14 = db.get_node_properties(%12#0, "isFrench") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %15 = db.eq %13, %14 : (!db.column<none>, !db.column<none>) -> !db.column<!storage.bool>
+  %16:2 = db.filter(%15, {%12#0, %12#1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%16#1) : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/complex_predicates.nl.mlir
+++ b/samples/mlir/complex_predicates.nl.mlir
@@ -1,0 +1,30 @@
+func.func @main() {
+  %0 = nl.get_property_type("isFrench")
+  %1 = nl.constant(32 : i64)
+  %2 = nl.get_property_type("age")
+  %3 = nl.constant("Cyrus" : !storage.string)
+  %4 = nl.get_property_type("name")
+  %5 = nl.scan_nodes()
+  nl.for %arg0 in %5 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %6 = nl.scan_nodes()
+    nl.for %arg1 in %6 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %7:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      %8 = nl.get_node_properties(%7#0, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+      %9 = nl.eq %8, %3 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+      %10 = nl.get_node_properties(%7#1, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+      %11 = nl.get_node_properties(%7#0, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+      %12 = nl.eq %10, %11 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.chunk<!storage.nullable<i1>>
+      %13 = nl.and %9, %12 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+      %14 = nl.get_node_properties(%7#1, %2) : !nl.chunk<!storage.nullable<i64>>
+      %15 = nl.eq %14, %1 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+      %16 = nl.and %13, %15 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+      %17:2 = nl.filter %16, (%7#1, %7#0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+      %18 = nl.get_node_properties(%17#1, %0) : !nl.chunk<!storage.nullable<i1>>
+      %19 = nl.get_node_properties(%17#0, %0) : !nl.chunk<!storage.nullable<i1>>
+      %20 = nl.eq %18, %19 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+      %21:2 = nl.filter %20, (%17#0, %17#1) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+      nl.output(%21#1) : !nl.chunk<!storage.node_id>
+    }
+  }
+  return
+}

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -398,6 +398,35 @@ TEST_F(EquivalenceTest, inlineEdgePropertyConstraints) {
     // expectEquivalent("MATCH (a {name: 'Remy'})-[e {duration: 20}]->(b) RETURN b");
 }
 
+TEST_F(EquivalenceTest, arbitraryFilters) {
+    expectEquivalent("MATCH (a{age:32})-->(b{age:32}) WHERE a.isFrench RETURN a, b");
+
+    expectEquivalent("MATCH (a {age: 32})-->(b) WHERE a.hasPhD RETURN a, b");
+    expectEquivalent("MATCH (a {isFrench: true})-->(b) WHERE a.hasPhD RETURN a, b");
+    expectEquivalent("MATCH (a {isFrench: false})-->(b) WHERE NOT a.hasPhD RETURN a, b");
+
+    expectEquivalent("MATCH (a)-[e {duration: 20}]->(b) WHERE a.isFrench RETURN a, b");
+    expectEquivalent("MATCH (a)-[e {duration: 20}]->(b) WHERE a.hasPhD RETURN a, b");
+
+    expectEquivalent("MATCH (a {hasPhD: true})-[e {duration: 20}]->(b) WHERE a.isFrench RETURN a, b");
+    expectEquivalent("MATCH (a {age: 32})-[e {duration: 20}]->(b) WHERE a.isFrench RETURN a, b");
+
+    expectEquivalent("MATCH (a)-->(b {isReal: true}) WHERE a.isFrench RETURN a, b");
+    expectEquivalent("MATCH (a)-->(b {isReal: false}) WHERE a.hasPhD RETURN a, b");
+
+    expectEquivalent("MATCH (a {isFrench: true})-->(b)-->(c) WHERE a.hasPhD RETURN a, c");
+    expectEquivalent("MATCH (a {age: 32})-->(b)-->(c) WHERE a.isFrench RETURN a, b, c");
+
+    expectEquivalent("MATCH (a {isFrench: true}), (b {isFrench: false}) RETURN a, b");
+    expectEquivalent("MATCH (a {isFrench: true}), (b {hasPhD: false}) RETURN a, b");
+
+    expectEquivalent("MATCH (a {isFrench: true}), (b {isFrench: false}) WHERE a.hasPhD RETURN a, b");
+    expectEquivalent("MATCH (a {age: 32}), (b {isFrench: false}) WHERE b.hasPhD RETURN a, b");
+
+    expectEquivalent("MATCH (a {isFrench: true})-->(b), (c {hasPhD: false}) WHERE a.hasPhD RETURN a, b, c");
+    expectEquivalent("MATCH (a {age: 32})-->(b), (c {isFrench: false}) WHERE a.isFrench RETURN a, c");
+}
+
 TEST_F(EquivalenceTest, constants) {
     expectEquivalent("RETURN 5");
     expectEquivalent("RETURN 5 + 10");

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -356,6 +356,48 @@ TEST_F(EquivalenceTest, eqFilters) {
     expectEquivalent("MATCH (n)-[e]->(m) WHERE e.duration = 10 + 10 return m");
 }
 
+// FIXME: Enable commented tests below once string literals are supported
+TEST_F(EquivalenceTest, inlineNodePropertyConstraints) {
+    // Single string constraint — exactly one person named Remy.
+    // expectEquivalent("MATCH (n {name: 'Remy'}) RETURN n");
+
+    // Integer constraint — both Remy and Adam have age 32.
+    expectEquivalent("MATCH (n {age: 32}) RETURN n");
+
+    // Bool constraint — several Person nodes have isFrench = true.
+    expectEquivalent("MATCH (n {isFrench: true}) RETURN n");
+
+    // Multiple constraints ANDed — only Maxime is French with no PhD.
+    expectEquivalent("MATCH (n {isFrench: true, hasPhD: false}) RETURN n");
+
+    // Constraint that matches no node in the graph.
+    // expectEquivalent("MATCH (n {name: 'Nobody'}) RETURN n");
+
+    // Constraint on the source of a traversal.
+    // expectEquivalent("MATCH (a {name: 'Remy'})-->(b) RETURN b");
+
+    // Constraint on the target of a traversal.
+    // expectEquivalent("MATCH (a)-->(b {name: 'Bio'}) RETURN a");
+
+    // Constraints on both endpoints of a traversal.
+    // expectEquivalent("MATCH (a {isFrench: true})-->(b {name: 'Bio'}) RETURN a");
+}
+
+// FIXME: Enable commented tests below once string literals are supported
+TEST_F(EquivalenceTest, inlineEdgePropertyConstraints) {
+    // Integer edge property constraint.
+    expectEquivalent("MATCH (a)-[e {duration: 20}]->(b) RETURN a, b");
+
+    // String edge property constraint — only expert edges.
+    // expectEquivalent("MATCH (a)-[e {proficiency: 'expert'}]->(b) RETURN a, b");
+
+    // Edge constraint that matches no edge in the graph.
+    expectEquivalent("MATCH (a)-[e {duration: 999}]->(b) RETURN a, b");
+
+    // Combined node and edge constraints.
+    // expectEquivalent("MATCH (a {name: 'Remy'})-[e {duration: 20}]->(b) RETURN b");
+}
+
 TEST_F(EquivalenceTest, constants) {
     expectEquivalent("RETURN 5");
     expectEquivalent("RETURN 5 + 10");


### PR DESCRIPTION
`DBProgramGenerator` now generates filters for inline property constraints: `MATCH (n{age:10} ... `