### PR TITLE
MLIR: bound the sort and group-aggregate emit loops by the limit

### DIFF
--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1755,10 +1755,12 @@ void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) 
     const size_t chunkSize = context->getChunkSize();
     ColumnVector<size_t>* indices = loopData->getIndices();
 
+    const NLLimitState* limit = loopData->getLimit();
+
     // Re-chunk the sorted rows: each step gathers the next chunkSize rows, in
     // permutation order, into the loop variables, then runs the body (nl.output).
     // The last chunk may be partial; an empty result runs the body zero times.
-    for (size_t offset = 0; offset < totalRows; offset += chunkSize) {
+    const auto runIteration = [&](size_t offset) {
         const size_t stepRows = std::min(chunkSize, totalRows - offset);
 
         std::vector<size_t>& indicesRaw = indices->getRaw();
@@ -1770,6 +1772,16 @@ void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) 
         }
 
         runBody(context, loopBody);
+    };
+
+    if (limit) {
+        for (size_t offset = 0; offset < totalRows && limit->getRemaining() > 0; offset += chunkSize) {
+            runIteration(offset);
+        }
+    } else {
+        for (size_t offset = 0; offset < totalRows; offset += chunkSize) {
+            runIteration(offset);
+        }
     }
 }
 
@@ -1972,12 +1984,14 @@ void NLExecutor::runGroupAggregateLoop(NLExecutionContext* context, NLFunctionDa
     std::vector<NLGroupAggregateState::KeyColumn>& keyColumns = state->keyColumns();
     std::vector<NLGroupAggregateState::Aggregate>& aggregates = state->aggregates();
 
+    const NLLimitState* limit = loopData->getLimit();
+
     // Re-chunk the accumulated groups: each step materializes the next chunk of
     // group rows - the key values sliced from the buffers and each aggregate
     // finalized from the per-group state - into the loop variables, then runs the
     // body (the nl.output) per chunk. An empty result (no group) runs the body zero
     // times, so a grouped aggregate over no row emits nothing.
-    for (size_t offset = 0; offset < totalGroups; offset += chunkSize) {
+    const auto runIteration = [&](size_t offset) {
         const size_t stepGroups = std::min(chunkSize, totalGroups - offset);
 
         for (const NLGroupAggregateState::KeyColumn& keyColumn : keyColumns) {
@@ -1989,6 +2003,16 @@ void NLExecutor::runGroupAggregateLoop(NLExecutionContext* context, NLFunctionDa
         }
 
         runBody(context, loopBody);
+    };
+
+    if (limit) {
+        for (size_t offset = 0; offset < totalGroups && limit->getRemaining() > 0; offset += chunkSize) {
+            runIteration(offset);
+        }
+    } else {
+        for (size_t offset = 0; offset < totalGroups; offset += chunkSize) {
+            runIteration(offset);
+        }
     }
 }
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -868,11 +868,15 @@ public:
 
     ColumnVector<size_t>* getIndices() { return &_indices; }
 
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
 private:
     NLSortState* _state {nullptr};
+    NLLimitState* _limit {nullptr};
     std::vector<NLCarriedColumn> _columns;
     ColumnVector<size_t> _indices;
     NLStmtContainer _stmts;
@@ -1410,11 +1414,15 @@ public:
 
     NLGroupAggregateState* getState() const { return _state; }
 
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
 private:
     NLGroupAggregateState* _state {nullptr};
+    NLLimitState* _limit {nullptr};
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -437,12 +437,9 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
     } else if (config._kind == IteratorKind::ScanEdges) {
         translateScanEdgesLoop(loopBody, limit, body);
     } else if (config._kind == IteratorKind::Sort) {
-        // A sort emit loop is never limit-bounded: ORDER BY must see every row.
-        translateSortLoop(config, loopBody, body);
+        translateSortLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::GroupAggregate) {
-        // A grouped-aggregate emit loop is never limit-bounded: every row must be
-        // folded before the first group is emitted.
-        translateGroupAggregateLoop(config, loopBody, body);
+        translateGroupAggregateLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::UnwindCollect) {
         // A collect drain emit loop is never limit-bounded: every row must be folded
         // before the first element is emitted.
@@ -1361,6 +1358,7 @@ void NLTranslator::translateSortCollect(nl::SortCollect collect, NLStmtContainer
 
 void NLTranslator::translateSortLoop(const IteratorConfig& config,
                                      mlir::Block& loopBody,
+                                     NLLimitState* limit,
                                      NLStmtContainer* body) {
     NLSortState* state = config._sortState;
     if (!state) {
@@ -1376,6 +1374,7 @@ void NLTranslator::translateSortLoop(const IteratorConfig& config,
     }
 
     NLSortLoopData* loopData = _program->allocFunctionData<NLSortLoopData>(state);
+    loopData->setLimit(limit);
 
     // Reserve the permutation-slice scratch so the per-step gather stays
     // allocation-free, the same as the edge loop's indices column.
@@ -1722,6 +1721,7 @@ void NLTranslator::translateGroupAggregateUpdate(nl::GroupAggregateUpdate update
 
 void NLTranslator::translateGroupAggregateLoop(const IteratorConfig& config,
                                                mlir::Block& loopBody,
+                                               NLLimitState* limit,
                                                NLStmtContainer* body) {
     NLGroupAggregateState* state = config._groupAggregateState;
     if (!state) {
@@ -1738,6 +1738,7 @@ void NLTranslator::translateGroupAggregateLoop(const IteratorConfig& config,
     }
 
     NLGroupAggregateLoopData* loopData = _program->allocFunctionData<NLGroupAggregateLoopData>(state);
+    loopData->setLimit(limit);
 
     // Each loop variable is the emit output of one column: the first keyCount are the
     // grouping keys (filled by slicing their key buffers), the rest the aggregate

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -206,9 +206,11 @@ private:
 
     // Translate the nl.for over an nl.sort iterator: allocate one loop variable
     // per buffer, set up the gather that fills it from the buffer in permutation
-    // order, and record the emit-loop statement (sort once, then re-chunk)
+    // order, and record the emit-loop statement (sort once, then re-chunk). limit is
+    // the counter the drain early-exits on, or null for an unbounded drain.
     void translateSortLoop(const IteratorConfig& config,
                            mlir::Block& loopBody,
+                           NLLimitState* limit,
                            NLStmtContainer* body);
 
     // The runtime accumulator a sort handle names. Throws if the handle was not
@@ -293,9 +295,11 @@ private:
     // Translate the nl.for over an nl.group_aggregate iterator: allocate one loop
     // variable per output column (a grouping key or an aggregate result), wire it as
     // that column's emit output, and record the emit-loop statement (re-chunk the
-    // groups).
+    // groups). limit is the counter the drain early-exits on, or null for an
+    // unbounded drain.
     void translateGroupAggregateLoop(const IteratorConfig& config,
                                      mlir::Block& loopBody,
+                                     NLLimitState* limit,
                                      NLStmtContainer* body);
 
     // The runtime accumulator a group-aggregate handle names. Throws if the handle

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -4473,6 +4473,25 @@ TEST_F(DBLoweringTest, sortSkipLimitPagesTheSortedRowsAcrossChunks) {
     EXPECT_EQ(rows, expected);
 }
 
+TEST_F(DBLoweringTest, sortSkipLimitStopsTheEmitLoopEarly) {
+    auto graph = buildDiamondGraph();
+    addSecondPart(*graph);
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Six sorted rows at chunk size 1: the emit loop gathers one row per step, so an
+    // unbudgeted drain would re-chunk all six and hand the sink three empty windows
+    // once the budget is spent. SKIP 1 LIMIT 2 spends it on the second and third
+    // steps, so the drain must stop there - three calls, not six.
+    CountingSink sink;
+    const std::string program = sortSkipLimitNodesDescProgram(1, 2);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    EXPECT_EQ(sink.getTotalRows(), 2u);
+    EXPECT_EQ(sink.getCalls(), 3u);
+}
+
 TEST_F(DBLoweringTest, lowersSortSkipLimitToALimitOnTheEmitLoopOnly) {
     auto graph = buildDiamondGraph();
     const FrozenCommitTx transaction = graph->openTransaction();

--- a/test/query/ir/GroupAggregateTest.cpp
+++ b/test/query/ir/GroupAggregateTest.cpp
@@ -980,6 +980,23 @@ TEST_F(GroupAggregateTest, limitCapsTheEmittedGroups) {
     EXPECT_EQ(allSink.getTotalRows(), 2u);
 }
 
+TEST_F(GroupAggregateTest, limitStopsTheEmitLoopEarly) {
+    auto graph = buildManyTeamGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Four single-node groups at chunk size 1: the emit loop materializes one group
+    // per step, so an unbudgeted drain would materialize all four and hand the sink
+    // three empty windows once the budget is spent. LIMIT 1 budgets the emit loop, so
+    // it must stop after the first group - one call, not four.
+    CountingSink sink;
+    const std::string program = groupCountStarLimitProgram(1);
+    runLoweredProgram(program.c_str(), reader.getView(), sink, /*chunkSize=*/1);
+
+    EXPECT_EQ(sink.getTotalRows(), 1u);
+    EXPECT_EQ(sink.getCalls(), 1u);
+}
+
 TEST_F(GroupAggregateTest, lowersGroupAggregateLimitToALimitOnTheEmitLoopOnly) {
     auto graph = buildTeamGraph();
     const FrozenCommitTx transaction = graph->openTransaction();


### PR DESCRIPTION
Make ORDER BY and aggregates honor the limit budget in loops