### PR TITLE
MLIR: implement unwind_const for UNWIND of a literal list

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -64,6 +64,7 @@
 #include "stmt/SetStmt.h"
 #include "stmt/Skip.h"
 #include "stmt/StmtContainer.h"
+#include "stmt/UnwindStmt.h"
 #include "Symbol.h"
 #include "SymbolChain.h"
 
@@ -189,6 +190,23 @@ void collectCutColumns(const Projection* projection,
     }
 }
 
+// The one type every element attribute shares, or a null type when they differ or the
+// list is empty - db.unwind_const's homogeneity verdict, which decides whether the
+// unwound column is that type or a type-erased column of tagged scalars.
+mlir::Type sharedAttrType(llvm::ArrayRef<mlir::Attribute> elements) {
+    if (elements.empty()) {
+        return nullptr;
+    }
+
+    const mlir::Type firstType = mlir::cast<mlir::TypedAttr>(elements.front()).getType();
+
+    const auto hasFirstType = [firstType](mlir::Attribute element) {
+        return mlir::cast<mlir::TypedAttr>(element).getType() == firstType;
+    };
+
+    return std::ranges::all_of(elements, hasFirstType) ? firstType : nullptr;
+}
+
 mlir::Value findVarOrThrow(const DBProgramGenerator::VariableIdentityMap& map,
                         const VariableDependency* var) {
     const auto findIt = map.find(var);
@@ -225,6 +243,63 @@ void DBProgramGenerator::addScanNodes(const VariableDependency* var) {
     auto scan = _opBuilder.create<mlir::db::ScanNodes>(_opBuilder.getUnknownLoc(), col);
 
     registerValue(var, scan.getResult());
+}
+
+void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind) {
+    bioassert(!_varMap.contains(var), "UnwindConst for registered variable");
+
+    // The analyzer restricts UNWIND to a literal list, so anything else here is a
+    // statement it let through and this path cannot lower.
+    const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
+    if (!literalExpr) {
+        throw TuringException("Non-literal UNWIND expressions are not yet supported.");
+    }
+
+    const ListLiteral* list = dynamic_cast<const ListLiteral*>(literalExpr->getLiteral());
+    if (!list) {
+        throw TuringException("Non-list arguments to UNWIND are not yet supported.");
+    }
+
+    llvm::SmallVector<mlir::Attribute> elements;
+    translateUnwindElements(list, elements);
+
+    // The result element type is the homogeneity verdict db.unwind_const reads: elements
+    // sharing one type unwind into a column of that type, and a mixed - or empty - list
+    // into a type-erased column of tagged scalars.
+    const mlir::Type sharedType = sharedAttrType(elements);
+    const mlir::Type elementType = sharedType ? sharedType
+                                              : mlir::storage::ListElementType::get(_mlirCtxt);
+
+    const mlir::db::ColumnType resultType = allocColumnType(elementType);
+    const mlir::ArrayAttr elementsAttr = _opBuilder.getArrayAttr(elements);
+
+    mlir::db::UnwindConst unwindConst = _opBuilder.create<mlir::db::UnwindConst>(_opBuilder.getUnknownLoc(),
+                                                                                resultType,
+                                                                                elementsAttr);
+
+    registerValue(var, unwindConst.getResult());
+}
+
+void DBProgramGenerator::translateUnwindElements(const ListLiteral* list,
+                                                 llvm::SmallVectorImpl<mlir::Attribute>& elements) {
+    const ListLiteral::Items& items = list->items();
+    elements.reserve(items.size());
+
+    for (const Expr* item : items) {
+        const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(item);
+        if (!literalExpr) {
+            throw TuringException("Only literal elements are supported in an UNWIND list.");
+        }
+
+        // Only the scalar literals the runtime can store as a tagged element are
+        // unwindable: a nested list, an embedding or a null has no such form.
+        const mlir::TypedAttr elementAttr = scalarLiteralAttr(literalExpr->getLiteral());
+        if (!elementAttr) {
+            throw TuringException("Only booleans, integers, floats and strings can be unwound.");
+        }
+
+        elements.push_back(elementAttr);
+    }
 }
 
 template<typename EdgeOp>
@@ -577,7 +652,17 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
         }
     };
 
-    addScanNodes(root);
+    // A root either is a pattern variable, whose dataflow opens with a node scan, or is
+    // bound by an UNWIND, whose dataflow opens with the literal list itself.
+    const VariableDependencyGraph::UnwindSourceMap& unwindSources = _vdg.unwindSources();
+    const auto unwindIt = unwindSources.find(root);
+
+    if (unwindIt != unwindSources.end()) {
+        addUnwindConst(root, unwindIt->second);
+    } else {
+        addScanNodes(root);
+    }
+
     markDefined(root);
 
     // Forms the "carried set" for this connected component
@@ -1804,33 +1889,50 @@ void DBProgramGenerator::translateBinaryExpr(const Expr* expr, const BinaryExpr*
     }
 }
 
-mlir::Value DBProgramGenerator::translateLiteralExpr(const Literal* literal) {
-    const mlir::Location uloc = _opBuilder.getUnknownLoc();
-
-    mlir::TypedAttr valueAttr;
-
+mlir::TypedAttr DBProgramGenerator::scalarLiteralAttr(const Literal* literal) {
     switch (literal->getKind()) {
         case Literal::Kind::BOOL: {
             const BoolLiteral* boolLiteral = static_cast<const BoolLiteral*>(literal);
-            valueAttr = _opBuilder.getBoolAttr(boolLiteral->getValue());
+            return _opBuilder.getBoolAttr(boolLiteral->getValue());
         }
         break;
+
         case Literal::Kind::INTEGER: {
             const IntegerLiteral* intLiteral = static_cast<const IntegerLiteral*>(literal);
-            valueAttr = _opBuilder.getI64IntegerAttr(intLiteral->getValue());
+            return _opBuilder.getI64IntegerAttr(intLiteral->getValue());
         }
         break;
+
         case Literal::Kind::DOUBLE: {
             const DoubleLiteral* doubleLiteral = static_cast<const DoubleLiteral*>(literal);
-            valueAttr = _opBuilder.getF64FloatAttr(doubleLiteral->getValue());
+            return _opBuilder.getF64FloatAttr(doubleLiteral->getValue());
         }
         break;
 
         case Literal::Kind::STRING: {
             const StringLiteral* stringLiteral = static_cast<const StringLiteral*>(literal);
             const mlir::Type stringType = mlir::storage::StringType::get(_mlirCtxt);
-            valueAttr = mlir::StringAttr::get(stringLiteral->getValue(), stringType);
+            return mlir::StringAttr::get(stringLiteral->getValue(), stringType);
         }
+        break;
+
+        default:
+            return {};
+        break;
+    }
+}
+
+mlir::Value DBProgramGenerator::translateLiteralExpr(const Literal* literal) {
+    const mlir::Location uloc = _opBuilder.getUnknownLoc();
+
+    mlir::TypedAttr valueAttr;
+
+    switch (literal->getKind()) {
+        case Literal::Kind::BOOL:
+        case Literal::Kind::INTEGER:
+        case Literal::Kind::DOUBLE:
+        case Literal::Kind::STRING:
+            valueAttr = scalarLiteralAttr(literal);
         break;
 
         case Literal::Kind::EMBEDDING: {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -29,8 +29,10 @@ class UnaryExpr;
 class CypherAST;
 class Expr;
 class Literal;
+class ListLiteral;
 class Projection;
 class PropertyExpr;
+class UnwindStmt;
 class VarDecl;
 class VariableDependency;
 class DependencyEdge;
@@ -134,7 +136,19 @@ private:
     mlir::Value translateLiteralExpr(const Literal* literal);
     mlir::Value translatePropertyExpr(const PropertyExpr* propExpr);
 
+    // The attribute carrying a scalar literal's value and type, or a null attribute for
+    // any other literal kind
+    mlir::TypedAttr scalarLiteralAttr(const Literal* literal);
+
+    // Fills one attribute per element of an UNWIND list, each keeping its literal's type
+    void translateUnwindElements(const ListLiteral* list,
+                                 llvm::SmallVectorImpl<mlir::Attribute>& elements);
+
     void addScanNodes(const VariableDependency* var);
+
+    // Opens a dataflow from an UNWIND's literal list, the way addScanNodes opens one
+    // from the graph's nodes
+    void addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind);
     void filterAllColumns(mlir::Value predicate);
 
     void addMergeFilter(const VariableDependency* var,

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -533,3 +533,49 @@ LogicalResult UnwindCollect::verify() {
 
     return success();
 }
+
+// db.unwind_const carries its literal list as an array of typed attributes and emits
+// one column. The result element type is the homogeneity verdict the frontend derived
+// from the analyzer: a heterogeneous or empty list is a type-erased list_element
+// column, whose cells may differ, so nothing more is checked; a homogeneous list is a
+// typed column, so all its literals must share one attribute type. We check the
+// literals agree with each other rather than with the column's element type - a
+// StringAttr carries no !storage.string to compare against - so a homogeneous verdict
+// paired with the wrong column type is not an op-level error; the runtime fill catches
+// it on the element's type tag rather than reading a value of the wrong type.
+LogicalResult UnwindConst::verify() {
+    const ColumnType resultColumn = llvm::dyn_cast<ColumnType>(getResult().getType());
+    if (!resultColumn) {
+        return emitOpError("result must be a column");
+    }
+
+    const mlir::Type elementType = resultColumn.getType();
+    const bool isTypeErased = llvm::isa<storage::ListElementType>(elementType);
+
+    if (isTypeErased) {
+        return success();
+    }
+
+    const ArrayAttr elements = getElements();
+    if (elements.empty()) {
+        return emitOpError("a homogeneous unwind_const must carry at least one element; "
+                           "an empty list is the list_element form");
+    }
+
+    const TypedAttr firstElement = llvm::dyn_cast<TypedAttr>(elements[0]);
+    if (!firstElement) {
+        return emitOpError("unwind_const element is not a typed attribute");
+    }
+
+    const mlir::Type payloadType = firstElement.getType();
+    for (const Attribute element : elements) {
+        const TypedAttr typedElement = llvm::dyn_cast<TypedAttr>(element);
+        if (!typedElement) {
+            return emitOpError("unwind_const element is not a typed attribute");
+        } else if (typedElement.getType() != payloadType) {
+            return emitOpError("a homogeneous unwind_const requires every element to share one type");
+        }
+    }
+
+    return success();
+}

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -534,15 +534,10 @@ LogicalResult UnwindCollect::verify() {
     return success();
 }
 
-// db.unwind_const carries its literal list as an array of typed attributes and emits
-// one column. The result element type is the homogeneity verdict the frontend derived
-// from the analyzer: a heterogeneous or empty list is a type-erased list_element
-// column, whose cells may differ, so nothing more is checked; a homogeneous list is a
-// typed column, so all its literals must share one attribute type. We check the
-// literals agree with each other rather than with the column's element type - a
-// StringAttr carries no !storage.string to compare against - so a homogeneous verdict
-// paired with the wrong column type is not an op-level error; the runtime fill catches
-// it on the element's type tag rather than reading a value of the wrong type.
+// The literals are checked against each other, not against the column's element type -
+// a StringAttr carries no !storage.string to compare against - so a homogeneous result
+// type paired with literals of another type is not an op-level error; the runtime fill
+// catches that on the element's type tag.
 LogicalResult UnwindConst::verify() {
     const ColumnType resultColumn = llvm::dyn_cast<ColumnType>(getResult().getType());
     if (!resultColumn) {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -101,6 +101,48 @@ def ConstScanNodes : TuringOp<"const_scan_nodes", [Pure]> {
 }
 
 /**
+* UnwindConst
+*/
+def UnwindConst : TuringOp<"unwind_const", [Pure]> {
+  let summary = "Produce one row per element of a compile-time-known literal list";
+
+  let description = [{
+    The source op for `UNWIND [<literals>] AS x` where the list is known at plan
+    time, independent of any input row. It opens a dataflow, one row per element, the
+    way db.const_scan_nodes opens one from a fixed set of node IDs:
+
+      %x = db.unwind_const([1, 2, 3]) : !db.column<i64>
+
+    `elements` carries the literals as an array of typed attributes, so each element
+    keeps its own type. When they share one type the list is homogeneous and the
+    result is that typed column; when they differ - or the list is empty - it is
+    heterogeneous and the result is a type-erased !storage.list_element column, a
+    tagged scalar per row, matching Cypher's LIST OF ANY:
+
+      %row = db.unwind_const([true, "s", 10]) : !db.column<!storage.list_element>
+
+    So the result element type is the homogeneity verdict: a downstream op sees a
+    concrete typed column for a homogeneous list, and a list_element column - which
+    only pass-through ops (a cross_product broadcast, the output) accept - for a
+    heterogeneous one. An empty list yields no row, matching UNWIND of an empty list.
+    Producing a fixed list is deterministic, so the op is Pure. With incoming rows
+    (MATCH (a) UNWIND [...] AS x) it is crossed with the input through
+    db.cross_product; there is no expanding variant of this op.
+  }];
+
+  // `elements` is the literal list, each entry a typed builtin attribute carrying its
+  // own type. Being an attribute and not an SSA value, it is absent from `operands`.
+  let arguments = (ins ArrayAttr:$elements);
+  let results   = (outs Column:$result);
+  let hasVerifier = 1;
+
+  // The literals print inside the parens as `[1, 2, 3]`, ahead of the colon, the same
+  // place db.const_scan_nodes prints its IDs; the result column type follows,
+  // qualified, as db.const_scan_nodes prints it.
+  let assemblyFormat = "`(` $elements `)` attr-dict `:` qualified(type($result))";
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : TuringOp<"scan_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -70,6 +70,36 @@ def ConstScanNodes : NLOp<"const_scan_nodes", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* UnwindConst
+*/
+// Pure: emitting a fixed list is deterministic; the per-element fan-out is in the nl.for.
+def UnwindConst : NLOp<"unwind_const", [Pure]> {
+  let summary = "Create a database iterator over a compile-time-known literal list";
+  let description = [{
+    Imperative counterpart of db.unwind_const. Each step of an enclosing nl.for fills
+    one chunk of the literal list's elements:
+
+      %rows = nl.unwind_const([1, 2, 3]) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+      nl.for %x in %rows : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+        nl.output(%x) : !nl.chunk<!storage.nullable<i64>>
+      }
+
+    `elements` is the same literal array db.unwind_const carried, each entry a typed
+    attribute keeping its own type. A homogeneous list yields a nullable value chunk of
+    that type - the shape a property fetch and the unwind_collect drain emit, so the
+    unwound column feeds the same consumers, even though a literal is never null; a
+    heterogeneous or empty list yields a type-erased !storage.list_element chunk (a
+    tagged scalar per row). The single chunk element type depends on the elements, so -
+    unlike nl.scan_nodes, whose node-ID iterator is fixed and inferred - it is spelled
+    after the colon, as nl.collect's is. It opens the dataflow: no input, no carry.
+  }];
+
+  let arguments = (ins ArrayAttr:$elements);
+  let results   = (outs NLIterator:$result);
+  let assemblyFormat = "`(` $elements `)` attr-dict `:` qualified(type($result))";
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : NLOp<"scan_edges", [Pure, InferTypeOpAdaptor]> {

--- a/query/ir/dialect/storage/StorageTypes.td
+++ b/query/ir/dialect/storage/StorageTypes.td
@@ -66,6 +66,20 @@ def Nullable : StorageType<"Nullable", "nullable"> {
     let assemblyFormat = "`<` $valueType `>`";
 }
 
+def ListElement : StorageType<"ListElement", "list_element"> {
+    let summary = "A single type-tagged scalar value";
+    let description = [{
+        The element type of a chunk holding one type-tagged scalar per row - storage's
+        ColumnVector<ListElementView>. Each cell carries its own type tag beside its
+        value, so a heterogeneous list - whose elements share no single type - unwinds
+        into a column of these. Unlike !storage.list it is a fixed-width scalar, not a
+        variable-length list: one value per cell, not a span, so it needs none of the
+        list machinery. Produced by db.unwind_const for a heterogeneous (or empty)
+        literal list, and only ever passed through (a cross_product broadcast) or
+        rendered - never fed to an op that needs a concrete element type.
+    }];
+}
+
 def List : StorageType<"List", "list"> {
     let summary = "A list value";
     let description = [{

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -81,16 +81,13 @@ void VariableDependencyGraph::buildFromAST(const CypherAST* ast) {
     const StmtContainer::Stmts& stmts = stmtsContainer->stmts();
 
     for (const Stmt* stmt : stmts) {
-        const MatchStmt* match = dynamic_cast<const MatchStmt*>(stmt);
-        const UnwindStmt* unwind = dynamic_cast<const UnwindStmt*>(stmt);
-
-        if (match) {
+        if (const MatchStmt* match = dynamic_cast<const MatchStmt*>(stmt)) {
             const Pattern* pattern = match->getPattern();
             const Pattern::PatternElements& elements = pattern->elements();
             for (const PatternElement* element : elements) {
                 registerPatternElement(element);
             }
-        } else if (unwind) {
+        } else if (const UnwindStmt* unwind = dynamic_cast<const UnwindStmt*>(stmt)) {
             registerUnwindStmt(unwind);
         } else {
             spdlog::warn("Non-match statement: skipped");

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -17,8 +17,10 @@
 #include "SinglePartQuery.h"
 #include "Pattern.h"
 #include "PatternElement.h"
+#include "Symbol.h"
 #include "stmt/MatchStmt.h"
 #include "stmt/StmtContainer.h"
+#include "stmt/UnwindStmt.h"
 #include "decl/VarDecl.h"
 
 #include "DependencyEdge.h"
@@ -79,16 +81,19 @@ void VariableDependencyGraph::buildFromAST(const CypherAST* ast) {
     const StmtContainer::Stmts& stmts = stmtsContainer->stmts();
 
     for (const Stmt* stmt : stmts) {
-        const auto* match = dynamic_cast<const MatchStmt*>(stmt);
-        if (!match) {
-            spdlog::warn("Non-match statement: skipped");
-            continue;
-        }
+        const MatchStmt* match = dynamic_cast<const MatchStmt*>(stmt);
+        const UnwindStmt* unwind = dynamic_cast<const UnwindStmt*>(stmt);
 
-        const Pattern* pattern = match->getPattern();
-        const Pattern::PatternElements& elements = pattern->elements();
-        for (const PatternElement* element : elements) {
-            registerPatternElement(element);
+        if (match) {
+            const Pattern* pattern = match->getPattern();
+            const Pattern::PatternElements& elements = pattern->elements();
+            for (const PatternElement* element : elements) {
+                registerPatternElement(element);
+            }
+        } else if (unwind) {
+            registerUnwindStmt(unwind);
+        } else {
+            spdlog::warn("Non-match statement: skipped");
         }
     }
 
@@ -158,6 +163,17 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
 
         prev = tgt;
     }
+}
+
+void VariableDependencyGraph::registerUnwindStmt(const UnwindStmt* stmt) {
+    const Symbol* symbol = stmt->symbol();
+    bioassert(symbol, "UNWIND without a variable.");
+
+    // An UNWIND variable is bound to a list rather than to a pattern, so it depends on
+    // no other variable and enters the graph isolated - a root of its own connected
+    // component, whose dataflow the code generator opens from the list.
+    VariableDependency* unwindVar = newVariable(symbol->getName());
+    _unwindSources[unwindVar] = stmt;
 }
 
 VariableDependency* VariableDependencyGraph::newVariable(const EntityPattern* entity) {

--- a/query/ir/frontend/cypher/VariableDependencyGraph.h
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.h
@@ -14,6 +14,7 @@ namespace db {
 class CypherAST;
 class EntityPattern;
 class PatternElement;
+class UnwindStmt;
 
 /**
  * @brief Graph representation of the dependencies among variables, generated from
@@ -35,6 +36,7 @@ class VariableDependencyGraph {
 public:
     using Cycle = std::vector<VariableDependency*>;
     using EdgeIdentityMap = std::unordered_map<std::string, std::vector<VariableDependency*>>;
+    using UnwindSourceMap = std::unordered_map<const VariableDependency*, const UnwindStmt*>;
 
     VariableDependencyGraph();
     ~VariableDependencyGraph();
@@ -44,10 +46,15 @@ public:
     /// Given a pattern (e.g. (n)-[e]->(m)), inserts all vars into the dependency graph
     void registerPatternElement(const PatternElement* ptn);
 
+    /// Given an UNWIND (e.g. UNWIND [1, 2, 3] AS x), inserts its variable into the
+    /// dependency graph
+    void registerUnwindStmt(const UnwindStmt* stmt);
+
     /// Iteration order has no semantic meaning
     const auto& vars() const { return _vars; }
     const auto& edges() const { return _edges; }
     const EdgeIdentityMap& edgeIdentities() const { return _edgeIdentities; }
+    const UnwindSourceMap& unwindSources() const { return _unwindSources; }
 
     bool empty() const { return _vars.empty() && _edges.empty(); }
 
@@ -67,6 +74,9 @@ private:
 
     // Maps each Cypher edge variable name to all anonymous VDG variables created for it
     EdgeIdentityMap _edgeIdentities;
+
+    // Maps each UNWIND variable to the statement whose list it is bound to
+    UnwindSourceMap _unwindSources;
 
     VariableDependency* getOrCreateVariable(const EntityPattern* entity);
     VariableDependency* newVariable(const EntityPattern* entity);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -28,6 +28,7 @@
 #include "columns/ColumnOperatorDispatcher.h"
 #include "columns/AllowedKinds.h"
 #include "columns/UnaryPredicates.h"
+#include "list/ListUtils.h"
 #include "metadata/PropertyType.h"
 
 #include "versioning/CommitWriteBuffer.h"
@@ -43,6 +44,48 @@
 using namespace db;
 
 namespace {
+
+// Copy a slice of a ListView's tagged scalars straight into a
+// ColumnVector<ListElementView> - the heterogeneous unwind's type-erased column.
+void fillListElementChunk(Column* output, const ListView list, size_t offset, size_t rows) {
+    ColumnVector<ListElementView>* typed = static_cast<ColumnVector<ListElementView>*>(output);
+    const std::span<const ListElementView> elements = list.elements();
+
+    std::vector<ListElementView>& raw = typed->getRaw();
+    raw.assign(elements.begin() + offset, elements.begin() + offset + rows);
+}
+
+// Fill a slice of a ListView into a nullable value column, extracting each element as
+// the homogeneous primitive. The homogeneous unwind's fast path, ported from
+// UnwindProcessor::fillHomogeneous onto the ColumnOptVector every other value-chunk
+// consumer reads; a literal list holds no null, so every cell is present.
+void fillHomogeneousChunk(Column* output, ValueType valueType, const ListView list, size_t offset, size_t rows) {
+    const std::span<const ListElementView> elements = list.elements();
+
+    const auto fill = [&]<SupportedType T>() {
+        using Primitive = typename T::Primitive;
+
+        ColumnOptVector<Primitive>* typed = static_cast<ColumnOptVector<Primitive>*>(output);
+
+        std::vector<std::optional<Primitive>>& raw = typed->getRaw();
+        raw.resize(rows);
+
+        // ListElementView::getAs reinterprets the element's bytes as the primitive
+        // without consulting its type tag, so check the tag against the one the
+        // primitive is stored under: a homogeneous unwind whose column type disagrees
+        // with its literals would otherwise read a value of the wrong type.
+        constexpr ListBufferTypeTag expectedTag = TypeToListBufferTag<Primitive>::Tag;
+
+        for (size_t index = 0; index < rows; index++) {
+            const ListElementView element = elements[offset + index];
+            bioassert(element.getTag() == expectedTag, "Unwound element does not have the unwind's value type.");
+
+            raw[index] = element.getAs<Primitive>();
+        }
+    };
+
+    ValueTypeDispatcher {valueType}.execute(fill);
+}
 
 template <ColumnOperator Op>
 struct BinaryOpTraits;
@@ -1519,6 +1562,51 @@ void NLExecutor::runConstScanNodesLoop(NLExecutionContext* context, NLFunctionDa
 
         std::vector<NodeID>& raw = nodeIDs->getRaw();
         raw.assign(constNodeIDs.begin() + cursor, constNodeIDs.begin() + cursor + rows);
+
+        cursor += rows;
+
+        runBody(context, loopBody);
+    };
+
+    if (limit) {
+        while (cursor < totalCount && limit->getRemaining() > 0) {
+            runIteration();
+        }
+    } else {
+        while (cursor < totalCount) {
+            runIteration();
+        }
+    }
+}
+
+void NLExecutor::runUnwindConstLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLUnwindConstLoopData* loopData = static_cast<NLUnwindConstLoopData*>(data);
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    const ListView list = loopData->getList();
+    Column* output = loopData->getOutput();
+    const bool heterogeneous = loopData->isHeterogeneous();
+    const ValueType valueType = loopData->getValueType();
+    const size_t chunkSize = context->getChunkSize();
+    const size_t totalCount = list.size();
+
+    // A null limit leaves the loop unbounded, exactly as in runConstScanNodesLoop.
+    const NLLimitState* limit = loopData->getLimit();
+
+    // Emit the fixed list one chunk at a time: each step fills the value chunk with the
+    // next slice and runs the body over it. The cursor is local to this call, so an
+    // unwind nested in a cross product restarts from the first element on every outer
+    // step - the same way runConstScanNodesLoop reopens its slice each call.
+    size_t cursor = 0;
+
+    const auto runIteration = [&]() {
+        const size_t remaining = totalCount - cursor;
+        const size_t rows = std::min(chunkSize, remaining);
+
+        if (heterogeneous) {
+            fillListElementChunk(output, list, cursor, rows);
+        } else {
+            fillHomogeneousChunk(output, valueType, list, cursor, rows);
+        }
 
         cursor += rows;
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2583,6 +2583,16 @@ NLBroadcastFunction NLExecutor::selectOptTileFunction(ValueType valueType) {
     return broadcast;
 }
 
+// A list_element chunk is a ColumnVector<ListElementView> of fixed-width tagged
+// scalars, so the same broadcast templates carry the tag along with the value.
+NLBroadcastFunction NLExecutor::selectListElementBlockRepeatFunction() {
+    return &blockRepeatColumn<ListElementView>;
+}
+
+NLBroadcastFunction NLExecutor::selectListElementTileFunction() {
+    return &tileColumn<ListElementView>;
+}
+
 NLCopyFunction NLExecutor::selectCopyFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -255,6 +255,11 @@ public:
     // Tile for a nullable value chunk of this value type (inner column).
     static NLBroadcastFunction selectOptTileFunction(ValueType valueType);
 
+    // Block-repeat (outer column) and tile (inner column) for a list_element chunk: a
+    // tagged scalar carries its own type, so there is no value type to dispatch on.
+    static NLBroadcastFunction selectListElementBlockRepeatFunction();
+    static NLBroadcastFunction selectListElementTileFunction();
+
     // Range copy for an ID chunk of this kind (skip suffix copy).
     static NLCopyFunction selectCopyFunction(NLChunkKind kind);
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -57,6 +57,12 @@ public:
     // list one chunk at a time - no graph walk - running the body over each slice.
     static void runConstScanNodesLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    // The literal-list sibling of runConstScanNodesLoop: stream the loop data's
+    // ListView one chunk at a time into its value column - a nullable value column
+    // for a homogeneous list, a ColumnVector<ListElementView> for a heterogeneous one -
+    // running the body over each slice. A null limit leaves it unbounded.
+    static void runUnwindConstLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -19,6 +19,7 @@
 #include "list/ListView.h"
 #include "metadata/LabelSet.h"
 #include "metadata/LabelSetHandle.h"
+#include "metadata/PropertyType.h"
 
 namespace db {
 
@@ -252,6 +253,42 @@ public:
 
 private:
     std::vector<NodeID> _constNodeIDs;
+};
+
+// The literal-list sibling of NLConstScanLoopData: streams a fixed ListView one chunk
+// at a time. A homogeneous list fills a nullable value column of _valueType, the shape
+// every value-chunk consumer reads; a heterogeneous list fills a
+// ColumnVector<ListElementView> of tagged scalars, in which case _valueType is unused.
+// The ListView spans the query-scoped ListBuffer, so the elements outlive the loop. A
+// plain source, so a downstream LIMIT can bound it.
+class NLUnwindConstLoopData : public NLFunctionData {
+public:
+    NLUnwindConstLoopData(Column* output, ListView list, bool heterogeneous, ValueType valueType)
+        : _output(output),
+        _list(list),
+        _heterogeneous(heterogeneous),
+        _valueType(valueType)
+    {
+    }
+
+    Column* getOutput() const { return _output; }
+    ListView getList() const { return _list; }
+    bool isHeterogeneous() const { return _heterogeneous; }
+    ValueType getValueType() const { return _valueType; }
+
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    Column* _output {nullptr};
+    ListView _list;
+    bool _heterogeneous {false};
+    ValueType _valueType {ValueType::Invalid};
+    NLLimitState* _limit {nullptr};
+    NLStmtContainer _stmts;
 };
 
 // nl.scan_edges loop data: the edge sibling of NLScanLoopData. A source loop

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -578,9 +578,7 @@ void NLTranslator::translateUnwindConstLoop(const IteratorConfig& config,
     ValueType valueType {ValueType::Invalid};
 
     if (heterogeneous) {
-        ColumnVector<ListElementView>* elements = _memory->alloc<ColumnVector<ListElementView>>();
-        elements->reserve(_program->getChunkSize());
-        output = elements;
+        output = allocListElementColumn();
     } else {
         valueType = nullableChunkValueType(valueChunk.getType());
         output = allocOptColumnForValueType(valueType);
@@ -2342,7 +2340,8 @@ void NLTranslator::addCrossColumn(mlir::Value inputValue,
 
     // The output keeps the input's element type, only the row count changes. A
     // nullable value chunk allocates a ColumnOptVector and broadcasts on its
-    // value type; an ID chunk allocates on its chunk kind.
+    // value type; a list_element chunk allocates a column of tagged scalars, which
+    // carry their own type; an ID chunk allocates on its chunk kind.
     Column* output = nullptr;
     NLBroadcastFunction broadcast = nullptr;
 
@@ -2351,6 +2350,10 @@ void NLTranslator::addCrossColumn(mlir::Value inputValue,
         output = allocOptColumnForValueType(valueType);
         broadcast = isOuter ? NLExecutor::selectOptBlockRepeatFunction(valueType)
                             : NLExecutor::selectOptTileFunction(valueType);
+    } else if (mlir::isa<storage::ListElementType>(elementType)) {
+        output = allocListElementColumn();
+        broadcast = isOuter ? NLExecutor::selectListElementBlockRepeatFunction()
+                            : NLExecutor::selectListElementTileFunction();
     } else {
         const NLChunkKind kind = getChunkKind(chunkType);
         output = allocColumnForKind(kind);
@@ -2441,6 +2444,13 @@ bool NLTranslator::isCountElementType(mlir::Type elementType) {
 
 ColumnVector<uint64_t>* NLTranslator::allocCountColumn() {
     ColumnVector<uint64_t>* column = _memory->alloc<ColumnVector<uint64_t>>();
+    column->reserve(_program->getChunkSize());
+
+    return column;
+}
+
+Column* NLTranslator::allocListElementColumn() {
+    ColumnVector<ListElementView>* column = _memory->alloc<ColumnVector<ListElementView>>();
     column->reserve(_program->getChunkSize());
 
     return column;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -173,13 +173,14 @@ GroupAggregateKind toRuntimeGroupAggregateKind(storage::GroupAggregateKind kind)
 }
 
 // The value type wrapped by a nullable value chunk (!nl.chunk<!storage.nullable<T>>).
-// An aggregate reduces property values, so its input and result are always such
-// chunks; a chunk that is not a nullable value chunk (an ID chunk) is rejected.
+// Every chunk carrying scalar values is such a chunk - an aggregate's input and result,
+// a property fetch, a homogeneous unwind - so a chunk that is not one (an ID chunk) is
+// rejected.
 ValueType nullableChunkValueType(mlir::Type chunkType) {
     const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
     const auto nullableType = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
     if (!nullableType) {
-        throw IRException("aggregate requires a nullable value chunk");
+        throw IRException("Expected a nullable value chunk");
     }
 
     return valueTypeFromElementType(nullableType.getValueType());
@@ -319,6 +320,11 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             config._kind = IteratorKind::Collect;
             config._collectState = collectStateFor(collect.getState());
             _iteratorConfigs[collect.getResult()] = config;
+        } else if (nl::UnwindConst unwindConst = mlir::dyn_cast<nl::UnwindConst>(operation)) {
+            IteratorConfig config;
+            config._kind = IteratorKind::UnwindConst;
+            config._list = materializeListView(unwindConst.getElements());
+            _iteratorConfigs[unwindConst.getResult()] = config;
         } else if (nl::For forLoop = mlir::dyn_cast<nl::For>(operation)) {
             translateFor(forLoop, body);
         } else if (mlir::isa<nl::GetPropertyType, nl::GetEdgeType>(operation)) {
@@ -472,6 +478,10 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         translateUnwindCollectLoop(config, loopBody, body);
     } else if (config._kind == IteratorKind::Collect) {
         translateCollectLoop(config, loopBody, body);
+    } else if (config._kind == IteratorKind::UnwindConst) {
+        // A const unwind is a plain source, so - like a scan - a downstream LIMIT can
+        // bound its loop through the ordinary early-exit.
+        translateUnwindConstLoop(config, loopBody, limit, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -549,6 +559,69 @@ void NLTranslator::translateConstScanLoop(const IteratorConfig& config,
     body->emplaceStmt(&NLExecutor::runConstScanNodesLoop, loopData);
 
     translateBlock(loopBody, loopData->getStmts());
+}
+
+void NLTranslator::translateUnwindConstLoop(const IteratorConfig& config,
+                                            mlir::Block& loopBody,
+                                            NLLimitState* limit,
+                                            NLStmtContainer* body) {
+    // An unwind_const binds a single value chunk: the loop emits one element per row.
+    const mlir::Value valueChunk = loopBody.getArgument(0);
+    const mlir::Type elementType = mlir::cast<nl::ChunkType>(valueChunk.getType()).getElementType();
+
+    // The chunk element type is the homogeneity verdict: a list_element chunk is the
+    // type-erased column of tagged scalars; a nullable value chunk is a homogeneous
+    // column of that one value type, the shape every other value-chunk consumer reads.
+    const bool heterogeneous = llvm::isa<storage::ListElementType>(elementType);
+
+    Column* output {nullptr};
+    ValueType valueType {ValueType::Invalid};
+
+    if (heterogeneous) {
+        ColumnVector<ListElementView>* elements = _memory->alloc<ColumnVector<ListElementView>>();
+        elements->reserve(_program->getChunkSize());
+        output = elements;
+    } else {
+        valueType = nullableChunkValueType(valueChunk.getType());
+        output = allocOptColumnForValueType(valueType);
+    }
+
+    _valueSlots[valueChunk] = output;
+
+    NLUnwindConstLoopData* loopData = _program->allocFunctionData<NLUnwindConstLoopData>(output,
+                                                                                        config._list,
+                                                                                        heterogeneous,
+                                                                                        valueType);
+    loopData->setLimit(limit);
+
+    body->emplaceStmt(&NLExecutor::runUnwindConstLoop, loopData);
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+ListView NLTranslator::materializeListView(mlir::ArrayAttr elements) {
+    std::vector<ListBuffer<>::ListItemVariant> items;
+    items.reserve(elements.size());
+
+    for (const mlir::Attribute element : elements) {
+        // BoolAttr is an i1 IntegerAttr, so it must be tested before IntegerAttr; an
+        // i64 literal falls through to the integer case.
+        if (const auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(element)) {
+            items.emplace_back(types::Bool::Primitive(boolAttr.getValue()));
+        } else if (const auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(element)) {
+            items.emplace_back(static_cast<types::Int64::Primitive>(intAttr.getInt()));
+        } else if (const auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(element)) {
+            items.emplace_back(floatAttr.getValueAsDouble());
+        } else if (const auto stringAttr = mlir::dyn_cast<mlir::StringAttr>(element)) {
+            const llvm::StringRef value = stringAttr.getValue();
+            items.emplace_back(types::String::Primitive(value.data(), value.size()));
+        } else {
+            throw IRException("Unsupported literal attribute in nl.unwind_const");
+        }
+    }
+
+    LocalMemory::DefaultListBuffer& buffer = _memory->listBuffer();
+    return buffer.insert(items);
 }
 
 void NLTranslator::translateScanEdgesLoop(mlir::Block& loopBody, NLLimitState* limit, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -83,9 +83,8 @@ private:
         llvm::ArrayRef<int64_t> _nodeIDs;
 
         // The literal list an UnwindConst iterator emits; a null (empty) ListView
-        // for the other kinds. Materialized from the op's element attributes into
-        // the query-scoped ListBuffer at config setup, so the elements are copied
-        // into stable storage that outlives the loop.
+        // for the other kinds. Materialized by materializeListView into the
+        // query-scoped ListBuffer at config setup.
         ListView _list;
     };
 
@@ -169,10 +168,9 @@ private:
                                   NLStmtContainer* body);
 
     // Materialize an nl.unwind_const's literal element attributes into a ListView in
-    // the query-scoped ListBuffer: each typed builtin attribute becomes a tagged
-    // ListItemVariant, so the elements land in stable storage the loop reads chunk by
-    // chunk. String bytes are copied in, so the StringAttr views need only outlive
-    // this call (the MLIRContext keeps them alive through translation).
+    // the query-scoped ListBuffer, which the loop then reads chunk by chunk. A string
+    // element stores the string_view, not the characters, so the module the literals
+    // came from must outlive execution - not just this call.
     ListView materializeListView(mlir::ArrayAttr elements);
 
     // Translate the nl.for over an nl.scan_edges iterator: allocate the four
@@ -489,6 +487,10 @@ private:
     // ColumnVector<uint64_t>.
     static bool isCountElementType(mlir::Type elementType);
     ColumnVector<uint64_t>* allocCountColumn();
+
+    // Allocate a type-erased column of tagged scalars - the shape a heterogeneous
+    // unwind emits and a cross product broadcasts - reserving a full chunk.
+    Column* allocListElementColumn();
 
     Column* getColumn(mlir::Value chunkValue) const;
     static NLChunkKind getChunkKind(mlir::Type chunkType);

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -45,6 +45,7 @@ private:
         GroupAggregate,
         UnwindCollect,
         Collect,
+        UnwindConst,
     };
 
     // Settings of the iterators passed to each for loop
@@ -80,6 +81,12 @@ private:
         // keeps alive for the whole translation; resolved to owned NodeIDs when the
         // loop is translated.
         llvm::ArrayRef<int64_t> _nodeIDs;
+
+        // The literal list an UnwindConst iterator emits; a null (empty) ListView
+        // for the other kinds. Materialized from the op's element attributes into
+        // the query-scoped ListBuffer at config setup, so the elements are copied
+        // into stable storage that outlives the loop.
+        ListView _list;
     };
 
     NLProgram* _program {nullptr};
@@ -149,6 +156,24 @@ private:
                                 mlir::Block& loopBody,
                                 NLLimitState* limit,
                                 NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.unwind_const iterator: allocate the single
+    // value loop variable (a nullable value column for a homogeneous list, a
+    // ColumnVector<ListElementView> for a heterogeneous one) and record the
+    // unwind-const loop statement in body. The literal sibling of
+    // translateConstScanLoop - a source loop that streams a fixed ListView one chunk
+    // at a time rather than a set of node IDs.
+    void translateUnwindConstLoop(const IteratorConfig& config,
+                                  mlir::Block& loopBody,
+                                  NLLimitState* limit,
+                                  NLStmtContainer* body);
+
+    // Materialize an nl.unwind_const's literal element attributes into a ListView in
+    // the query-scoped ListBuffer: each typed builtin attribute becomes a tagged
+    // ListItemVariant, so the elements land in stable storage the loop reads chunk by
+    // chunk. String bytes are copied in, so the StringAttr views need only outlive
+    // this call (the MLIRContext keeps them alive through translation).
+    ListView materializeListView(mlir::ArrayAttr elements);
 
     // Translate the nl.for over an nl.scan_edges iterator: allocate the four
     // fixed edge loop variables (sources, edge IDs, edge type IDs, targets) and

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -383,6 +383,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerScanNodesByLabel(scanNodesByLabel);
     } else if (mlir::db::ConstScanNodes constScanNodes = mlir::dyn_cast<mlir::db::ConstScanNodes>(operation)) {
         lowerConstScanNodes(constScanNodes);
+    } else if (mlir::db::UnwindConst unwindConst = mlir::dyn_cast<mlir::db::UnwindConst>(operation)) {
+        lowerUnwindConst(unwindConst);
     } else if (mlir::db::ScanEdges scanEdges = mlir::dyn_cast<mlir::db::ScanEdges>(operation)) {
         lowerScanEdges(scanEdges);
     } else if (mlir::db::GetOutEdges getOutEdges = mlir::dyn_cast<mlir::db::GetOutEdges>(operation)) {
@@ -518,6 +520,39 @@ void DBLowering::lowerConstScanNodes(mlir::db::ConstScanNodes constScanNodes) {
     nl::ConstScanNodes nodes = _builder.create<nl::ConstScanNodes>(_builder.getUnknownLoc(),
                                                                    constScanNodes.getNodeIDsAttr());
     buildLoopForSource(nodes.getResult(), constScanNodes.getOperation());
+}
+
+void DBLowering::lowerUnwindConst(mlir::db::UnwindConst unwindConst) {
+    // The literal-list sibling of lowerConstScanNodes: a source reads no column, so
+    // its loop sits at the top of the current root block. The literals are the rows to
+    // emit, forwarded as-is; translation materializes them into a ListView. Unlike a
+    // node-ID scan the chunk element type varies with the list (a homogeneous value
+    // type, or list_element for a heterogeneous one), so - like nl.collect - the
+    // iterator type is spelled here from the db column's element type rather than
+    // inferred.
+    setInsertionInto(_rootBlock);
+
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::db::ColumnType column = mlir::cast<mlir::db::ColumnType>(unwindConst.getResult().getType());
+    const mlir::Type elementType = column.getType();
+
+    // A homogeneous list rides a nullable value chunk, as a property fetch and the
+    // unwind_collect drain do: the elements are never null, but every value-chunk
+    // consumer (a cross product broadcast, a filter, a skip, an aggregate) dispatches
+    // on nullable<T>, so the uniform shape is what makes the unwound column composable.
+    // A heterogeneous list keeps its type-erased list_element chunk, which only
+    // pass-through consumers accept.
+    const bool heterogeneous = mlir::isa<storage::ListElementType>(elementType);
+    const mlir::Type chunkElementType = heterogeneous ? elementType
+                                                      : storage::NullableType::get(context, elementType);
+
+    const nl::ChunkType chunk = nl::ChunkType::get(context, chunkElementType);
+    const nl::IteratorType iteratorType = nl::IteratorType::get(context, {chunk});
+
+    nl::UnwindConst rows = _builder.create<nl::UnwindConst>(_builder.getUnknownLoc(),
+                                                            iteratorType,
+                                                            unwindConst.getElementsAttr());
+    buildLoopForSource(rows.getResult(), unwindConst.getOperation());
 }
 
 void DBLowering::lowerScanEdges(mlir::db::ScanEdges scanEdges) {
@@ -1432,6 +1467,7 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
 
     const bool opensLoop = mlir::isa<mlir::db::ScanNodes,
                                      mlir::db::ConstScanNodes,
+                                     mlir::db::UnwindConst,
                                      mlir::db::ScanNodesByLabel,
                                      mlir::db::ScanEdges,
                                      mlir::db::GetOutEdges,

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -162,6 +162,7 @@ private:
     void lowerScanNodes(mlir::db::ScanNodes scanNodes);
     void lowerScanNodesByLabel(mlir::db::ScanNodesByLabel scanNodesByLabel);
     void lowerConstScanNodes(mlir::db::ConstScanNodes constScanNodes);
+    void lowerUnwindConst(mlir::db::UnwindConst unwindConst);
     void lowerScanEdges(mlir::db::ScanEdges scanEdges);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetInEdges(mlir::db::GetInEdges getInEdges);

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -329,6 +329,8 @@ private:
             // ColumnConst
         } else if (printListCell(column, row)) {
             // A per-group list cell from an nl.collect drain
+        } else if (printListElementCell(column, row)) {
+            // A tagged scalar from a heterogeneous unwind
         } else {
             std::cout << "?";
         }
@@ -431,6 +433,20 @@ private:
                 std::cout << "?";
             break;
         }
+    }
+
+    // Print one cell of a type-tagged scalar column (a ColumnVector<ListElementView>
+    // from a heterogeneous nl.unwind_const, whose cells need not share a type) as the
+    // value alone; returns whether the column matched.
+    static bool printListElementCell(const Column* column, size_t row) {
+        const auto* elements = dynamic_cast<const ColumnVector<ListElementView>*>(column);
+        if (!elements) {
+            return false;
+        }
+
+        printListElement((*elements)[row]);
+
+        return true;
     }
 
     // Print one cell of a list column (a ColumnVector<ListView> from an nl.collect

--- a/samples/mlir/unwind_const.mlir
+++ b/samples/mlir/unwind_const.mlir
@@ -1,0 +1,27 @@
+module {
+  func.func @main() {
+    // UNWIND [1, 2, 3] AS x RETURN x: the literal-list source. The list is known at plan
+    // time and reads no row, so it opens a dataflow one row per element, the way
+    // db.const_scan_nodes opens one from a fixed set of node IDs.
+    //
+    // The literals ride the op as an array of typed attributes, each keeping its own
+    // type, and the result element type is the homogeneity verdict: these three share
+    // one type, so the column is a typed i64 one. A list whose elements disagree - or an
+    // empty list - is heterogeneous instead, and unwinds into a type-erased
+    // !storage.list_element column of tagged scalars (see the heterogeneous form below).
+    // An empty list yields no row.
+    //
+    // Needs no -graph: nothing here is resolved against a schema.
+    //
+    // With incoming rows (MATCH (a) UNWIND [1, 2, 3] AS x) the source is crossed with
+    // the input through db.cross_product; there is no expanding variant of this op.
+    //
+    // The heterogeneous form, whose cells need not share a type:
+    //   %x = db.unwind_const([true, "mixed", 10]) : !db.column<!storage.list_element>
+    %x = db.unwind_const([1, 2, 3]) : !db.column<i64>
+
+    db.output(%x) : !db.column<i64>
+
+    return
+  }
+}

--- a/samples/mlir/unwind_const.nl.mlir
+++ b/samples/mlir/unwind_const.nl.mlir
@@ -1,0 +1,22 @@
+// Generated nl-dialect lowering of unwind_const.mlir (db dialect).
+// Reproduce with: mlir -f unwind_const.mlir -l
+// This is the DBLowering output; edit unwind_const.mlir, not this file.
+//
+// Needs no -graph: the chunk element type comes from the literals, not from a schema.
+// db.unwind_const lowers to an nl.unwind_const source op whose nl.for binds the single
+// value chunk, each step filling it with the next slice of the list.
+//
+// The homogeneous list rides a !storage.nullable<i64> chunk - the shape a property fetch
+// and the unwind_collect drain emit - even though a literal is never null: every
+// value-chunk consumer (a cross product broadcast, a filter, a skip, an aggregate)
+// dispatches on nullable<T>, so the uniform shape is what makes the unwound column
+// composable. A heterogeneous list keeps its !storage.list_element chunk instead.
+module {
+  func.func @main() {
+    %0 = nl.unwind_const([1, 2, 3]) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+    nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+      nl.output(%arg0) : !nl.chunk<!storage.nullable<i64>>
+    }
+    return
+  }
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -284,6 +284,27 @@ target_link_libraries(test_query_ir_distinct PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_distinct PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_cypher_unwind CypherUnwindTest.cpp)
+target_link_libraries(test_query_ir_cypher_unwind PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_cypher_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cypher_output CypherOutputTest.cpp)
 target_link_libraries(test_query_ir_cypher_output PRIVATE
         turing_db_s

--- a/test/query/ir/CypherUnwindTest.cpp
+++ b/test/query/ir/CypherUnwindTest.cpp
@@ -265,6 +265,30 @@ TEST_F(CypherUnwindTest, crossesUnwindWithMatchedNodes) {
     expectRows("MATCH (n) UNWIND [10, 20] AS x RETURN n, x", expected);
 }
 
+TEST_F(CypherUnwindTest, crossesHeterogeneousUnwindWithMatchedNodes) {
+    // The heterogeneous sibling of crossesUnwindWithMatchedNodes: the unwound column is
+    // type-erased, so the cross product broadcasts tagged scalars whose cells differ in
+    // type. Every node pairs with all three elements, in list order.
+    constexpr uint64_t simpleGraphNodeCount = 18;
+    const Row elements = {"true", "mixed", "10"};
+
+    Rows expected;
+    for (uint64_t nodeID = 0; nodeID < simpleGraphNodeCount; nodeID++) {
+        for (const std::string& element : elements) {
+            expected.push_back({std::to_string(nodeID), element});
+        }
+    }
+
+    expectRows("MATCH (n) UNWIND [true, 'mixed', 10] AS x RETURN n, x", expected);
+}
+
+TEST_F(CypherUnwindTest, crossesEmptyUnwindWithMatchedNodesToNoRows) {
+    // An empty list pairs with nothing, so the whole query returns no row - it is not an
+    // unsupported shape.
+    const Rows expected = {};
+    expectRows("MATCH (n) UNWIND [] AS x RETURN n, x", expected);
+}
+
 TEST_F(CypherUnwindTest, filtersOnUnwoundVariableInWhere) {
     // The unwound variable is one side of the WHERE predicate, so the filter runs over the
     // cross product of the nodes and the elements: a node survives only against the element

--- a/test/query/ir/CypherUnwindTest.cpp
+++ b/test/query/ir/CypherUnwindTest.cpp
@@ -1,0 +1,278 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListBufferTypeTag.h"
+#include "list/ListElementView.h"
+#include "metadata/PropertyType.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = std::vector<std::string>;
+using Rows = std::vector<Row>;
+
+// Render one cell of a nullable value column of primitive T, or nothing when the column
+// has another element type.
+template <typename T>
+std::optional<std::string> renderOptCell(const Column* column, size_t row) {
+    const auto* values = dynamic_cast<const ColumnOptVector<T>*>(column);
+    if (!values) {
+        return std::nullopt;
+    }
+
+    const std::optional<T>& value = (*values)[row];
+    if (!value) {
+        return "null";
+    }
+
+    if constexpr (std::is_same_v<T, CustomBool>) {
+        return static_cast<bool>(*value) ? "true" : "false";
+    } else if constexpr (std::is_same_v<T, std::string_view>) {
+        return std::string(*value);
+    } else {
+        return std::to_string(*value);
+    }
+}
+
+// Render one cell of a type-tagged scalar column - the column a heterogeneous UNWIND
+// emits, whose cells need not share a type.
+std::optional<std::string> renderTaggedCell(const Column* column, size_t row) {
+    const auto* elements = dynamic_cast<const ColumnVector<ListElementView>*>(column);
+    if (!elements) {
+        return std::nullopt;
+    }
+
+    const ListElementView element = (*elements)[row];
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            return std::to_string(element.getAs<int64_t>());
+        break;
+
+        case ListBufferTypeTag::Double:
+            return std::to_string(element.getAs<double>());
+        break;
+
+        case ListBufferTypeTag::Bool:
+            return static_cast<bool>(element.getAs<CustomBool>()) ? "true" : "false";
+        break;
+
+        case ListBufferTypeTag::String:
+            return std::string(element.getAs<std::string_view>());
+        break;
+
+        default:
+            return "?";
+        break;
+    }
+}
+
+// Render one output cell, whatever column shape the program emitted: a node ID from a
+// scan, a nullable value from an unwound homogeneous list, or a tagged scalar from an
+// unwound heterogeneous one.
+std::string renderCell(const Column* column, size_t row) {
+    if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
+        return std::to_string((*nodeIDs)[row].getValue());
+    }
+
+    if (const std::optional<std::string> integer = renderOptCell<int64_t>(column, row)) {
+        return *integer;
+    } else if (const std::optional<std::string> real = renderOptCell<double>(column, row)) {
+        return *real;
+    } else if (const std::optional<std::string> boolean = renderOptCell<CustomBool>(column, row)) {
+        return *boolean;
+    } else if (const std::optional<std::string> text = renderOptCell<std::string_view>(column, row)) {
+        return *text;
+    } else if (const std::optional<std::string> tagged = renderTaggedCell(column, row)) {
+        return *tagged;
+    }
+
+    throw TuringException("CypherUnwindTest: unsupported output column type");
+}
+
+class CollectingRowSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* column : chunks) {
+                row.push_back(renderCell(column, rowIndex));
+            }
+        }
+    }
+
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
+};
+
+}
+
+// The Cypher frontend path for UNWIND of a literal list: parse, analyze and generate the
+// db dialect, then lower and execute, so each test asserts the rows a query returns
+// rather than the shape of the IR.
+class CypherUnwindTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, Rows& rows) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        CollectingRowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory);
+        interpreter.run();
+
+        rows = sink.rows();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        Rows actual;
+        runQuery(query, actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(CypherUnwindTest, unwindsIntegerList) {
+    // One row per element, in list order - the whole query is the unwind source.
+    const Rows expected = {{"1"}, {"2"}, {"3"}};
+    expectRows("UNWIND [1, 2, 3] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsStringList) {
+    const Rows expected = {{"one"}, {"two"}};
+    expectRows("UNWIND ['one', 'two'] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsDoubleList) {
+    const Rows expected = {{std::to_string(1.5)}, {std::to_string(2.5)}};
+    expectRows("UNWIND [1.5, 2.5] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsBoolList) {
+    const Rows expected = {{"true"}, {"false"}};
+    expectRows("UNWIND [true, false] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsHeterogeneousList) {
+    // The elements share no type, so the column is type-erased and each cell keeps its
+    // own tag.
+    const Rows expected = {{"true"}, {"mixed"}, {"10"}};
+    expectRows("UNWIND [true, 'mixed', 10] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsMixedNumericListAsTaggedScalars) {
+    // An integer and a float share no single type either, matching the legacy engine's
+    // exact-type homogeneity rule: no promotion to a double column.
+    const Rows expected = {{"1"}, {std::to_string(2.5)}};
+    expectRows("UNWIND [1, 2.5] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, unwindsEmptyListToNoRows) {
+    const Rows expected = {};
+    expectRows("UNWIND [] AS x RETURN x", expected);
+}
+
+TEST_F(CypherUnwindTest, crossesUnwindWithMatchedNodes) {
+    // MATCH and UNWIND share no variable, so the two dataflows meet in a cross product:
+    // every node paired with every element, the node repeated across its pair.
+    // SimpleGraph holds 18 nodes, numbered 0 through 17.
+    constexpr uint64_t simpleGraphNodeCount = 18;
+
+    Rows expected;
+    for (uint64_t nodeID = 0; nodeID < simpleGraphNodeCount; nodeID++) {
+        expected.push_back({std::to_string(nodeID), "10"});
+        expected.push_back({std::to_string(nodeID), "20"});
+    }
+
+    expectRows("MATCH (n) UNWIND [10, 20] AS x RETURN n, x", expected);
+}
+
+TEST_F(CypherUnwindTest, rejectsNestedListElements) {
+    // A nested list has no tagged scalar form, so codegen refuses it rather than
+    // emitting IR the interpreter cannot materialize.
+    Rows rows;
+    EXPECT_THROW(runQuery("UNWIND [[1, 2], [3]] AS x RETURN x", rows), TuringException);
+}
+
+TEST_F(CypherUnwindTest, rejectsNullListElements) {
+    Rows rows;
+    EXPECT_THROW(runQuery("UNWIND [1, null] AS x RETURN x", rows), TuringException);
+}

--- a/test/query/ir/CypherUnwindTest.cpp
+++ b/test/query/ir/CypherUnwindTest.cpp
@@ -265,6 +265,23 @@ TEST_F(CypherUnwindTest, crossesUnwindWithMatchedNodes) {
     expectRows("MATCH (n) UNWIND [10, 20] AS x RETURN n, x", expected);
 }
 
+TEST_F(CypherUnwindTest, filtersOnUnwoundVariableInWhere) {
+    // The unwound variable is one side of the WHERE predicate, so the filter runs over the
+    // cross product of the nodes and the elements: a node survives only against the element
+    // equal to its own age. In SimpleGraph only Remy (0) and Adam (1) carry an age, both
+    // 32, so 99 keeps nobody and every ageless node compares null against both elements.
+    const Rows expected = {{"Remy", "32"}, {"Adam", "32"}};
+    expectRows("UNWIND [32, 99] AS wantedAge MATCH (n) WHERE n.age = wantedAge RETURN n.name, wantedAge", expected);
+}
+
+TEST_F(CypherUnwindTest, filtersOnUnwoundVariableInPropertyConstraint) {
+    // The same filter written as an inline property constraint rather than a WHERE: the
+    // unwound variable is the constraint's value, so the pattern is matched against a
+    // value that varies per row instead of a literal. Same rows as the WHERE form.
+    const Rows expected = {{"Remy", "32"}, {"Adam", "32"}};
+    expectRows("UNWIND [32, 99] AS wantedAge MATCH (n {age: wantedAge}) RETURN n.name, wantedAge", expected);
+}
+
 TEST_F(CypherUnwindTest, rejectsNestedListElements) {
     // A nested list has no tagged scalar form, so codegen refuses it rather than
     // emitting IR the interpreter cannot materialize.

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -958,6 +958,45 @@ func.func @main() {
 }
 )mlir";
 
+// UNWIND [1, 2, 3] AS x RETURN x: a source over a homogeneous literal list, so the
+// elements share one type and the result is a typed i64 column.
+const char* const unwindConstProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([1, 2, 3]) : !db.column<i64>
+  db.output(%x) : !db.column<i64>
+  return
+}
+)mlir";
+
+// UNWIND [true, "string", 10] AS x RETURN x: a heterogeneous list, so the elements
+// share no single type and the result is a type-erased list_element column.
+const char* const heterogeneousUnwindConstProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([true, "string", 10]) : !db.column<!storage.list_element>
+  db.output(%x) : !db.column<!storage.list_element>
+  return
+}
+)mlir";
+
+// UNWIND [] AS x: an empty list is the type-erased form and yields no row - valid.
+const char* const emptyUnwindConstProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([]) : !db.column<!storage.list_element>
+  db.output(%x) : !db.column<!storage.list_element>
+  return
+}
+)mlir";
+
+// A mixed-type list typed as a homogeneous i64 column: the verifier rejects it, since
+// a homogeneous unwind_const requires every element to share one type.
+const char* const mixedHomogeneousUnwindConstProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([1, "string"]) : !db.column<i64>
+  db.output(%x) : !db.column<i64>
+  return
+}
+)mlir";
+
 // MATCH ()-[e]->() RETURN a, b: scan every edge, exposing the four edge columns
 // (source node, edge, edge type, target node); the output keeps the endpoints.
 const char* const scanEdgesProgram = R"mlir(
@@ -1055,6 +1094,89 @@ TEST_F(DBDialectTest, constScanNodesWithoutNodeIDsIsValid) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyConstScanNodesProgram);
     ASSERT_TRUE(module);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));
+}
+
+TEST_F(DBDialectTest, parsesUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindConstProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::UnwindConst unwind;
+    module.get().walk([&](mlir::db::UnwindConst op) {
+        unwind = op;
+    });
+    ASSERT_TRUE(unwind);
+
+    // The three literals come back in order, and a homogeneous list resolves to a
+    // typed i64 column - the result element type carries the homogeneity verdict.
+    const mlir::ArrayAttr elements = unwind.getElements();
+    ASSERT_EQ(elements.size(), 3u);
+
+    const mlir::Type int64ColumnType = mlir::db::ColumnType::get(&_context, mlir::IntegerType::get(&_context, 64));
+    EXPECT_EQ(unwind.getResult().getType(), int64ColumnType);
+}
+
+TEST_F(DBDialectTest, unwindConstRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindConstProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing yields a module that still verifies, so the
+    // db.unwind_const printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, parsesHeterogeneousUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(heterogeneousUnwindConstProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::UnwindConst unwind;
+    module.get().walk([&](mlir::db::UnwindConst op) {
+        unwind = op;
+    });
+    ASSERT_TRUE(unwind);
+
+    // A heterogeneous list keeps every element but resolves to a type-erased
+    // list_element column, since the elements share no single type.
+    const mlir::ArrayAttr elements = unwind.getElements();
+    ASSERT_EQ(elements.size(), 3u);
+
+    const mlir::Type listElementColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::ListElementType::get(&_context));
+    EXPECT_EQ(unwind.getResult().getType(), listElementColumnType);
+}
+
+TEST_F(DBDialectTest, heterogeneousUnwindConstRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(heterogeneousUnwindConstProgram);
+    ASSERT_TRUE(module);
+
+    // Printing then re-parsing a mixed-type list yields a module that still verifies,
+    // so the printer and parser are inverses through the list_element column too.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, unwindConstWithEmptyListIsValid) {
+    // An empty list is the type-erased list_element form: it simply yields no row, so
+    // the module builds and verifies.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyUnwindConstProgram);
+    ASSERT_TRUE(module);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));
+}
+
+TEST_F(DBDialectTest, verifierRejectsHomogeneousUnwindConstWithMixedElements) {
+    // A mixed-type list typed as a homogeneous i64 column fails the verifier during
+    // parsing, so the module is null.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(mixedHomogeneousUnwindConstProgram);
+    EXPECT_FALSE(module);
 }
 
 // MATCH (a)-[:KNOWS]->(b)<-[:LIKES]-(c): one by-type out-edge hop and one by-type

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -20,6 +20,9 @@
 #include "columns/ColumnMask.h"
 #include "columns/ColumnOptMask.h"
 #include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListBufferTypeTag.h"
 #include "datapart/EdgeRecord.h"
 #include "iterators/ChunkConfig.h"
 #include "metadata/PropertyType.h"
@@ -97,6 +100,77 @@ public:
 
 private:
     std::vector<std::vector<uint64_t>> _columns;
+};
+
+// Collects a single homogeneous int64 value column: a UNWIND of an all-integer literal
+// list lowers to one nullable ColumnOptVector<int64_t> chunk per step, whose cells are
+// all present - a literal list holds no null.
+class CollectingIntUnwindSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const std::vector<std::optional<int64_t>>& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            const std::optional<int64_t>& value = raw[rowIndex];
+            ASSERT_TRUE(value.has_value());
+
+            _values.push_back(*value);
+        }
+    }
+
+    const std::vector<int64_t>& values() const { return _values; }
+
+private:
+    std::vector<int64_t> _values;
+};
+
+// Collects a single heterogeneous value column, rendering each type-tagged cell to a
+// string: a UNWIND of a mixed literal list lowers to one ColumnVector<ListElementView>
+// chunk per step, each cell carrying its own tag.
+class CollectingListElementSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnVector<ListElementView>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const std::vector<ListElementView>& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(render(raw[rowIndex]));
+        }
+    }
+
+    const std::vector<std::string>& values() const { return _values; }
+
+private:
+    // Render one tagged cell to a string, dispatching on its type tag. The test list
+    // holds an int, a bool and a string, so only those tags occur.
+    static std::string render(const ListElementView& element) {
+        switch (element.getTag()) {
+            case ListBufferTypeTag::Int:
+                return std::to_string(element.getAs<int64_t>());
+            break;
+
+            case ListBufferTypeTag::Bool:
+                return element.getAs<CustomBool>() ? "true" : "false";
+            break;
+
+            case ListBufferTypeTag::String:
+                return std::string(element.getAs<std::string_view>());
+            break;
+
+            default:
+                return "?";
+            break;
+        }
+    }
+
+    std::vector<std::string> _values;
 };
 
 // Collects (node ID, nullable int64 property) rows. Output programs that read
@@ -1007,6 +1081,68 @@ constexpr const char* constScanNodesProgram = R"mlir(
 func.func @main() {
   %a = db.const_scan_nodes([2, 0]) : !db.column<!storage.node_id>
   db.output(%a) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// UNWIND [1, 2, 3] AS x RETURN x: a homogeneous literal list, so the unwound column is
+// a typed i64 column and the source emits one row per element.
+constexpr const char* unwindConstIntProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([1, 2, 3]) : !db.column<i64>
+  db.output(%x) : !db.column<i64>
+  return
+}
+)mlir";
+
+// UNWIND [true, "hello", 10] AS x RETURN x: a heterogeneous list, so the unwound column
+// is a type-erased list_element column of tagged scalars.
+constexpr const char* unwindConstHeteroProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([true, "hello", 10]) : !db.column<!storage.list_element>
+  db.output(%x) : !db.column<!storage.list_element>
+  return
+}
+)mlir";
+
+// UNWIND [] AS x RETURN x: an empty list yields no row.
+constexpr const char* unwindConstEmptyProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([]) : !db.column<!storage.list_element>
+  db.output(%x) : !db.column<!storage.list_element>
+  return
+}
+)mlir";
+
+// MATCH (a) UNWIND [10, 20] AS x RETURN a, x: the unwind source crossed with the
+// incoming rows - the way UNWIND takes input, since there is no expanding variant of
+// the op. Two rows per node, the node ID repeated across the pair. The unwound column
+// rides a nullable value chunk, so the cross product broadcasts it with the same
+// families it uses for a property column.
+constexpr const char* unwindConstCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %a : !db.column<!storage.node_id>
+  } factor {
+    %x = db.unwind_const([10, 20]) : !db.column<i64>
+    db.yield %x : !db.column<i64>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<i64>
+  return
+}
+)mlir";
+
+// UNWIND [1, 2, 3, 4] AS x WITH x WHERE x > 2 RETURN x: a predicate over the unwound
+// column itself, so the filter reads the same nullable value chunk a property filter
+// reads and keeps the two surviving rows.
+constexpr const char* unwindConstFilterProgram = R"mlir(
+func.func @main() {
+  %x = db.unwind_const([1, 2, 3, 4]) : !db.column<i64>
+  %bound = db.constant(2 : i64)
+  %keep = db.gt %x, %bound : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kept = db.filter(%keep, {%x}) : (!db.column<!storage.bool>, !db.column<i64>) -> !db.column<i64>
+  db.output(%kept) : !db.column<i64>
   return
 }
 )mlir";
@@ -2207,6 +2343,91 @@ TEST_F(DBLoweringTest, executesConstScanNodes) {
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesUnwindConstHomogeneous) {
+    // A standalone UNWIND reads no graph, but runLoweredProgram needs a view; any
+    // graph does, and the result depends only on the literal list.
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingIntUnwindSink sink;
+    runLoweredProgram(unwindConstIntProgram, reader.getView(), sink);
+
+    // One row per element of the homogeneous list.
+    std::vector<int64_t> values = sink.values();
+    std::sort(values.begin(), values.end());
+    const std::vector<int64_t> expected {1, 2, 3};
+    EXPECT_EQ(values, expected);
+}
+
+TEST_F(DBLoweringTest, executesUnwindConstHeterogeneous) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingListElementSink sink;
+    runLoweredProgram(unwindConstHeteroProgram, reader.getView(), sink);
+
+    // One row per element, each cell keeping its own type (bool, string, int).
+    std::vector<std::string> values = sink.values();
+    std::sort(values.begin(), values.end());
+    const std::vector<std::string> expected {"10", "hello", "true"};
+    EXPECT_EQ(values, expected);
+}
+
+TEST_F(DBLoweringTest, executesUnwindConstEmptyYieldsNoRow) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // An empty list has nothing to emit, so the source runs cleanly and produces no row.
+    CollectingListElementSink sink;
+    runLoweredProgram(unwindConstEmptyProgram, reader.getView(), sink);
+
+    EXPECT_TRUE(sink.values().empty());
+}
+
+TEST_F(DBLoweringTest, executesUnwindConstCrossedWithIncomingRows) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The sink is the one an Int64 property read fills: crossing the unwind against the
+    // scan yields a node ID chunk and a nullable value chunk, the pair a property
+    // program emits - which is the point of the unwound column riding nullable<T>.
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(unwindConstCrossProductProgram, reader.getView(), sink);
+
+    // Two elements per node over the four diamond nodes: eight pairs, every node
+    // carrying both literals.
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {{0, 10},
+                                                                            {0, 20},
+                                                                            {1, 10},
+                                                                            {1, 20},
+                                                                            {2, 10},
+                                                                            {2, 20},
+                                                                            {3, 10},
+                                                                            {3, 20}};
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesFilterOverUnwindConst) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingIntUnwindSink sink;
+    runLoweredProgram(unwindConstFilterProgram, reader.getView(), sink);
+
+    // Only the elements above the bound survive the predicate.
+    std::vector<int64_t> values = sink.values();
+    std::sort(values.begin(), values.end());
+    const std::vector<int64_t> expected {3, 4};
+    EXPECT_EQ(values, expected);
 }
 
 TEST_F(DBLoweringTest, constScanNodesDropsIDsWithNoNode) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -128,6 +128,28 @@ private:
     std::vector<int64_t> _values;
 };
 
+// Render one tagged cell to a string, dispatching on its type tag. The test lists hold
+// an int, a bool and a string, so only those tags occur.
+std::string renderListElement(const ListElementView& element) {
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            return std::to_string(element.getAs<int64_t>());
+        break;
+
+        case ListBufferTypeTag::Bool:
+            return element.getAs<CustomBool>() ? "true" : "false";
+        break;
+
+        case ListBufferTypeTag::String:
+            return std::string(element.getAs<std::string_view>());
+        break;
+
+        default:
+            return "?";
+        break;
+    }
+}
+
 // Collects a single heterogeneous value column, rendering each type-tagged cell to a
 // string: a UNWIND of a mixed literal list lowers to one ColumnVector<ListElementView>
 // chunk per step, each cell carrying its own tag.
@@ -141,36 +163,43 @@ public:
 
         const std::vector<ListElementView>& raw = values->getRaw();
         for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
-            _values.push_back(render(raw[rowIndex]));
+            _values.push_back(renderListElement(raw[rowIndex]));
         }
     }
 
     const std::vector<std::string>& values() const { return _values; }
 
 private:
-    // Render one tagged cell to a string, dispatching on its type tag. The test list
-    // holds an int, a bool and a string, so only those tags occur.
-    static std::string render(const ListElementView& element) {
-        switch (element.getTag()) {
-            case ListBufferTypeTag::Int:
-                return std::to_string(element.getAs<int64_t>());
-            break;
+    std::vector<std::string> _values;
+};
 
-            case ListBufferTypeTag::Bool:
-                return element.getAs<CustomBool>() ? "true" : "false";
-            break;
+// Collects (node ID, tagged scalar) rows in emission order: the pair a cross product of
+// a node scan with a heterogeneous unwind emits, a node ID chunk beside a
+// ColumnVector<ListElementView>.
+class CollectingNodeListElementSink : public NLOutputSink {
+public:
+    using Rows = std::vector<std::pair<uint64_t, std::string>>;
 
-            case ListBufferTypeTag::String:
-                return std::string(element.getAs<std::string_view>());
-            break;
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
 
-            default:
-                return "?";
-            break;
+        const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        const auto* values = dynamic_cast<const ColumnVector<ListElementView>*>(chunks[1]);
+        ASSERT_NE(nodeIDs, nullptr);
+        ASSERT_NE(values, nullptr);
+        ASSERT_EQ(nodeIDs->size(), values->size());
+
+        const std::vector<NodeID>& idRaw = nodeIDs->getRaw();
+        const std::vector<ListElementView>& valueRaw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.push_back({idRaw[rowIndex].getValue(), renderListElement(valueRaw[rowIndex])});
         }
     }
 
-    std::vector<std::string> _values;
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
 };
 
 // Collects (node ID, nullable int64 property) rows. Output programs that read
@@ -1129,6 +1158,39 @@ func.func @main() {
     db.yield %x : !db.column<i64>
   }
   db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<i64>
+  return
+}
+)mlir";
+
+// MATCH (a) UNWIND [true, "hello", 10] AS x RETURN a, x: the heterogeneous sibling of
+// unwindConstCrossProductProgram. The unwound column is a type-erased list_element
+// chunk, so the cross product broadcasts tagged scalars rather than a value type.
+constexpr const char* unwindConstHeteroCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %a : !db.column<!storage.node_id>
+  } factor {
+    %x = db.unwind_const([true, "hello", 10]) : !db.column<!storage.list_element>
+    db.yield %x : !db.column<!storage.list_element>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.list_element>
+  return
+}
+)mlir";
+
+// MATCH (a) UNWIND [] AS x RETURN a, x: an empty list is the list_element form too, and
+// it pairs with nothing, so the cross product emits no row rather than failing.
+constexpr const char* unwindConstEmptyCrossProductProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %a : !db.column<!storage.node_id>
+  } factor {
+    %x = db.unwind_const([]) : !db.column<!storage.list_element>
+    db.yield %x : !db.column<!storage.list_element>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.list_element>
   return
 }
 )mlir";
@@ -2355,11 +2417,9 @@ TEST_F(DBLoweringTest, executesUnwindConstHomogeneous) {
     CollectingIntUnwindSink sink;
     runLoweredProgram(unwindConstIntProgram, reader.getView(), sink);
 
-    // One row per element of the homogeneous list.
-    std::vector<int64_t> values = sink.values();
-    std::sort(values.begin(), values.end());
+    // One row per element of the homogeneous list, in list order.
     const std::vector<int64_t> expected {1, 2, 3};
-    EXPECT_EQ(values, expected);
+    EXPECT_EQ(sink.values(), expected);
 }
 
 TEST_F(DBLoweringTest, executesUnwindConstHeterogeneous) {
@@ -2370,11 +2430,39 @@ TEST_F(DBLoweringTest, executesUnwindConstHeterogeneous) {
     CollectingListElementSink sink;
     runLoweredProgram(unwindConstHeteroProgram, reader.getView(), sink);
 
-    // One row per element, each cell keeping its own type (bool, string, int).
-    std::vector<std::string> values = sink.values();
-    std::sort(values.begin(), values.end());
-    const std::vector<std::string> expected {"10", "hello", "true"};
-    EXPECT_EQ(values, expected);
+    // One row per element in list order, each cell keeping its own type (bool, string,
+    // int).
+    const std::vector<std::string> expected {"true", "hello", "10"};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+TEST_F(DBLoweringTest, executesUnwindConstAcrossChunkBoundary) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 2 splits the three elements into one full chunk and one partial, so the
+    // loop's cursor has to resume where the first slice stopped and emit a short second
+    // slice rather than a whole chunk.
+    CollectingIntUnwindSink sink;
+    runLoweredProgram(unwindConstIntProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<int64_t> expected {1, 2, 3};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+TEST_F(DBLoweringTest, executesHeterogeneousUnwindConstAcrossChunkBoundary) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // The tagged-scalar fill slices the same ListView, so it has to survive the same
+    // partial final chunk.
+    CollectingListElementSink sink;
+    runLoweredProgram(unwindConstHeteroProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::string> expected {"true", "hello", "10"};
+    EXPECT_EQ(sink.values(), expected);
 }
 
 TEST_F(DBLoweringTest, executesUnwindConstEmptyYieldsNoRow) {
@@ -2401,7 +2489,8 @@ TEST_F(DBLoweringTest, executesUnwindConstCrossedWithIncomingRows) {
     runLoweredProgram(unwindConstCrossProductProgram, reader.getView(), sink);
 
     // Two elements per node over the four diamond nodes: eight pairs, every node
-    // carrying both literals.
+    // carrying both literals. The scan is the outer factor, so its rows block-repeat
+    // while the elements tile - node-major, each node's pair in list order.
     const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {{0, 10},
                                                                             {0, 20},
                                                                             {1, 10},
@@ -2411,8 +2500,68 @@ TEST_F(DBLoweringTest, executesUnwindConstCrossedWithIncomingRows) {
                                                                             {3, 10},
                                                                             {3, 20}};
     std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
-    sink.sortedRows(rows);
+    sink.orderedRows(rows);
     EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, unwindConstRestartsPerOuterStep) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // chunkSize 2 splits the scan into two chunks, so the nested unwind loop runs twice.
+    // Its cursor is local to each call, so the second outer chunk sees the list from its
+    // first element again rather than an exhausted one - the same eight pairs.
+    CollectingNodeIntPropSink sink;
+    runLoweredProgram(unwindConstCrossProductProgram, reader.getView(), sink, /*chunkSize=*/2);
+
+    const std::vector<std::pair<uint64_t, std::optional<int64_t>>> expected {{0, 10},
+                                                                            {0, 20},
+                                                                            {1, 10},
+                                                                            {1, 20},
+                                                                            {2, 10},
+                                                                            {2, 20},
+                                                                            {3, 10},
+                                                                            {3, 20}};
+    std::vector<std::pair<uint64_t, std::optional<int64_t>>> rows;
+    sink.orderedRows(rows);
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(DBLoweringTest, executesHeterogeneousUnwindConstCrossedWithIncomingRows) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeListElementSink sink;
+    runLoweredProgram(unwindConstHeteroCrossProductProgram, reader.getView(), sink);
+
+    // The scan is the outer factor, so its rows block-repeat while the three tagged
+    // elements tile: every node carries all three, in list order.
+    const CollectingNodeListElementSink::Rows expected {{0, "true"},
+                                                        {0, "hello"},
+                                                        {0, "10"},
+                                                        {1, "true"},
+                                                        {1, "hello"},
+                                                        {1, "10"},
+                                                        {2, "true"},
+                                                        {2, "hello"},
+                                                        {2, "10"},
+                                                        {3, "true"},
+                                                        {3, "hello"},
+                                                        {3, "10"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, executesEmptyUnwindConstCrossedWithIncomingRowsAsNoRow) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingNodeListElementSink sink;
+    runLoweredProgram(unwindConstEmptyCrossProductProgram, reader.getView(), sink);
+
+    EXPECT_TRUE(sink.rows().empty());
 }
 
 TEST_F(DBLoweringTest, executesFilterOverUnwindConst) {

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -6,6 +6,7 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
 
 #include "NLDialect.h"
 #include "NLOps.h"
@@ -424,6 +425,64 @@ TEST_F(NLDialectTest, constScanNodesInfersNodeIDIterator) {
     EXPECT_EQ(scan.getResult().getType(), iteratorType);
     EXPECT_EQ(scan.getNodeIDs().size(), 3u);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+}
+
+// nl.unwind_const spells its iterator type rather than inferring it - the chunk
+// element type depends on the literals, not on a fixed shape - so a homogeneous i64
+// list is a chunk of i64. The literals ride the op as a typed attribute array.
+TEST_F(NLDialectTest, unwindConstBuildsTypedChunkIterator) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type chunkType = mlir::nl::ChunkType::get(&_context, int64Type);
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {chunkType});
+
+    const mlir::ArrayAttr elements = builder.getArrayAttr({builder.getI64IntegerAttr(1),
+                                                           builder.getI64IntegerAttr(2),
+                                                           builder.getI64IntegerAttr(3)});
+    mlir::nl::UnwindConst unwind = builder.create<mlir::nl::UnwindConst>(loc, iteratorType, elements);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_EQ(unwind.getResult().getType(), iteratorType);
+    EXPECT_EQ(unwind.getElements().size(), 3u);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+}
+
+// Building an nl.unwind_const, printing the module and re-parsing it yields a module
+// that still verifies, so the nl.unwind_const printer and parser are inverses.
+TEST_F(NLDialectTest, unwindConstRoundTripsThroughTextualForm) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type chunkType = mlir::nl::ChunkType::get(&_context, int64Type);
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context, {chunkType});
+
+    const mlir::ArrayAttr elements = builder.getArrayAttr({builder.getI64IntegerAttr(1),
+                                                           builder.getI64IntegerAttr(2),
+                                                           builder.getI64IntegerAttr(3)});
+    builder.create<mlir::nl::UnwindConst>(loc, iteratorType, elements);
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module->print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed =
+        mlir::parseSourceString<mlir::ModuleOp>(printed, mlir::ParserConfig(&_context));
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
 // nl.get_out_edges_by_type infers the same four-chunk edge iterator as


### PR DESCRIPTION
Adds the db.unwind_const op and its !storage.list_element type, the lowering and NL runtime, and the Cypher frontend wiring, so UNWIND of a plan-time literal list executes end to end.