### PR TITLE
Add v3 prefix to TuringShell for MLIR execution

### DIFF
--- a/query/interpreter/CMakeLists.txt
+++ b/query/interpreter/CMakeLists.txt
@@ -17,3 +17,22 @@ target_link_libraries(turing_db_interpreter_s PRIVATE
     turing_db_system_s
     turing_db_jobs_s
     turing_vector_s)
+
+set(interpreter_v3_sources
+    QueryInterpreterV3.cpp)
+
+add_library(turing_db_interpreter_v3_s STATIC ${interpreter_v3_sources})
+target_include_directories(turing_db_interpreter_v3_s PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(turing_db_interpreter_v3_s
+    PUBLIC
+        turing_db_ir_interpreter_s
+        turing_db_system_s
+        turing_common_s
+    PRIVATE
+        turing_db_ir_dbdialect_s
+        turing_db_ir_codegen_s
+        turing_db_frontend_cypher_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_ast_s)

--- a/query/interpreter/QueryInterpreterV3.cpp
+++ b/query/interpreter/QueryInterpreterV3.cpp
@@ -1,0 +1,151 @@
+#include "QueryInterpreterV3.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "SystemManager.h"
+#include "SystemAccessor.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "CompilerException.h"
+#include "TuringTime.h"
+
+using namespace db;
+
+QueryInterpreterV3::QueryInterpreterV3(SystemManager* sysMan)
+    : _sysMan(sysMan)
+{
+}
+
+QueryInterpreterV3::~QueryInterpreterV3() {
+}
+
+void QueryInterpreterV3::execute(QueryStatus& status,
+                                 std::string_view query,
+                                 std::string_view graphName,
+                                 CommitHash hash,
+                                 ChangeID changeID,
+                                 LocalMemory* mem,
+                                 NLOutputSink* sink) {
+    const TimePoint start = Clock::now();
+    executeImpl(status, query, graphName, hash, changeID, mem, sink);
+    const TimePoint end = Clock::now();
+
+    status.setTotalTime(end - start);
+}
+
+void QueryInterpreterV3::executeImpl(QueryStatus& status,
+                                     std::string_view query,
+                                     std::string_view graphName,
+                                     CommitHash hash,
+                                     ChangeID changeID,
+                                     LocalMemory* mem,
+                                     NLOutputSink* sink) {
+    SystemAccessor system = _sysMan->accessShared();
+
+    auto txRes = system.openTransaction(graphName, hash, changeID);
+    if (!txRes) {
+        switch (txRes.error().getType()) {
+            case ChangeErrorType::GRAPH_NOT_FOUND: {
+                status.setStatus(QueryStatus::Status::GRAPH_NOT_FOUND);
+                return;
+            }
+            break;
+            case ChangeErrorType::CHANGE_NOT_FOUND: {
+                status.setStatus(QueryStatus::Status::CHANGE_NOT_FOUND);
+                return;
+            }
+            break;
+            case ChangeErrorType::COMMIT_NOT_LOADED: {
+                status.setStatus(QueryStatus::Status::COMMIT_NOT_LOADED);
+                status.setMessage(txRes.error().fmtMessage());
+                return;
+            }
+            break;
+            default: {
+                status.setStatus(QueryStatus::Status::COMMIT_NOT_FOUND);
+                return;
+            }
+            break;
+        }
+    }
+
+    const GraphView view = txRes->viewGraph();
+
+    CypherAST ast(system.getProcedures(), query);
+    CypherParser parser(&ast);
+    try {
+        parser.parse(query);
+    } catch (const CompilerException& e) {
+        status.setStatus(QueryStatus::Status::PARSE_ERROR);
+        status.setMessage(e.what());
+        return;
+    } catch (const std::exception& e) {
+        status.setStatus(QueryStatus::Status::PARSE_ERROR);
+        status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    }
+
+    CypherAnalyzer analyzer(&ast, view);
+    try {
+        analyzer.analyze();
+    } catch (const CompilerException& e) {
+        status.setStatus(QueryStatus::Status::ANALYZE_ERROR);
+        status.setMessage(e.what());
+        return;
+    } catch (const std::exception& e) {
+        status.setStatus(QueryStatus::Status::ANALYZE_ERROR);
+        status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    }
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    mlir::OpBuilder builder(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+    mlir::ModuleOp module = owningModule.get();
+
+    DBProgramGenerator generator(&module);
+    try {
+        generator.generate(&ast);
+    } catch (const CompilerException& e) {
+        status.setStatus(QueryStatus::Status::PLAN_ERROR);
+        status.setMessage(e.what());
+        return;
+    } catch (const std::exception& e) {
+        status.setStatus(QueryStatus::Status::PLAN_ERROR);
+        status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    }
+
+    DBDialectInterpreter interpreter(module, &view, sink, mem);
+    try {
+        interpreter.run();
+    } catch (const CompilerException& e) {
+        status.setStatus(QueryStatus::Status::EXEC_ERROR);
+        status.setMessage(e.what());
+        return;
+    } catch (const std::exception& e) {
+        status.setStatus(QueryStatus::Status::EXEC_ERROR);
+        status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    }
+}

--- a/query/interpreter/QueryInterpreterV3.h
+++ b/query/interpreter/QueryInterpreterV3.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryStatus.h"
+#include "versioning/CommitHash.h"
+#include "versioning/ChangeID.h"
+
+namespace db {
+
+class SystemManager;
+class LocalMemory;
+
+class QueryInterpreterV3 {
+public:
+    explicit QueryInterpreterV3(SystemManager* sysMan);
+    ~QueryInterpreterV3();
+
+    void execute(QueryStatus& status,
+                 std::string_view query,
+                 std::string_view graphName,
+                 CommitHash hash,
+                 ChangeID changeID,
+                 LocalMemory* mem,
+                 NLOutputSink* sink);
+
+private:
+    SystemManager* _sysMan {nullptr};
+
+    void executeImpl(QueryStatus& status,
+                     std::string_view query,
+                     std::string_view graphName,
+                     CommitHash hash,
+                     ChangeID changeID,
+                     LocalMemory* mem,
+                     NLOutputSink* sink);
+};
+
+}

--- a/tools/turingdb/CMakeLists.txt
+++ b/tools/turingdb/CMakeLists.txt
@@ -16,13 +16,7 @@ target_link_libraries(turingdb PUBLIC
     turing_db_auth_s
     turing_db_memory_s
     turing_db_proto_client_s
-    turing_db_ir_interpreter_s
-    turing_db_ir_dbdialect_s
-    turing_db_ir_codegen_s
-    turing_db_frontend_cypher_s
-    turing_db_parser_s
-    turing_db_analyzer_s
-    turing_db_ast_s
+    turing_db_interpreter_v3_s
     argparse
     tabulate
     linenoise_s

--- a/tools/turingdb/CMakeLists.txt
+++ b/tools/turingdb/CMakeLists.txt
@@ -16,6 +16,13 @@ target_link_libraries(turingdb PUBLIC
     turing_db_auth_s
     turing_db_memory_s
     turing_db_proto_client_s
+    turing_db_ir_interpreter_s
+    turing_db_ir_dbdialect_s
+    turing_db_ir_codegen_s
+    turing_db_frontend_cypher_s
+    turing_db_parser_s
+    turing_db_analyzer_s
+    turing_db_ast_s
     argparse
     tabulate
     linenoise_s

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -23,6 +23,25 @@
 #include "LineNoiseHandle.h"
 #include "LocalMemory.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "views/GraphView.h"
+
 #include "columns/Block.h"
 #include "columns/Column.h"
 #include "columns/ColumnVector.h"
@@ -331,7 +350,7 @@ void shCommand(const TuringShell::Command::Words& args, TuringShell& shell, std:
     }
 }
 
-} // namespace
+}
 
 TuringShell::TuringShell(TuringDB& turingDB,
                          LocalMemory* mem,
@@ -681,6 +700,131 @@ void queryCallback(size_t execCount, const Dataframe* df, tabulate::Table& table
     }
 }
 
+namespace {
+
+class TuringShellNLSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        if (_execCount == 0) {
+            tabulate::RowStream headerRow;
+            for (size_t columnIndex = 0; columnIndex < chunks.size(); columnIndex++) {
+                headerRow << ("$" + std::to_string(columnIndex));
+            }
+            _table.add_row(std::move(headerRow));
+        }
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            tabulate::RowStream rs;
+            for (const Column* col : chunks) {
+                switch (col->getKind()) {
+                    TABULATE_COL_CASE(ColumnVector<NodeID>, rowIndex)
+                    TABULATE_COL_CASE(ColumnVector<EdgeID>, rowIndex)
+                    TABULATE_COL_CASE(ColumnVector<EdgeTypeID>, rowIndex)
+                    TABULATE_COL_CASE(ColumnVector<types::UInt64::Primitive>, rowIndex)
+                    TABULATE_COL_CASE(ColumnOptVector<types::Int64::Primitive>, rowIndex)
+                    TABULATE_COL_CASE(ColumnOptVector<types::Double::Primitive>, rowIndex)
+                    TABULATE_COL_CASE(ColumnOptVector<types::Bool::Primitive>, rowIndex)
+                    TABULATE_COL_CASE(ColumnOptVector<types::String::Primitive>, rowIndex)
+                    default: {
+                        rs << "?";
+                    } break;
+                }
+            }
+            _table.add_row(std::move(rs));
+            _rowCount++;
+        }
+
+        _execCount++;
+    }
+
+    tabulate::Table& getTable() { return _table; }
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    tabulate::Table _table;
+    size_t _execCount {0};
+    size_t _rowCount {0};
+};
+
+}
+
+void TuringShell::runMLIRQuery(std::string_view query) {
+    if (_remoteConnected) {
+        spdlog::error("#v3 is only available in local mode");
+        return;
+    }
+
+    const TimePoint start = Clock::now();
+
+    SystemAccessor system = _turingDB.getSystemManager().accessShared();
+
+    auto txRes = system.openTransaction(_graphName, _hash, _changeID);
+    if (!txRes) {
+        spdlog::error("Could not open transaction: {}", txRes.error().fmtMessage());
+        return;
+    }
+
+    const GraphView view = txRes->viewGraph();
+
+    CypherAST ast(system.getProcedures(), query);
+    CypherParser parser(&ast);
+    try {
+        parser.parse(query);
+    } catch (const TuringException& e) {
+        spdlog::error("Parse error: {}", e.what());
+        return;
+    }
+
+    CypherAnalyzer analyzer(&ast, view);
+    try {
+        analyzer.analyze();
+    } catch (const TuringException& e) {
+        spdlog::error("Analyze error: {}", e.what());
+        return;
+    }
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    mlir::OpBuilder builder(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+    mlir::ModuleOp module = owningModule.get();
+
+    DBProgramGenerator generator(&module);
+    try {
+        generator.generate(&ast);
+    } catch (const TuringException& e) {
+        spdlog::error("IR generation error: {}", e.what());
+        return;
+    }
+
+    TuringShellNLSink sink;
+    DBDialectInterpreter interpreter(module, &view, &sink, _mem);
+    try {
+        interpreter.run();
+    } catch (const TuringException& e) {
+        spdlog::error("MLIR execution error: {}", e.what());
+        return;
+    }
+
+    const TimePoint end = Clock::now();
+    const Milliseconds elapsed = end - start;
+
+    if (_mem) {
+        _mem->clear();
+    }
+
+    if (!_quiet) {
+        std::cout << sink.getTable() << "\n";
+    }
+
+    std::cout << "Query returned " << sink.getRowCount() << " rows.\n";
+    std::cout << "Query executed in " << elapsed.count() << " ms.\n";
+}
+
 // Cleans double-escaped characters to single-escaped characters
 void TuringShell::formatMessage(std::string& msg) {
     const std::regex newLine(R"(\\n)");
@@ -720,6 +864,16 @@ void TuringShell::processLine(std::string& line) {
         if (line.empty()) {
             return;
         }
+    }
+
+    // Check for #v3 prefix to route through the MLIR executor
+    constexpr std::string_view v3Prefix = "#v3 ";
+    const bool useMLIR = line.size() >= v3Prefix.size() && line.substr(0, v3Prefix.size()) == v3Prefix;
+    if (useMLIR) {
+        line = line.substr(v3Prefix.size());
+        trim(line);
+        runMLIRQuery(line);
+        return;
     }
 
     // Execute query

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -23,24 +23,8 @@
 #include "LineNoiseHandle.h"
 #include "LocalMemory.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/OwningOpRef.h"
-
-#include "DBDialect.h"
-#include "DBDialectInterpreter.h"
-#include "DBProgramGenerator.h"
-#include "NLDialect.h"
 #include "NLOutputSink.h"
-#include "StorageDialect.h"
-
-#include "CypherAST.h"
-#include "CypherAnalyzer.h"
-#include "CypherParser.h"
-
-#include "views/GraphView.h"
+#include "QueryInterpreterV3.h"
 
 #include "columns/Block.h"
 #include "columns/Column.h"
@@ -754,67 +738,24 @@ void TuringShell::runMLIRQuery(std::string_view query) {
         return;
     }
 
-    const TimePoint start = Clock::now();
-
-    SystemAccessor system = _turingDB.getSystemManager().accessShared();
-
-    auto txRes = system.openTransaction(_graphName, _hash, _changeID);
-    if (!txRes) {
-        spdlog::error("Could not open transaction: {}", txRes.error().fmtMessage());
-        return;
-    }
-
-    const GraphView view = txRes->viewGraph();
-
-    CypherAST ast(system.getProcedures(), query);
-    CypherParser parser(&ast);
-    try {
-        parser.parse(query);
-    } catch (const TuringException& e) {
-        spdlog::error("Parse error: {}", e.what());
-        return;
-    }
-
-    CypherAnalyzer analyzer(&ast, view);
-    try {
-        analyzer.analyze();
-    } catch (const TuringException& e) {
-        spdlog::error("Analyze error: {}", e.what());
-        return;
-    }
-
-    mlir::MLIRContext context;
-    context.getOrLoadDialect<mlir::func::FuncDialect>();
-    context.getOrLoadDialect<mlir::storage::Storage>();
-    context.getOrLoadDialect<mlir::db::DB>();
-    context.getOrLoadDialect<mlir::nl::NL>();
-
-    mlir::OpBuilder builder(&context);
-    mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
-    mlir::ModuleOp module = owningModule.get();
-
-    DBProgramGenerator generator(&module);
-    try {
-        generator.generate(&ast);
-    } catch (const TuringException& e) {
-        spdlog::error("IR generation error: {}", e.what());
-        return;
-    }
-
     TuringShellNLSink sink;
-    DBDialectInterpreter interpreter(module, &view, &sink, _mem);
-    try {
-        interpreter.run();
-    } catch (const TuringException& e) {
-        spdlog::error("MLIR execution error: {}", e.what());
-        return;
-    }
-
-    const TimePoint end = Clock::now();
-    const Milliseconds elapsed = end - start;
+    QueryStatus status;
+    QueryInterpreterV3 interp(&_turingDB.getSystemManager());
+    interp.execute(status, query, _graphName, _hash, _changeID, _mem, &sink);
 
     if (_mem) {
         _mem->clear();
+    }
+
+    if (!status.isOk()) {
+        if (status.hasErrorMessage()) {
+            std::string errorMsg = status.getError();
+            formatMessage(errorMsg);
+            spdlog::error("{}: {}", QueryStatusDescription::value(status.getStatus()), errorMsg);
+        } else {
+            spdlog::error("{}", QueryStatusDescription::value(status.getStatus()));
+        }
+        return;
     }
 
     if (!_quiet) {
@@ -822,7 +763,7 @@ void TuringShell::runMLIRQuery(std::string_view query) {
     }
 
     std::cout << "Query returned " << sink.getRowCount() << " rows.\n";
-    std::cout << "Query executed in " << elapsed.count() << " ms.\n";
+    std::cout << "Query executed in " << status.getTotalTime().count() << " ms.\n";
 }
 
 // Cleans double-escaped characters to single-escaped characters

--- a/tools/turingdb/TuringShell.h
+++ b/tools/turingdb/TuringShell.h
@@ -64,6 +64,7 @@ private:
     std::unordered_map<std::string_view, Command> _localCommands;
 
     void processLine(std::string& line);
+    void runMLIRQuery(std::string_view query);
     void formatMessage(std::string& msg);
     std::string composePrompt();
     void checkShellContext();


### PR DESCRIPTION
Enables execution of Cypher queries in TuringShell via the `#v3` prefix