### PR TITLE
Docs: require minimal comments in new code

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -75,6 +75,7 @@
 - @feedback_parquet_helpers.md — tools/turing-parquet: multi-step ops on Parquet types get a dedicated ParquetXxx class
 - @feedback_dump_object_bytes.md — bulk-write trivially-copyable object bytes, layouts pinned by central static_asserts; no staging
 - @feedback_doc_utility_functions.md — one-line WHAT comment above each free function in tool .cpp drivers
+- @feedback_minimal_comments.md — write almost no comments; default is none, hard cap 2-4 lines when one is justified
 
 ## Workflow Preferences
 - @feedback_test_first.md — write failing test before fix

--- a/.claude/memory/feedback_minimal_comments.md
+++ b/.claude/memory/feedback_minimal_comments.md
@@ -1,0 +1,33 @@
+Write far fewer comments. The default is **none**. When one is genuinely
+warranted, cap it at **2-4 lines**.
+
+**Why:** User feedback: "You write too much comments." Generated code arrives
+padded with narration that restates the code, section banners, and doc blocks on
+every function. It bloats diffs, goes stale, and buries the rare comment that
+actually carries information. If code needs prose to be understood, the fix is a
+better name or a smaller function — not a paragraph above it.
+
+**How to apply:**
+- Write no comment unless the code genuinely cannot express the point.
+- Never restate the code (`// increment counter`, `// loop over rows`), never
+  write section banners (`// ---- helpers ----`), never doc-block every
+  public function by reflex.
+- A justified comment explains a **why**: a non-obvious invariant, a subtle
+  ordering constraint, a workaround for an external bug. Max 2-4 lines — longer
+  explanations go in the commit message, the PR, or a design doc. The bar is
+  high; when in doubt, leave it out.
+- Never annotate the project's own conventions. The unreachable `break;` after a
+  `case` body's `return`, plainly-named unused parameters, no `= default` in
+  headers — these are house style, not oddities needing `// unreachable` or
+  `// intentionally unused`.
+- `CODING_STYLE.md`'s examples all carry `//` markers (`// Good:`, `// Bad:`,
+  `// Do something`) to label the snippets. Don't read them as a model for how
+  much to comment real code.
+- No change-log narration (`// was previously X`, `// NEW:`, `// fixes bug ...`);
+  git history covers that.
+- Never re-add a comment a reviewer deleted, and don't sprinkle comments into
+  untouched code you're merely editing near — see
+  [[feedback_no_build_during_iteration]] on keeping diffs minimal.
+- Standing exception: the free-function layer at the top of `tools/*` drivers
+  with a `main()` gets one one-line description each — see
+  [[feedback_doc_utility_functions]].

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,17 @@ Key points:
 - Use the layer-appropriate exception type: `FatalException` in `storage/` code (available via `common`), `PipelineException` in `query/pipeline/`. Storage cannot include pipeline headers (would create a circular dependency).
 - In `main()`, return `EXIT_SUCCESS` / `EXIT_FAILURE` (from `<stdlib.h>`), not literal `0` / `1`.
 
+**Comments — write as few as possible:**
+- **The default is no comment at all.** Code that needs a comment to be understood usually needs a better name or a smaller function — fix that instead of narrating it.
+- Never restate what the code already says (`// increment the counter`, `// loop over the rows`, `// return the result`), never add section banners (`// ---- helpers ----`), and never add a doc block on top of every function/class/member just because it's public.
+- When a comment is genuinely warranted, it explains a **why** that the code cannot: a non-obvious invariant, a subtle ordering constraint, a workaround for an external bug. **Hard cap: 2-4 lines.** If it doesn't fit, the explanation belongs in the commit message, the PR, or a design doc — not in the source.
+- That bar is high, and "non-obvious invariant" is not a licence to annotate everything. If a teammate reading the function would already know it, it doesn't qualify. **When in doubt, leave it out** — a reviewer asking for one comment is cheap, deleting the ones nobody asked for is not.
+- **Never annotate the conventions in this file.** Several rules here mandate constructs that look odd out of context — the unreachable `break;` after a `return` in a `case`, unused parameters left plainly named, no `= default` in headers, `bioassert` in place of a check. They are house style and every reader knows them; `// unreachable`, `// intentionally unused`, `// see CLAUDE.md` is precisely the noise this section forbids.
+- Don't leave behind change-log narration (`// was previously X`, `// NEW:`, `// fixed bug where...`) — git history holds that.
+- Do not re-add comments a reviewer deleted, and don't add comments to untouched code you happen to be editing near.
+- `CODING_STYLE.md`'s snippets carry `//` markers (`// Good:`, `// Bad:`, `// Do something` bodies) to label the *examples*. They are not a model for how much to comment real code.
+- The one standing exception is the free-function layer at the top of `tools/*` drivers with a `main()`: one single-line description per helper. It does not extend to class methods, to library code under `storage/`, `query/`, `net/`, or to any file outside `tools/`.
+
 **Other rules:**
 - Never `using namespace` in headers
 - Never `using namespace std`


### PR DESCRIPTION
Add explicit instructions in CLAUDE.md for minimising comments