### PR TITLE
MLIR: various fixes for collect and aggregates

### DIFF
--- a/query/interpreter/QueryInterpreterV3.cpp
+++ b/query/interpreter/QueryInterpreterV3.cpp
@@ -110,6 +110,10 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
         status.setStatus(QueryStatus::Status::PARSE_ERROR);
         status.setMessage(std::string("Unexpected exception: ") + e.what());
         return;
+    } catch (...) {
+        status.setStatus(QueryStatus::Status::PARSE_ERROR);
+        status.setMessage("Unknown exception occurred");
+        return;
     }
 
     CypherAnalyzer analyzer(&ast, view);
@@ -123,6 +127,10 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
     } catch (const std::exception& e) {
         status.setStatus(QueryStatus::Status::ANALYZE_ERROR);
         status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    } catch (...) {
+        status.setStatus(QueryStatus::Status::ANALYZE_ERROR);
+        status.setMessage("Unknown exception occurred");
         return;
     }
 
@@ -157,6 +165,10 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
         status.setStatus(QueryStatus::Status::PLAN_ERROR);
         status.setMessage(std::string("Unexpected exception: ") + e.what());
         return;
+    } catch (...) {
+        status.setStatus(QueryStatus::Status::PLAN_ERROR);
+        status.setMessage("Unknown exception occurred");
+        return;
     }
 
     DBDialectInterpreter interpreter(module, &view, sink, mem, ChunkConfig::CHUNK_SIZE, writeBuffer, metadataBuilder);
@@ -169,6 +181,10 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
     } catch (const std::exception& e) {
         status.setStatus(QueryStatus::Status::EXEC_ERROR);
         status.setMessage(std::string("Unexpected exception: ") + e.what());
+        return;
+    } catch (...) {
+        status.setStatus(QueryStatus::Status::EXEC_ERROR);
+        status.setMessage("Unknown exception occurred");
         return;
     }
 }

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -487,6 +487,18 @@ LogicalResult Collect::verify() {
         return emitOpError("collected result must be a list column");
     }
 
+    // The list holds the values of the collected column, so its element is that
+    // column's type. DBLowering builds the emit chunk from the collected column and
+    // rebinds this result to it, so an element type that disagrees is discarded rather
+    // than honoured - the verifier is the only place it can be caught.
+    const ColumnType valueColumn = llvm::cast<ColumnType>(columns[keyCount].getType());
+    const storage::ListType collectedList = llvm::cast<storage::ListType>(listColumn.getType());
+    if (collectedList.getElementType() != valueColumn.getType()) {
+        return emitOpError("collected result must be a list of ") << valueColumn.getType()
+                                                                  << ", the collected column's type, but collects "
+                                                                  << collectedList.getElementType();
+    }
+
     return success();
 }
 
@@ -517,6 +529,14 @@ LogicalResult UnwindCollect::verify() {
                                                        << " must have the same type as key column "
                                                        << keyIndex;
         }
+    }
+
+    // The unwound value is one element of the collected column, so the trailing result
+    // keeps that column's type. DBLowering builds the emit chunk from the collected
+    // column and rebinds this result to it, so a type that disagrees is discarded rather
+    // than honoured - the verifier is the only place it can be caught.
+    if (columns[keyCount].getType() != results[keyCount].getType()) {
+        return emitOpError("unwound value result must have the same type as the collected column");
     }
 
     return success();

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2030,6 +2030,23 @@ void NLExecutor::runGroupAggregateUpdate(NLExecutionContext* context, NLFunction
 
     // Every column is row-aligned, so the first grouping key sizes this step's rows.
     const size_t rowCount = keyColumns.front()._input->size();
+
+    // That alignment is this step's precondition, not a property of the op's types:
+    // the group assignment is computed once per key row, then indexed by each fold as
+    // it walks its own input, so a column of another length folds rows into the wrong
+    // group - or, when it is the longer one, reads past the assignments entirely.
+    // Generated IR places the update where every column is bound together, so a
+    // mismatch here means malformed IR.
+    for (const NLGroupAggregateState::KeyColumn& keyColumn : keyColumns) {
+        bioassert(keyColumn._input->size() == rowCount,
+                  "nl.group_aggregate_update grouping keys must be row-aligned");
+    }
+
+    for (const NLGroupAggregateState::Aggregate& aggregate : aggregates) {
+        bioassert(aggregate._input->size() == rowCount,
+                  "nl.group_aggregate_update aggregate inputs must be row-aligned with the grouping keys");
+    }
+
     if (rowCount == 0) {
         return;
     }
@@ -2135,6 +2152,21 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
     // rows; ungrouped (no key), the collected value column sizes it.
     const Column* valueInput = state->getValueInput();
     const size_t rowCount = keyColumns.empty() ? valueInput->size() : keyColumns.front()._input->size();
+
+    // That alignment is this step's precondition, not a property of the op's types:
+    // the group assignment is computed once per key row, then indexed by the fold as it
+    // walks the value column, so a column of another length appends values to the wrong
+    // group - or, when the value column is the longer one, reads past the assignments
+    // entirely. Generated IR places the update where every column is bound together, so
+    // a mismatch here means malformed IR.
+    for (const NLCollectState::KeyColumn& keyColumn : keyColumns) {
+        bioassert(keyColumn._input->size() == rowCount,
+                  "nl.collect_update grouping keys must be row-aligned");
+    }
+
+    bioassert(valueInput->size() == rowCount,
+              "nl.collect_update value column must be row-aligned with the grouping keys");
+
     if (rowCount == 0) {
         return;
     }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -216,6 +216,19 @@ bool isConstantLike(mlir::Value value) {
                        [](mlir::Value operand) { return isConstantLike(operand); });
 }
 
+// A drain wires its emit loop's variables into the accumulator's one output slot per
+// column, so an accumulator can serve exactly one nl.collect or nl.unwind_collect. A
+// second drain would rebind the first's outputs to its own, incompatible column types
+// (a per-group list cell against an unwound value), leaving the first to emit through
+// the other's columns. Generated IR names each accumulator from a single drain, so a
+// second one means malformed IR - the accumulate side rejects a second
+// nl.collect_update the same way.
+void throwIfAlreadyDrained(const NLCollectState* state) {
+    if (state->getValueOutput()) {
+        throw IRException("an nl.collect_buffer must be drained by a single nl.collect or nl.unwind_collect");
+    }
+}
+
 }
 
 NLTranslator::NLTranslator(NLProgram* program,
@@ -1953,6 +1966,8 @@ void NLTranslator::translateUnwindCollectLoop(const IteratorConfig& config,
         throw IRException("nl.unwind_collect iterator must carry a collect accumulator");
     }
 
+    throwIfAlreadyDrained(state);
+
     // For::verify binds one loop variable per iterator chunk; the unwind iterator's
     // chunks are the grouping keys then the element value, so the loop takes one
     // variable per grouping key plus one for the value.
@@ -1994,6 +2009,8 @@ void NLTranslator::translateCollectLoop(const IteratorConfig& config,
     if (!state) {
         throw IRException("nl.collect iterator must carry a collect accumulator");
     }
+
+    throwIfAlreadyDrained(state);
 
     // The collect iterator's chunks are the grouping keys then the list cell, so the
     // loop takes one variable per grouping key plus one for the list.

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -24,9 +24,12 @@ target_link_libraries(test_query_ir_group_aggregate PRIVATE
         turing_db_interpreter_v3_s)
 add_ir_tests(test_query_ir_collect CollectTest.cpp)
 
-# The collect row-alignment tests run against the shared SimpleGraph fixture.
+# The collect row-alignment and drain tests run against the shared SimpleGraph fixture.
 add_ir_tests(test_query_ir_collect_row_alignment CollectRowAlignmentTest.cpp)
 target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_examples_s)
+
+add_ir_tests(test_query_ir_collect_drain CollectDrainTest.cpp)
+target_link_libraries(test_query_ir_collect_drain PRIVATE turing_db_examples_s)
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(test_query_ir_group_aggregate PRIVATE
         turing_db_system_s
         turing_db_interpreter_v3_s)
 add_ir_tests(test_query_ir_collect CollectTest.cpp)
+
+# The collect row-alignment tests run against the shared SimpleGraph fixture.
+add_ir_tests(test_query_ir_collect_row_alignment CollectRowAlignmentTest.cpp)
+target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_examples_s)
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -30,6 +30,8 @@ target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_exam
 
 add_ir_tests(test_query_ir_collect_drain CollectDrainTest.cpp)
 target_link_libraries(test_query_ir_collect_drain PRIVATE turing_db_examples_s)
+
+add_ir_tests(test_query_ir_collect_result_type CollectResultTypeTest.cpp)
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 

--- a/test/query/ir/CollectDrainTest.cpp
+++ b/test/query/ir/CollectDrainTest.cpp
@@ -1,0 +1,215 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "IRException.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "SimpleGraph.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Collects the (dob, [names]) rows the nl.collect drain emits: a nullable string key
+// chunk and a per-group list cell chunk (ColumnVector<ListView>).
+class KeyedStringListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<std::string>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<std::string> names;
+            for (const ListElementView& element : listRaw[row]) {
+                names.push_back(std::string(element.getAs<std::string_view>()));
+            }
+
+            _rows.push_back({key, names});
+        }
+    }
+
+    // Fills the rows with each group's names sorted, then the rows themselves sorted:
+    // both the group order and the append order within a group follow the
+    // datapart-major scan, so the assert stays order-independent.
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        for (Row& row : rows) {
+            std::sort(row.second.begin(), row.second.end());
+        }
+
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Tallies the emitted rows without reading them, for a program whose translation must
+// fail before any chunk is produced. It makes no claim about the column shapes, so the
+// only thing a run of the rejected module can report is that it was not rejected.
+class RowCountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+// WITH n.dob AS dob, collect(n.name) AS names RETURN dob, names over the Persons, in the
+// shape DBLowering emits: one nl.collect_buffer, the nl.collect_update that fills it,
+// and a single drain - here the per-group nl.collect. The prefix the two-drain module
+// below extends, so it is also the control that the prefix itself is valid.
+constexpr const char* singleDrainProgram = R"mlir(
+func.func @main() {
+  %buf = nl.collect_buffer keys 1
+  %dobType = nl.get_property_type("dob")
+  %nameType = nl.get_property_type("name")
+  %persons = nl.scan_nodes_by_label(["Person"])
+  nl.for %a in %persons : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %dob = nl.get_node_properties(%a, %dobType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %name = nl.get_node_properties(%a, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.collect_update %buf, (%dob, %name) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %groups = nl.collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>>
+  nl.for %gdob, %names in %groups : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>> {
+    nl.output(%gdob, %names) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>
+  }
+  func.return
+}
+)mlir";
+
+// The same accumulator drained twice: the per-group nl.collect and then the
+// per-element nl.unwind_collect, each with its own emit loop. Both drains write through
+// the one output slot the shared NLCollectState carries, so the accumulator can only
+// serve one of them.
+constexpr const char* twoDrainsProgram = R"mlir(
+func.func @main() {
+  %buf = nl.collect_buffer keys 1
+  %dobType = nl.get_property_type("dob")
+  %nameType = nl.get_property_type("name")
+  %persons = nl.scan_nodes_by_label(["Person"])
+  nl.for %a in %persons : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %dob = nl.get_node_properties(%a, %dobType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %name = nl.get_node_properties(%a, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.collect_update %buf, (%dob, %name) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %groups = nl.collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>>
+  nl.for %gdob, %names in %groups : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>> {
+    nl.output(%gdob, %names) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>
+  }
+  %elements = nl.unwind_collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>>
+  nl.for %udob, %uname in %elements : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>> {
+    nl.output(%udob, %uname) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  func.return
+}
+)mlir";
+
+}
+
+class CollectDrainTest : public TuringTest {
+protected:
+    void runProgram(const char* programText, const GraphView& view, NLOutputSink& sink) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+    }
+};
+
+// The control: a single drain on the accumulator groups the Persons by dob. Only the
+// four carrying a dob form a named group; the other four fall into the null-key group.
+TEST_F(CollectDrainTest, collectDrainGroupsNamesPerDob) {
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    KeyedStringListSink sink;
+    runProgram(singleDrainProgram, reader.getView(), sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {std::nullopt, {"Cyrus", "Doruk", "Martina", "Suhas"}},
+        {"18/01", {"Remy"}},
+        {"18/08", {"Adam"}},
+        {"24/07", {"Maxime"}},
+        {"28/05", {"Luc"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// REVIEW.md #12: NLCollectState holds one output slot for the drained value (and one per
+// grouping key), so the second drain's translation rebinds the first drain's outputs to
+// its own, incompatible column types - the nl.collect drain ends up emitting ListViews
+// through the nl.unwind_collect drain's ColumnOptVector. translateCollectUpdate already
+// rejects a second update on one accumulator; the drains need the same rejection, since
+// nothing in NLOps.td constrains how many name a given nl.collect_buffer.
+TEST_F(CollectDrainTest, rejectsTwoDrainsOnOneCollectBuffer) {
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    RowCountingSink sink;
+    EXPECT_THROW(runProgram(twoDrainsProgram, reader.getView(), sink), IRException);
+}

--- a/test/query/ir/CollectResultTypeTest.cpp
+++ b/test/query/ir/CollectResultTypeTest.cpp
@@ -1,0 +1,183 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "StorageDialect.h"
+
+namespace {
+
+// MATCH (a) WITH a.team AS team, collect(a.name) AS names RETURN team, names, with the
+// element type of the trailing list result spelled by the caller. The frontend leaves a
+// property column unresolved as !db.column<none>, so none is what this collect gathers
+// and the only list element the lowering can produce for it.
+std::string collectNamesProgram(const char* listElement) {
+    const std::string listColumn = std::string("!db.column<!storage.list<") + listElement + ">>";
+
+    return "func.func @main() {\n"
+           "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+           "  %team = db.get_node_properties(%a, \"team\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+           "  %name = db.get_node_properties(%a, \"name\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+           "  %gteam, %names = db.collect(%team, %name) keys 1 : (!db.column<none>, !db.column<none>) -> (!db.column<none>, "
+           + listColumn
+           + ")\n"
+             "  db.output(%gteam, %names) : !db.column<none>, "
+           + listColumn
+           + "\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) WITH collect(a) AS ids RETURN ids: the ungrouped (keys 0) collect over the
+// scan's own node ID column, with the element type of the list result spelled by the
+// caller. The value column is fully typed here, so the element gathered is
+// !storage.node_id - the type check is a real comparison, not a none-against-none one.
+std::string collectNodesProgram(const char* listElement) {
+    const std::string listColumn = std::string("!db.column<!storage.list<") + listElement + ">>";
+
+    return "func.func @main() {\n"
+           "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+           "  %ids = db.collect(%a) keys 0 : (!db.column<!storage.node_id>) -> "
+           + listColumn
+           + "\n"
+             "  db.output(%ids) : "
+           + listColumn
+           + "\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) WITH a.team AS team, collect(a.name) AS names UNWIND names AS name RETURN
+// team, name, with the element type of the trailing value result spelled by the caller.
+// The unwound value is one element of the collected column, so its type is the collected
+// column's - none for an unresolved property column.
+std::string unwindNamesProgram(const char* valueElement) {
+    const std::string valueColumn = std::string("!db.column<") + valueElement + ">";
+
+    return "func.func @main() {\n"
+           "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+           "  %team = db.get_node_properties(%a, \"team\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+           "  %name = db.get_node_properties(%a, \"name\") : (!db.column<!storage.node_id>) -> !db.column<none>\n"
+           "  %gteam, %uname = db.unwind_collect(%team, %name) keys 1 : (!db.column<none>, !db.column<none>) -> (!db.column<none>, "
+           + valueColumn
+           + ")\n"
+             "  db.output(%gteam, %uname) : !db.column<none>, "
+           + valueColumn
+           + "\n"
+             "  return\n"
+             "}\n";
+}
+
+// MATCH (a) WITH collect(a) AS ids UNWIND ids AS id RETURN id: the ungrouped fused form
+// over the scan's node ID column, with the element type of the value result spelled by
+// the caller.
+std::string unwindNodesProgram(const char* valueElement) {
+    const std::string valueColumn = std::string("!db.column<") + valueElement + ">";
+
+    return "func.func @main() {\n"
+           "  %a = db.scan_nodes() : !db.column<!storage.node_id>\n"
+           "  %uid = db.unwind_collect(%a) keys 0 : (!db.column<!storage.node_id>) -> "
+           + valueColumn
+           + "\n"
+             "  db.output(%uid) : "
+           + valueColumn
+           + "\n"
+             "  return\n"
+             "}\n";
+}
+
+}
+
+// A context with the dialects a db-dialect collect program names: db for the ops,
+// storage for the node ID and list types, func for the enclosing function.
+class CollectResultTypeTest : public ::testing::Test {
+protected:
+    CollectResultTypeTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    // Parses a db-dialect module, returning a null module on failure. The verifier runs
+    // as part of parsing, so an op the verifier rejects makes this null. The diagnostics
+    // are swallowed so a deliberately mistyped program does not print to the test log.
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const std::string& programText) {
+        const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+            return mlir::success();
+        });
+
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// The control for the two db.collect rejections below: a list result whose element is
+// the collected column's own type is the shape the lowering produces, and it verifies.
+TEST_F(CollectResultTypeTest, acceptsCollectListElementMatchingValueColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(collectNamesProgram("none"));
+    EXPECT_TRUE(module);
+}
+
+// REVIEW.md #15: Collect::verify checks only that the trailing result is *some* list
+// column, never that its element is the collected column's type. A list<i64> declared
+// over a none value column passes the isa<storage::ListType> check, and lowerCollect
+// then builds the emit chunk from the collected column instead, so the declared element
+// type is silently discarded rather than diagnosed.
+TEST_F(CollectResultTypeTest, verifierRejectsCollectListElementTypeMismatch) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(collectNamesProgram("i64"));
+    EXPECT_FALSE(module);
+}
+
+// The control for the typed collect rejection: collecting the node ID column into a
+// list of node IDs verifies.
+TEST_F(CollectResultTypeTest, acceptsCollectNodeIDListElement) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(collectNodesProgram("!storage.node_id"));
+    EXPECT_TRUE(module);
+}
+
+// The same hole on a fully typed value column: the collected column is node IDs, the
+// declared list element is i64, and nothing compares the two.
+TEST_F(CollectResultTypeTest, verifierRejectsCollectNodeIDsDeclaredAsInt64List) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(collectNodesProgram("i64"));
+    EXPECT_FALSE(module);
+}
+
+// The control for the two db.unwind_collect rejections below: a value result carrying
+// the collected column's type is the shape the lowering produces, and it verifies.
+TEST_F(CollectResultTypeTest, acceptsUnwindValueResultMatchingValueColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindNamesProgram("none"));
+    EXPECT_TRUE(module);
+}
+
+// REVIEW.md #15: UnwindCollect::verify checks the operand and result counts and the
+// pass-through of the keyCount grouping keys, but never compares results[keyCount] with
+// columns[keyCount] - so a value result type that has nothing to do with the collected
+// string column verifies. lowerUnwindCollect then builds the emit chunk from the
+// collected column's type and buildLoopForSource rebinds the db result to that loop
+// variable, so the declared type is discarded instead of diagnosed.
+TEST_F(CollectResultTypeTest, verifierRejectsUnwindValueResultTypeMismatch) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindNamesProgram("!storage.node_id"));
+    EXPECT_FALSE(module);
+}
+
+// The control for the typed unwind rejection: unwinding a collected node ID column back
+// into node IDs verifies.
+TEST_F(CollectResultTypeTest, acceptsUnwindNodeIDValueResult) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindNodesProgram("!storage.node_id"));
+    EXPECT_TRUE(module);
+}
+
+// The same hole on a fully typed value column: the collected column is node IDs and the
+// unwound value is declared i64.
+TEST_F(CollectResultTypeTest, verifierRejectsUnwindNodeIDsDeclaredAsInt64) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindNodesProgram("i64"));
+    EXPECT_FALSE(module);
+}

--- a/test/query/ir/CollectRowAlignmentTest.cpp
+++ b/test/query/ir/CollectRowAlignmentTest.cpp
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "TuringException.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "SimpleGraph.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Collects the (dob, [names]) rows a grouped nl.collect emits: a nullable string key
+// chunk and a per-group list cell chunk (ColumnVector<ListView>).
+class KeyedStringListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<std::string>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<std::string> names;
+            for (const ListElementView& element : listRaw[row]) {
+                names.push_back(std::string(element.getAs<std::string_view>()));
+            }
+
+            _rows.push_back({key, names});
+        }
+    }
+
+    // Fills the rows with each group's names sorted, then the rows themselves sorted:
+    // both the group order and the append order within a group follow the
+    // datapart-major scan, so the assert stays order-independent.
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        for (Row& row : rows) {
+            std::sort(row.second.begin(), row.second.end());
+        }
+
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// WITH n.dob AS dob, collect(n.name) AS names RETURN dob, names, in the shape
+// DBLowering emits: the grouping key and the collected value are two property fetches
+// of the same scan chunk, so the columns nl.collect_update folds are row-aligned. The
+// control for the misaligned program below.
+constexpr const char* alignedCollectProgram = R"mlir(
+func.func @main() {
+  %buf = nl.collect_buffer keys 1
+  %dobType = nl.get_property_type("dob")
+  %nameType = nl.get_property_type("name")
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %dob = nl.get_node_properties(%a, %dobType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %name = nl.get_node_properties(%a, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.collect_update %buf, (%dob, %name) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %groups = nl.collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>>
+  nl.for %gdob, %names in %groups : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>> {
+    nl.output(%gdob, %names) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>
+  }
+  func.return
+}
+)mlir";
+
+// The same collect, but the grouping key is cut down by an nl.filter while the
+// collected value column keeps every row of the step, so the two columns
+// nl.collect_update folds are no longer row-aligned. On simpledb's first data part the
+// step carries 7 nodes and only Remy and Adam have age 32, so the key column holds 2
+// rows against the value column's 7.
+constexpr const char* misalignedCollectProgram = R"mlir(
+func.func @main() {
+  %buf = nl.collect_buffer keys 1
+  %dobType = nl.get_property_type("dob")
+  %nameType = nl.get_property_type("name")
+  %ageType = nl.get_property_type("age")
+  %thirtyTwo = nl.constant(32 : i64)
+  %nodes = nl.scan_nodes()
+  nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %dob = nl.get_node_properties(%a, %dobType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %name = nl.get_node_properties(%a, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %age = nl.get_node_properties(%a, %ageType) : !nl.chunk<!storage.nullable<i64>>
+    %mask = nl.eq %age, %thirtyTwo : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %fewerDobs = nl.filter %mask, (%dob) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.chunk<!storage.nullable<!storage.string>>
+    nl.collect_update %buf, (%fewerDobs, %name) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %groups = nl.collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>>
+  nl.for %gdob, %names in %groups : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>> {
+    nl.output(%gdob, %names) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>
+  }
+  func.return
+}
+)mlir";
+
+}
+
+class CollectRowAlignmentTest : public TuringTest {
+protected:
+    void runProgram(const char* programText, const GraphView& view, NLOutputSink& sink) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+    }
+};
+
+// The control: with the key and the value column row-aligned, the collect groups
+// simpledb's nodes by dob. Only the four Persons carrying a dob form a named group;
+// every other node falls into the null-key group.
+TEST_F(CollectRowAlignmentTest, collectGroupsNamesPerDob) {
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    KeyedStringListSink sink;
+    runProgram(alignedCollectProgram, reader.getView(), sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {std::nullopt, {"Animals",
+                        "Bio",
+                        "Computers",
+                        "Cooking",
+                        "Cyrus",
+                        "Doruk",
+                        "Eighties",
+                        "Ghosts",
+                        "Gym",
+                        "JiuJitsu",
+                        "Martina",
+                        "Padel",
+                        "Suhas",
+                        "Travel"}},
+        {"18/01", {"Remy"}},
+        {"18/08", {"Adam"}},
+        {"24/07", {"Maxime"}},
+        {"28/05", {"Luc"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// REVIEW.md #11: collectFold bounds its loop by the value column's row count but
+// indexes the group assignments, which runCollectUpdate sized from the first key
+// column. A value column longer than the keys walks past that vector and uses the
+// garbage it reads to index the per-group position lists - a wrong group at best, a
+// heap write out of range at worst. Row alignment is nl.collect_update's precondition,
+// so a step that breaks it must be rejected, not folded.
+TEST_F(CollectRowAlignmentTest, collectUpdateRejectsValueColumnLongerThanKeys) {
+    auto graph = Graph::create();
+    SimpleGraph::createSimpleGraph(graph.get());
+
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    KeyedStringListSink sink;
+    EXPECT_THROW(runProgram(misalignedCollectProgram, reader.getView(), sink), TuringException);
+}


### PR DESCRIPTION
- `nl.collect_update` and `nl.group_aggregate_update` now reject input columns that are not row-aligned with the grouping keys, instead of folding rows into the wrong group (shorter column) or reading past the group assignments (longer column).
- `nl.collect` / `nl.unwind_collect` now reject an `nl.collect_buffer` that is already drained, instead of letting the second drain rebind the first's output columns to its own incompatible types.
- `db.collect` / `db.unwind_collect` now reject a trailing result whose type does not match the collected column, instead of letting a mismatched list element type or unwound value type verify and then be silently discarded by the lowering.
- `QueryInterpreterV3` now carries the `catch (...)` arm `QueryInterpreterV2` has at every stage, so a throw not derived from `std::exception` is reported as an error status instead of unwinding out of the shell.
