### PR TITLE
MLIR: Only allocate columns if they are use in edge loops

### DIFF
--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1065,8 +1065,10 @@ void runEdgeLoopSteps(NLExecutionContext* context,
             return;
         }
 
-        // Gather either source or target if we are get_out or get_in (the source side)
-        gatherColumn<NodeID>(loopData->getInput(), indices, gatheredNodeIDs);
+        // Column many not have been allocated (=nullptr) if its var wasn't used
+        if (gatheredNodeIDs) {
+            gatherColumn<NodeID>(loopData->getInput(), indices, gatheredNodeIDs);
+        }
 
         // Transform all the columns in the carried set according to indices
         for (const NLCarriedColumn& carriedColumn : loopData->carriedColumns()) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -560,11 +560,17 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
                                      NLStmtContainer* body) {
     // The four fixed chunks of an edge iterator step, in the block-argument
     // order established by getEdgeIteratorType: sources, edge IDs, edge type
-    // IDs, targets
-    ColumnNodeIDs* sources = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(0)));
-    ColumnEdgeIDs* edgeIDs = static_cast<ColumnEdgeIDs*>(allocColumn(loopBody.getArgument(1)));
-    ColumnEdgeTypes* edgeTypes = static_cast<ColumnEdgeTypes*>(allocColumn(loopBody.getArgument(2)));
-    ColumnNodeIDs* targets = static_cast<ColumnNodeIDs*>(allocColumn(loopBody.getArgument(3)));
+    // IDs, targets.
+    ColumnNodeIDs* sources = static_cast<ColumnNodeIDs*>(allocColumnIfUsed(loopBody.getArgument(0)));
+    ColumnEdgeIDs* edgeIDs = static_cast<ColumnEdgeIDs*>(allocColumnIfUsed(loopBody.getArgument(1)));
+    ColumnEdgeTypes* edgeTypes = static_cast<ColumnEdgeTypes*>(allocColumnIfUsed(loopBody.getArgument(2)));
+    ColumnNodeIDs* targets = static_cast<ColumnNodeIDs*>(allocColumnIfUsed(loopBody.getArgument(3)));
+
+    // Allocate for edge IDs even if they aren't read if we have to check tombstones
+    if (!edgeIDs && _view->tombstones().hasEdges()) {
+        edgeIDs = _memory->alloc<ColumnEdgeIDs>();
+        edgeIDs->reserve(_program->getChunkSize());
+    }
 
     const ColumnNodeIDs* inputNodeIDs = static_cast<const ColumnNodeIDs*>(getColumn(config._inputNodes));
 
@@ -2240,6 +2246,14 @@ Column* NLTranslator::allocColumn(mlir::Value chunkValue) {
     Column* column = allocColumnForKind(kind);
     _valueSlots[chunkValue] = column;
     return column;
+}
+
+Column* NLTranslator::allocColumnIfUsed(mlir::Value chunkValue) {
+    if (chunkValue.use_empty()) {
+        return nullptr;
+    }
+
+    return allocColumn(chunkValue);
 }
 
 // Pool-allocate a chunk column of the right concrete type from the external

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -443,6 +443,7 @@ private:
                        NLSkipTruncateData* data);
 
     Column* allocColumn(mlir::Value chunkValue);
+    Column* allocColumnIfUsed(mlir::Value chunkValue);
     Column* allocColumnForKind(NLChunkKind kind);
 
     // Allocate a nullable value column for the value type's primitive. The

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -1258,10 +1258,15 @@ protected:
         mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
         ASSERT_TRUE(module);
 
-        // run() reaches the translator before touching the graph view or sink,
-        // so a rejected program surfaces its IRException with neither supplied
+        // Translation runs against a real view in production and may read graph
+        // state (edge-type resolution, tombstone filtering), so supply an empty
+        // one. The sink stays null: a rejected program throws before execution.
+        auto graph = Graph::create();
+        const FrozenCommitTx transaction = graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+
         LocalMemory memory;
-        NLInterpreter interpreter(*module, nullptr, nullptr, &memory);
+        NLInterpreter interpreter(*module, &reader.getView(), nullptr, &memory);
         EXPECT_THROW(interpreter.run(), IRException);
     }
 


### PR DESCRIPTION
A possible solution for "dead" outputs of `db.get_out_edges` and co. Doesn't make it explicit in the textual IR, but means that iterators only allocate columns they use