### PR TITLE
MLIR: Implement node label constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,14 +116,14 @@ endif()
 
 if (${DEBUG_BUILD})
     message(STATUS "Debug build")
-    set(OPTIMIZE_FLAGS "-O0 -g ${CFP_FLAG} -Wno-maybe-uninitialized" )
+    set(OPTIMIZE_FLAGS "-O0 -g ${CFP_FLAG}" )
 else()
     message(STATUS "Optimized build")
     add_definitions(-DNDEBUG)
-    set(OPTIMIZE_FLAGS "-O3 ${CFP_FLAG} -Wno-maybe-uninitialized")
+    set(OPTIMIZE_FLAGS "-O3 ${CFP_FLAG}")
 
     if (${RELDEBUG})
-        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -g -Wno-maybe-uninitialized")
+        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -g")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,14 +116,14 @@ endif()
 
 if (${DEBUG_BUILD})
     message(STATUS "Debug build")
-    set(OPTIMIZE_FLAGS "-O0 -g ${CFP_FLAG}" )
+    set(OPTIMIZE_FLAGS "-O0 -g ${CFP_FLAG} -Wno-maybe-uninitialized" )
 else()
     message(STATUS "Optimized build")
     add_definitions(-DNDEBUG)
-    set(OPTIMIZE_FLAGS "-O3 ${CFP_FLAG}")
+    set(OPTIMIZE_FLAGS "-O3 ${CFP_FLAG} -Wno-maybe-uninitialized")
 
     if (${RELDEBUG})
-        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -g")
+        set(OPTIMIZE_FLAGS "${OPTIMIZE_FLAGS} -g -Wno-maybe-uninitialized")
     endif()
 endif()
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -720,6 +720,8 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
 
     // Reused across iterations
     std::vector<const Expr*> constraintExprs;
+    using NodeDataPair = std::pair<const NodePattern*, const NodePatternData*>;
+    std::vector<NodeDataPair> labelConstrainedNodes;
     llvm::SmallVector<mlir::Value> columnsToFilter;
     llvm::SmallVector<const VariableDependency*> orderedVars;
     llvm::SmallVector<mlir::Type> resultTypes;
@@ -732,10 +734,9 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
         const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
         const Pattern* pattern = matchStmt->getPattern();
 
-        // Collect all property constraint expressions from every entity pattern
-        // in this MATCH. Each EntityPropertyConstraint._expr is a synthesized
-        // equality BinaryExpr (e.g. n.name = "Alice") produced by the analyzer.
+        // Collect all property and label constraints
         constraintExprs.clear();
+        labelConstrainedNodes.clear();
 
         for (const PatternElement* element : pattern->elements()) {
             const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
@@ -744,6 +745,10 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             if (rootData) {
                 for (const EntityPropertyConstraint& constraint : rootData->exprConstraints()) {
                     constraintExprs.push_back(constraint._expr);
+                }
+
+                if (!rootData->labelConstraints().empty()) {
+                    labelConstrainedNodes.emplace_back(rootNode, rootData);
                 }
             }
 
@@ -760,19 +765,27 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
                     for (const EntityPropertyConstraint& constraint : nodeData->exprConstraints()) {
                         constraintExprs.push_back(constraint._expr);
                     }
+
+                    if (!nodeData->labelConstraints().empty()) {
+                        labelConstrainedNodes.emplace_back(nodePattern, nodeData);
+                    }
                 }
             }
         }
 
-        if (constraintExprs.empty()) {
+        const bool hasConstraints = !constraintExprs.empty() || !labelConstrainedNodes.empty();
+        if (!hasConstraints) {
             continue;
         }
 
         const mlir::Location loc = _opBuilder.getUnknownLoc();
         const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+        const mlir::db::ColumnType labelSetIDType = allocColumnType(
+            mlir::storage::LabelSetIDType::get(_mlirCtxt));
 
         // Fold left on all expressions, combining with AND
         mlir::Value combinedPredicate;
+
         for (const Expr* constraintExpr : constraintExprs) {
             translateExpr(constraintExpr);
             const mlir::Value predicate = _exprMap.at(constraintExpr);
@@ -780,7 +793,53 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             if (!combinedPredicate) {
                 combinedPredicate = predicate;
             } else {
-                combinedPredicate = _opBuilder.create<mlir::db::AndOp>(loc, boolType, combinedPredicate, predicate).getResult();
+                combinedPredicate = _opBuilder
+                                        .create<mlir::db::AndOp>(
+                                            loc, boolType, combinedPredicate, predicate)
+                                        .getResult();
+            }
+        }
+
+        // NOTE: currently produces separate filters for properties and nodes,
+        // TODO: consider combining in optimisation pass
+        for (auto [nodePattern, nodeData] : labelConstrainedNodes) {
+            const VarDecl* vardecl = nodePattern->getDecl();
+            bioassert(vardecl, "Null variable declaration.");
+            const std::string_view nodeName = vardecl->getName();
+
+            mlir::Value nodeColumn;
+            for (const auto& [var, values] : _varMap) {
+                if (var->getName() == nodeName) {
+                    nodeColumn = values.back();
+                    break;
+                }
+            }
+
+            bioassert(nodeColumn, "Label-constrained node not found in variable map: {}", nodeName);
+
+            const mlir::Value labelSetIDColumn = _opBuilder.create<mlir::db::GetNodeLabelSet>(
+                loc,
+                labelSetIDType,
+                nodeColumn).getResult();
+
+            llvm::SmallVector<llvm::StringRef> labelNames;
+            for (const std::string_view label : nodeData->labelConstraints()) {
+                labelNames.push_back(llvm::StringRef(label.data(), label.size()));
+            }
+
+            const mlir::ArrayAttr labelsAttr = _opBuilder.getStrArrayAttr(labelNames);
+            const mlir::Value labelMask = _opBuilder.create<mlir::db::CheckLabelConstraint>(
+                loc,
+                boolType,
+                labelSetIDColumn,
+                labelsAttr).getResult();
+
+            if (!combinedPredicate) {
+                combinedPredicate = labelMask;
+            } else {
+                auto andop = _opBuilder.create<mlir::db::AndOp>(
+                    loc, boolType, combinedPredicate, labelMask);
+                combinedPredicate = andop.getResult();
             }
         }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -208,6 +208,7 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
     generateTraversal(ast);
     resolveEdgeIdentities();
     generatePropertyConstraints(ast);
+    generateLabelConstraints(ast);
     generateFilters(ast);
     generateOutput(ast);
 
@@ -718,13 +719,7 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
         return;
     }
 
-    // Reused across iterations
     std::vector<const Expr*> constraintExprs;
-    using NodeDataPair = std::pair<const NodePattern*, const NodePatternData*>;
-    std::vector<NodeDataPair> labelConstrainedNodes;
-    llvm::SmallVector<mlir::Value> columnsToFilter;
-    llvm::SmallVector<const VariableDependency*> orderedVars;
-    llvm::SmallVector<mlir::Type> resultTypes;
 
     for (const Stmt* stmt : stmtsContainer->stmts()) {
         if (stmt->getKind() != Stmt::Kind::MATCH) {
@@ -734,9 +729,7 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
         const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
         const Pattern* pattern = matchStmt->getPattern();
 
-        // Collect all property and label constraints
         constraintExprs.clear();
-        labelConstrainedNodes.clear();
 
         for (const PatternElement* element : pattern->elements()) {
             const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
@@ -745,10 +738,6 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             if (rootData) {
                 for (const EntityPropertyConstraint& constraint : rootData->exprConstraints()) {
                     constraintExprs.push_back(constraint._expr);
-                }
-
-                if (!rootData->labelConstraints().empty()) {
-                    labelConstrainedNodes.emplace_back(rootNode, rootData);
                 }
             }
 
@@ -765,25 +754,17 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
                     for (const EntityPropertyConstraint& constraint : nodeData->exprConstraints()) {
                         constraintExprs.push_back(constraint._expr);
                     }
-
-                    if (!nodeData->labelConstraints().empty()) {
-                        labelConstrainedNodes.emplace_back(nodePattern, nodeData);
-                    }
                 }
             }
         }
 
-        const bool hasConstraints = !constraintExprs.empty() || !labelConstrainedNodes.empty();
-        if (!hasConstraints) {
+        if (constraintExprs.empty()) {
             continue;
         }
 
         const mlir::Location loc = _opBuilder.getUnknownLoc();
         const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
-        const mlir::db::ColumnType labelSetIDType = allocColumnType(
-            mlir::storage::LabelSetIDType::get(_mlirCtxt));
 
-        // Fold left on all expressions, combining with AND
         mlir::Value combinedPredicate;
 
         for (const Expr* constraintExpr : constraintExprs) {
@@ -800,8 +781,68 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             }
         }
 
-        // NOTE: currently produces separate filters for properties and nodes,
-        // TODO: consider combining in optimisation pass
+        filterAllColumns(combinedPredicate);
+    }
+}
+
+void DBProgramGenerator::generateLabelConstraints(const CypherAST* ast) {
+    const CypherAST::QueryCommands& queries = ast->queries();
+    if (queries.size() != 1) {
+        throw TuringException("Multiple queries not yet supported.");
+    }
+
+    const QueryCommand* query = queries.front();
+
+    const SinglePartQuery* sglPart = dynamic_cast<const SinglePartQuery*>(query);
+    if (!sglPart) {
+        return;
+    }
+
+    const StmtContainer* stmtsContainer = sglPart->getReadStmts();
+    if (!stmtsContainer) {
+        return;
+    }
+
+    using NodeDataPair = std::pair<const NodePattern*, const NodePatternData*>;
+    std::vector<NodeDataPair> labelConstrainedNodes;
+
+    for (const Stmt* stmt : stmtsContainer->stmts()) {
+        if (stmt->getKind() != Stmt::Kind::MATCH) {
+            continue;
+        }
+
+        const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
+        const Pattern* pattern = matchStmt->getPattern();
+
+        labelConstrainedNodes.clear();
+
+        for (const PatternElement* element : pattern->elements()) {
+            const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
+            const NodePatternData* rootData = rootNode->getData();
+
+            if (rootData && !rootData->labelConstraints().empty()) {
+                labelConstrainedNodes.emplace_back(rootNode, rootData);
+            }
+
+            for (auto [edgePattern, nodePattern] : element->getElementChain()) {
+                const NodePatternData* nodeData = nodePattern->getData();
+                if (nodeData && !nodeData->labelConstraints().empty()) {
+                    labelConstrainedNodes.emplace_back(nodePattern, nodeData);
+                }
+            }
+        }
+
+        if (labelConstrainedNodes.empty()) {
+            continue;
+        }
+
+        const mlir::Location loc = _opBuilder.getUnknownLoc();
+        const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+        const mlir::db::ColumnType labelSetIDType = allocColumnType(
+            mlir::storage::LabelSetIDType::get(_mlirCtxt));
+
+        mlir::Value combinedPredicate;
+
         for (auto [nodePattern, nodeData] : labelConstrainedNodes) {
             const VarDecl* vardecl = nodePattern->getDecl();
             bioassert(vardecl, "Null variable declaration.");
@@ -837,9 +878,8 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             if (!combinedPredicate) {
                 combinedPredicate = labelMask;
             } else {
-                auto andop = _opBuilder.create<mlir::db::AndOp>(
-                    loc, boolType, combinedPredicate, labelMask);
-                combinedPredicate = andop.getResult();
+                combinedPredicate = _opBuilder.create<mlir::db::AndOp>(
+                    loc, boolType, combinedPredicate, labelMask).getResult();
             }
         }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -85,6 +85,7 @@ private:
     void generateOutput(const CypherAST* ast);
 
     void generatePropertyConstraints(const CypherAST* ast);
+    void generateLabelConstraints(const CypherAST* ast);
     void generateFilters(const CypherAST* ast);
 
     void translateExpr(const Expr* expr);

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -222,6 +222,14 @@ LogicalResult ScanNodesByLabel::verify() {
     return success();
 }
 
+LogicalResult CheckLabelConstraint::verify() {
+    if (getLabels().empty()) {
+        return emitOpError("requires at least one label");
+    }
+
+    return success();
+}
+
 // db.limit passes its columns straight through, so the results must be exactly
 // the input columns - same count, same types and in the same order.
 LogicalResult Limit::verify() {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -357,6 +357,45 @@ def GetEdgeProperties : TuringOp<"get_edge_properties", [Pure]> {
   }];
 }
 
+def GetNodeLabelSet : TuringOp<"get_node_label_set", [Pure]> {
+  let summary = "Read the label-set ID of each node as a column";
+
+  let description = [{
+    For each node in the input column, fetches its LabelSetID.
+
+      %ls = db.get_node_label_set(%a) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+      %ok = db.check_label_constraint(%ls, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  }];
+
+  let arguments = (ins Column:$input_nodes);
+  let results   = (outs Column:$result);
+
+  let assemblyFormat = [{
+    `(` $input_nodes `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def CheckLabelConstraint : TuringOp<"check_label_constraint", [Pure]> {
+  let summary = "Test each label-set ID against a required-label constraint";
+
+  let description = [{
+    For each LabelSetID in the input column, emits true if the node's label set
+    contains every label in `labels` (a superset match), false otherwise.
+
+      %ok = db.check_label_constraint(%ls, ["Person", "Employee"])
+              : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  }];
+
+  let arguments = (ins Column:$labelset_ids, StrArrayAttr:$labels);
+  let results   = (outs Column:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `(` $labelset_ids `,` $labels `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 /**
 * CrossProduct
 */

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -332,6 +332,46 @@ def GetEdgeProperties : NLOp<"get_edge_properties", [Pure]> {
   }];
 }
 
+def GetNodeLabelSet : NLOp<"get_node_label_set", [Pure]> {
+  let summary = "Read the label-set ID of each node in a chunk";
+  let description = [{
+    For each node ID in the input chunk, fetches its LabelSetID.
+
+      nl.for %nodes in %scan {
+        %ls = nl.get_node_label_set(%nodes) : !nl.chunk<!storage.labelset_id>
+        ...
+      }
+  }];
+
+  let arguments = (ins NLNodeIDChunk:$input_nodes);
+  let results   = (outs NLChunk:$label_set_ids);
+
+  let assemblyFormat = [{
+    `(` $input_nodes `)` attr-dict `:` qualified(type($label_set_ids))
+  }];
+}
+
+def CheckLabelConstraint : NLOp<"check_label_constraint", [Pure]> {
+  let summary = "Test each label-set ID against a precomputed matching set";
+  let description = [{
+    For each LabelSetID in the input chunk, emits true if the ID appears in
+    `matching_ids`.
+
+      nl.for %nodes in %scan {
+        %ls  = nl.get_node_label_set(%nodes) : !nl.chunk<!storage.labelset_id>
+        %ok  = nl.check_label_constraint(%ls, [3, 7]) : !nl.chunk<!storage.bool>
+        ...
+      }
+  }];
+
+  let arguments = (ins NLLabelSetIDChunk:$labelset_ids, DenseI64ArrayAttr:$matching_ids);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = [{
+    `(` $labelset_ids `,` $matching_ids `)` attr-dict `:` qualified(type($result))
+  }];
+}
+
 /**
 * For
 */

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -181,6 +181,13 @@ def NLEdgeIDChunk : Type<
     BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
                   "::mlir::storage::EdgeIDType::get($_builder.getContext()))">;
 
+def NLLabelSetIDChunk : Type<
+        CPred<"::llvm::isa<::mlir::nl::ChunkType>($_self) && "
+              "::llvm::isa<::mlir::storage::LabelSetIDType>(::llvm::cast<::mlir::nl::ChunkType>($_self).getElementType())">,
+        "chunk of label set IDs", "::mlir::nl::ChunkType">,
+    BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
+                  "::mlir::storage::LabelSetIDType::get($_builder.getContext()))">;
+
 // Constrains an operand to a resolved !nl.property_type handle, the same way
 // NLNodeIDChunk constrains a chunk operand. The single concrete type - there is
 // only ever !nl.property_type - is what lets the property fetches omit the

--- a/query/ir/dialect/storage/StorageTypes.td
+++ b/query/ir/dialect/storage/StorageTypes.td
@@ -39,6 +39,11 @@ def Bool : StorageType<"Bool", "bool"> {
     let summary = "TuringDB Boolean type";
 }
 
+def LabelSetID : StorageType<"LabelSetID", "labelset_id"> {
+    let summary = "A label-set identifier";
+    let description = "The element type of a chunk holding label set IDs";
+}
+
 def Embedding : StorageType<"Embedding", "embedding"> {
     let summary = "An embedding property value";
     let description = [{

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -10,6 +10,7 @@
 
 #include "iterators/GetInEdgesIterator.h"
 #include "iterators/GetInEdgesByTypeIterator.h"
+#include "iterators/GetNodeLabelSetIterator.h"
 #include "iterators/GetOutEdgesIterator.h"
 #include "iterators/GetOutEdgesByTypeIterator.h"
 #include "iterators/GetPropertiesWithNullIterator.h"
@@ -2218,6 +2219,33 @@ template void NLExecutor::runPropertyFetch<EdgeID, types::Double>(NLExecutionCon
 template void NLExecutor::runPropertyFetch<EdgeID, types::Bool>(NLExecutionContext*, NLFunctionData*);
 template void NLExecutor::runPropertyFetch<EdgeID, types::String>(NLExecutionContext*, NLFunctionData*);
 template void NLExecutor::runPropertyFetch<EdgeID, types::Embedding>(NLExecutionContext*, NLFunctionData*);
+
+void NLExecutor::runGetNodeLabelSet(NLExecutionContext* context, NLFunctionData* data) {
+    NLGetNodeLabelSetData* fetchData = static_cast<NLGetNodeLabelSetData*>(data);
+
+    const GraphView& view = *context->getView();
+    const ColumnNodeIDs* input = fetchData->getInput();
+    ColumnLabelSetIDs* output = fetchData->getOutput();
+
+    GetNodeLabelSetChunkWriter writer(view, input);
+    writer.setLabelSetIDs(output);
+    writer.fill(input->size());
+}
+
+void NLExecutor::runCheckLabelConstraint(NLExecutionContext* context, NLFunctionData* data) {
+    NLCheckLabelConstraintData* checkData = static_cast<NLCheckLabelConstraintData*>(data);
+
+    const ColumnLabelSetIDs* input = checkData->getInput();
+    ColumnMask* output = checkData->getOutput();
+
+    const size_t rowCount = input->size();
+    output->resize(rowCount);
+
+    for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        const LabelSetID id = (*input)[rowIndex];
+        (*output)[rowIndex] = checkData->isMatching(id);
+    }
+}
 
 template NLBinaryFn NLExecutor::selectBinary<OP_ADD>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
 template NLBinaryFn NLExecutor::selectBinary<OP_SUB>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -61,6 +61,11 @@ public:
     static void runGetOutEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesByTypeLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    static void runGetNodeLabelSet(NLExecutionContext* context, NLFunctionData* data);
+
+    // Fills a boolean mask
+    static void runCheckLabelConstraint(NLExecutionContext* context, NLFunctionData* data);
+
     static void runCrossProduct(NLExecutionContext* context, NLFunctionData* data);
 
     // Reset a limit counter to its budget; runs each time its block runs.

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -12,6 +12,7 @@
 #include "ID.h"
 #include "columns/ColumnEdgeTypes.h"
 #include "columns/ColumnIDs.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnVector.h"
 #include "iterators/ChunkConfig.h"
 #include "metadata/LabelSet.h"
@@ -401,6 +402,42 @@ private:
     const Column* _input {nullptr};
     Column* _output {nullptr};
     PropertyTypeID _propertyTypeID;
+};
+
+class NLGetNodeLabelSetData : public NLFunctionData {
+public:
+    NLGetNodeLabelSetData(const ColumnNodeIDs* input, ColumnLabelSetIDs* output)
+        : _input(input),
+        _output(output)
+    {
+    }
+
+    const ColumnNodeIDs* getInput() const { return _input; }
+    ColumnLabelSetIDs* getOutput() const { return _output; }
+
+private:
+    const ColumnNodeIDs* _input {nullptr};
+    ColumnLabelSetIDs* _output {nullptr};
+};
+
+class NLCheckLabelConstraintData : public NLFunctionData {
+public:
+    NLCheckLabelConstraintData(const ColumnLabelSetIDs* input, ColumnMask* output)
+        : _input(input),
+        _output(output)
+    {
+    }
+
+    const ColumnLabelSetIDs* getInput() const { return _input; }
+    ColumnMask* getOutput() const { return _output; }
+
+    void addMatchingID(LabelSetID id) { _matchingIDs.insert(id.getValue()); }
+    bool isMatching(LabelSetID id) const { return _matchingIDs.count(id.getValue()) > 0; }
+
+private:
+    const ColumnLabelSetIDs* _input {nullptr};
+    ColumnMask* _output {nullptr};
+    std::unordered_set<uint32_t> _matchingIDs;
 };
 
 // A cross product emits N*M rows (every outer row paired with every inner row),

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -11,6 +11,7 @@
 #include "mlir/IR/Verifier.h"
 
 #include "columns/ColumnConst.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOptVector.h"
 #include "metadata/GraphMetadata.h"
 #include "metadata/PropertyNull.h"
@@ -316,6 +317,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
                                    getEdgeProperties.getValues(),
                                    /*isNode=*/false,
                                    body);
+        } else if (nl::GetNodeLabelSet getNodeLabelSet = mlir::dyn_cast<nl::GetNodeLabelSet>(operation)) {
+            translateGetNodeLabelSet(getNodeLabelSet, body);
+        } else if (nl::CheckLabelConstraint checkLabelConstraint = mlir::dyn_cast<nl::CheckLabelConstraint>(operation)) {
+            translateCheckLabelConstraint(checkLabelConstraint, body);
         } else if (nl::CrossProduct crossProduct = mlir::dyn_cast<nl::CrossProduct>(operation)) {
             translateCrossProduct(crossProduct, body);
         } else if (nl::Limit limit = mlir::dyn_cast<nl::Limit>(operation)) {
@@ -618,6 +623,36 @@ void NLTranslator::translatePropertyFetch(mlir::Value inputValue,
 
     const NLHandlerFunction handler = selectPropertyFetchHandler(isNode, valueType);
     body->emplaceStmt(handler, fetchData);
+}
+
+void NLTranslator::translateGetNodeLabelSet(nl::GetNodeLabelSet op, NLStmtContainer* body) {
+    const mlir::TypedValue<::mlir::nl::ChunkType> nodes = op.getInputNodes();
+    const Column* nodeCol = getColumn(nodes);
+    const ColumnNodeIDs* input = static_cast<const ColumnNodeIDs*>(nodeCol);
+
+    ColumnLabelSetIDs* output = _memory->alloc<ColumnLabelSetIDs>();
+    output->reserve(_program->getChunkSize());
+    _valueSlots[op.getLabelSetIds()] = output;
+
+    NLGetNodeLabelSetData* data = _program->allocFunctionData<NLGetNodeLabelSetData>(input, output);
+    body->emplaceStmt(&NLExecutor::runGetNodeLabelSet, data);
+}
+
+void NLTranslator::translateCheckLabelConstraint(nl::CheckLabelConstraint op, NLStmtContainer* body) {
+    const mlir::TypedValue<::mlir::nl::ChunkType> lbls = op.getLabelsetIds();
+    const Column* lblsCol = getColumn(lbls);
+    const ColumnLabelSetIDs* input = static_cast<const ColumnLabelSetIDs*>(lblsCol);
+
+    ColumnMask* output = _memory->alloc<ColumnMask>();
+    output->reserve(_program->getChunkSize());
+    _valueSlots[op.getResult()] = output;
+
+    NLCheckLabelConstraintData* data = _program->allocFunctionData<NLCheckLabelConstraintData>(input, output);
+    for (const int64_t rawID : op.getMatchingIds()) {
+        data->addMatchingID(LabelSetID(static_cast<uint32_t>(rawID)));
+    }
+
+    body->emplaceStmt(&NLExecutor::runCheckLabelConstraint, data);
 }
 
 void NLTranslator::translateConstant(nl::Constant constant) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -320,6 +320,10 @@ private:
                                 bool isNode,
                                 NLStmtContainer* body);
 
+    void translateGetNodeLabelSet(mlir::nl::GetNodeLabelSet op, NLStmtContainer* body);
+
+    void translateCheckLabelConstraint(mlir::nl::CheckLabelConstraint op, NLStmtContainer* body);
+
     // Allocates singleton column for the constant and assigns MLIR value
     void translateConstant(mlir::nl::Constant constant);
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -11,6 +11,11 @@
 #include "NLOps.h"
 
 #include "views/GraphView.h"
+#include "metadata/GraphMetadata.h"
+#include "metadata/LabelSet.h"
+#include "metadata/LabelSetHandle.h"
+#include "metadata/LabelSetMap.h"
+#include "metadata/LabelMap.h"
 #include "metadata/PropertyType.h"
 
 #include "IRException.h"
@@ -391,6 +396,10 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerGetNodeProperties(getNodeProperties);
     } else if (mlir::db::GetEdgeProperties getEdgeProperties = mlir::dyn_cast<mlir::db::GetEdgeProperties>(operation)) {
         lowerGetEdgeProperties(getEdgeProperties);
+    } else if (mlir::db::GetNodeLabelSet getNodeLabelSet = mlir::dyn_cast<mlir::db::GetNodeLabelSet>(operation)) {
+        lowerGetNodeLabelSet(getNodeLabelSet);
+    } else if (mlir::db::CheckLabelConstraint checkLabelConstraint = mlir::dyn_cast<mlir::db::CheckLabelConstraint>(operation)) {
+        lowerCheckLabelConstraint(checkLabelConstraint);
     } else if (mlir::db::CrossProduct crossProduct = mlir::dyn_cast<mlir::db::CrossProduct>(operation)) {
         lowerCrossProduct(crossProduct);
     } else if (mlir::db::Limit limit = mlir::dyn_cast<mlir::db::Limit>(operation)) {
@@ -614,6 +623,63 @@ void DBLowering::lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgePrope
                                                                          inputChunk,
                                                                          handle);
     _valueMap[getEdgeProperties.getResult()] = fetch.getValues();
+}
+
+void DBLowering::lowerGetNodeLabelSet(mlir::db::GetNodeLabelSet getNodeLabelSet) {
+    const mlir::Value inputChunk = mapValue(getNodeLabelSet.getInputNodes());
+
+    setInsertionInto(ownerBlock(inputChunk));
+
+    const mlir::Type labelSetIDChunkType = nl::ChunkType::get(
+        _builder.getContext(),
+        storage::LabelSetIDType::get(_builder.getContext()));
+
+    nl::GetNodeLabelSet fetch = _builder.create<nl::GetNodeLabelSet>(
+        _builder.getUnknownLoc(),
+        labelSetIDChunkType,
+        inputChunk);
+
+    _valueMap[getNodeLabelSet.getResult()] = fetch.getLabelSetIds();
+}
+
+void DBLowering::lowerCheckLabelConstraint(mlir::db::CheckLabelConstraint checkLabelConstraint) {
+    const LabelMap& labelMap = _view->metadata().labels();
+
+    LabelSet constraintLabelSet;
+    for (const mlir::Attribute labelAttr : checkLabelConstraint.getLabels()) {
+        const llvm::StringRef labelName = mlir::cast<mlir::StringAttr>(labelAttr).getValue();
+        const std::optional<LabelID> labelID = labelMap.get(
+            std::string_view(labelName.data(), labelName.size()));
+
+        bioassert(labelID.has_value(), "Invalid label passed analyzer.");
+
+        constraintLabelSet.set(*labelID);
+    }
+
+    llvm::SmallVector<int64_t> matchingIDs;
+    const LabelSetHandle constraintHandle(constraintLabelSet);
+    for (const LabelSetMap::Pair& pair : _view->metadata().labelsets()) {
+        const LabelSetHandle candidate(*pair._value);
+        if (candidate.hasAtLeastLabels(constraintHandle)) {
+            matchingIDs.push_back(static_cast<int64_t>(pair._id.getValue()));
+        }
+    }
+
+    const mlir::Value inputChunk = mapValue(checkLabelConstraint.getLabelsetIds());
+
+    setInsertionInto(ownerBlock(inputChunk));
+
+    const mlir::Type boolChunkType = nl::ChunkType::get(
+        _builder.getContext(),
+        storage::BoolType::get(_builder.getContext()));
+
+    nl::CheckLabelConstraint check = _builder.create<nl::CheckLabelConstraint>(
+        _builder.getUnknownLoc(),
+        boolChunkType,
+        inputChunk,
+        _builder.getDenseI64ArrayAttr(matchingIDs));
+
+    _valueMap[checkLabelConstraint.getResult()] = check.getResult();
 }
 
 void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -169,6 +169,8 @@ private:
     void lowerGetInEdgesByType(mlir::db::GetInEdgesByType getInEdgesByType);
     void lowerGetNodeProperties(mlir::db::GetNodeProperties getNodeProperties);
     void lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgeProperties);
+    void lowerGetNodeLabelSet(mlir::db::GetNodeLabelSet getNodeLabelSet);
+    void lowerCheckLabelConstraint(mlir::db::CheckLabelConstraint checkLabelConstraint);
     void lowerCrossProduct(mlir::db::CrossProduct product);
     void lowerLimit(mlir::db::Limit limit);
     void lowerSkip(mlir::db::Skip skip);

--- a/samples/mlir/label_constraint.mlir
+++ b/samples/mlir/label_constraint.mlir
@@ -1,0 +1,9 @@
+// MATCH (n:Person) RETURN n
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_label_set(%0) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %2 = db.check_label_constraint(%1, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %3 = db.filter(%2, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%3) : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/label_constraint.nl.mlir
+++ b/samples/mlir/label_constraint.nl.mlir
@@ -1,0 +1,12 @@
+// MATCH (n:Person) RETURN n
+func.func @main() {
+  %0 = nl.scan_nodes()
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %1 = nl.get_node_label_set(%arg0) : !nl.chunk<!storage.labelset_id>
+    %2 = nl.check_label_constraint(%1, [0, 1, 6, 7, 9]) : !nl.chunk<!storage.bool>
+    %3 = nl.filter %2, (%arg0) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%3) : !nl.chunk<!storage.node_id>
+  }
+  return
+}
+

--- a/samples/mlir/label_constraint_inline_filter.mlir
+++ b/samples/mlir/label_constraint_inline_filter.mlir
@@ -1,0 +1,13 @@
+// MATCH (n:Person{name:'Cyrus'}) RETURN n
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_properties(%0, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.constant("Cyrus" : !storage.string)
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %4 = db.filter(%3, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %5 = db.get_node_label_set(%4) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %6 = db.check_label_constraint(%5, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %7 = db.filter(%6, {%4}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%7) : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/label_constraint_inline_filter.nl.mlir
+++ b/samples/mlir/label_constraint_inline_filter.nl.mlir
@@ -1,0 +1,17 @@
+// MATCH (n:Person{name:'Cyrus'}) RETURN n
+func.func @main() {
+  %0 = nl.constant("Cyrus" : !storage.string)
+  %1 = nl.get_property_type("name")
+  %2 = nl.scan_nodes()
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %3 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<!storage.string>>
+    %4 = nl.eq %3, %0 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+    %5 = nl.filter %4, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %6 = nl.get_node_label_set(%5) : !nl.chunk<!storage.labelset_id>
+    %7 = nl.check_label_constraint(%6, [0, 1, 6, 7, 9]) : !nl.chunk<!storage.bool>
+    %8 = nl.filter %7, (%5) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%8) : !nl.chunk<!storage.node_id>
+  }
+  return
+}
+

--- a/samples/mlir/label_constraint_inline_filter_where.mlir
+++ b/samples/mlir/label_constraint_inline_filter_where.mlir
@@ -1,0 +1,17 @@
+// MATCH (n:Person{name:'Cyrus'}) WHERE n.age = 23 RETURN n
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_properties(%0, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.constant("Cyrus" : !storage.string)
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %4 = db.filter(%3, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %5 = db.get_node_label_set(%4) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %6 = db.check_label_constraint(%5, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %7 = db.filter(%6, {%4}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %8 = db.get_node_properties(%7, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %9 = db.constant(23 : i64)
+  %10 = db.eq %8, %9 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %11 = db.filter(%10, {%7}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%11) : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/label_constraint_inline_filter_where.nl.mlir
+++ b/samples/mlir/label_constraint_inline_filter_where.nl.mlir
@@ -1,0 +1,22 @@
+// MATCH (n:Person{name:'Cyrus'}) WHERE n.age = 23 RETURN n
+func.func @main() {
+  %0 = nl.constant(23 : i64)
+  %1 = nl.get_property_type("age")
+  %2 = nl.constant("Cyrus" : !storage.string)
+  %3 = nl.get_property_type("name")
+  %4 = nl.scan_nodes()
+  nl.for %arg0 in %4 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %5 = nl.get_node_properties(%arg0, %3) : !nl.chunk<!storage.nullable<!storage.string>>
+    %6 = nl.eq %5, %2 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+    %7 = nl.filter %6, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %8 = nl.get_node_label_set(%7) : !nl.chunk<!storage.labelset_id>
+    %9 = nl.check_label_constraint(%8, [0, 1, 6, 7, 9]) : !nl.chunk<!storage.bool>
+    %10 = nl.filter %9, (%7) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %11 = nl.get_node_properties(%10, %1) : !nl.chunk<!storage.nullable<i64>>
+    %12 = nl.eq %11, %0 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %13 = nl.filter %12, (%10) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%13) : !nl.chunk<!storage.node_id>
+  }
+  return
+}
+

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -427,6 +427,22 @@ TEST_F(EquivalenceTest, arbitraryFilters) {
     expectEquivalent("MATCH (a {age: 32})-->(b), (c {isFrench: false}) WHERE a.isFrench RETURN a, c");
 }
 
+TEST_F(EquivalenceTest, labelConstraints) {
+    expectEquivalent("MATCH (n:Person) RETURN n");
+    expectEquivalent("MATCH (n:Interest) RETURN n");
+    expectEquivalent("MATCH (n:Founder) RETURN n");
+
+    expectEquivalent("MATCH (n:Person:Founder) RETURN n");
+    expectEquivalent("MATCH (n:Interest:SleepDisturber) RETURN n");
+
+    expectEquivalent("MATCH (n:Person)-->(m) RETURN n");
+    expectEquivalent("MATCH (n:Person)-->(m:Interest) RETURN n, m");
+    expectEquivalent("MATCH (n)-->(m:Interest) RETURN n, m");
+
+    expectEquivalent("MATCH (n:Person) WHERE n.isFrench RETURN n");
+    expectEquivalent("MATCH (n:Person) WHERE n.hasPhD RETURN n");
+}
+
 TEST_F(EquivalenceTest, constants) {
     expectEquivalent("RETURN 5");
     expectEquivalent("RETURN 5 + 10");


### PR DESCRIPTION
Allows queries which impose a label constraint on a node, e.g.
~~~
MATCH (n:Person) RETURN n
~~~

Currently this emits a scan nodes + filter by label; future work would involve writing an MLIR pass which would squash a scan + label filter into a scan nodes by label.