### PR TITLE
query: support edge type filters on quantified paths

### DIFF
--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -474,13 +474,6 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
             }
         }
 
-        const auto& types = edgePattern->types();
-        if (types && !types->empty()) {
-            throwError("Edge type filters are not supported with "
-                       "variable-length paths yet",
-                       edgePattern);
-        }
-
         if (properties) {
             throwError("Edge property filters are not supported with "
                        "variable-length paths yet",

--- a/query/pipeline/PipelineBuilder.cpp
+++ b/query/pipeline/PipelineBuilder.cpp
@@ -426,6 +426,7 @@ PipelineBlockOutputInterface& PipelineBuilder::addPathExplorer(uint64_t minHops,
     proc->setBfsEdgesColumn(_mem->alloc<ColumnEdgeIDs>());
     proc->setBfsIntermediatesColumn(_mem->alloc<ColumnNodeIDs>());
     proc->setBfsSourcesColumn(_mem->alloc<ColumnNodeIDs>());
+    proc->setBfsEdgeTypesColumn(_mem->alloc<ColumnEdgeTypes>());
 
     output.setStream(EntityOutputStream::createNodeStream(targetNodes->getTag()));
 

--- a/query/pipeline/processors/PathExplorerProcessor.cpp
+++ b/query/pipeline/processors/PathExplorerProcessor.cpp
@@ -8,6 +8,7 @@
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnVector.h"
 #include "columns/ColumnIndices.h"
+#include "columns/ColumnEdgeTypes.h"
 #include "iterators/GetOutEdgesIterator.h"
 #include "iterators/GetInEdgesIterator.h"
 #include "iterators/GetEdgesIterator.h"
@@ -32,8 +33,12 @@ PathExplorerProcessor<Dir>::~PathExplorerProcessor() {
 
 template <PathExplorationDir Dir>
 std::string PathExplorerProcessor<Dir>::describe() const {
-    return fmt::format("PathExplorerProcessor @={} hops=[{},{}]",
-                       fmt::ptr(this), _minHops, _maxHops);
+    return fmt::format("PathExplorerProcessor @={} hops=[{},{}] candidates={} emitted={}",
+                       fmt::ptr(this),
+                       _minHops,
+                       _maxHops,
+                       _candidateEdges,
+                       _emittedRows);
 }
 
 template <PathExplorationDir Dir>
@@ -61,11 +66,9 @@ void PathExplorerProcessor<Dir>::prepare(ExecutionContext* ctxt) {
     _ctxt = ctxt;
     const GraphView& view = ctxt->getGraphView();
 
-    // Input
     _inputSources = _input.getNodeIDs()->as<ColumnNodeIDs>();
     bioassert(_inputSources, "Input nodes column is null");
 
-    // Output
     bioassert(_outputTargets, "Output target nodes column is null");
     bioassert(_outputPaths, "Output paths column is null");
     bioassert(_outputIndices, "Output indices column is null");
@@ -79,16 +82,25 @@ void PathExplorerProcessor<Dir>::prepare(ExecutionContext* ctxt) {
         _bfsWriter->setIndices(_bfsIndices);
         _bfsWriter->setEdgeIDs(_bfsEdges);
         _bfsWriter->setOtherIDs(_bfsIntermediates);
+        if (_edgeTypeConstraint) {
+            _bfsWriter->setEdgeTypes(_bfsEdgeTypes);
+        }
     } else if constexpr (Dir == PathExplorationDir::FORWARD) {
         _bfsWriter = std::make_unique<BFSChunkWriter>(view, _bfsSources);
         _bfsWriter->setIndices(_bfsIndices);
         _bfsWriter->setEdgeIDs(_bfsEdges);
         _bfsWriter->setTgtIDs(_bfsIntermediates);
+        if (_edgeTypeConstraint) {
+            _bfsWriter->setEdgeTypes(_bfsEdgeTypes);
+        }
     } else if constexpr (Dir == PathExplorationDir::BACKWARD) {
         _bfsWriter = std::make_unique<BFSChunkWriter>(view, _bfsSources);
         _bfsWriter->setIndices(_bfsIndices);
         _bfsWriter->setEdgeIDs(_bfsEdges);
         _bfsWriter->setSrcIDs(_bfsIntermediates);
+        if (_edgeTypeConstraint) {
+            _bfsWriter->setEdgeTypes(_bfsEdgeTypes);
+        }
     } else {
         COMPILE_ERROR("Invalid PathExplorationDir");
     }
@@ -104,6 +116,8 @@ void PathExplorerProcessor<Dir>::reset() {
     _allEntries.clear();
     _depthStart = 0;
     _depthEnd = 0;
+    _candidateEdges = 0;
+    _emittedRows = 0;
     markAsReset();
 }
 
@@ -111,19 +125,14 @@ template <PathExplorationDir Dir>
 void PathExplorerProcessor<Dir>::reconstructPath(size_t entryIdx, EntityList& path) const {
     path.resize(_depth);
 
-    // Current index into the _allEntries array
     size_t idx = entryIdx;
 
-    // Current position into the outputed path array
     size_t pathCursor = _depth - 1;
 
-    // Walk up the parent chain to fill the path until we reach the root
     while (idx != ROOT) {
         const FrontierEntry& e = _allEntries[idx];
 
         if (e.parentIdx == ROOT) {
-            // The "root edge" entry is a special case,
-            // it is not part of the path, do not output it
             break;
         }
 
@@ -135,7 +144,6 @@ void PathExplorerProcessor<Dir>::reconstructPath(size_t entryIdx, EntityList& pa
     }
 }
 
-/// Walk up the parent chain to check if edge is already used in the current row.
 template <PathExplorationDir Dir>
 bool PathExplorerProcessor<Dir>::edgeUsedInPath(size_t entryIdx, EdgeID edge) const {
     size_t idx = entryIdx;
@@ -165,15 +173,11 @@ void PathExplorerProcessor<Dir>::execute() {
     size_t remaining = _ctxt->getChunkSize();
 
     if (!_bfsInitialized) {
-        // Step 1. This is the first time execute() is called on the input chunk.
-        //         It initializes the breadth-first exploration on it.
         _bfsInitialized = true;
 
         const ColumnNodeIDs& inputNodes = *_inputSources;
         const size_t inputSize = inputNodes.size();
 
-        // Seed _allEntries with root entries (one per input source node).
-        // Root entries have parentIdx = -1 and no edge.
         _allEntries.resize(inputSize);
         for (size_t i = 0; i < inputSize; i++) {
             _allEntries[i] = FrontierEntry {
@@ -185,12 +189,13 @@ void PathExplorerProcessor<Dir>::execute() {
         }
 
         if (_minHops == 0) {
-            // Write all paths corresponding to no hops
             for (size_t i = 0; i < inputSize; i++) {
                 _outputIndices->push_back(i);
                 outputTargets->push_back(inputNodes[i]);
                 outputPaths->emplace_back();
             }
+
+            _emittedRows += inputSize;
 
             remaining = remaining >= inputSize
                           ? remaining - inputSize
@@ -207,17 +212,6 @@ void PathExplorerProcessor<Dir>::execute() {
               "Initialization error, depth should always be greater than 0 at this point");
 
     if (_depthNeedsSetup) {
-        // Step 2. This is the first time execute() is called on the current depth.
-        //         It sets up the current depth window and feeds it to the BFS writer.
-        //         It prepares a chunk of size `windowSize` to be fed to the ChunkWriter.
-        //
-        //         > [!WARNING]
-        //         > `windowSize` can exceed the maximum ChunkSize
-        //         >   -> the memory usage is unbounded.
-
-        // If:
-        //  - _depth > _maxHops -> We have reached the maximum hops
-        //  - _depthStart == _depthEnd -> No more edges to expand
         if (_depth > _maxHops || _depthStart == _depthEnd) {
             _input.getPort()->consume();
             _output.getPort()->writeData();
@@ -237,33 +231,30 @@ void PathExplorerProcessor<Dir>::execute() {
         _depthNeedsSetup = false;
     }
 
-    // Step 3. Fill one chunk of edges from the current depth set of sources.
     _bfsWriter->fill(remaining);
 
     ColumnEdgeIDs& bfsEdges = *_bfsEdges;
     ColumnNodeIDs& bfsIntermediates = *_bfsIntermediates;
     ColumnIndices& bfsIndices = *_bfsIndices;
 
-    for (size_t i = 0; i < bfsEdges.size(); i++) {
-        // Step 4. For each edges at this depth:
-        //           - Check if the edge is already used in the current path.
-        //           - If not, add it to the entries (to be used by deeper levels).
-        //           - Reconstruct and write the path in the output if minHops is met.
+    _candidateEdges += bfsEdges.size();
 
+    for (size_t i = 0; i < bfsEdges.size(); i++) {
         const NodeID intermediate = bfsIntermediates[i];
         const EdgeID edge = bfsEdges[i];
 
-        // `parentIdx` references the parent of the current edge in the
-        // frontier entries array
+        if (_edgeTypeConstraint) {
+            if ((*_bfsEdgeTypes)[i] != *_edgeTypeConstraint) {
+                continue;
+            }
+        }
+
         const size_t parentIdx = _depthStart + bfsIndices[i];
 
-        // Per-path edge uniqueness check - O(depth) walk up parent chain
-        // To check if the edge was already encountered in the current path
         if (edgeUsedInPath(parentIdx, edge)) {
             continue;
         }
 
-        // Append new entry to the persistent frontier entries store
         const size_t newIdx = _allEntries.size();
         _allEntries.push_back(FrontierEntry {
             .node = intermediate,
@@ -272,18 +263,15 @@ void PathExplorerProcessor<Dir>::execute() {
             .sourceIdx = _allEntries[parentIdx].sourceIdx,
         });
 
-        // If the current depth is at least minHops, write the path to the output
-        // The path is reconstructed by walking up the parent chain
         if (_depth >= _minHops) {
             _outputIndices->push_back(_allEntries[parentIdx].sourceIdx);
             outputTargets->push_back(intermediate);
             EntityList& p = outputPaths->emplace_back();
             reconstructPath(newIdx, p);
+            _emittedRows++;
         }
     }
 
-    // Current depth fully expanded - advance to next depth. Next execute()
-    // call will trigger Step 2, as well as Step 1 if the input chunk is exhausted
     if (!_bfsWriter->isValid()) {
         _depthStart = _depthEnd;
         _depthEnd = _allEntries.size();

--- a/query/pipeline/processors/PathExplorerProcessor.h
+++ b/query/pipeline/processors/PathExplorerProcessor.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <limits>
 #include <memory>
+#include <optional>
 #include <stdint.h>
+#include <type_traits>
 #include <vector>
 
 #include "Processor.h"
@@ -9,11 +12,13 @@
 #include "interfaces/PipelineNodeInputInterface.h"
 #include "interfaces/PipelineBlockOutputInterface.h"
 
+#include "columns/ColumnEdgeTypes.h"
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnIndices.h"
 
 #include "PathExplorationDir.h"
 #include "EntityList.h"
+#include "ID.h"
 
 namespace db {
 
@@ -66,6 +71,12 @@ public:
     void setBfsSourcesColumn(ColumnNodeIDs* sources) {
         _bfsSources = sources;
     }
+    void setBfsEdgeTypesColumn(ColumnEdgeTypes* types) {
+        _bfsEdgeTypes = types;
+    }
+    void setEdgeTypeConstraint(const std::optional<EdgeTypeID>& edgeType) {
+        _edgeTypeConstraint = edgeType;
+    }
 
     NamedColumn* getOutputTargetsColumn() const {
         return _outputTargets;
@@ -79,9 +90,9 @@ private:
 
     struct FrontierEntry {
         NodeID node;
-        EdgeID edge;             // single edge that led to this node
-        size_t parentIdx {ROOT}; // index into _allEntries, -1 for root
-        size_t sourceIdx {ROOT}; // original input source index
+        EdgeID edge;
+        size_t parentIdx {ROOT};
+        size_t sourceIdx {ROOT};
     };
 
     PathExplorerProcessor(uint64_t minHops,
@@ -94,33 +105,32 @@ private:
     PipelineNodeInputInterface _input;
     PipelineBlockOutputInterface _output;
 
-    // Processor input/outputs
     ColumnNodeIDs* _inputSources {nullptr};
     NamedColumn* _outputTargets {nullptr};
     NamedColumn* _outputPaths {nullptr};
     ColumnIndices* _outputIndices {nullptr};
 
-    // BFS chunk writer internals
     ColumnNodeIDs* _bfsSources {nullptr};
     ColumnEdgeIDs* _bfsEdges {nullptr};
     ColumnNodeIDs* _bfsIntermediates {nullptr};
     ColumnIndices* _bfsIndices {nullptr};
+    ColumnEdgeTypes* _bfsEdgeTypes {nullptr};
     std::unique_ptr<BFSChunkWriter> _bfsWriter;
+    std::optional<EdgeTypeID> _edgeTypeConstraint {};
 
     bool _bfsInitialized {false};
     bool _depthNeedsSetup {true};
 
-    /** @brief Current depth of the exploration */
     uint64_t _depth {0};
 
-    /** @brief Persistent tree, never shrunk until new input chunk received */
     std::vector<FrontierEntry> _allEntries;
 
-    /** @brief Index of first entry at current depth */
     size_t _depthStart {0};
 
-    /** @brief Index one past last entry at current depth */
     size_t _depthEnd {0};
+
+    size_t _candidateEdges {0};
+    size_t _emittedRows {0};
 
     bool edgeUsedInPath(size_t entryIdx, EdgeID edge) const;
     void reconstructPath(size_t entryIdx, EntityList& path) const;

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -1812,8 +1812,10 @@ PipelineOutputInterface* PipelineGenerator::translatePathExplorerNode(PathExplor
     const auto makeProcessor = [&]<PathExplorationDir Dir>() {
         _builder.addPathExplorer<Dir>(minHops, maxHops);
 
-        const auto* proc = dynamic_cast<PathExplorerProcessor<Dir>*>(_builder.getLastProc());
+        auto* proc = dynamic_cast<PathExplorerProcessor<Dir>*>(_builder.getLastProc());
         bioassert(proc, "Failed to cast last proc to PathExplorerProcessor");
+
+        proc->setEdgeTypeConstraint(node->getEdgeTypeConstraint());
 
         const VarDecl* edgeDecl = node->getEdgeDecl();
         const VarDecl* targetDecl = node->getTargetDecl();

--- a/query/plan/PlanGraphDebug.cpp
+++ b/query/plan/PlanGraphDebug.cpp
@@ -1,5 +1,6 @@
 #include "PlanGraphDebug.h"
 
+#include <optional>
 #include <range/v3/view/enumerate.hpp>
 
 #include "expr/Expr.h"
@@ -13,6 +14,7 @@
 #include "nodes/JoinNode.h"
 #include "nodes/LoadJsonlNode.h"
 #include "nodes/OrderByNode.h"
+#include "nodes/PathExplorerNode.h"
 #include "nodes/ProcedureEvalNode.h"
 #include "nodes/UnwindNode.h"
 #include "nodes/VarNode.h"
@@ -586,13 +588,20 @@ void PlanGraphDebug::dumpMermaidContent(std::ostream& output, const GraphView& v
             case PlanGraphOpcode::LOAD_COMMIT:
             case PlanGraphOpcode::INSTALL_EXTENSION:
             case PlanGraphOpcode::SHOW_EXTENSIONS:
-            case PlanGraphOpcode::PATH_EXPLORER:
             case PlanGraphOpcode::CREATE_PROPERTY_INDEX:
             case PlanGraphOpcode::INDEX_LOOKUP:
             case PlanGraphOpcode::DROP_INDEX:
             case PlanGraphOpcode::MERGE_DATAPARTS:
             // No extra info required
             break;
+
+            case PlanGraphOpcode::PATH_EXPLORER: {
+                const auto* n = dynamic_cast<PathExplorerNode*>(node.get());
+                const std::optional<EdgeTypeID>& edgeType = n->getEdgeTypeConstraint();
+                if (edgeType) {
+                    output << "        __edge_type__: " << edgeTypeMap.getName(*edgeType).value() << "\n";
+                }
+            } break;
 
             case PlanGraphOpcode::_SIZE:
             case PlanGraphOpcode::UNKNOWN:

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -518,6 +518,18 @@ PlanGraphNode* ReadStmtGenerator::generatePatternElementVariableLengthPath(PlanG
         } break;
     }
 
+    const std::span edgeTypes = edge->getData()->edgeTypeConstraints();
+    if (edgeTypes.size() > 1) {
+        throwError("Only one edge type constraint is supported for now", edge);
+    } else if (!edgeTypes.empty()) {
+        const std::optional edgeType = _graphMetadata.edgeTypes().get(edgeTypes.front());
+        if (!edgeType) {
+            throwError(fmt::format("Unknown edge type: {}", edgeTypes.front()), edge);
+        }
+
+        expandNode->setEdgeTypeConstraint(edgeType.value());
+    }
+
     _variables->setProducer(edgeDecl, expandNode);
     return expandNode;
 }

--- a/query/plan/nodes/PathExplorerNode.h
+++ b/query/plan/nodes/PathExplorerNode.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <stdint.h>
 
+#include "ID.h"
 #include "PathExplorationDir.h"
 #include "PlanGraphNode.h"
 
@@ -25,12 +27,14 @@ public:
     }
 
     void setDir(PathExplorationDir dir) { _dir = dir; }
+    void setEdgeTypeConstraint(EdgeTypeID edgeType) { _edgeTypeConstraint = edgeType; }
 
     PathExplorationDir getDir() const { return _dir; }
     uint64_t getMinHops() const { return _minHops; }
     uint64_t getMaxHops() const { return _maxHops; }
     const VarDecl* getEdgeDecl() const { return _edgeDecl; }
     const VarDecl* getTargetDecl() const { return _targetDecl; }
+    const std::optional<EdgeTypeID>& getEdgeTypeConstraint() const { return _edgeTypeConstraint; }
 
 private:
     PathExplorationDir _dir {PathExplorationDir::BOTH};
@@ -38,6 +42,7 @@ private:
     const VarDecl* _targetDecl {nullptr};
     uint64_t _minHops {0};
     uint64_t _maxHops {0};
+    std::optional<EdgeTypeID> _edgeTypeConstraint {};
 };
 
 }

--- a/scripts/bench_qpp.sh
+++ b/scripts/bench_qpp.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Benchmark quantified-path edge type filtering on reactome.
+#
+# Compares typed versus untyped variable-length path queries and
+# checks that untyped queries stay flat after the feature lands.
+#
+# Prerequisites:
+#   - turingdb built and on PATH (source setup.sh)
+#   - reactome graph loaded (LOAD JSONL 'reactome.jsonl')
+#
+# Examples:
+#   ./bench_qpp.sh
+
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT=6668
+DATABASE="reactome"
+WARMUP_ROUNDS=1
+BENCH_ROUNDS=5
+CURL_TIMEOUT=180
+
+QUERY_NAMES=(
+    "untyped_forward_2"
+    "typed_hasevent_forward_2"
+    "typed_hasevent_forward_3"
+    "typed_hasevent_forward_4"
+    "typed_species_forward_2"
+    "typed_hascomponent_forward_2"
+    "untyped_undirected_2"
+    "typed_hasevent_undirected_2"
+)
+
+QUERIES=(
+    "MATCH (a:Pathway)-[e]->{1,2}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e:hasEvent]->{1,2}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e:hasEvent]->{1,3}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e:hasEvent]->{1,4}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e:species]->{1,2}(b) RETURN count(*) AS c"
+    "MATCH (a:Complex)-[e:hasComponent]->{1,2}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e]-{1,2}(b) RETURN count(*) AS c"
+    "MATCH (a:Pathway)-[e:hasEvent]-{1,2}(b) RETURN count(*) AS c"
+)
+
+stop_turingdb() {
+    pkill -9 turingdb 2>/dev/null || true
+    for _ in $(seq 1 50); do
+        nc -z 127.0.0.1 $PORT 2>/dev/null || break
+        sleep 0.1
+    done
+    sleep 0.3
+}
+
+start_turingdb() {
+    turingdb start -demon -p $PORT -load "$DATABASE" -start-timeout 30000
+    if ! nc -z 127.0.0.1 $PORT 2>/dev/null; then
+        echo "ERROR: TuringDB failed to start on port $PORT" >&2
+        exit 1
+    fi
+    sleep 1
+}
+
+run_query() {
+    local query="$1"
+    local resp
+
+    resp=$(curl -s --max-time $CURL_TIMEOUT \
+        -X POST "http://127.0.0.1:${PORT}/query?graph=${DATABASE}" \
+        -d "$query" 2>&1) || { echo "TIMEOUT"; return 0; }
+
+    if echo "$resp" | grep -q '"error"'; then
+        echo "ERROR: $(echo "$resp" | grep -o '"error_details":"[^"]*"')" >&2
+        echo "ERROR"
+        return 0
+    fi
+
+    echo "$resp" | grep -o '"time":[0-9.]*' | head -1 | cut -d: -f2
+}
+
+bench_query() {
+    local name="$1"
+    local query="$2"
+    local times=()
+    local t
+
+    for _ in $(seq 1 $WARMUP_ROUNDS); do
+        t=$(run_query "$query") || true
+    done
+
+    for _ in $(seq 1 $BENCH_ROUNDS); do
+        t=$(run_query "$query")
+        if [ "$t" = "TIMEOUT" ] || [ "$t" = "ERROR" ]; then
+            _LAST_MEDIAN="FAILED"
+            printf "  %-35s  FAILED (%s)\n" "$name" "$t"
+            return
+        fi
+        times+=("$t")
+    done
+
+    IFS=$'\n' sorted=($(sort -g <<<"${times[*]}")); unset IFS
+
+    local min=${sorted[0]}
+    local max=${sorted[$((${#sorted[@]} - 1))]}
+    local mid_idx=$(( ${#sorted[@]} / 2 ))
+    local median=${sorted[$mid_idx]}
+    _LAST_MEDIAN="$median"
+
+    printf "  %-35s  min=%10s ms  median=%10s ms  max=%10s ms\n" \
+        "$name" "$min" "$median" "$max"
+}
+
+REPORT_DIR="$SCRIPT_DIR/reports"
+mkdir -p "$REPORT_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+REPORT_FILE="$REPORT_DIR/qpp_queries_${TIMESTAMP}.txt"
+
+echo ""
+echo "=== Quantified-Path Edge Type Filter Benchmark ==="
+echo "Database:      $DATABASE"
+echo "Warmup:        $WARMUP_ROUNDS round(s)"
+echo "Bench rounds:  $BENCH_ROUNDS"
+echo "Timeout:       ${CURL_TIMEOUT}s per query"
+echo "Timestamp:     $TIMESTAMP"
+echo ""
+echo "Comparisons:"
+echo "  - untyped vs typed at equal hops (expect typed faster)"
+echo "  - typed at {1,2}/{1,3}/{1,4} (expect sub-superlinear growth)"
+echo "  - high-selectivity (species) vs low-selectivity (hasEvent)"
+echo "  - undirected typed vs untyped"
+echo ""
+
+{
+echo "--------------------------------------------------------------"
+echo "  Quantified-path edge type filter queries"
+echo "--------------------------------------------------------------"
+stop_turingdb
+start_turingdb
+
+MEDIANS=()
+num_queries=${#QUERIES[@]}
+for i in $(seq 0 $((num_queries - 1))); do
+    bench_query "${QUERY_NAMES[$i]}" "${QUERIES[$i]}"
+    MEDIANS+=("$_LAST_MEDIAN")
+done
+
+stop_turingdb
+
+TABLE_LINE="+-----------------------------------+----------------------+"
+echo ""
+echo "$TABLE_LINE"
+printf "| %-33s | %20s |\n" "Query" "Median (ms)"
+echo "$TABLE_LINE"
+for i in $(seq 0 $((num_queries - 1))); do
+    printf "| %-33s | %20s |\n" "${QUERY_NAMES[$i]}" "${MEDIANS[$i]}"
+done
+echo "$TABLE_LINE"
+
+echo ""
+echo "Interpretation checklist:"
+echo "  1. typed_hasevent_forward_2 << untyped_forward_2  (frontier prune)"
+echo "  2. typed_species_forward_2   << typed_hasevent_forward_2  (selectivity)"
+echo "  3. forward_2 < forward_3 < forward_4 without cliff growth"
+echo "  4. Re-run untyped_forward_2 against a pre-change binary; must be flat"
+echo ""
+echo "--------------------------------------------------------------"
+echo "  Done. Report: $REPORT_FILE"
+echo "--------------------------------------------------------------"
+
+} 2>&1 | tee "$REPORT_FILE"

--- a/test/query-test-suite/tests/variable-length-paths-typed-backward.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-backward.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)<-[e:KNOWS_WELL]-+(m:Person) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Person\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name\nRemy,[[4]],Adam\nAdam,[[0]],Remy\nRemy,\"[[4], [0]]\",Remy\nAdam,\"[[0], [4]]\",Adam",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":0}]],[\"Adam\",\"Remy\"]],[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}]],[\"Remy\",\"Adam\"]],[[],[],[]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "backward"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-bounded.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-bounded.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL]->{1,2}(m:Person) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Person\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name\nRemy,[[0]],Adam\nAdam,[[4]],Remy\nRemy,\"[[0], [4]]\",Remy\nAdam,\"[[4], [0]]\",Adam",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":4}]],[\"Adam\",\"Remy\"]],[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}]],[\"Remy\",\"Adam\"]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "bounded"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-forward.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-forward.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL]->+(m:Person) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Person\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name\nRemy,[[0]],Adam\nAdam,[[4]],Remy\nRemy,\"[[0], [4]]\",Remy\nAdam,\"[[4], [0]]\",Adam",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":4}]],[\"Adam\",\"Remy\"]],[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}]],[\"Remy\",\"Adam\"]],[[],[],[]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "forward"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-multi-type-error.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-multi-type-error.json
@@ -1,0 +1,17 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL|INTERESTED_IN]->+(m:Person) RETURN n.name",
+    "expect": {
+        "plan": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n:Person)-[e:KNOWS_WELL|INTERESTED_IN]->+(m:Person) RETURN n.name\n       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^\n-------* Not implemented: EdgeType | EdgeType | ...",
+        "result": "PARSE ERROR\n-------* Cypher parser\n     1 | MATCH (n:Person)-[e:KNOWS_WELL|INTERESTED_IN]->+(m:Person) RETURN n.name\n       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^\n-------* Not implemented: EdgeType | EdgeType | ...",
+        "resultJson": "{\"error\":\"PARSE_ERROR\",\"error_details\":\"-------* Cypher parser\\n     1 | MATCH (n:Person)-[e:KNOWS_WELL|INTERESTED_IN]->+(m:Person) RETURN n.name\\n       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^\\n-------* Not implemented: EdgeType | EdgeType | ...\"}"
+    },
+    "tags": [
+        "fail",
+        "variable",
+        "quantified-path",
+        "edge-type"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-pruning.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-pruning.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL]->+(m:Interest) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Interest\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[],[],[]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "pruning"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-star.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-star.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL]->*(m:Person) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Person\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name\nRemy,[],Remy\nAdam,[],Adam\nMaxime,[],Maxime\nLuc,[],Luc\nMartina,[],Martina\nSuhas,[],Suhas\nCyrus,[],Cyrus\nDoruk,[],Doruk\nRemy,[[0]],Adam\nAdam,[[4]],Remy\nRemy,\"[[0], [4]]\",Remy\nAdam,\"[[4], [0]]\",Adam",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[\"Remy\",\"Adam\",\"Maxime\",\"Luc\",\"Martina\",\"Suhas\",\"Cyrus\",\"Doruk\",\"Remy\",\"Adam\"],[[],[],[],[],[],[],[],[],[{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":4}]],[\"Remy\",\"Adam\",\"Maxime\",\"Luc\",\"Martina\",\"Suhas\",\"Cyrus\",\"Doruk\",\"Adam\",\"Remy\"]],[[\"Remy\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}]],[\"Remy\",\"Adam\"]],[[],[],[]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "star"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-undirected.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-undirected.json
@@ -1,0 +1,19 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:KNOWS_WELL]-+(m:Person) RETURN n.name, e, m.name",
+    "expect": {
+        "plan": "flowchart TD\n    0[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    1[\"`\n        __PATH_EXPLORER__\n        __edge_type__: KNOWS_WELL\n    `\"]\n    2[\"`\n        __VAR__\n        __name__: m\n    `\"]\n    3[\"`\n        __FILTER_NODE__\n        __label__: Person\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ m\n        __prop__ name\n    `\"]\n    6[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    7[\"`\n        __SCAN_NODES_BY_LABEL__\n        __label__: Person\n    `\"]\n    0-->1\n    1-->3\n    2-->4\n    3-->2\n    4-->5\n    5-->6\n    7-->0",
+        "result": "n.name,e,m.name\nRemy,[[0]],Adam\nRemy,[[4]],Adam\nAdam,[[4]],Remy\nAdam,[[0]],Remy\nRemy,\"[[0], [4]]\",Remy\nRemy,\"[[4], [0]]\",Remy\nAdam,\"[[4], [0]]\",Adam\nAdam,\"[[0], [4]]\",Adam",
+        "resultJson": "{\"header\":{\"column_names\":[\"n.name\",\"e\",\"m.name\"],\"column_types\":[\"String\",\"EntityList\",\"String\"]},\"data\":[[[\"Remy\",\"Remy\",\"Adam\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":0}]],[\"Adam\",\"Adam\",\"Remy\",\"Remy\"]],[[\"Remy\",\"Remy\",\"Adam\",\"Adam\"],[[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}],[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":4},{\"type\":\"edge\",\"id\":0}],[{\"type\":\"edge\",\"id\":0},{\"type\":\"edge\",\"id\":4}]],[\"Remy\",\"Remy\",\"Adam\",\"Adam\"]],[[],[],[]]]}"
+    },
+    "tags": [
+        "variable",
+        "quantified-path",
+        "variable-length",
+        "bfs",
+        "edge-type",
+        "undirected"
+    ],
+    "write-required": false
+}

--- a/test/query-test-suite/tests/variable-length-paths-typed-unknown-type-error.json
+++ b/test/query-test-suite/tests/variable-length-paths-typed-unknown-type-error.json
@@ -1,0 +1,17 @@
+{
+    "enabled": true,
+    "graph": "simpledb",
+    "query": "MATCH (n:Person)-[e:DOES_NOT_EXIST]->+(m:Person) RETURN n.name",
+    "expect": {
+        "plan": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n:Person)-[e:DOES_NOT_EXIST]->+(m:Person) RETURN n.name\n       |                 ^^^^^^^^^^^^^^^^^^^^^\n-------* Unknown edge type: DOES_NOT_EXIST",
+        "result": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n:Person)-[e:DOES_NOT_EXIST]->+(m:Person) RETURN n.name\n       |                 ^^^^^^^^^^^^^^^^^^^^^\n-------* Unknown edge type: DOES_NOT_EXIST",
+        "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n:Person)-[e:DOES_NOT_EXIST]->+(m:Person) RETURN n.name\\n       |                 ^^^^^^^^^^^^^^^^^^^^^\\n-------* Unknown edge type: DOES_NOT_EXIST\"}"
+    },
+    "tags": [
+        "fail",
+        "variable",
+        "quantified-path",
+        "edge-type"
+    ],
+    "write-required": false
+}


### PR DESCRIPTION
Enable typed quantified paths such as `(a)-[:SOME_TYPE]->+(b)` by threading a single edge-type constraint into PathExplorer BFS instead of rejecting it in the analyzer.

Made with [Cursor](https://cursor.com)