### PR TITLE
MLIR: implement const_scan_nodes in db and nl dialects

### DIFF
--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -222,17 +222,6 @@ LogicalResult ScanNodesByLabel::verify() {
     return success();
 }
 
-// A const scan must name at least one node ID. An empty set opens no dataflow and
-// yields no row, so - like an empty db.scan_nodes_by_label - it is malformed IR
-// here rather than a scan that silently produces nothing.
-LogicalResult ConstScanNodes::verify() {
-    if (getNodeIDs().empty()) {
-        return emitOpError("requires at least one node ID");
-    }
-
-    return success();
-}
-
 // db.limit passes its columns straight through, so the results must be exactly
 // the input columns - same count, same types and in the same order.
 LogicalResult Limit::verify() {

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -222,6 +222,17 @@ LogicalResult ScanNodesByLabel::verify() {
     return success();
 }
 
+// A const scan must name at least one node ID. An empty set opens no dataflow and
+// yields no row, so - like an empty db.scan_nodes_by_label - it is malformed IR
+// here rather than a scan that silently produces nothing.
+LogicalResult ConstScanNodes::verify() {
+    if (getNodeIDs().empty()) {
+        return emitOpError("requires at least one node ID");
+    }
+
+    return success();
+}
+
 // db.limit passes its columns straight through, so the results must be exactly
 // the input columns - same count, same types and in the same order.
 LogicalResult Limit::verify() {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -84,16 +84,15 @@ def ConstScanNodes : TuringOp<"const_scan_nodes", [Pure]> {
     the index list db.sort carries; each entry is a storage NodeID once lowered.
     A listed ID that names no node in the graph matches nothing, so it is dropped
     during lowering and the scan yields only the nodes that exist - the same
-    set-membership semantics as the WHERE id(n) IN ... it models. The list must
-    not be empty: an empty set opens no dataflow, so a scan that can never produce
-    a row is malformed IR here rather than a silent no-op.
+    set-membership semantics as the WHERE id(n) IN ... it models. A list whose IDs
+    are all absent, or an empty list, simply yields no row - not an error, matching
+    that same set-membership.
   }];
 
   // `nodeIDs` is the constant set of node IDs to emit. Being an attribute and not
   // an SSA value, it is absent from `operands`; lowering forwards it as-is.
   let arguments = (ins DenseI64ArrayAttr:$nodeIDs);
   let results   = (outs ColumnNodeIDs:$result);
-  let hasVerifier = 1;
 
   // The node ID list prints inside the parens as `[0, 3, 7]`, ahead of the colon,
   // the same place db.scan_nodes_by_label prints its labels; the result type

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -82,8 +82,11 @@ def ConstScanNodes : TuringOp<"const_scan_nodes", [Pure]> {
 
     A node ID is a non-negative handle, so the signless i64 dense array matches
     the index list db.sort carries; each entry is a storage NodeID once lowered.
-    The list must not be empty: an empty set opens no dataflow, so a scan that can
-    never produce a row is malformed IR here rather than a silent no-op.
+    A listed ID that names no node in the graph matches nothing, so it is dropped
+    during lowering and the scan yields only the nodes that exist - the same
+    set-membership semantics as the WHERE id(n) IN ... it models. The list must
+    not be empty: an empty set opens no dataflow, so a scan that can never produce
+    a row is malformed IR here rather than a silent no-op.
   }];
 
   // `nodeIDs` is the constant set of node IDs to emit. Being an attribute and not

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -60,6 +60,45 @@ def ScanNodesByLabel : TuringOp<"scan_nodes_by_label", [Pure]> {
 }
 
 /**
+* ConstScanNodes
+*/
+def ConstScanNodes : TuringOp<"const_scan_nodes", [Pure]> {
+  let summary = "Produce a fixed, explicitly listed set of nodes";
+
+  let description = [{
+    The constant-set counterpart of db.scan_nodes: where that produces every node
+    in the graph, this produces exactly the nodes whose IDs are listed on the op -
+    a set known at plan time rather than discovered by walking the graph:
+
+      %a = db.const_scan_nodes([0, 3, 7]) : !db.column<!storage.node_id>
+
+    It seeds a dataflow from a known set of nodes - the declarative counterpart of
+    the plan's ConstScanNode, which turns a node-ID membership predicate
+    (MATCH (n) WHERE id(n) IN [0, 3, 7]) into a direct scan of those IDs rather
+    than a full scan followed by a filter. Like db.scan_nodes it reads no column
+    and takes no input, so it opens a dataflow rather than consuming one; the IDs
+    are emitted in the order listed. Producing a fixed list is deterministic, so
+    the op is Pure.
+
+    A node ID is a non-negative handle, so the signless i64 dense array matches
+    the index list db.sort carries; each entry is a storage NodeID once lowered.
+    The list must not be empty: an empty set opens no dataflow, so a scan that can
+    never produce a row is malformed IR here rather than a silent no-op.
+  }];
+
+  // `nodeIDs` is the constant set of node IDs to emit. Being an attribute and not
+  // an SSA value, it is absent from `operands`; lowering forwards it as-is.
+  let arguments = (ins DenseI64ArrayAttr:$nodeIDs);
+  let results   = (outs ColumnNodeIDs:$result);
+  let hasVerifier = 1;
+
+  // The node ID list prints inside the parens as `[0, 3, 7]`, ahead of the colon,
+  // the same place db.scan_nodes_by_label prints its labels; the result type
+  // follows, qualified, as db.scan_nodes prints it.
+  let assemblyFormat = "`(` $nodeIDs `)` attr-dict `:` qualified(type($result))";
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : TuringOp<"scan_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -94,6 +94,17 @@ LogicalResult ScanNodesByLabel::inferReturnTypes(MLIRContext* context,
     return success();
 }
 
+// A const scan emits a fixed set of node IDs, but its row shape is a plain node
+// scan's, so it produces the same single chunk of node IDs per step - the ID list
+// is which rows are emitted, not a result type.
+LogicalResult ConstScanNodes::inferReturnTypes(MLIRContext* context,
+                                               std::optional<Location> location,
+                                               ConstScanNodes::Adaptor adaptor,
+                                               SmallVectorImpl<Type>& inferredReturnTypes) {
+    inferredReturnTypes.push_back(IteratorType::get(context, {getNodeIDChunkType(context)}));
+    return success();
+}
+
 // An edge scan produces the same four fixed edge chunks per step as an
 // out-edges fetch, but reads no input and carries nothing, so the iterator has
 // exactly those four chunks and no carried tail.

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -48,6 +48,28 @@ def ScanNodesByLabel : NLOp<"scan_nodes_by_label", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* ConstScanNodes
+*/
+def ConstScanNodes : NLOp<"const_scan_nodes", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Create a database iterator over a fixed, explicitly listed set of nodes";
+  let description = [{
+    Imperative counterpart of db.const_scan_nodes. Each step of an enclosing
+    nl.for fills one chunk of the node IDs listed in `nodeIDs`:
+
+      %nodes = nl.const_scan_nodes([0, 3, 7])
+
+    `nodeIDs` is the same constant list db.const_scan_nodes carried; translation
+    resolves each entry to a storage NodeID. Emitting a known set needs no graph
+    walk, but it narrows only which rows are produced, never their shape, so -
+    like nl.scan_nodes - the result is always
+    !nl.iter<!nl.chunk<!storage.node_id>> and is inferred, not spelled out.
+  }];
+  let arguments = (ins DenseI64ArrayAttr:$nodeIDs);
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(` $nodeIDs `)` attr-dict";
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : NLOp<"scan_edges", [Pure, InferTypeOpAdaptor]> {

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -59,9 +59,9 @@ def ConstScanNodes : NLOp<"const_scan_nodes", [Pure, InferTypeOpAdaptor]> {
       %nodes = nl.const_scan_nodes([0, 3, 7])
 
     `nodeIDs` is the same constant list db.const_scan_nodes carried; translation
-    resolves each entry to a storage NodeID. Emitting a known set needs no graph
-    walk, but it narrows only which rows are produced, never their shape, so -
-    like nl.scan_nodes - the result is always
+    resolves each entry to a storage NodeID, dropping any that name no node in the
+    graph. Emitting a known set needs no graph walk, but it narrows only which rows
+    are produced, never their shape, so - like nl.scan_nodes - the result is always
     !nl.iter<!nl.chunk<!storage.node_id>> and is inferred, not spelled out.
   }];
   let arguments = (ins DenseI64ArrayAttr:$nodeIDs);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <span>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -1036,6 +1037,47 @@ void NLExecutor::runScanNodesByLabelLoop(NLExecutionContext* context, NLFunction
         }
     } else {
         while (chunkWriter.isValid()) {
+            runIteration();
+        }
+    }
+}
+
+void NLExecutor::runConstScanNodesLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLConstScanLoopData* loopData = static_cast<NLConstScanLoopData*>(data);
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    ColumnNodeIDs* nodeIDs = loopData->getNodeIDs();
+    const std::span<const NodeID> constNodeIDs = loopData->getConstNodeIDs();
+    const size_t chunkSize = context->getChunkSize();
+    const size_t totalCount = constNodeIDs.size();
+
+    // A null limit leaves the loop unbounded, exactly as in runScanNodesLoop.
+    const NLLimitState* limit = loopData->getLimit();
+
+    // Emit the fixed node ID list one chunk at a time: each step copies the next
+    // slice into the loop's node chunk and runs the body over it. The cursor is
+    // local to this call, so a const scan nested in a cross product restarts from
+    // the first ID on every outer step, the same way runScanNodesLoop opens a
+    // fresh chunk writer each call.
+    size_t cursor = 0;
+
+    const auto runIteration = [&]() {
+        const size_t remaining = totalCount - cursor;
+        const size_t rows = std::min(chunkSize, remaining);
+
+        std::vector<NodeID>& raw = nodeIDs->getRaw();
+        raw.assign(constNodeIDs.begin() + cursor, constNodeIDs.begin() + cursor + rows);
+
+        cursor += rows;
+
+        runBody(context, loopBody);
+    };
+
+    if (limit) {
+        while (cursor < totalCount && limit->getRemaining() > 0) {
+            runIteration();
+        }
+    } else {
+        while (cursor < totalCount) {
             runIteration();
         }
     }

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -46,6 +46,11 @@ public:
 
     static void runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runScanNodesByLabelLoop(NLExecutionContext* context, NLFunctionData* data);
+
+    // The fixed sibling of runScanNodesLoop: emit the loop data's constant node ID
+    // list one chunk at a time - no graph walk - running the body over each slice.
+    static void runConstScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -228,17 +228,23 @@ private:
 // nl.const_scan_nodes loop data: a node scan over a fixed, explicitly listed set
 // of node IDs rather than a walk of the graph. Reuses the plain scan's node chunk,
 // limit and body; adds the owned list of node IDs the loop emits, one chunk-sized
-// slice per step. The list is owned here so it outlives the op's attribute storage
-// (this data lives for the whole program).
+// slice per step. The translator fills the list in place through addNodeID after
+// allocating the data, so the resolved IDs are never staged in a temporary; the
+// list is owned here so it outlives the op's attribute storage (this data lives
+// for the whole program).
 class NLConstScanLoopData : public NLScanLoopData {
 public:
-    NLConstScanLoopData(ColumnNodeIDs* nodeIDs, const std::vector<NodeID>& constNodeIDs)
-        : NLScanLoopData(nodeIDs),
-        _constNodeIDs(constNodeIDs)
+    NLConstScanLoopData(ColumnNodeIDs* nodeIDs)
+        : NLScanLoopData(nodeIDs)
     {
     }
 
     std::span<const NodeID> getConstNodeIDs() const { return _constNodeIDs; }
+
+    // Reserve room for the resolved list, then append each valid ID in turn: the
+    // translator fills the list here directly rather than building and copying one.
+    void reserveNodeIDs(size_t count) { _constNodeIDs.reserve(count); }
+    void addNodeID(NodeID nodeID) { _constNodeIDs.push_back(nodeID); }
 
 private:
     std::vector<NodeID> _constNodeIDs;

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -3,6 +3,7 @@
 #include <stddef.h>
 #include <algorithm>
 #include <memory>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -222,6 +223,25 @@ public:
 private:
     LabelSet _labelset;
     bool _matchable {true};
+};
+
+// nl.const_scan_nodes loop data: a node scan over a fixed, explicitly listed set
+// of node IDs rather than a walk of the graph. Reuses the plain scan's node chunk,
+// limit and body; adds the owned list of node IDs the loop emits, one chunk-sized
+// slice per step. The list is owned here so it outlives the op's attribute storage
+// (this data lives for the whole program).
+class NLConstScanLoopData : public NLScanLoopData {
+public:
+    NLConstScanLoopData(ColumnNodeIDs* nodeIDs, const std::vector<NodeID>& constNodeIDs)
+        : NLScanLoopData(nodeIDs),
+        _constNodeIDs(constNodeIDs)
+    {
+    }
+
+    std::span<const NodeID> getConstNodeIDs() const { return _constNodeIDs; }
+
+private:
+    std::vector<NodeID> _constNodeIDs;
 };
 
 // nl.scan_edges loop data: the edge sibling of NLScanLoopData. A source loop

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -450,27 +450,26 @@ void NLTranslator::translateConstScanLoop(const IteratorConfig& config,
     const mlir::Value nodeChunk = loopBody.getArgument(0);
     ColumnNodeIDs* nodeIDs = static_cast<ColumnNodeIDs*>(allocColumn(nodeChunk));
 
-    // Resolve the constant i64 list into the NodeIDs the loop emits. A node ID is a
-    // non-negative handle stored signless, so each entry maps straight to a NodeID.
-    // A listed ID that names no node in the graph matches nothing, so it is dropped
-    // here rather than emitted - the same set-membership semantics as the pipeline's
+    NLConstScanLoopData* loopData = _program->allocFunctionData<NLConstScanLoopData>(nodeIDs);
+    loopData->setLimit(limit);
+
+    // Resolve the constant i64 list into the NodeIDs the loop emits, appending each
+    // straight into the loop data's owned list. A node ID is a non-negative handle
+    // stored signless, so each entry maps straight to a NodeID. A listed ID that
+    // names no node in the graph matches nothing, so it is dropped here rather than
+    // emitted - the same set-membership semantics as the pipeline's
     // ConstScanProcessor, and resolved once against the graph view (fixed for the
-    // whole run) the way the label scan resolves its LabelSet. The surviving IDs keep
-    // their listed order. The list is copied into the loop data so it outlives the
-    // op's attribute storage (the data lives for the whole program).
+    // whole run) the way the label scan resolves its LabelSet. The surviving IDs
+    // keep their listed order.
     const GraphReader reader = _view->read();
 
-    std::vector<NodeID> constNodeIDs;
-    constNodeIDs.reserve(config._nodeIDs.size());
+    loopData->reserveNodeIDs(config._nodeIDs.size());
     for (const int64_t nodeID : config._nodeIDs) {
         const NodeID candidate(static_cast<uint64_t>(nodeID));
         if (reader.graphHasNode(candidate)) {
-            constNodeIDs.emplace_back(candidate);
+            loopData->addNodeID(candidate);
         }
     }
-
-    NLConstScanLoopData* loopData = _program->allocFunctionData<NLConstScanLoopData>(nodeIDs, constNodeIDs);
-    loopData->setLimit(limit);
 
     body->emplaceStmt(&NLExecutor::runConstScanNodesLoop, loopData);
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -239,6 +239,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
                 config._labels.emplace_back(mlir::cast<mlir::StringAttr>(label).getValue());
             }
             _iteratorConfigs[scanNodesByLabel.getResult()] = config;
+        } else if (nl::ConstScanNodes constScanNodes = mlir::dyn_cast<nl::ConstScanNodes>(operation)) {
+            IteratorConfig config {IteratorKind::ConstScanNodes, {}, {}};
+            config._nodeIDs = constScanNodes.getNodeIDs();
+            _iteratorConfigs[constScanNodes.getResult()] = config;
         } else if (nl::ScanEdges scanEdges = mlir::dyn_cast<nl::ScanEdges>(operation)) {
             _iteratorConfigs[scanEdges.getResult()] = IteratorConfig {IteratorKind::ScanEdges, {}, {}};
         } else if (nl::GetOutEdges getOutEdges = mlir::dyn_cast<nl::GetOutEdges>(operation)) {
@@ -373,6 +377,8 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         translateScanLoop(loopBody, limit, body);
     } else if (config._kind == IteratorKind::ScanNodesByLabel) {
         translateScanByLabelLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::ConstScanNodes) {
+        translateConstScanLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::ScanEdges) {
         translateScanEdgesLoop(loopBody, limit, body);
     } else if (config._kind == IteratorKind::Sort) {
@@ -431,6 +437,32 @@ void NLTranslator::translateScanByLabelLoop(const IteratorConfig& config,
     loopData->setLimit(limit);
 
     body->emplaceStmt(&NLExecutor::runScanNodesByLabelLoop, loopData);
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+void NLTranslator::translateConstScanLoop(const IteratorConfig& config,
+                                          mlir::Block& loopBody,
+                                          NLLimitState* limit,
+                                          NLStmtContainer* body) {
+    // A const scan binds the same single node ID chunk as a plain scan.
+    const mlir::Value nodeChunk = loopBody.getArgument(0);
+    ColumnNodeIDs* nodeIDs = static_cast<ColumnNodeIDs*>(allocColumn(nodeChunk));
+
+    // Resolve the constant i64 list into the NodeIDs the loop emits. A node ID is a
+    // non-negative handle stored signless, so each entry maps straight to a NodeID.
+    // The list is copied into the loop data so it outlives the op's attribute
+    // storage (the data lives for the whole program).
+    std::vector<NodeID> constNodeIDs;
+    constNodeIDs.reserve(config._nodeIDs.size());
+    for (const int64_t nodeID : config._nodeIDs) {
+        constNodeIDs.emplace_back(static_cast<uint64_t>(nodeID));
+    }
+
+    NLConstScanLoopData* loopData = _program->allocFunctionData<NLConstScanLoopData>(nodeIDs, constNodeIDs);
+    loopData->setLimit(limit);
+
+    body->emplaceStmt(&NLExecutor::runConstScanNodesLoop, loopData);
 
     translateBlock(loopBody, loopData->getStmts());
 }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -14,6 +14,7 @@
 #include "metadata/GraphMetadata.h"
 #include "metadata/PropertyNull.h"
 #include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
 #include "views/GraphView.h"
 
 #include "NLExecutor.h"
@@ -451,12 +452,21 @@ void NLTranslator::translateConstScanLoop(const IteratorConfig& config,
 
     // Resolve the constant i64 list into the NodeIDs the loop emits. A node ID is a
     // non-negative handle stored signless, so each entry maps straight to a NodeID.
-    // The list is copied into the loop data so it outlives the op's attribute
-    // storage (the data lives for the whole program).
+    // A listed ID that names no node in the graph matches nothing, so it is dropped
+    // here rather than emitted - the same set-membership semantics as the pipeline's
+    // ConstScanProcessor, and resolved once against the graph view (fixed for the
+    // whole run) the way the label scan resolves its LabelSet. The surviving IDs keep
+    // their listed order. The list is copied into the loop data so it outlives the
+    // op's attribute storage (the data lives for the whole program).
+    const GraphReader reader = _view->read();
+
     std::vector<NodeID> constNodeIDs;
     constNodeIDs.reserve(config._nodeIDs.size());
     for (const int64_t nodeID : config._nodeIDs) {
-        constNodeIDs.emplace_back(static_cast<uint64_t>(nodeID));
+        const NodeID candidate(static_cast<uint64_t>(nodeID));
+        if (reader.graphHasNode(candidate)) {
+            constNodeIDs.emplace_back(candidate);
+        }
     }
 
     NLConstScanLoopData* loopData = _program->allocFunctionData<NLConstScanLoopData>(nodeIDs, constNodeIDs);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -453,14 +453,6 @@ void NLTranslator::translateConstScanLoop(const IteratorConfig& config,
     NLConstScanLoopData* loopData = _program->allocFunctionData<NLConstScanLoopData>(nodeIDs);
     loopData->setLimit(limit);
 
-    // Resolve the constant i64 list into the NodeIDs the loop emits, appending each
-    // straight into the loop data's owned list. A node ID is a non-negative handle
-    // stored signless, so each entry maps straight to a NodeID. A listed ID that
-    // names no node in the graph matches nothing, so it is dropped here rather than
-    // emitted - the same set-membership semantics as the pipeline's
-    // ConstScanProcessor, and resolved once against the graph view (fixed for the
-    // whole run) the way the label scan resolves its LabelSet. The surviving IDs
-    // keep their listed order.
     const GraphReader reader = _view->read();
 
     loopData->reserveNodeIDs(config._nodeIDs.size());

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -29,6 +29,7 @@ private:
     enum class IteratorKind {
         ScanNodes,
         ScanNodesByLabel,
+        ConstScanNodes,
         ScanEdges,
         GetOutEdges,
         GetInEdges,
@@ -62,6 +63,12 @@ private:
         // the whole translation; resolved to an EdgeTypeID when the loop is
         // translated.
         llvm::StringRef _edgeType;
+
+        // The node IDs a ConstScanNodes iterator emits; empty for the other kinds.
+        // A view into the op's DenseI64ArrayAttr storage, which the MLIRContext
+        // keeps alive for the whole translation; resolved to owned NodeIDs when the
+        // loop is translated.
+        llvm::ArrayRef<int64_t> _nodeIDs;
     };
 
     NLProgram* _program {nullptr};
@@ -112,6 +119,16 @@ private:
                                   mlir::Block& loopBody,
                                   NLLimitState* limit,
                                   NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.const_scan_nodes iterator: allocate the node
+    // loop variable, resolve the config's constant i64 list into the owned NodeIDs
+    // the loop emits, and record the const-scan loop statement in body. The fixed
+    // sibling of translateScanLoop - a source loop that emits a known set of node
+    // IDs rather than walking the graph.
+    void translateConstScanLoop(const IteratorConfig& config,
+                                mlir::Block& loopBody,
+                                NLLimitState* limit,
+                                NLStmtContainer* body);
 
     // Translate the nl.for over an nl.scan_edges iterator: allocate the four
     // fixed edge loop variables (sources, edge IDs, edge type IDs, targets) and

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -375,6 +375,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerScanNodes(scanNodes);
     } else if (mlir::db::ScanNodesByLabel scanNodesByLabel = mlir::dyn_cast<mlir::db::ScanNodesByLabel>(operation)) {
         lowerScanNodesByLabel(scanNodesByLabel);
+    } else if (mlir::db::ConstScanNodes constScanNodes = mlir::dyn_cast<mlir::db::ConstScanNodes>(operation)) {
+        lowerConstScanNodes(constScanNodes);
     } else if (mlir::db::ScanEdges scanEdges = mlir::dyn_cast<mlir::db::ScanEdges>(operation)) {
         lowerScanEdges(scanEdges);
     } else if (mlir::db::GetOutEdges getOutEdges = mlir::dyn_cast<mlir::db::GetOutEdges>(operation)) {
@@ -460,6 +462,18 @@ void DBLowering::lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLab
     nl::ScanNodesByLabel nodes = _builder.create<nl::ScanNodesByLabel>(_builder.getUnknownLoc(),
                                                                        scanNodesByLabel.getLabelsAttr());
     buildLoopForSource(nodes.getResult(), scanNodesByLabel.getOperation());
+}
+
+void DBLowering::lowerConstScanNodes(mlir::db::ConstScanNodes constScanNodes) {
+    // The constant-set sibling of lowerScanNodes: a scan reads no column, so its
+    // loop sits at the top of the current root block. The node ID list is the set
+    // of rows to emit, not a column input, so it is forwarded as-is to the nl op -
+    // translation resolves each entry to a storage NodeID.
+    setInsertionInto(_rootBlock);
+
+    nl::ConstScanNodes nodes = _builder.create<nl::ConstScanNodes>(_builder.getUnknownLoc(),
+                                                                   constScanNodes.getNodeIDsAttr());
+    buildLoopForSource(nodes.getResult(), constScanNodes.getOperation());
 }
 
 void DBLowering::lowerScanEdges(mlir::db::ScanEdges scanEdges) {
@@ -1162,6 +1176,7 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
     }
 
     const bool opensLoop = mlir::isa<mlir::db::ScanNodes,
+                                     mlir::db::ConstScanNodes,
                                      mlir::db::ScanNodesByLabel,
                                      mlir::db::ScanEdges,
                                      mlir::db::GetOutEdges,

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -161,6 +161,7 @@ private:
     void lowerOperation(mlir::Operation& operation);
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLabel);
+    void lowerConstScanNodes(mlir::db::ConstScanNodes constScanNodes);
     void lowerScanEdges(mlir::db::ScanEdges scanEdges);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetInEdges(mlir::db::GetInEdges getInEdges);

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -893,7 +893,7 @@ func.func @main() {
 }
 )mlir";
 
-// A const scan with no node IDs: rejected by the verifier.
+// A const scan with no node IDs: a valid, empty (zero-row) scan.
 const char* const emptyConstScanNodesProgram = R"mlir(
 func.func @main() {
   %a = db.const_scan_nodes([]) : !db.column<!storage.node_id>
@@ -992,11 +992,13 @@ TEST_F(DBDialectTest, constScanNodesRoundTripsThroughTextualForm) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
-TEST_F(DBDialectTest, verifierRejectsConstScanNodesWithoutNodeIDs) {
-    // The op parses - an empty array is well-formed syntax - but the verifier
-    // rejects a const scan with no node IDs, so the module fails to build.
+TEST_F(DBDialectTest, constScanNodesWithoutNodeIDsIsValid) {
+    // An empty node ID list is a valid const scan - it simply yields no row, the
+    // same set-membership semantics as a list whose IDs are all absent - so the
+    // module builds and verifies.
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyConstScanNodesProgram);
-    EXPECT_FALSE(module);
+    ASSERT_TRUE(module);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));
 }
 
 // MATCH (a)-[:KNOWS]->(b)<-[:LIKES]-(c): one by-type out-edge hop and one by-type

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -883,6 +883,25 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n) WHERE id(n) IN [0, 3, 7] RETURN n: a scan of a fixed, listed set of
+// node IDs.
+const char* const constScanNodesProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([0, 3, 7]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A const scan with no node IDs: rejected by the verifier.
+const char* const emptyConstScanNodesProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // MATCH ()-[e]->() RETURN a, b: scan every edge, exposing the four edge columns
 // (source node, edge, edge type, target node); the output keeps the endpoints.
 const char* const scanEdgesProgram = R"mlir(
@@ -933,6 +952,50 @@ TEST_F(DBDialectTest, verifierRejectsScanNodesByLabelWithoutLabels) {
     // The op parses - an empty array is well-formed syntax - but the verifier
     // rejects a label-free label scan, so the module fails to build.
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyLabelScanProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, parsesConstScanNodes) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(constScanNodesProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::ConstScanNodes scan;
+    module.get().walk([&](mlir::db::ConstScanNodes op) {
+        scan = op;
+    });
+    ASSERT_TRUE(scan);
+
+    // The three listed node IDs come back in order, and the result is a single
+    // node ID column.
+    const llvm::ArrayRef<int64_t> nodeIDs = scan.getNodeIDs();
+    ASSERT_EQ(nodeIDs.size(), 3u);
+    EXPECT_EQ(nodeIDs[0], 0);
+    EXPECT_EQ(nodeIDs[1], 3);
+    EXPECT_EQ(nodeIDs[2], 7);
+
+    const mlir::Type nodeIDColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    EXPECT_EQ(scan.getResult().getType(), nodeIDColumnType);
+}
+
+TEST_F(DBDialectTest, constScanNodesRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(constScanNodesProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.const_scan_nodes printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, verifierRejectsConstScanNodesWithoutNodeIDs) {
+    // The op parses - an empty array is well-formed syntax - but the verifier
+    // rejects a const scan with no node IDs, so the module fails to build.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyConstScanNodesProgram);
     EXPECT_FALSE(module);
 }
 

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -1002,6 +1002,16 @@ func.func @main() {
 }
 )mlir";
 
+// Const scan mixing an ID no node carries (99) with a real diamond node (1); the
+// unknown ID is dropped, leaving only the real one.
+constexpr const char* constScanNodesUnknownProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([99, 1]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // One hop along out-edges, outputting (source, target) pairs
 constexpr const char* oneHopOutProgram = R"mlir(
 func.func @main() {
@@ -2040,6 +2050,22 @@ TEST_F(DBLoweringTest, executesConstScanNodes) {
 
     // The scan emits exactly the two listed nodes, nothing else.
     const std::vector<std::vector<uint64_t>> expected {{0}, {2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, constScanNodesDropsIDsWithNoNode) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The diamond graph has nodes 0..3; the listed 99 names no node, so it is
+    // dropped and only the real node 1 survives.
+    CollectingNodeSink sink;
+    runLoweredProgram(constScanNodesUnknownProgram, reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{1}};
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -983,6 +983,25 @@ func.func @main() {
 }
 )mlir";
 
+// Scan exactly the nodes 2 and 0, in that order: a fixed set, not a graph walk
+constexpr const char* constScanNodesProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([2, 0]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// Const scan of all four diamond nodes in a scrambled order, so a test can assert
+// the listed order is preserved (and, at a small chunk size, that it spans chunks)
+constexpr const char* constScanNodesOrderedProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([3, 1, 2, 0]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // One hop along out-edges, outputting (source, target) pairs
 constexpr const char* oneHopOutProgram = R"mlir(
 func.func @main() {
@@ -1261,6 +1280,19 @@ private:
 std::string limitScanProgram(uint64_t count) {
     return std::string("func.func @main() {\n"
                        "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %la = db.limit(%a) count ")
+           + std::to_string(count)
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%la) : !db.column<!storage.node_id>\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (n) WHERE id(n) IN [3, 1, 2, 0] RETURN n LIMIT count: a const scan capped
+// by db.limit, so the same early-exit that bounds a plain scan bounds it too.
+std::string limitConstScanProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.const_scan_nodes([3, 1, 2, 0]) : !db.column<!storage.node_id>\n"
                        "  %la = db.limit(%a) count ")
            + std::to_string(count)
            + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
@@ -1996,6 +2028,69 @@ TEST_F(DBLoweringTest, executesScanNodesByLabelUnknownIsEmpty) {
     std::vector<uint64_t> robots;
     collectScan(scanByLabelUnknownProgram, reader.getView(), robots);
     EXPECT_TRUE(robots.empty());
+}
+
+TEST_F(DBLoweringTest, executesConstScanNodes) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(constScanNodesProgram, reader.getView(), sink);
+
+    // The scan emits exactly the two listed nodes, nothing else.
+    const std::vector<std::vector<uint64_t>> expected {{0}, {2}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, constScanNodesPreservesListedOrder) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeSink sink;
+    runLoweredProgram(constScanNodesOrderedProgram, reader.getView(), sink);
+
+    // A const scan emits its IDs in the order listed, not the storage scan order.
+    const std::vector<std::vector<uint64_t>> expected {{3}, {1}, {2}, {0}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, constScanNodesSpansChunkBoundary) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four IDs in chunks of two: the list is emitted across two steps, and every
+    // ID still comes out exactly once and in the listed order.
+    CollectingNodeSink sink;
+    runLoweredProgram(constScanNodesOrderedProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {1}, {2}, {0}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, limitsConstScanToFewerThanListSize) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // A const scan opens a loop like a plain scan, so a chained LIMIT bounds it:
+    // four listed IDs in chunks of two, LIMIT 2, so exactly the first two survive.
+    CollectingNodeSink sink;
+    const std::string program = limitConstScanProgram(2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::vector<uint64_t>> expected {{3}, {1}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
 }
 
 TEST_F(DBLoweringTest, lowersSingleConstant) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -1012,6 +1012,16 @@ func.func @main() {
 }
 )mlir";
 
+// Const scan with an empty ID list: nothing to emit, so the scan yields no row -
+// the same zero-row outcome as a list whose IDs are all absent from the graph.
+constexpr const char* constScanNodesEmptyProgram = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([]) : !db.column<!storage.node_id>
+  db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // One hop along out-edges, outputting (source, target) pairs
 constexpr const char* oneHopOutProgram = R"mlir(
 func.func @main() {
@@ -2069,6 +2079,21 @@ TEST_F(DBLoweringTest, constScanNodesDropsIDsWithNoNode) {
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, constScanNodesEmptyYieldsNoRow) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // An empty ID list has nothing to emit, so the scan runs cleanly and produces
+    // no row at all.
+    CollectingNodeSink sink;
+    runLoweredProgram(constScanNodesEmptyProgram, reader.getView(), sink);
+
+    std::vector<std::vector<uint64_t>> rows;
+    sink.sortedRows(rows);
+    EXPECT_TRUE(rows.empty());
 }
 
 TEST_F(DBLoweringTest, constScanNodesPreservesListedOrder) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -403,6 +403,29 @@ TEST_F(NLDialectTest, scanNodesByLabelInfersNodeIDIterator) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
 }
 
+// nl.const_scan_nodes infers a single node-ID chunk iterator - the same result
+// shape as nl.scan_nodes - since the ID list picks which rows are emitted, not
+// their columns. The listed IDs are carried on the op verbatim.
+TEST_F(NLDialectTest, constScanNodesInfersNodeIDIterator) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::DenseI64ArrayAttr nodeIDs = builder.getDenseI64ArrayAttr({0, 3, 7});
+    mlir::nl::ConstScanNodes scan = builder.create<mlir::nl::ConstScanNodes>(loc, nodeIDs);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    const mlir::Type chunkType = mlir::nl::ChunkType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {chunkType});
+    EXPECT_EQ(scan.getResult().getType(), iteratorType);
+    EXPECT_EQ(scan.getNodeIDs().size(), 3u);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+}
+
 // nl.get_out_edges_by_type infers the same four-chunk edge iterator as
 // nl.get_out_edges - sources, edge IDs, edge type IDs, targets - since the edge
 // type filters rows, not columns. The type is a resolved nl.get_edge_type handle,


### PR DESCRIPTION
Add a const_scan_nodes op to the db and nl dialects that injects an explicitly-listed set of node IDs into a variable. Drops the NodeIDs that don't exist in the graph.