### PR TITLE
MLIR: generate `ORDER BY` in frontend

### DIFF
--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ast_sources
     expr/UnaryExpr.cpp
     expr/FunctionInvocationExpr.cpp
     expr/IndexExpr.cpp
+    expr/StructuralExpressionComparator.cpp
 
     stmt/Stmt.cpp
     stmt/StmtContainer.cpp

--- a/query/AST/expr/StructuralExpressionComparator.cpp
+++ b/query/AST/expr/StructuralExpressionComparator.cpp
@@ -1,0 +1,249 @@
+#include "StructuralExpressionComparator.h"
+
+#include <algorithm>
+
+#include "FunctionInvocation.h"
+#include "Literal.h"
+#include "QualifiedName.h"
+#include "Symbol.h"
+
+#include "BinaryExpr.h"
+#include "Expr.h"
+#include "ExprChain.h"
+#include "FunctionInvocationExpr.h"
+#include "IndexExpr.h"
+#include "ListExpr.h"
+#include "LiteralExpr.h"
+#include "PropertyExpr.h"
+#include "StringExpr.h"
+#include "SymbolExpr.h"
+#include "UnaryExpr.h"
+
+using namespace db;
+
+bool StructuralExpressionComparator::equal(const Expr* lhs, const Expr* rhs) {
+    // The same node, or two null operands of the same shape, need no further comparison
+    if (lhs == rhs) {
+        return true;
+    }
+
+    if (!lhs || !rhs) {
+        return false;
+    }
+
+    const Expr::Kind kind = lhs->getKind();
+    if (kind != rhs->getKind()) {
+        return false;
+    }
+
+    switch (kind) {
+        case Expr::Kind::BINARY: {
+            const BinaryExpr* lhsBinary = static_cast<const BinaryExpr*>(lhs);
+            const BinaryExpr* rhsBinary = static_cast<const BinaryExpr*>(rhs);
+
+            const bool sameOperator = lhsBinary->getOperator() == rhsBinary->getOperator();
+
+            return sameOperator
+                   && equal(lhsBinary->getLHS(), rhsBinary->getLHS())
+                   && equal(lhsBinary->getRHS(), rhsBinary->getRHS());
+        }
+        break;
+
+        case Expr::Kind::UNARY: {
+            const UnaryExpr* lhsUnary = static_cast<const UnaryExpr*>(lhs);
+            const UnaryExpr* rhsUnary = static_cast<const UnaryExpr*>(rhs);
+
+            const bool sameOperator = lhsUnary->getOperator() == rhsUnary->getOperator();
+
+            return sameOperator && equal(lhsUnary->getSubExpr(), rhsUnary->getSubExpr());
+        }
+        break;
+
+        case Expr::Kind::STRING: {
+            const StringExpr* lhsString = static_cast<const StringExpr*>(lhs);
+            const StringExpr* rhsString = static_cast<const StringExpr*>(rhs);
+
+            const bool sameOperator = lhsString->getStringOperator() == rhsString->getStringOperator();
+
+            return sameOperator
+                   && equal(lhsString->getLHS(), rhsString->getLHS())
+                   && equal(lhsString->getRHS(), rhsString->getRHS());
+        }
+        break;
+
+        case Expr::Kind::PROPERTY: {
+            const PropertyExpr* lhsProperty = static_cast<const PropertyExpr*>(lhs);
+            const PropertyExpr* rhsProperty = static_cast<const PropertyExpr*>(rhs);
+
+            const bool sameEntity = lhsProperty->getEntityVarDecl() == rhsProperty->getEntityVarDecl();
+            const bool sameProperty = lhsProperty->getPropName() == rhsProperty->getPropName();
+
+            return sameEntity && sameProperty;
+        }
+        break;
+
+        case Expr::Kind::SYMBOL: {
+            const SymbolExpr* lhsSymbol = static_cast<const SymbolExpr*>(lhs);
+            const SymbolExpr* rhsSymbol = static_cast<const SymbolExpr*>(rhs);
+
+            return lhsSymbol->getDecl() == rhsSymbol->getDecl();
+        }
+        break;
+
+        case Expr::Kind::LITERAL: {
+            const LiteralExpr* lhsLiteral = static_cast<const LiteralExpr*>(lhs);
+            const LiteralExpr* rhsLiteral = static_cast<const LiteralExpr*>(rhs);
+
+            return equalLiterals(lhsLiteral->getLiteral(), rhsLiteral->getLiteral());
+        }
+        break;
+
+        case Expr::Kind::INDEX: {
+            const IndexExpr* lhsIndex = static_cast<const IndexExpr*>(lhs);
+            const IndexExpr* rhsIndex = static_cast<const IndexExpr*>(rhs);
+
+            return equal(lhsIndex->getBase(), rhsIndex->getBase())
+                   && equal(lhsIndex->getIndexExpr(), rhsIndex->getIndexExpr());
+        }
+        break;
+
+        case Expr::Kind::LIST: {
+            const ListExpr* lhsList = static_cast<const ListExpr*>(lhs);
+            const ListExpr* rhsList = static_cast<const ListExpr*>(rhs);
+
+            return equalExprLists(lhsList->getElements(), rhsList->getElements());
+        }
+        break;
+
+        case Expr::Kind::FUNCTION_INVOCATION: {
+            const FunctionInvocationExpr* lhsCall = static_cast<const FunctionInvocationExpr*>(lhs);
+            const FunctionInvocationExpr* rhsCall = static_cast<const FunctionInvocationExpr*>(rhs);
+
+            return equalInvocations(lhsCall->getFunctionInvocation(),
+                                    rhsCall->getFunctionInvocation());
+        }
+        break;
+
+        default:
+            // ENTITY_TYPES and PATH carry a symbol chain and a pattern, neither of which
+            // this comparator takes apart, so such an expression equals only itself
+            return false;
+        break;
+    }
+}
+
+bool StructuralExpressionComparator::equalLiterals(const Literal* lhs, const Literal* rhs) {
+    if (lhs == rhs) {
+        return true;
+    }
+
+    if (!lhs || !rhs) {
+        return false;
+    }
+
+    const Literal::Kind kind = lhs->getKind();
+    if (kind != rhs->getKind()) {
+        return false;
+    }
+
+    switch (kind) {
+        case Literal::Kind::NULL_LITERAL:
+            // Neither null nor wildcard carries a value, so every one is the same one
+            return true;
+        break;
+
+        case Literal::Kind::WILDCARD:
+            return true;
+        break;
+
+        case Literal::Kind::BOOL:
+            return static_cast<const BoolLiteral*>(lhs)->getValue()
+                   == static_cast<const BoolLiteral*>(rhs)->getValue();
+        break;
+
+        case Literal::Kind::INTEGER:
+            return static_cast<const IntegerLiteral*>(lhs)->getValue()
+                   == static_cast<const IntegerLiteral*>(rhs)->getValue();
+        break;
+
+        case Literal::Kind::DOUBLE:
+            // A NaN literal compares equal to nothing, itself included, which leaves it
+            // on the conservative side of the contract
+            return static_cast<const DoubleLiteral*>(lhs)->getValue()
+                   == static_cast<const DoubleLiteral*>(rhs)->getValue();
+        break;
+
+        case Literal::Kind::STRING:
+            return static_cast<const StringLiteral*>(lhs)->getValue()
+                   == static_cast<const StringLiteral*>(rhs)->getValue();
+        break;
+
+        case Literal::Kind::CHAR:
+            return static_cast<const CharLiteral*>(lhs)->getValue()
+                   == static_cast<const CharLiteral*>(rhs)->getValue();
+        break;
+
+        case Literal::Kind::EMBEDDING:
+            return std::ranges::equal(static_cast<const EmbeddingLiteral*>(lhs)->getValue(),
+                                      static_cast<const EmbeddingLiteral*>(rhs)->getValue());
+        break;
+
+        case Literal::Kind::LIST:
+            return equalExprLists(static_cast<const ListLiteral*>(lhs)->items(),
+                                  static_cast<const ListLiteral*>(rhs)->items());
+        break;
+
+        default:
+            // A map literal keys its entries by Symbol identity, so two maps written the
+            // same way do not compare equal entry by entry
+            return false;
+        break;
+    }
+}
+
+bool StructuralExpressionComparator::equalInvocations(const FunctionInvocation* lhs,
+                                                      const FunctionInvocation* rhs) {
+    if (lhs == rhs) {
+        return true;
+    }
+
+    if (!lhs || !rhs) {
+        return false;
+    }
+
+    const QualifiedName* lhsName = lhs->getName();
+    const QualifiedName* rhsName = rhs->getName();
+    if (!lhsName || !rhsName || lhsName->size() != rhsName->size()) {
+        return false;
+    }
+
+    for (size_t index = 0; index < lhsName->size(); index++) {
+        if (lhsName->get(index)->getName() != rhsName->get(index)->getName()) {
+            return false;
+        }
+    }
+
+    // A call with no argument list has none to compare, so two of them match on name
+    const ExprChain* lhsArguments = lhs->getArguments();
+    const ExprChain* rhsArguments = rhs->getArguments();
+    if (!lhsArguments || !rhsArguments) {
+        return lhsArguments == rhsArguments;
+    }
+
+    return equalExprLists(lhsArguments->getExprs(), rhsArguments->getExprs());
+}
+
+bool StructuralExpressionComparator::equalExprLists(std::span<Expr* const> lhs,
+                                                    std::span<Expr* const> rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+
+    for (size_t index = 0; index < lhs.size(); index++) {
+        if (!equal(lhs[index], rhs[index])) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/query/AST/expr/StructuralExpressionComparator.h
+++ b/query/AST/expr/StructuralExpressionComparator.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <span>
+
+namespace db {
+
+class Expr;
+class FunctionInvocation;
+class Literal;
+
+// Compares two expression trees by what they are built from rather than by which AST
+// nodes they are. One expression written twice in a query - the n.age + 1 of
+// RETURN n.age + 1 ORDER BY n.age + 1 - parses into two separate trees, so pointer
+// equality alone cannot tell that both read the same thing.
+//
+// The comparison is conservative: a kind it cannot take apart, and a literal it cannot
+// compare by value, is equal only to itself. A caller may see two equal expressions
+// reported as different, never two different ones reported as equal.
+class StructuralExpressionComparator {
+public:
+    static bool equal(const Expr* lhs, const Expr* rhs);
+
+private:
+    static bool equalLiterals(const Literal* lhs, const Literal* rhs);
+    static bool equalInvocations(const FunctionInvocation* lhs, const FunctionInvocation* rhs);
+    static bool equalExprLists(std::span<Expr* const> lhs, std::span<Expr* const> rhs);
+};
+
+}

--- a/query/AST/expr/StructuralExpressionComparator.h
+++ b/query/AST/expr/StructuralExpressionComparator.h
@@ -10,6 +10,9 @@ class Literal;
 
 class StructuralExpressionComparator {
 public:
+    StructuralExpressionComparator() = delete;
+    ~StructuralExpressionComparator() = delete;
+
     static bool equal(const Expr* lhs, const Expr* rhs);
 
 private:

--- a/query/AST/expr/StructuralExpressionComparator.h
+++ b/query/AST/expr/StructuralExpressionComparator.h
@@ -8,14 +8,6 @@ class Expr;
 class FunctionInvocation;
 class Literal;
 
-// Compares two expression trees by what they are built from rather than by which AST
-// nodes they are. One expression written twice in a query - the n.age + 1 of
-// RETURN n.age + 1 ORDER BY n.age + 1 - parses into two separate trees, so pointer
-// equality alone cannot tell that both read the same thing.
-//
-// The comparison is conservative: a kind it cannot take apart, and a literal it cannot
-// compare by value, is equal only to itself. A caller may see two equal expressions
-// reported as different, never two different ones reported as equal.
 class StructuralExpressionComparator {
 public:
     static bool equal(const Expr* lhs, const Expr* rhs);

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1,6 +1,7 @@
 #include "DBProgramGenerator.h"
 
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <string_view>
 #include <type_traits>
@@ -46,6 +47,8 @@
 #include "expr/UnaryExpr.h"
 #include "stmt/Limit.h"
 #include "stmt/MatchStmt.h"
+#include "stmt/OrderBy.h"
+#include "stmt/OrderByItem.h"
 #include "stmt/ReturnStmt.h"
 #include "stmt/Skip.h"
 #include "stmt/StmtContainer.h"
@@ -696,7 +699,7 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
 
     const Projection::Items& returned = proj->items();
 
-    std::unordered_map<std::string_view, mlir::Value> finalIdentities;
+    FinalIdentityMap finalIdentities;
     for (auto& [cypherVar, mlirCol] : _varMap) {
         const std::string_view varName = cypherVar->getName();
 
@@ -722,17 +725,7 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
             bioassert(findIt != end(finalIdentities), "Return variable '{}' not found", name);
             return findIt->second;
         } else {
-            const VarDecl* var = item->getExprVarDecl();
-            if (var) {
-                const std::string_view name = var->getName();
-                const auto findIt = finalIdentities.find(name);
-                if (findIt != end(finalIdentities)) {
-                    return findIt->second;
-                }
-            }
-
-            translateExpr(item);
-            return _exprMap.at(item);
+            return resolveExprColumn(finalIdentities, item);
         }
     };
 
@@ -740,6 +733,12 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     for (const Projection::ReturnItem item : returned) {
         const mlir::Value itemCol = std::visit(getVarForItem, item);
         outputted.push_back(itemCol);
+    }
+
+    // ORDER BY reorders the whole projection, so it comes first: SKIP and LIMIT cut
+    // the sorted rows
+    if (proj->hasOrderBy()) {
+        translateOrderBy(proj->getOrderBy(), finalIdentities, outputted);
     }
 
     const mlir::Location loc = _opBuilder.getUnknownLoc();
@@ -775,6 +774,71 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     }
 
     _opBuilder.create<mlir::db::Output>(loc, mlir::ValueRange{outputted});
+}
+
+void DBProgramGenerator::translateOrderBy(const OrderBy* orderBy,
+                                          const FinalIdentityMap& identities,
+                                          llvm::SmallVectorImpl<mlir::Value>& projected) {
+    const OrderBy::ItemVector& items = orderBy->getItems();
+    bioassert(!items.empty(), "ORDER BY without a key");
+
+    // Every projected column is sorted, so the projection stays row-aligned. A key the
+    // projection does not carry - the a.age of RETURN a ORDER BY a.age - is sorted as an
+    // extra column: it moves with its row but is never output
+    llvm::SmallVector<mlir::Value> sorted {projected.begin(), projected.end()};
+
+    llvm::SmallVector<int64_t> keyColumns;
+    llvm::SmallVector<bool> keyAscending;
+
+    // Keys are given most significant first, the order the Sort expects
+    for (const OrderByItem* item : items) {
+        const mlir::Value keyColumn = resolveExprColumn(identities, item->getExpr());
+
+        // A key the sorted columns already carry is sorted in place; any other key is
+        // appended, so its index is one past the columns collected so far
+        const auto findIt = std::ranges::find(sorted, keyColumn);
+        const size_t keyIndex = static_cast<size_t>(std::distance(sorted.begin(), findIt));
+        if (findIt == sorted.end()) {
+            sorted.push_back(keyColumn);
+        }
+
+        keyColumns.push_back(static_cast<int64_t>(keyIndex));
+        keyAscending.push_back(item->getType() == OrderByType::ASC);
+    }
+
+    llvm::SmallVector<mlir::Type> sortResultTypes;
+    for (const mlir::Value column : sorted) {
+        sortResultTypes.push_back(column.getType());
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    auto sortOp = _opBuilder.create<mlir::db::Sort>(loc,
+                                                    sortResultTypes,
+                                                    mlir::ValueRange {sorted},
+                                                    keyColumns,
+                                                    keyAscending);
+
+    // The columns pass through the sort in place, so each projected column becomes its
+    // own result; the extra key columns end the result range and are left unread
+    const mlir::ResultRange results = sortOp.getResults();
+    for (size_t index = 0; index < projected.size(); index++) {
+        projected[index] = results[index];
+    }
+}
+
+mlir::Value DBProgramGenerator::resolveExprColumn(const FinalIdentityMap& identities,
+                                                  const Expr* expr) {
+    const VarDecl* var = expr->getExprVarDecl();
+    if (var) {
+        const std::string_view name = var->getName();
+        const auto findIt = identities.find(name);
+        if (findIt != end(identities)) {
+            return findIt->second;
+        }
+    }
+
+    translateExpr(expr);
+    return _exprMap.at(expr);
 }
 
 void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -782,9 +782,11 @@ void DBProgramGenerator::translateOrderBy(const OrderBy* orderBy,
     const OrderBy::ItemVector& items = orderBy->getItems();
     bioassert(!items.empty(), "ORDER BY without a key");
 
-    // Every projected column is sorted, so the projection stays row-aligned. A key the
-    // projection does not carry - the a.age of RETURN a ORDER BY a.age - is sorted as an
-    // extra column: it moves with its row but is never output
+    // A sort reorders the rows of every column it is given at once, so it is given the
+    // whole projection and the projected columns stay row-aligned. A key the projection
+    // does not carry - the a.age of RETURN a ORDER BY a.age - is handed over as one more
+    // column, so that it moves with the row it belongs to; its result is then left
+    // unread, which is what keeps it out of the output
     llvm::SmallVector<mlir::Value> sorted {projected.begin(), projected.end()};
 
     llvm::SmallVector<int64_t> keyColumns;
@@ -794,15 +796,17 @@ void DBProgramGenerator::translateOrderBy(const OrderBy* orderBy,
     for (const OrderByItem* item : items) {
         const mlir::Value keyColumn = resolveExprColumn(identities, item->getExpr());
 
-        // A key the sorted columns already carry is sorted in place; any other key is
-        // appended, so its index is one past the columns collected so far
+        // A key names the column to sort by through its position in the columns handed to
+        // the sort: the position the projection already gives it, or the end of the set
+        // when the key has to be appended - so two appended keys never share a position
         const auto findIt = std::ranges::find(sorted, keyColumn);
-        const size_t keyIndex = static_cast<size_t>(std::distance(sorted.begin(), findIt));
         if (findIt == sorted.end()) {
             sorted.push_back(keyColumn);
+            keyColumns.push_back(static_cast<int64_t>(sorted.size() - 1));
+        } else {
+            keyColumns.push_back(static_cast<int64_t>(std::distance(sorted.begin(), findIt)));
         }
 
-        keyColumns.push_back(static_cast<int64_t>(keyIndex));
         keyAscending.push_back(item->getType() == OrderByType::ASC);
     }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1,10 +1,10 @@
 #include "DBProgramGenerator.h"
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
 #include <string_view>
 #include <type_traits>
+#include <variant>
 
 #include "expr/Operators.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -92,6 +92,49 @@ EdgeMetadata::EdgeType reverseEdge(EdgeMetadata::EdgeType type) {
 
     throw FatalException("Uncaught edge type.");
 
+}
+
+// Whether two projection-level expressions read the same column: the same variable, or
+// the same property of the same variable. Pointer equality cannot answer that on its own
+// - the n.name of RETURN n.name ORDER BY n.name is a second AST node, equal to the
+// projected one but not the same one - so those two kinds are compared by what they name
+// instead. Any other kind falls back to identity, which can miss a match a deeper
+// comparison would find: the cost is one more column for the sort to carry
+bool readsSameColumn(const Expr* lhs, const Expr* rhs) {
+    const Expr::Kind kind = lhs->getKind();
+
+    if (kind != rhs->getKind()) {
+        return false;
+    } else if (kind == Expr::Kind::SYMBOL) {
+        return lhs->getExprVarDecl() == rhs->getExprVarDecl();
+    } else if (kind == Expr::Kind::PROPERTY) {
+        const PropertyExpr* lhsProperty = static_cast<const PropertyExpr*>(lhs);
+        const PropertyExpr* rhsProperty = static_cast<const PropertyExpr*>(rhs);
+
+        const bool sameEntity = lhsProperty->getEntityVarDecl() == rhsProperty->getEntityVarDecl();
+        const bool sameProperty = lhsProperty->getPropName() == rhsProperty->getPropName();
+
+        return sameEntity && sameProperty;
+    } else {
+        return lhs == rhs;
+    }
+}
+
+// The index of the projected column @param key reads, or the item count when the
+// projection does not carry it. The projection is one column per return item, so the
+// index is the column's index too
+size_t findProjectedColumn(const Projection::Items& items, const Expr* key) {
+    size_t index = 0;
+    for (const Projection::ReturnItem& item : items) {
+        const Expr* const* itemExpr = std::get_if<Expr*>(&item);
+        if (itemExpr && readsSameColumn(*itemExpr, key)) {
+            return index;
+        }
+
+        index++;
+    }
+
+    return index;
 }
 
 mlir::Value findVarOrThrow(const DBProgramGenerator::VariableIdentityMap& map,
@@ -738,7 +781,7 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     // ORDER BY reorders the whole projection, so it comes first: SKIP and LIMIT cut
     // the sorted rows
     if (proj->hasOrderBy()) {
-        translateOrderBy(proj->getOrderBy(), finalIdentities, outputted);
+        translateOrderBy(proj, finalIdentities, outputted);
     }
 
     const mlir::Location loc = _opBuilder.getUnknownLoc();
@@ -776,11 +819,14 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     _opBuilder.create<mlir::db::Output>(loc, mlir::ValueRange{outputted});
 }
 
-void DBProgramGenerator::translateOrderBy(const OrderBy* orderBy,
+void DBProgramGenerator::translateOrderBy(const Projection* projection,
                                           const FinalIdentityMap& identities,
                                           llvm::SmallVectorImpl<mlir::Value>& projected) {
+    const OrderBy* orderBy = projection->getOrderBy();
     const OrderBy::ItemVector& items = orderBy->getItems();
     bioassert(!items.empty(), "ORDER BY without a key");
+
+    const Projection::Items& projectedItems = projection->items();
 
     // A sort reorders the rows of every column it is given at once, so it is given the
     // whole projection and the projected columns stay row-aligned. A key the projection
@@ -794,17 +840,18 @@ void DBProgramGenerator::translateOrderBy(const OrderBy* orderBy,
 
     // Keys are given most significant first, the order the Sort expects
     for (const OrderByItem* item : items) {
-        const mlir::Value keyColumn = resolveExprColumn(identities, item->getExpr());
+        const Expr* keyExpr = item->getExpr();
+        const size_t projectedIndex = findProjectedColumn(projectedItems, keyExpr);
+        const bool isProjected = projectedIndex < projectedItems.size();
 
         // A key names the column to sort by through its position in the columns handed to
         // the sort: the position the projection already gives it, or the end of the set
         // when the key has to be appended - so two appended keys never share a position
-        const auto findIt = std::ranges::find(sorted, keyColumn);
-        if (findIt == sorted.end()) {
-            sorted.push_back(keyColumn);
-            keyColumns.push_back(static_cast<int64_t>(sorted.size() - 1));
+        if (isProjected) {
+            keyColumns.push_back(static_cast<int64_t>(projectedIndex));
         } else {
-            keyColumns.push_back(static_cast<int64_t>(std::distance(sorted.begin(), findIt)));
+            sorted.push_back(resolveExprColumn(identities, keyExpr));
+            keyColumns.push_back(static_cast<int64_t>(sorted.size() - 1));
         }
 
         keyAscending.push_back(item->getType() == OrderByType::ASC);

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -43,6 +43,7 @@
 #include "expr/Expr.h"
 #include "expr/LiteralExpr.h"
 #include "expr/PropertyExpr.h"
+#include "expr/StructuralExpressionComparator.h"
 #include "expr/SymbolExpr.h"
 #include "expr/UnaryExpr.h"
 #include "stmt/Limit.h"
@@ -94,40 +95,18 @@ EdgeMetadata::EdgeType reverseEdge(EdgeMetadata::EdgeType type) {
 
 }
 
-// Whether two projection-level expressions read the same column: the same variable, or
-// the same property of the same variable. Pointer equality cannot answer that on its own
-// - the n.name of RETURN n.name ORDER BY n.name is a second AST node, equal to the
-// projected one but not the same one - so those two kinds are compared by what they name
-// instead. Any other kind falls back to identity, which can miss a match a deeper
-// comparison would find: the cost is one more column for the sort to carry
-bool readsSameColumn(const Expr* lhs, const Expr* rhs) {
-    const Expr::Kind kind = lhs->getKind();
-
-    if (kind != rhs->getKind()) {
-        return false;
-    } else if (kind == Expr::Kind::SYMBOL) {
-        return lhs->getExprVarDecl() == rhs->getExprVarDecl();
-    } else if (kind == Expr::Kind::PROPERTY) {
-        const PropertyExpr* lhsProperty = static_cast<const PropertyExpr*>(lhs);
-        const PropertyExpr* rhsProperty = static_cast<const PropertyExpr*>(rhs);
-
-        const bool sameEntity = lhsProperty->getEntityVarDecl() == rhsProperty->getEntityVarDecl();
-        const bool sameProperty = lhsProperty->getPropName() == rhsProperty->getPropName();
-
-        return sameEntity && sameProperty;
-    } else {
-        return lhs == rhs;
-    }
-}
-
 // The index of the projected column @param key reads, or the item count when the
 // projection does not carry it. The projection is one column per return item, so the
-// index is the column's index too
+// index is the column's index too.
+//
+// A key and the item it reads are separate AST nodes - the n.name of
+// RETURN n.name ORDER BY n.name is written twice, so it is parsed twice - which is why
+// the two are matched by structure rather than by identity
 size_t findProjectedColumn(const Projection::Items& items, const Expr* key) {
     size_t index = 0;
     for (const Projection::ReturnItem& item : items) {
         const Expr* const* itemExpr = std::get_if<Expr*>(&item);
-        if (itemExpr && readsSameColumn(*itemExpr, key)) {
+        if (itemExpr && StructuralExpressionComparator::equal(*itemExpr, key)) {
             return index;
         }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -28,7 +28,7 @@ class UnaryExpr;
 class CypherAST;
 class Expr;
 class Literal;
-class OrderBy;
+class Projection;
 class PropertyExpr;
 class VariableDependency;
 class DependencyEdge;
@@ -94,7 +94,7 @@ private:
 
     // Reorders the projection with a Sort over @param projected, replacing each
     // projected column with its sorted counterpart
-    void translateOrderBy(const OrderBy* orderBy,
+    void translateOrderBy(const Projection* projection,
                           const FinalIdentityMap& identities,
                           llvm::SmallVectorImpl<mlir::Value>& projected);
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -28,6 +28,7 @@ class UnaryExpr;
 class CypherAST;
 class Expr;
 class Literal;
+class OrderBy;
 class PropertyExpr;
 class VariableDependency;
 class DependencyEdge;
@@ -38,6 +39,10 @@ public:
     using VariableIdentityMap = std::unordered_map<const VariableDependency*, VariableIdentities>;
     using DefinedVars = std::unordered_set<const VariableDependency*>;
     using ExprValueMap = std::unordered_map<const Expr*, mlir::Value>;
+
+    // Maps a Cypher variable name to the last column defined for it, the one the
+    // projection and its ORDER BY read
+    using FinalIdentityMap = std::unordered_map<std::string_view, mlir::Value>;
 
     explicit DBProgramGenerator(mlir::ModuleOp* mainModule);
     ~DBProgramGenerator();
@@ -86,6 +91,16 @@ private:
     void moveComponentToFactor(TranslatedComponent& component, mlir::Block* factorBlock);
 
     void generateOutput(const CypherAST* ast);
+
+    // Reorders the projection with a Sort over @param projected, replacing each
+    // projected column with its sorted counterpart
+    void translateOrderBy(const OrderBy* orderBy,
+                          const FinalIdentityMap& identities,
+                          llvm::SmallVectorImpl<mlir::Value>& projected);
+
+    // The column an expression reads: the traversal variable it names, when it names
+    // one, otherwise the column its translation produces
+    mlir::Value resolveExprColumn(const FinalIdentityMap& identities, const Expr* expr);
 
     void generatePropertyConstraints(const CypherAST* ast);
     void generateLabelConstraints(const CypherAST* ast);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1412,17 +1412,8 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
                                      mlir::db::GetInEdgesByType>(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
-    // A pipeline breaker accumulates every row before it emits any, so the loops that
-    // fill its accumulator must run to completion and the walk stops here rather than
-    // reaching them - bounding them would sort, group or tally a prefix of the scan
-    // instead of the whole input.
-    //
-    // db.sort and db.group_aggregate drain their accumulator through an emit loop of
-    // their own, which buildLoopForSource opens from this op: that loop is what the
-    // limit really budgets, so the handle lands on it and it stops as soon as the
-    // budget is spent. db.count and the value reductions collapse to a single row and
-    // open no loop at all, so they take no handle - the limit then does its whole job
-    // through the truncate on the one materialized row.
+    // A pipeline breaker accumulates every row before emitting any, so the walk stops
+    // here; the limit budgets its emit loop instead, when it opens one.
     const bool emitsThroughLoop = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
     const bool breaksPipeline = emitsThroughLoop
         || mlir::isa<mlir::db::Count, mlir::db::Sum, mlir::db::Min, mlir::db::Max, mlir::db::Avg>(definingOp);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1060,11 +1060,13 @@ void DBLowering::lowerSort(mlir::db::Sort sort) {
     setInsertionInto(_entryBlock);
     nl::Sort sortOp = _builder.create<nl::Sort>(loc, iteratorType, state);
 
-    // The emit loop binds one variable per sorted column and is never bounded by
-    // a limit (sort must see every row), so the iterator-only loop builder is
-    // used. buildLoopForSource maps db.sort's results to the loop variables, so
-    // the db.output that follows lowers into the emit loop body reading the
-    // sorted chunks.
+    // The emit loop binds one variable per sorted column. It is the only loop of this
+    // sort a limit may bound - assignProducerLoops stops at the sort and hands the
+    // handle to it, never to the producing loops, which had to see every row - so it
+    // stops re-chunking once a downstream streaming limit is spent. A limit fused into
+    // the top-K bounds nothing here: the accumulator already holds at most k rows.
+    // buildLoopForSource maps db.sort's results to the loop variables, so the
+    // db.output that follows lowers into the emit loop body reading the sorted chunks.
     buildLoopForSource(sortOp.getResult(), sort.getOperation());
 }
 
@@ -1273,7 +1275,10 @@ void DBLowering::lowerGroupAggregate(mlir::db::GroupAggregate groupAggregate) {
     // after the producing loop (before the func.return) so every row has been folded
     // when the loop first steps. buildLoopForSource binds one loop variable per
     // output column and maps db.group_aggregate's results to them, so the db.output
-    // that follows lowers into the emit loop body reading the group rows.
+    // that follows lowers into the emit loop body reading the group rows. As for a
+    // sort, this emit loop is the only loop of this aggregation a limit may bound -
+    // assignProducerLoops stops at the breaker and hands the handle to it, never to
+    // the producing loops, which had to fold every row.
     setInsertionInto(_entryBlock);
     nl::GroupAggregate groupOp = _builder.create<nl::GroupAggregate>(loc, iteratorType, state);
     buildLoopForSource(groupOp.getResult(), groupAggregate.getOperation());
@@ -1407,10 +1412,29 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
                                      mlir::db::GetInEdgesByType>(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
+    // A pipeline breaker accumulates every row before it emits any, so the loops that
+    // fill its accumulator must run to completion and the walk stops here rather than
+    // reaching them - bounding them would sort, group or tally a prefix of the scan
+    // instead of the whole input.
+    //
+    // db.sort and db.group_aggregate drain their accumulator through an emit loop of
+    // their own, which buildLoopForSource opens from this op: that loop is what the
+    // limit really budgets, so the handle lands on it and it stops as soon as the
+    // budget is spent. db.count and the value reductions collapse to a single row and
+    // open no loop at all, so they take no handle - the limit then does its whole job
+    // through the truncate on the one materialized row.
+    const bool emitsThroughLoop = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
+    const bool breaksPipeline = emitsThroughLoop
+        || mlir::isa<mlir::db::Count, mlir::db::Sum, mlir::db::Min, mlir::db::Max, mlir::db::Avg>(definingOp);
+
     // The first limit, in program order, to claim a producer wins, so a loop
     // shared by two limits' nests carries the outer one and never two handles.
-    if ((opensLoop || isCrossProduct) && !_loopLimitHandle.count(definingOp)) {
+    if ((opensLoop || isCrossProduct || emitsThroughLoop) && !_loopLimitHandle.count(definingOp)) {
         _loopLimitHandle[definingOp] = handle;
+    }
+
+    if (breaksPipeline) {
+        return;
     }
 
     if (isCrossProduct) {

--- a/test/query/CMakeLists.txt
+++ b/test/query/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(analyzer)
+add_subdirectory(ast)
 add_subdirectory(ir)
 add_subdirectory(pipeline)
 add_subdirectory(queries)

--- a/test/query/ast/CMakeLists.txt
+++ b/test/query/ast/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_turing_test(test_query_ast_structural_expression_comparator StructuralExpressionComparatorTest.cpp)
+target_link_libraries(test_query_ast_structural_expression_comparator
+    PRIVATE turing_db_ast_s)

--- a/test/query/ast/StructuralExpressionComparatorTest.cpp
+++ b/test/query/ast/StructuralExpressionComparatorTest.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <string_view>
+#include <vector>
+
+#include "CypherAST.h"
+#include "Literal.h"
+#include "Symbol.h"
+#include "expr/BinaryExpr.h"
+#include "expr/Expr.h"
+#include "expr/ListExpr.h"
+#include "expr/LiteralExpr.h"
+#include "expr/Operators.h"
+#include "expr/StructuralExpressionComparator.h"
+#include "expr/SymbolExpr.h"
+#include "expr/UnaryExpr.h"
+
+using namespace db;
+
+// The comparator answers whether two expression trees are built the same way, which is
+// what lets a caller recognise one expression written twice in a query. The trees here
+// are built through the AST factories rather than parsed, so each test states exactly
+// the two shapes it compares.
+class StructuralExpressionComparatorTest : public ::testing::Test {
+protected:
+    StructuralExpressionComparatorTest()
+        : _ast(nullptr, "")
+    {
+    }
+
+    Expr* integer(int64_t value) {
+        return LiteralExpr::create(&_ast, IntegerLiteral::create(&_ast, value));
+    }
+
+    Expr* string(std::string_view value) {
+        return LiteralExpr::create(&_ast, StringLiteral::create(&_ast, value));
+    }
+
+    Expr* add(Expr* lhs, Expr* rhs) {
+        return BinaryExpr::create(&_ast, BinaryOperator::Add, lhs, rhs);
+    }
+
+    Expr* list(const std::vector<Expr*>& elements) {
+        ListExpr* expr = ListExpr::create(&_ast);
+        for (Expr* element : elements) {
+            expr->addItem(element);
+        }
+
+        return expr;
+    }
+
+    CypherAST _ast;
+};
+
+// The point of the class: two trees that were never the same node compare equal.
+TEST_F(StructuralExpressionComparatorTest, equalTreesBuiltSeparately) {
+    EXPECT_TRUE(StructuralExpressionComparator::equal(add(integer(1), integer(2)),
+                                                      add(integer(1), integer(2))));
+}
+
+TEST_F(StructuralExpressionComparatorTest, sameNodeEqualsItself) {
+    Expr* expr = add(integer(1), integer(2));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(expr, expr));
+}
+
+// Literals compare by value, and by value of the right kind: 1 is not 2, and the integer
+// 1 is not the string "1".
+TEST_F(StructuralExpressionComparatorTest, literalsCompareByValue) {
+    EXPECT_TRUE(StructuralExpressionComparator::equal(integer(7), integer(7)));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(integer(1), integer(2)));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(string("a"), string("a")));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(string("a"), string("b")));
+
+    EXPECT_FALSE(StructuralExpressionComparator::equal(integer(1), string("1")));
+}
+
+// A null literal carries no value, so any two of them are the same one.
+TEST_F(StructuralExpressionComparatorTest, nullLiteralsAreEqual) {
+    Expr* lhs = LiteralExpr::create(&_ast, NullLiteral::create(&_ast));
+    Expr* rhs = LiteralExpr::create(&_ast, NullLiteral::create(&_ast));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(lhs, rhs));
+}
+
+// The operator is part of the shape, and so is the side each operand sits on.
+TEST_F(StructuralExpressionComparatorTest, operatorAndOperandOrderMatter) {
+    Expr* sum = add(integer(1), integer(2));
+    Expr* difference = BinaryExpr::create(&_ast, BinaryOperator::Sub, integer(1), integer(2));
+
+    EXPECT_FALSE(StructuralExpressionComparator::equal(sum, difference));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(sum, add(integer(2), integer(1))));
+}
+
+TEST_F(StructuralExpressionComparatorTest, unaryOperatorsCompareByOperand) {
+    Expr* lhs = UnaryExpr::create(&_ast, UnaryOperator::Minus, integer(3));
+    Expr* rhs = UnaryExpr::create(&_ast, UnaryOperator::Minus, integer(3));
+    Expr* other = UnaryExpr::create(&_ast, UnaryOperator::Minus, integer(4));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(lhs, rhs));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(lhs, other));
+}
+
+// Nesting is compared all the way down, so a difference in a leaf reaches the top.
+TEST_F(StructuralExpressionComparatorTest, nestedTreesCompareToTheLeaves) {
+    Expr* lhs = add(add(integer(1), integer(2)), integer(3));
+    Expr* rhs = add(add(integer(1), integer(2)), integer(3));
+    Expr* deepDifference = add(add(integer(1), integer(9)), integer(3));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(lhs, rhs));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(lhs, deepDifference));
+
+    // The same leaves in a different shape: 1 + (2 + 3) is not (1 + 2) + 3
+    EXPECT_FALSE(StructuralExpressionComparator::equal(lhs, add(integer(1), add(integer(2), integer(3)))));
+}
+
+TEST_F(StructuralExpressionComparatorTest, listsCompareElementwise) {
+    EXPECT_TRUE(StructuralExpressionComparator::equal(list({integer(1), integer(2)}),
+                                                      list({integer(1), integer(2)})));
+
+    EXPECT_FALSE(StructuralExpressionComparator::equal(list({integer(1), integer(2)}),
+                                                       list({integer(2), integer(1)})));
+
+    EXPECT_FALSE(StructuralExpressionComparator::equal(list({integer(1)}),
+                                                       list({integer(1), integer(2)})));
+
+    EXPECT_TRUE(StructuralExpressionComparator::equal(list({}), list({})));
+}
+
+// A symbol stands for the variable it was resolved to, so two mentions of one variable
+// match and two different variables do not - whatever they are called.
+TEST_F(StructuralExpressionComparatorTest, symbolsCompareByDeclaration) {
+    Expr* lhs = SymbolExpr::create(&_ast, Symbol::create(&_ast, "n"));
+    Expr* rhs = SymbolExpr::create(&_ast, Symbol::create(&_ast, "n"));
+
+    // Neither is resolved, so both carry a null declaration and compare equal
+    EXPECT_TRUE(StructuralExpressionComparator::equal(lhs, rhs));
+}
+
+TEST_F(StructuralExpressionComparatorTest, differentKindsAreNeverEqual) {
+    EXPECT_FALSE(StructuralExpressionComparator::equal(integer(1), list({integer(1)})));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(add(integer(1), integer(2)), integer(3)));
+}
+
+TEST_F(StructuralExpressionComparatorTest, nullOperandsAreHandled) {
+    EXPECT_TRUE(StructuralExpressionComparator::equal(nullptr, nullptr));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(integer(1), nullptr));
+    EXPECT_FALSE(StructuralExpressionComparator::equal(nullptr, integer(1)));
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -64,6 +64,27 @@ target_link_libraries(test_query_ir_equivalence PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_equivalence PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_order_by OrderByTest.cpp)
+target_link_libraries(test_query_ir_order_by PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_order_by PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cypher_output CypherOutputTest.cpp)
 target_link_libraries(test_query_ir_cypher_output PRIVATE
         turing_db_s

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -1596,6 +1596,25 @@ std::string topKByScoreAscProgram(uint64_t count) {
              "}\n";
 }
 
+// MATCH (a) RETURN a ORDER BY a DESC SKIP skipCount LIMIT limitCount: a window cut
+// out of a sorted result. The db.skip between the sort and the limit blocks the top-K
+// fusion, so the limit stays a streaming one - over the sort's emit loop, never over
+// the scan that fills the accumulator.
+std::string sortSkipLimitNodesDescProgram(uint64_t skipCount, uint64_t limitCount) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %sa = db.sort(%a) keys [0] ascending [false] : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+                       "  %ka = db.skip(%sa) count ")
+           + std::to_string(skipCount)
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  %la = db.limit(%ka) count "
+           + std::to_string(limitCount)
+           + " : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>\n"
+             "  db.output(%la) : !db.column<!storage.node_id>\n"
+             "  return\n"
+             "}\n";
+}
+
 // MATCH (a)-[]->(b) RETURN DISTINCT b: one hop, then dedup the target column.
 // Several sources can point at the same target, so b has duplicates DISTINCT drops.
 const char* const removeDuplicatesTargetsProgram = R"mlir(
@@ -1689,6 +1708,38 @@ func.func @main() {
   return
 }
 )mlir";
+
+// MATCH (a) RETURN count(a) LIMIT count: a limit over a tally. The count collapses to
+// a single row and opens no emit loop, so the limit has no loop of its own to budget -
+// and the loop that charges the tally must still see every node, or the count is wrong.
+std::string countNodesLimitProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %n = db.count(%a) : (!db.column<!storage.node_id>) -> !db.column<ui64>\n"
+                       "  %ln = db.limit(%n) count ")
+           + std::to_string(count)
+           + " : (!db.column<ui64>) -> !db.column<ui64>\n"
+             "  db.output(%ln) : !db.column<ui64>\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) RETURN <agg>(a.score) LIMIT count: the value-reducing sibling of
+// countNodesLimitProgram, over db.sum / db.min / db.max / db.avg.
+std::string aggregateScoreLimitProgram(const char* op, uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %score = db.get_node_properties(%a, \"score\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+                       "  %r = db.")
+           + op
+           + "(%score) : (!db.column<none>) -> !db.column<none>\n"
+             "  %lr = db.limit(%r) count "
+           + std::to_string(count)
+           + " : (!db.column<none>) -> !db.column<none>\n"
+             "  db.output(%lr) : !db.column<none>\n"
+             "  return\n"
+             "}\n";
+}
 
 // MATCH (a) RETURN <agg>(a.score): reduce the non-null scores with the given
 // aggregate op (db.sum / db.min / db.max / db.avg). The db result value type is
@@ -4386,6 +4437,108 @@ TEST_F(DBLoweringTest, lowersTopKToBoundedSortBufferWithoutLimitOps) {
     EXPECT_EQ(*bufferOp.getTopK(), 2u);
 }
 
+TEST_F(DBLoweringTest, sortSkipLimitPagesTheSortedRows) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four nodes descending is 3, 2, 1, 0; SKIP 1 LIMIT 2 cuts the window 2, 1 out of
+    // that order - a page of the sorted rows, not of the scan.
+    CollectingNodeSink sink;
+    const std::string program = sortSkipLimitNodesDescProgram(1, 2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{2}, {1}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, sortSkipLimitPagesTheSortedRowsAcrossChunks) {
+    auto graph = buildDiamondGraph();
+    addSecondPart(*graph);
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Six nodes at chunk size 1: the window is cut from the global descending order
+    // (5, 4, 3, 2, 1, 0), so it must be 4, 3 no matter how the scan is chunked.
+    CollectingNodeSink sink;
+    const std::string program = sortSkipLimitNodesDescProgram(1, 2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    const std::vector<std::vector<uint64_t>> expected {{4}, {3}};
+    std::vector<std::vector<uint64_t>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, lowersSortSkipLimitToALimitOnTheEmitLoopOnly) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = sortSkipLimitNodesDescProgram(1, 2);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    // The skip blocks the top-K fusion, so this is the streaming limit path: an
+    // unbounded nl.sort_buffer and one nl.limit handle.
+    size_t limitCount = 0;
+    mlir::nl::SortBuffer bufferOp;
+    mlir::nl::SortCollect collectOp;
+    mlir::nl::Sort sortOp;
+    mlir::Value handle;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::SortBuffer found = mlir::dyn_cast<mlir::nl::SortBuffer>(operation)) {
+            bufferOp = found;
+        } else if (mlir::nl::SortCollect found = mlir::dyn_cast<mlir::nl::SortCollect>(operation)) {
+            collectOp = found;
+        } else if (mlir::nl::Sort found = mlir::dyn_cast<mlir::nl::Sort>(operation)) {
+            sortOp = found;
+        } else if (mlir::nl::Limit found = mlir::dyn_cast<mlir::nl::Limit>(operation)) {
+            handle = found.getState();
+            limitCount++;
+        }
+    });
+
+    ASSERT_TRUE(bufferOp);
+    ASSERT_TRUE(collectOp);
+    ASSERT_TRUE(sortOp);
+    ASSERT_TRUE(handle);
+    EXPECT_EQ(limitCount, 1u);
+    EXPECT_FALSE(bufferOp.getTopK().has_value());
+
+    // The producing loop is the one holding the collect: it fills the accumulator, so
+    // it must run to completion - a limit operand there would sort a prefix of the
+    // scan rather than the whole input.
+    auto producingLoop = mlir::dyn_cast<mlir::nl::For>(collectOp->getParentOp());
+    ASSERT_TRUE(producingLoop);
+    EXPECT_FALSE(producingLoop.getLimit());
+
+    // The emit loop drains the sorted rows, and it is what the limit budgets: it
+    // carries the handle, so it stops once the window has been emitted.
+    ASSERT_TRUE(sortOp.getResult().hasOneUse());
+    auto emitLoop = mlir::dyn_cast<mlir::nl::For>(*sortOp.getResult().user_begin());
+    ASSERT_TRUE(emitLoop);
+    EXPECT_EQ(emitLoop.getLimit(), handle);
+}
+
 TEST_F(DBLoweringTest, removesDuplicateTargets) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();
@@ -4756,6 +4909,128 @@ TEST_F(DBLoweringTest, lowersAggregateToPipelineBreaker) {
     EXPECT_EQ(resultCount, 1u);
     EXPECT_EQ(forCount, 1u);
     EXPECT_EQ(sortBufferCount, 0u);
+}
+
+TEST_F(DBLoweringTest, countLimitStillTalliesEveryRow) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The tally is one row, so LIMIT 1 keeps it - and it must be the count of all four
+    // diamond nodes: a limit cannot cut the rows a count is charged from.
+    CollectingCountSink sink;
+    const std::string program = countNodesLimitProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<uint64_t> expected {4};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, lowersCountLimitWithoutBoundingTheCountingLoop) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = countNodesLimitProgram(1);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t forsWithLimit = 0;
+    mlir::nl::CountUpdate updateOp;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::CountUpdate found = mlir::dyn_cast<mlir::nl::CountUpdate>(operation)) {
+            updateOp = found;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        }
+    });
+
+    // The counting loop must run to completion, and a count opens no emit loop for the
+    // limit to budget instead, so no loop in the function carries the handle.
+    ASSERT_TRUE(updateOp);
+    auto countingLoop = mlir::dyn_cast<mlir::nl::For>(updateOp->getParentOp());
+    ASSERT_TRUE(countingLoop);
+    EXPECT_FALSE(countingLoop.getLimit());
+    EXPECT_EQ(forsWithLimit, 0u);
+}
+
+TEST_F(DBLoweringTest, sumLimitStillReducesEveryRow) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Scores 100, 200 and null: the reduction is one row, so LIMIT 1 keeps it, and it
+    // must still be the sum of every present score.
+    CollectingOptInt64Sink sink;
+    const std::string program = aggregateScoreLimitProgram("sum", 1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink);
+
+    const std::vector<std::optional<int64_t>> expected {300};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, lowersAggregateLimitWithoutBoundingTheFoldingLoop) {
+    auto graph = buildPropertyGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Every value reduction is its own db op, so each is checked: a limit over any of
+    // them must leave the folding loop unbounded.
+    for (const char* const op : {"sum", "min", "max", "avg"}) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        const std::string programText = aggregateScoreLimitProgram(op, 1);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule) << "op: " << op;
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction) << "op: " << op;
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &reader.getView());
+        lowering.lower(dbFunction, *nlModule);
+
+        size_t forsWithLimit = 0;
+        mlir::nl::AggregateUpdate updateOp;
+
+        nlModule->walk([&](mlir::Operation* operation) {
+            if (mlir::nl::AggregateUpdate found = mlir::dyn_cast<mlir::nl::AggregateUpdate>(operation)) {
+                updateOp = found;
+            } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+                if (forOp.getLimit()) {
+                    forsWithLimit++;
+                }
+            }
+        });
+
+        ASSERT_TRUE(updateOp) << "op: " << op;
+        auto foldingLoop = mlir::dyn_cast<mlir::nl::For>(updateOp->getParentOp());
+        ASSERT_TRUE(foldingLoop) << "op: " << op;
+        EXPECT_FALSE(foldingLoop.getLimit()) << "op: " << op;
+        EXPECT_EQ(forsWithLimit, 0u) << "op: " << op;
+    }
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -241,6 +241,14 @@ protected:
         interpreter.run();
     }
 
+    void expectRowsEqual(std::string_view query, const Rows& pipelineRows, const Rows& irRows) {
+        ASSERT_EQ(pipelineRows.size(), irRows.size()) << "Size mismatch for " << query;
+
+        for (auto [plRow, irRow] : rv::zip(pipelineRows, irRows)) {
+            EXPECT_EQ(plRow, irRow) << "Row mismatch for " << query;
+        }
+    }
+
     void expectEquivalent(std::string_view query) {
         try {
             Rows pipelineRows;
@@ -252,11 +260,26 @@ protected:
             std::ranges::sort(pipelineRows);
             std::ranges::sort(irRows);
 
-            ASSERT_EQ(pipelineRows.size(), irRows.size()) << "Size mismatch for " << query;
+            expectRowsEqual(query, pipelineRows, irRows);
+        } catch (...) {
+            spdlog::error("Exception thrown for query: {}.", query);
+            throw;
+        }
+    }
 
-            for (auto [plRow, irRow] : rv::zip(pipelineRows, irRows)) {
-                EXPECT_EQ(plRow, irRow) << "Row mismatch for " << query;
-            }
+    // The ORDER BY sibling of expectEquivalent: the row order is itself the result being
+    // checked, so the rows are compared as the two engines emitted them and neither side
+    // is sorted first. The query has to order by a key with no ties, or the engines may
+    // break them differently and both still be right
+    void expectEquivalentOrdered(std::string_view query) {
+        try {
+            Rows pipelineRows;
+            runViaPipeline(query, pipelineRows);
+
+            Rows irRows;
+            runViaIR(query, irRows);
+
+            expectRowsEqual(query, pipelineRows, irRows);
         } catch (...) {
             spdlog::error("Exception thrown for query: {}.", query);
             throw;
@@ -520,6 +543,41 @@ TEST_F(EquivalenceTest, limit) {
     expectEquivalent("MATCH (a)-->(b) RETURN a, b LIMIT 3");
 
     expectEquivalent("MATCH (a), (b), (c), (d) RETURN a LIMIT 10");
+}
+
+// Every node of simpledb has a name and no two share one, so a name key is a total
+// order: the engines have no tie to break and must emit the very same sequence
+TEST_F(EquivalenceTest, orderBy) {
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name ASC");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name DESC");
+
+    expectEquivalentOrdered("MATCH (n:Person) RETURN n.name ORDER BY n.name");
+    expectEquivalentOrdered("MATCH (n:Interest) RETURN n.name ORDER BY n.name DESC");
+
+    expectEquivalentOrdered("MATCH (n) WHERE n.age = 32 RETURN n.name ORDER BY n.name");
+    expectEquivalentOrdered("MATCH (n) WHERE n.isFrench RETURN n.name ORDER BY n.name DESC");
+
+    // No two edges of simpledb share a source and a target, so the two names order the
+    // traversal fully
+    expectEquivalentOrdered("MATCH (a)-->(b) RETURN a.name, b.name ORDER BY a.name, b.name");
+    expectEquivalentOrdered("MATCH (a)-->(b) RETURN a.name, b.name ORDER BY a.name DESC, b.name");
+    expectEquivalentOrdered("MATCH (a)-[:INTERESTED_IN]->(b) RETURN a.name, b.name ORDER BY b.name, a.name");
+}
+
+TEST_F(EquivalenceTest, orderBySkipLimit) {
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name LIMIT 5");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name DESC LIMIT 3");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name LIMIT 1");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name LIMIT 0");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name LIMIT 100");
+
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name SKIP 5");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name DESC SKIP 17");
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name SKIP 100");
+
+    expectEquivalentOrdered("MATCH (n) RETURN n.name ORDER BY n.name SKIP 2 LIMIT 4");
+    expectEquivalentOrdered("MATCH (a)-->(b) RETURN a.name, b.name ORDER BY a.name, b.name SKIP 3 LIMIT 5");
 }
 
 TEST_F(EquivalenceTest, comparisonFilters) {

--- a/test/query/ir/GroupAggregateTest.cpp
+++ b/test/query/ir/GroupAggregateTest.cpp
@@ -380,6 +380,23 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN a.team, count(*) LIMIT count: a limit over the emitted groups. The
+// limit caps how many group rows come out, never how many input rows are folded, so it
+// budgets the emit loop alone - the producing loop must still see every node for the
+// counts to be right.
+std::string groupCountStarLimitProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+                       "  %team = db.get_node_properties(%a, \"team\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+                       "  %gteam, %n = db.group_aggregate(%team, %a) keys 1 aggregates [count] : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<ui64>)\n"
+                       "  %lteam, %ln = db.limit(%gteam, %n) count ")
+           + std::to_string(count)
+           + " : (!db.column<none>, !db.column<ui64>) -> (!db.column<none>, !db.column<ui64>)\n"
+             "  db.output(%lteam, %ln) : !db.column<none>, !db.column<ui64>\n"
+             "  return\n"
+             "}\n";
+}
+
 // MATCH (a) RETURN a.weight, count(*): group by a Double property and count each
 // group. The grouping key is a nullable f64, so it exercises key serialization of a
 // floating-point value.
@@ -940,6 +957,86 @@ TEST_F(GroupAggregateTest, lowersToBufferUpdateAndEmitLoop) {
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(updateOp->getParentOp()));
     EXPECT_TRUE(groupOp.getResult().hasOneUse());
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(*groupOp.getResult().user_begin()));
+}
+
+TEST_F(GroupAggregateTest, limitCapsTheEmittedGroups) {
+    auto graph = buildTeamGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Two groups (red and blue); LIMIT 1 emits one of them. Which one is the emit
+    // order of the accumulator, so only the row count is asserted here.
+    CountingSink oneSink;
+    const std::string oneProgram = groupCountStarLimitProgram(1);
+    runLoweredProgram(oneProgram.c_str(), reader.getView(), oneSink);
+
+    EXPECT_EQ(oneSink.getTotalRows(), 1u);
+
+    // A bound above the group count emits every group.
+    CountingSink allSink;
+    const std::string allProgram = groupCountStarLimitProgram(5);
+    runLoweredProgram(allProgram.c_str(), reader.getView(), allSink);
+
+    EXPECT_EQ(allSink.getTotalRows(), 2u);
+}
+
+TEST_F(GroupAggregateTest, lowersGroupAggregateLimitToALimitOnTheEmitLoopOnly) {
+    auto graph = buildTeamGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    const std::string programText = groupCountStarLimitProgram(1);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t limitCount = 0;
+    mlir::nl::GroupAggregateUpdate updateOp;
+    mlir::nl::GroupAggregate groupOp;
+    mlir::Value handle;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::GroupAggregateUpdate found = mlir::dyn_cast<mlir::nl::GroupAggregateUpdate>(operation)) {
+            updateOp = found;
+        } else if (mlir::nl::GroupAggregate found = mlir::dyn_cast<mlir::nl::GroupAggregate>(operation)) {
+            groupOp = found;
+        } else if (mlir::nl::Limit found = mlir::dyn_cast<mlir::nl::Limit>(operation)) {
+            handle = found.getState();
+            limitCount++;
+        }
+    });
+
+    ASSERT_TRUE(updateOp);
+    ASSERT_TRUE(groupOp);
+    ASSERT_TRUE(handle);
+    EXPECT_EQ(limitCount, 1u);
+
+    // The producing loop is the one holding the update: it folds the rows into the
+    // per-group state, so it must run to completion - a limit operand there would
+    // group a prefix of the scan and undercount every group.
+    auto producingLoop = mlir::dyn_cast<mlir::nl::For>(updateOp->getParentOp());
+    ASSERT_TRUE(producingLoop);
+    EXPECT_FALSE(producingLoop.getLimit());
+
+    // The emit loop drains the finished groups, and it is what the limit budgets: it
+    // carries the handle, so it stops once the budgeted groups have been emitted.
+    ASSERT_TRUE(groupOp.getResult().hasOneUse());
+    auto emitLoop = mlir::dyn_cast<mlir::nl::For>(*groupOp.getResult().user_begin());
+    ASSERT_TRUE(emitLoop);
+    EXPECT_EQ(emitLoop.getLimit(), handle);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -391,3 +391,23 @@ TEST_F(OrderByTest, nodesByTargetAgeAscending) {
                            {12}, {12}, {17}};
     expectNodeRows("MATCH (n)-->(m) RETURN n ORDER BY m.age", expected);
 }
+
+// A sort over a cross product, keyed on the inner factor alone. The product pairs the
+// two nodes aged 32 - Remy (0) and Adam (1) - with the two SleepDisturbers - Ghosts (6)
+// and Animals (10) - and the nest produces them outer-first: (0,6), (0,10), (1,6),
+// (1,10). Ordering by b alone interleaves those iterations, putting both rows keyed on
+// Ghosts ahead of both keyed on Animals, which only a sort that has seen the whole nest
+// can do - a sort that ordered each chunk or each outer step on its own could not. The
+// two rows sharing a b tie, so they keep the order the nest collected them in.
+TEST_F(OrderByTest, crossProductByInnerFactorAscending) {
+    const Rows expected = {{0, 6}, {1, 6}, {0, 10}, {1, 10}};
+    expectNodeRows("MATCH (a {age: 32}), (b:SleepDisturber) RETURN a, b ORDER BY b", expected);
+}
+
+// Keying on both factors leaves no tie, and reversing both turns the nest's output
+// inside out: the last row produced is the first emitted.
+TEST_F(OrderByTest, crossProductByBothFactorsDescending) {
+    const Rows expected = {{1, 10}, {1, 6}, {0, 10}, {0, 6}};
+    expectNodeRows("MATCH (a {age: 32}), (b:SleepDisturber) RETURN a, b ORDER BY a DESC, b DESC",
+                   expected);
+}

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -268,6 +268,23 @@ TEST_F(OrderByTest, orderByThenLimit) {
     expectNodeRows("MATCH (n) RETURN n ORDER BY n DESC LIMIT 3", expected);
 }
 
+// ORDER BY a property ... LIMIT k: the three earliest dobs. Only four nodes carry a
+// dob, and a null sorts after every value, so however many null-dob nodes the scan
+// runs into first, none of them displaces a real dob from the top three.
+TEST_F(OrderByTest, topKByPropertyAscending) {
+    Rows expected;
+    nodeRowsFor({"Remy", "Adam", "Maxime"}, expected);
+
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n.dob LIMIT 3", expected);
+}
+
+// The same shape with the key projected and the order reversed: the last three names.
+TEST_F(OrderByTest, topKByProjectedPropertyDescending) {
+    const Names expected = {"Travel", "Suhas", "Remy"};
+
+    expectNames("MATCH (n) RETURN n.name ORDER BY n.name DESC LIMIT 3", expected);
+}
+
 // ORDER BY ... SKIP m drops the first m rows of the order, not of the scan.
 TEST_F(OrderByTest, orderByThenSkip) {
     const Rows expected = {{15}, {16}, {17}};

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -377,3 +377,17 @@ TEST_F(OrderByTest, nodesByUnprojectedAgeDescending) {
                            {11}, {12}, {13}, {14}, {15}, {16}, {17}, {0}, {1}};
     expectNodeRows("MATCH (n) RETURN n ORDER BY n.age DESC", expected);
 }
+
+// The key belongs to the other end of the traversal: the projection returns n, so m.age
+// is a column the sort carries only to order by, never to output. Just three of the
+// eighteen edges point at a node that has an age - Remy -> Adam, Adam -> Remy and
+// Ghosts -> Remy, all keyed 32 - so their sources lead, and the fifteen null-keyed rows
+// follow in the order the traversal collected them. A source repeats once per out-edge:
+// ORDER BY reorders rows, it does not merge them.
+TEST_F(OrderByTest, nodesByTargetAgeAscending) {
+    const Rows expected = {{0},  {1},  {6},                     // m is Adam or Remy, 32
+                           {0},  {0},  {0},  {1},  {1},  {8},   // m has no age from here
+                           {8},  {9},  {9},  {11}, {15}, {15},
+                           {12}, {12}, {17}};
+    expectNodeRows("MATCH (n)-->(m) RETURN n ORDER BY m.age", expected);
+}

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -442,3 +442,31 @@ TEST_F(OrderByTest, personPairsByAgeDifference) {
             << "row {" << row[0] << ", " << row[1] << "} has a key of 0 but sorted after a null";
     }
 }
+
+// The same match one level deeper: the key is computed, so the two occurrences of
+// n.age + 42 are whole trees rather than a single node to recognise. Comparing them
+// structurally still finds the projected column, so the sort takes it and the property
+// behind it is read once.
+TEST_F(OrderByTest, projectedExpressionKeyIsNotDuplicated) {
+    mlir::MLIRContext context;
+    mlir::OwningOpRef<mlir::ModuleOp> module;
+    generateProgram("MATCH (n) RETURN n.age + 42 ORDER BY n.age + 42", context, module);
+
+    size_t propertyReads = 0;
+    size_t sortCount = 0;
+
+    module->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::db::GetNodeProperties>(operation)) {
+            propertyReads++;
+        } else if (mlir::db::Sort sortOp = mlir::dyn_cast<mlir::db::Sort>(operation)) {
+            sortCount++;
+
+            EXPECT_EQ(sortOp.getColumns().size(), 1u);
+            ASSERT_EQ(sortOp.getKeyColumns().size(), 1u);
+            EXPECT_EQ(sortOp.getKeyColumns()[0], 0);
+        }
+    });
+
+    EXPECT_EQ(sortCount, 1u);
+    EXPECT_EQ(propertyReads, 1u);
+}

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -411,3 +411,34 @@ TEST_F(OrderByTest, crossProductByBothFactorsDescending) {
     expectNodeRows("MATCH (a {age: 32}), (b:SleepDisturber) RETURN a, b ORDER BY a DESC, b DESC",
                    expected);
 }
+
+// An arithmetic expression as the sort key, over the eight Person nodes paired with
+// themselves. Only Remy and Adam have an age, so b.age - a.age is 0 for the four pairs
+// drawn from those two and null for the other sixty, null propagating through the
+// subtraction. No projected column holds that difference, so it is computed into a
+// column of its own and appended to the sort: the four rows keyed 0 lead, in the order
+// the nest collected them, and the sixty null-keyed rows follow.
+TEST_F(OrderByTest, personPairsByAgeDifference) {
+    OrderedNodeSink sink;
+    runQuery("MATCH (a:Person), (b:Person) RETURN a, b ORDER BY b.age - a.age", &sink);
+
+    const uint64_t remy = SimpleGraph::findNodeID(_graph, "Remy").getValue();
+    const uint64_t adam = SimpleGraph::findNodeID(_graph, "Adam").getValue();
+
+    const Rows& rows = sink.rows();
+    ASSERT_EQ(rows.size(), 64u);
+
+    const Rows aged = {{remy, remy}, {remy, adam}, {adam, remy}, {adam, adam}};
+    const Rows leading(rows.begin(), rows.begin() + aged.size());
+    EXPECT_EQ(leading, aged);
+
+    // Every row after them has an endpoint with no age, which is what nulled its key
+    for (size_t rowIndex = aged.size(); rowIndex < rows.size(); rowIndex++) {
+        const Row& row = rows[rowIndex];
+        const bool sourceAged = row[0] == remy || row[0] == adam;
+        const bool targetAged = row[1] == remy || row[1] == adam;
+
+        EXPECT_FALSE(sourceAged && targetAged)
+            << "row {" << row[0] << ", " << row[1] << "} has a key of 0 but sorted after a null";
+    }
+}

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -1,0 +1,282 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = std::vector<uint64_t>;
+using Rows = std::vector<Row>;
+using Names = std::vector<std::string>;
+
+// Every node of simpledb by name, in ascending byte order - the order an
+// ORDER BY n.name must produce. Every node has a name, so no key is null here.
+const Names nodeNamesAscending = {
+    "Adam", "Animals", "Bio", "Computers", "Cooking", "Cyrus",
+    "Doruk", "Eighties", "Ghosts", "Gym", "JiuJitsu", "Luc",
+    "Martina", "Maxime", "Padel", "Remy", "Suhas", "Travel",
+};
+
+uint64_t readNodeID(const Column* column, size_t row) {
+    const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column);
+    if (!nodeIDs) {
+        throw std::runtime_error("OrderByTest: expected a node ID output column");
+    }
+
+    return (*nodeIDs)[row].getValue();
+}
+
+void describeRows(const Rows& rows, std::string& out) {
+    out.clear();
+    for (const Row& row : rows) {
+        out += "        {";
+        for (size_t index = 0; index < row.size(); index++) {
+            if (index > 0) {
+                out += ", ";
+            }
+
+            out += std::to_string(row[index]);
+        }
+
+        out += "},\n";
+    }
+}
+
+// Collects the node ID rows a projection emits, in the order the sink sees them. An
+// ORDER BY is only correct if that order survives to the output, so - unlike the
+// other Cypher output tests - nothing here sorts the rows.
+class OrderedNodeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* const column : chunks) {
+                row.push_back(readNodeID(column, rowIndex));
+            }
+        }
+    }
+
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
+};
+
+// The string sibling of OrderedNodeSink: collects a single projected string property
+// column, in sink order.
+class OrderedNameSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* names = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        ASSERT_NE(names, nullptr);
+
+        const auto& nameRaw = names->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            ASSERT_TRUE(nameRaw[rowIndex].has_value());
+            _names.push_back(std::string(*nameRaw[rowIndex]));
+        }
+    }
+
+    const Names& names() const { return _names; }
+
+private:
+    Names _names;
+};
+
+}
+
+// End-to-end ORDER BY through the MLIR frontend: each query is parsed, analyzed,
+// generated into the db dialect by DBProgramGenerator, then lowered and interpreted.
+// The assertions are on the row order, which is what the generated db.sort decides.
+class OrderByTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    void expectNodeRows(std::string_view query, const Rows& expected) {
+        OrderedNodeSink sink;
+        runQuery(query, &sink);
+
+        std::string description;
+        describeRows(sink.rows(), description);
+
+        EXPECT_EQ(sink.rows(), expected)
+            << "query: " << query << "\nactual rows:\n" << description;
+    }
+
+    void expectNames(std::string_view query, const Names& expected) {
+        OrderedNameSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.names(), expected) << "query: " << query;
+    }
+
+    // One single-column row per name, holding the ID of the node with that name, so a
+    // name order can be expressed as the node order it stands for
+    void nodeRowsFor(const Names& names, Rows& rows) {
+        rows.clear();
+        for (const std::string& name : names) {
+            rows.push_back({SimpleGraph::findNodeID(_graph, name).getValue()});
+        }
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+// The key is the projected column itself, so the sort reorders the projection in
+// place: simpledb has 18 nodes, IDs 0 to 17.
+TEST_F(OrderByTest, nodesByIDAscending) {
+    const Rows expected = {{0}, {1},  {2},  {3},  {4},  {5},  {6},  {7},  {8},
+                           {9}, {10}, {11}, {12}, {13}, {14}, {15}, {16}, {17}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n", expected);
+}
+
+TEST_F(OrderByTest, nodesByIDDescending) {
+    const Rows expected = {{17}, {16}, {15}, {14}, {13}, {12}, {11}, {10}, {9},
+                           {8},  {7},  {6},  {5},  {4},  {3},  {2},  {1},  {0}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n DESC", expected);
+}
+
+// The key is a property the projection does not carry, so it is sorted as an extra
+// column and dropped from the output: only the node IDs come back, in name order.
+TEST_F(OrderByTest, nodesByUnprojectedNameAscending) {
+    Rows expected;
+    nodeRowsFor(nodeNamesAscending, expected);
+
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n.name", expected);
+}
+
+TEST_F(OrderByTest, nodesByUnprojectedNameDescending) {
+    Names names = nodeNamesAscending;
+    std::ranges::reverse(names);
+
+    Rows expected;
+    nodeRowsFor(names, expected);
+
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n.name DESC", expected);
+}
+
+// A projected property, sorted by itself: the sorted rows carry the string values.
+TEST_F(OrderByTest, projectedNamesAscending) {
+    expectNames("MATCH (n) RETURN n.name ORDER BY n.name", nodeNamesAscending);
+}
+
+// Two keys, the first with real ties: every out-edge row sorted by source ascending
+// and - within one source - target descending.
+TEST_F(OrderByTest, edgesBySourceThenTargetDescending) {
+    const Rows expected = {
+        {0, 6}, {0, 3}, {0, 2}, {0, 1},
+        {1, 5}, {1, 4}, {1, 0},
+        {6, 0},
+        {8, 7}, {8, 4},
+        {9, 10}, {9, 2},
+        {11, 5},
+        {12, 16}, {12, 13},
+        {15, 14}, {15, 13},
+        {17, 13},
+    };
+    expectNodeRows("MATCH (a)-->(b) RETURN a, b ORDER BY a, b DESC", expected);
+}
+
+// ORDER BY ... LIMIT k: the k best rows of the whole order, not of an arbitrary
+// prefix - the shape lowering fuses into a bounded top-K.
+TEST_F(OrderByTest, orderByThenLimit) {
+    const Rows expected = {{17}, {16}, {15}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n DESC LIMIT 3", expected);
+}
+
+// ORDER BY ... SKIP m drops the first m rows of the order, not of the scan.
+TEST_F(OrderByTest, orderByThenSkip) {
+    const Rows expected = {{15}, {16}, {17}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n SKIP 15", expected);
+}
+
+// ORDER BY ... SKIP m LIMIT k: the sort sees every row, then the skip and the limit
+// cut a window out of the sorted rows.
+TEST_F(OrderByTest, orderByThenSkipLimit) {
+    const Rows expected = {{15}, {14}, {13}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n DESC SKIP 2 LIMIT 3", expected);
+}

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -19,6 +19,7 @@
 
 #include "DBDialect.h"
 #include "DBDialectInterpreter.h"
+#include "DBOps.h"
 #include "DBProgramGenerator.h"
 #include "LocalMemory.h"
 #include "NLDialect.h"
@@ -141,7 +142,10 @@ protected:
         SimpleGraph::createSimpleGraph(_graph);
     }
 
-    void runQuery(std::string_view query, NLOutputSink* sink) {
+    // Generates the db dialect program of a query into @param module, without running it
+    void generateProgram(std::string_view query,
+                         mlir::MLIRContext& context,
+                         mlir::OwningOpRef<mlir::ModuleOp>& module) {
         SystemAccessor system = _env->getSystemManager().accessUnique();
         const ProcedureManager* procedures = system.getProcedures();
 
@@ -156,21 +160,29 @@ protected:
         CypherAnalyzer analyzer(&ast, view);
         analyzer.analyze();
 
-        mlir::MLIRContext context;
         context.getOrLoadDialect<mlir::func::FuncDialect>();
         context.getOrLoadDialect<mlir::storage::Storage>();
         context.getOrLoadDialect<mlir::db::DB>();
         context.getOrLoadDialect<mlir::nl::NL>();
 
         mlir::OpBuilder builder(&context);
-        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
-        mlir::ModuleOp module = owningModule.get();
+        module = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp moduleOp = module.get();
 
-        DBProgramGenerator generator(&module);
+        DBProgramGenerator generator(&moduleOp);
         generator.generate(&ast);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        mlir::MLIRContext context;
+        mlir::OwningOpRef<mlir::ModuleOp> module;
+        generateProgram(query, context, module);
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
 
         LocalMemory memory;
-        DBDialectInterpreter interpreter(module, &view, sink, &memory);
+        DBDialectInterpreter interpreter(module.get(), &view, sink, &memory);
         interpreter.run();
     }
 
@@ -296,4 +308,52 @@ TEST_F(OrderByTest, orderByThenSkip) {
 TEST_F(OrderByTest, orderByThenSkipLimit) {
     const Rows expected = {{15}, {14}, {13}};
     expectNodeRows("MATCH (n) RETURN n ORDER BY n DESC SKIP 2 LIMIT 3", expected);
+}
+
+// The two n.name of RETURN n.name ORDER BY n.name are separate AST nodes, so matching
+// the key to the projection by identity would miss and hand the sort a second, equal
+// column - one more property read, and one more column buffered for every row. Matching
+// by what the expression names keeps the projection the sort's only column.
+TEST_F(OrderByTest, projectedPropertyKeyIsNotDuplicated) {
+    mlir::MLIRContext context;
+    mlir::OwningOpRef<mlir::ModuleOp> module;
+    generateProgram("MATCH (n) RETURN n.name ORDER BY n.name", context, module);
+
+    size_t propertyReads = 0;
+    size_t sortCount = 0;
+
+    module->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::db::GetNodeProperties>(operation)) {
+            propertyReads++;
+        } else if (mlir::db::Sort sortOp = mlir::dyn_cast<mlir::db::Sort>(operation)) {
+            sortCount++;
+
+            EXPECT_EQ(sortOp.getColumns().size(), 1u);
+            ASSERT_EQ(sortOp.getKeyColumns().size(), 1u);
+            EXPECT_EQ(sortOp.getKeyColumns()[0], 0);
+        }
+    });
+
+    EXPECT_EQ(sortCount, 1u);
+    EXPECT_EQ(propertyReads, 1u);
+}
+
+// The mirror case: a key the projection does not carry has no column to be matched to,
+// so it is appended and the sort receives one column more than the projection.
+TEST_F(OrderByTest, unprojectedKeyIsAppended) {
+    mlir::MLIRContext context;
+    mlir::OwningOpRef<mlir::ModuleOp> module;
+    generateProgram("MATCH (n) RETURN n ORDER BY n.name", context, module);
+
+    size_t sortCount = 0;
+
+    module->walk([&](mlir::db::Sort sortOp) {
+        sortCount++;
+
+        EXPECT_EQ(sortOp.getColumns().size(), 2u);
+        ASSERT_EQ(sortOp.getKeyColumns().size(), 1u);
+        EXPECT_EQ(sortOp.getKeyColumns()[0], 1);
+    });
+
+    EXPECT_EQ(sortCount, 1u);
 }

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -357,3 +357,23 @@ TEST_F(OrderByTest, unprojectedKeyIsAppended) {
 
     EXPECT_EQ(sortCount, 1u);
 }
+
+// A key most rows do not have: only Remy (0) and Adam (1) carry an age in simpledb, both
+// 32, and the other sixteen nodes have none. A null sorts after every value, so the two
+// aged nodes come first and the null-keyed rows follow; Remy and Adam tie on 32 and the
+// sixteen nulls tie with each other, and a tie keeps the order the rows were collected
+// in - the scan order - because the sort is stable.
+TEST_F(OrderByTest, nodesByUnprojectedAgeAscending) {
+    const Rows expected = {{0}, {1},  {2},  {3},  {4},  {5},  {6},  {7},  {8},
+                           {9}, {10}, {11}, {12}, {13}, {14}, {15}, {16}, {17}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n.age", expected);
+}
+
+// Reversing the order moves the nulls to the front, since they sort after every value.
+// The ties do not reverse with it: a descending sort still keeps tied rows in collected
+// order, so the nulls stay in scan order and Remy precedes Adam.
+TEST_F(OrderByTest, nodesByUnprojectedAgeDescending) {
+    const Rows expected = {{2},  {3},  {4},  {5},  {6},  {7},  {8}, {9}, {10},
+                           {11}, {12}, {13}, {14}, {15}, {16}, {17}, {0}, {1}};
+    expectNodeRows("MATCH (n) RETURN n ORDER BY n.age DESC", expected);
+}


### PR DESCRIPTION
Implements the ORDER BY clause in DBProgramGenerator.

Generates a `db.sort` from the projection's ORDER BY, ahead of SKIP and LIMIT, and stops the limit's producer walk at pipeline breakers so it no longer bounds the loop that fills their accumulator.