### PR TITLE
MLIR: Implement String, NULL, and Embedding literals

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -810,6 +810,43 @@ mlir::Value DBProgramGenerator::translateLiteralExpr(const Literal* literal) {
             valueAttr = _opBuilder.getF64FloatAttr(doubleLiteral->getValue());
         }
         break;
+
+        case Literal::Kind::STRING: {
+            const StringLiteral* stringLiteral = static_cast<const StringLiteral*>(literal);
+            const mlir::Type stringType = mlir::storage::StringType::get(_mlirCtxt);
+            valueAttr = mlir::StringAttr::get(stringLiteral->getValue(), stringType);
+        }
+        break;
+
+        case Literal::Kind::EMBEDDING: {
+            const EmbeddingLiteral* embeddingLiteral = static_cast<const EmbeddingLiteral*>(literal);
+            const std::span<const float> floats = embeddingLiteral->getValue();
+            const mlir::FloatType f32Type = _opBuilder.getF32Type();
+            const size_t size = floats.size();
+
+            const mlir::RankedTensorType tensorType = mlir::RankedTensorType::get(size, f32Type);
+
+            const auto* bytes = reinterpret_cast<const char*>(floats.data());
+            const size_t numBytes = size * sizeof(float);
+
+            const llvm::ArrayRef<char> rawBytes {bytes, numBytes};
+
+            const mlir::TypedAttr embAttr = mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawBytes);
+            const mlir::db::ColumnType embResultType = allocColumnType(mlir::storage::EmbeddingType::get(_mlirCtxt));
+            return _opBuilder.create<mlir::db::ConstantOp>(uloc, embResultType, embAttr).getResult();
+        }
+        break;
+
+        case Literal::Kind::NULL_LITERAL: {
+            const mlir::Type nullableType = mlir::storage::NullableType::get(
+                _mlirCtxt, mlir::NoneType::get(_mlirCtxt));
+            valueAttr = mlir::StringAttr::get("", nullableType);
+        }
+        break;
+        case Literal::Kind::LIST:
+            throw FatalException("List literals are not yet supported in MLIR codegen.");
+        break;
+
         default:
             throw FatalException("Unsupported literal kind in WHERE clause expression.");
         break;

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -303,8 +303,19 @@ LogicalResult ConstantOp::inferReturnTypes(MLIRContext* context,
                                            SmallVectorImpl<Type>& inferredReturnTypes) {
     ConstantOpGenericAdaptor adaptor(operands, attributes, properties, regions);
     const mlir::TypedAttr typedValue = mlir::cast<mlir::TypedAttr>(adaptor.getValue());
-    inferredReturnTypes.emplace_back(
-        mlir::db::ColumnType::get(context, typedValue.getType()));
+
+    mlir::Type elementType;
+    if (const auto elements = mlir::dyn_cast<mlir::DenseElementsAttr>(typedValue)) {
+        const auto shapedType = mlir::cast<mlir::ShapedType>(elements.getType());
+        const bool isEmbedding = shapedType.getElementType().isF32()
+                                 && shapedType.hasRank()
+                                 && shapedType.getRank() == 1;
+        elementType = isEmbedding ? storage::EmbeddingType::get(context) : typedValue.getType();
+    } else {
+        elementType = typedValue.getType();
+    }
+
+    inferredReturnTypes.emplace_back(mlir::db::ColumnType::get(context, elementType));
     return mlir::success();
 }
 

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -168,7 +168,19 @@ LogicalResult Constant::inferReturnTypes(MLIRContext* context,
                                          Constant::Adaptor adaptor,
                                          SmallVectorImpl<Type>& inferredReturnTypes) {
     const TypedAttr value = cast<TypedAttr>(adaptor.getValue());
-    inferredReturnTypes.push_back(ChunkType::get(context, value.getType()));
+
+    Type elementType;
+    if (const auto elements = dyn_cast<DenseElementsAttr>(value)) {
+        const auto shapedType = cast<ShapedType>(elements.getType());
+        const bool isEmbedding = shapedType.getElementType().isF32()
+                                 && shapedType.hasRank()
+                                 && shapedType.getRank() == 1;
+        elementType = isEmbedding ? storage::EmbeddingType::get(context) : value.getType();
+    } else {
+        elementType = value.getType();
+    }
+
+    inferredReturnTypes.push_back(ChunkType::get(context, elementType));
     return success();
 }
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -12,6 +12,7 @@
 #include "columns/ColumnConst.h"
 #include "columns/ColumnOptVector.h"
 #include "metadata/GraphMetadata.h"
+#include "metadata/PropertyNull.h"
 #include "metadata/PropertyType.h"
 #include "views/GraphView.h"
 
@@ -97,7 +98,16 @@ typename T::Primitive constantValueAs(mlir::TypedAttr value) {
         return mlir::cast<mlir::FloatAttr>(value).getValueAsDouble();
     } else if constexpr (std::same_as<T, types::Bool>) {
         return CustomBool(mlir::cast<mlir::IntegerAttr>(value).getInt() != 0);
-    } else { // string and embedding not yet supported
+    } else if constexpr (std::same_as<T, types::String>) {
+        return mlir::cast<mlir::StringAttr>(value).getValue();
+    } else if constexpr (std::same_as<T, types::Embedding>) {
+        const auto elements = mlir::cast<mlir::DenseElementsAttr>(value);
+        const llvm::ArrayRef<char> rawData = elements.getRawData();
+        return std::span<const float>{
+            reinterpret_cast<const float*>(rawData.data()),
+            rawData.size() / sizeof(float)
+        };
+    } else {
         throw IRException("Unsupported constant value type");
     }
 }
@@ -574,7 +584,16 @@ void NLTranslator::translateConstant(nl::Constant constant) {
     const mlir::TypedAttr value = mlir::cast<mlir::TypedAttr>(constant.getValue());
     const mlir::TypedValue<mlir::nl::ChunkType> res = constant.getResult();
     const auto chunkType = mlir::cast<nl::ChunkType>(res.getType());
-    const ValueType valueType = valueTypeFromElementType(chunkType.getElementType());
+    const mlir::Type elementType = chunkType.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (mlir::isa<mlir::NoneType>(nullableType.getValueType())) {
+            _valueSlots[res] = _memory->alloc<ColumnConst<PropertyNull>>();
+            return;
+        }
+    }
+
+    const ValueType valueType = valueTypeFromElementType(elementType);
 
     Column* column = nullptr;
     const auto materialize = [&]<SupportedType T>() {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -101,12 +101,12 @@ typename T::Primitive constantValueAs(mlir::TypedAttr value) {
     } else if constexpr (std::same_as<T, types::String>) {
         return mlir::cast<mlir::StringAttr>(value).getValue();
     } else if constexpr (std::same_as<T, types::Embedding>) {
-        const auto elements = mlir::cast<mlir::DenseElementsAttr>(value);
-        const llvm::ArrayRef<char> rawData = elements.getRawData();
-        return std::span<const float>{
-            reinterpret_cast<const float*>(rawData.data()),
-            rawData.size() / sizeof(float)
-        };
+        const mlir::DenseElementsAttr elements =
+            mlir::cast<mlir::DenseElementsAttr>(value);
+        const llvm::ArrayRef<char> rawBytes = elements.getRawData();
+        const float* floats = reinterpret_cast<const float*>(rawBytes.data());
+        const size_t size = rawBytes.size() / sizeof(float);
+        return std::span<const float>{floats, size};
     } else {
         throw IRException("Unsupported constant value type");
     }

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -325,4 +325,8 @@ TEST_F(EquivalenceTest, constants) {
     expectEquivalent("RETURN 5 + 10");
     expectEquivalent("RETURN 5 - 3");
     expectEquivalent("RETURN 5 * 3");
+
+    expectEquivalent("RETURN 'hello'");
+    expectEquivalent("RETURN (1, 2, 3)");
+    expectEquivalent("RETURN null");
 }

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -42,6 +42,7 @@
 #include "columns/ColumnOptVector.h"
 #include "dataframe/Dataframe.h"
 #include "dataframe/NamedColumn.h"
+#include "metadata/PropertyNull.h"
 #include "versioning/Transaction.h"
 #include "views/GraphView.h"
 
@@ -92,6 +93,38 @@ bool renderValueCell(const Column* column, size_t row, std::string& out) {
     return true;
 }
 
+bool renderEmbeddingCell(const Column* column, size_t row, std::string& out) {
+    const auto renderSpan = [](std::span<const float> floats, std::string& target) {
+        target = "[";
+        for (size_t i = 0; i < floats.size(); i++) {
+            if (i > 0) {
+                target += ", ";
+            }
+            target += std::to_string(floats[i]);
+        }
+        target += "]";
+    };
+
+    if (const auto* constCol = dynamic_cast<const ColumnConst<std::span<const float>>*>(column)) {
+        renderSpan(constCol->at(0), out);
+        return true;
+    }
+
+    const auto* values = dynamic_cast<const ColumnOptVector<std::span<const float>>*>(column);
+    if (!values) {
+        return false;
+    }
+
+    const std::optional<std::span<const float>> value = (*values)[row];
+    if (!value) {
+        out = "null";
+        return true;
+    }
+
+    renderSpan(*value, out);
+    return true;
+}
+
 void renderCell(const Column* column, size_t row, std::string& out) {
     if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
         out = std::to_string((*nodeIDs)[row].getValue());
@@ -99,11 +132,14 @@ void renderCell(const Column* column, size_t row, std::string& out) {
         out = std::to_string((*edgeIDs)[row].getValue());
     } else if (const auto* edgeTypes = dynamic_cast<const ColumnEdgeTypes*>(column)) {
         out = std::to_string((*edgeTypes)[row].getValue());
+    } else if (dynamic_cast<const ColumnConst<PropertyNull>*>(column)) {
+        out = "null";
     } else if (renderValueCell<int64_t>(column, row, out)
                || renderValueCell<uint64_t>(column, row, out)
                || renderValueCell<double>(column, row, out)
-               || renderValueCell<std::string_view>(column, row, out)) {
-        // Rendered by the helper for whichever nullable value type matched
+               || renderValueCell<std::string_view>(column, row, out)
+               || renderEmbeddingCell(column, row, out)) {
+        // Rendered by the helper for whichever value type matched
     } else {
         throw std::runtime_error("EquivalenceTest: unsupported output column type");
     }


### PR DESCRIPTION
Generate string, null and embedding literals from a Cypher query, into a `db.constant` op