### PR TITLE
MLIR: report generator rejections as clean plan errors

### DIFF
--- a/query/interpreter/QueryInterpreterV3.cpp
+++ b/query/interpreter/QueryInterpreterV3.cpp
@@ -24,6 +24,8 @@
 #include "views/GraphView.h"
 
 #include "CompilerException.h"
+#include "FatalException.h"
+#include "TuringException.h"
 #include "TuringTime.h"
 
 using namespace db;
@@ -137,6 +139,16 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
     try {
         generator.generate(&ast);
     } catch (const CompilerException& e) {
+        status.setStatus(QueryStatus::Status::PLAN_ERROR);
+        status.setMessage(e.what());
+        return;
+    } catch (const FatalException& e) {
+        status.setStatus(QueryStatus::Status::PLAN_ERROR);
+        status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    } catch (const TuringException& e) {
+        // The generator rejects unsupported constructs with a plain TuringException:
+        // those are deliberate user-input rejections, not internal errors
         status.setStatus(QueryStatus::Status::PLAN_ERROR);
         status.setMessage(e.what());
         return;

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -53,6 +53,16 @@ target_link_libraries(test_query_ir_create_equivalence PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_create_equivalence PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_interpreter_v3_error QueryInterpreterV3ErrorTest.cpp)
+target_link_libraries(test_query_ir_interpreter_v3_error PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_interpreter_v3_error PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_equivalence EquivalenceTest.cpp)
 target_link_libraries(test_query_ir_equivalence PRIVATE
         turing_db_s

--- a/test/query/ir/QueryInterpreterV3ErrorTest.cpp
+++ b/test/query/ir/QueryInterpreterV3ErrorTest.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Discards output — the queries under test are rejected before producing rows.
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+}
+
+class QueryInterpreterV3ErrorTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void runQuery(std::string_view query, QueryStatus& status) {
+        NullSink sink;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The program generator rejects an unsupported construct with a plain
+// TuringException: the user must see that message as-is.
+TEST_F(QueryInterpreterV3ErrorTest, reportsGeneratorRejectionAsIs) {
+    QueryStatus status;
+    runQuery("MATCH (n) RETURN labels(n)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "Unsupported expression: FUNCTION_INVOCATION");
+}
+
+TEST_F(QueryInterpreterV3ErrorTest, reportsUnaryOperatorRejectionAsIs) {
+    QueryStatus status;
+    runQuery("MATCH (n) WHERE -n.age = 33 RETURN n", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "Unsupported unary operator: MINUS");
+}
+
+// An internal generator failure is a FatalException and must keep reading as
+// one, rather than being dressed up as a deliberate rejection.
+TEST_F(QueryInterpreterV3ErrorTest, reportsInternalGeneratorFailureAsUnexpected) {
+    QueryStatus status;
+    runQuery("MATCH (n) WHERE n.age IN [1, 2] RETURN n", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "Unexpected exception: List literals are not yet supported in MLIR codegen.");
+}


### PR DESCRIPTION
QueryInterpreterV3 caught the program generator's plain TuringException rejections in the generic std::exception arm, so a deliberate user-input rejection was reported as "Unexpected exception". FatalException is caught first so internal errors keep reading as internal.