### PR TITLE
regress: run create_turingdb.py instead of the uv init stub

### DIFF
--- a/regress/create_turingdb_object/run.sh
+++ b/regress/create_turingdb_object/run.sh
@@ -26,7 +26,7 @@ fi
 uv init
 uv add $PYTURINGDB
 
-uv run main.py
+uv run create_turingdb.py
 testres=$?
 
 turingdb stop -turing-dir $SCRIPT_DIR/.turing


### PR DESCRIPTION
The create_turingdb_object test ran uv's scaffolded main.py rather than its own script, so it passed vacuously until uv 0.12.0 stopped generating the stub and CI started failing.