### PR TITLE
MLIR: carry the projection column names to the output sink

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <type_traits>
 #include <variant>
@@ -19,6 +20,7 @@
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "DBDialect.h"
 #include "DBOps.h"
@@ -1179,10 +1181,23 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
         }
     };
 
+    // The analyzer names every item it accepts, so an item without one is left for the
+    // sink to label by position rather than being a codegen error.
+    const auto getNameForItem = [&](auto&& item) -> llvm::StringRef {
+        const std::optional<std::string_view> name = proj->getName(item);
+        if (!name) {
+            return llvm::StringRef();
+        }
+
+        return llvm::StringRef(name->data(), name->size());
+    };
+
     llvm::SmallVector<mlir::Value> outputted;
+    llvm::SmallVector<llvm::StringRef> outputNames;
     for (const Projection::ReturnItem item : returned) {
         const mlir::Value itemCol = std::visit(getVarForItem, item);
         outputted.push_back(itemCol);
+        outputNames.push_back(std::visit(getNameForItem, item));
 
         // An alias is one variable declared once, so a key naming it holds the very
         // declaration of the item it names: publishing the column under that declaration
@@ -1258,7 +1273,9 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
         }
     }
 
-    _opBuilder.create<mlir::db::Output>(loc, mlir::ValueRange{outputted});
+    _opBuilder.create<mlir::db::Output>(loc,
+                                        mlir::ValueRange{outputted},
+                                        _opBuilder.getStrArrayAttr(outputNames));
 }
 
 void DBProgramGenerator::translateDistinct(const Projection* projection,

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -286,6 +286,20 @@ LogicalResult CheckEdgeTypeConstraint::verify() {
     return success();
 }
 
+void Output::build(OpBuilder& builder, OperationState& state, ValueRange columns) {
+    Output::build(builder, state, columns, ArrayAttr());
+}
+
+LogicalResult Output::verify() {
+    const ArrayAttr columnNames = getColumnNamesAttr();
+    if (columnNames && columnNames.size() != getColumns().size()) {
+        return emitOpError("names must give one name per output column, but has ")
+               << columnNames.size() << " names for " << getColumns().size() << " columns";
+    }
+
+    return success();
+}
+
 // db.limit passes its columns straight through, so the results must be exactly
 // the input columns - same count, same types and in the same order.
 LogicalResult Limit::verify() {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -576,13 +576,34 @@ def Output : TuringOp<"output"> {
     Variadic<Column> accepts any number of columns of any value. The op has no
     results and is deliberately not Pure: emitting the result is its whole
     purpose, so it must survive dead-code elimination.
+
+    An optional `names` array gives the result columns their query-level names,
+    one per column: the alias a RETURN item was given through AS, or the item
+    spelled as it was written when it has none. A hand-written program that
+    names nothing leaves the array off, and the result columns are unnamed.
+
+      db.output(%a, %b) names ["person", "n.age"] : !db.column<!storage.node_id>, !db.column<i64>
   }];
-  let arguments = (ins Variadic<Column>:$columns);
+  let arguments = (ins Variadic<Column>:$columns,
+                       OptionalAttr<StrArrayAttr>:$column_names);
 
   // The column types vary from query to query and cannot be built from a
   // recipe, so they are spelled after the colon, the same as nl.output.
-  // qualified(...) forces the leading !db. on every printed type.
-  let assemblyFormat = "`(` $columns `)` attr-dict `:` qualified(type($columns))";
+  // qualified(...) forces the leading !db. on every printed type. The names,
+  // when present, print after a `names` keyword, which anchors the optional
+  // group for the declarative parser.
+  let assemblyFormat = [{
+    `(` $columns `)` (`names` $column_names^)? attr-dict `:` qualified(type($columns))
+  }];
+
+  // A hand-written program names nothing, so it gets a builder taking the columns alone.
+  let builders = [
+      OpBuilder<(ins "::mlir::ValueRange":$columns)>
+  ];
+
+  // One name per column or none at all: a shorter array would name the wrong
+  // column, and a longer one names a column that is not emitted.
+  let hasVerifier = 1;
 }
 
 /**

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -437,6 +437,15 @@ LogicalResult For::verify() {
     return success();
 }
 
+void Output::build(OpBuilder& builder,
+                   OperationState& state,
+                   ValueRange columns,
+                   Value limit,
+                   Value skip,
+                   Value cardinality) {
+    Output::build(builder, state, columns, limit, skip, cardinality, ArrayAttr());
+}
+
 // A folded output reads the budgeted prefix (limit) or the surviving suffix
 // (skip) off a single handle - the truncate adjacent to it - so at most one may
 // be present. The interpreter reads them as an if(skip)/else if(limit) chain,
@@ -444,6 +453,12 @@ LogicalResult For::verify() {
 LogicalResult Output::verify() {
     if (getLimit() && getSkip()) {
         return emitOpError("carries both a limit and a skip handle; a folded output takes at most one");
+    }
+
+    const ArrayAttr columnNames = getColumnNamesAttr();
+    if (columnNames && columnNames.size() != getColumns().size()) {
+        return emitOpError("names must give one name per output column, but has ")
+               << columnNames.size() << " names for " << getColumns().size() << " columns";
     }
 
     return success();

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -587,6 +587,13 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     Absent for a per-row projection (its own columns size it) or a single-row emit.
 
     nl.output(%c) cardinality %n : !nl.chunk<i64>
+
+    An optional `names` array carries the result column names db.output was given,
+    one per column, which the interpreter hands to the sink so it can label the
+    columns it is fed. They name the result and never steer execution, so an output
+    that carries none emits exactly the same rows.
+
+    nl.output(%a) names ["person"] : !nl.chunk<!storage.node_id>
   }];
 
   // Four variable-length operand groups - the columns, the optional limit, the
@@ -598,7 +605,8 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   let arguments = (ins Variadic<NLChunk>:$columns,
                        Optional<NLLimitStateHandle>:$limit,
                        Optional<NLSkipStateHandle>:$skip,
-                       Optional<NLNodeIDChunk>:$cardinality);
+                       Optional<NLNodeIDChunk>:$cardinality,
+                       OptionalAttr<StrArrayAttr>:$column_names);
 
   // The chunk element types vary from call to call and - unlike the source
   // ops - cannot be inferred, so they are spelled after the colon. This keeps
@@ -610,13 +618,24 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   // `skip` keyword; both types are buildable and so omitted. Each optional group
   // has its own literal anchor, so the declarative parser tells them apart.
   let assemblyFormat = [{
-    `(` $columns `)` (`limit` $limit^)? (`skip` $skip^)? (`cardinality` $cardinality^)? attr-dict `:` qualified(type($columns))
+    `(` $columns `)` (`names` $column_names^)? (`limit` $limit^)? (`skip` $skip^)? (`cardinality` $cardinality^)? attr-dict `:` qualified(type($columns))
   }];
+
+  // Emitting an unnamed result is the common case - every hand-written program and
+  // every lowering of a db.output that carries no names - so it gets a builder that
+  // takes the operands alone.
+  let builders = [
+      OpBuilder<(ins "::mlir::ValueRange":$columns,
+                     "::mlir::Value":$limit,
+                     "::mlir::Value":$skip,
+                     "::mlir::Value":$cardinality)>
+  ];
 
   // Enforce the "at most one of limit/skip" invariant the description promises:
   // a folded output carries the single handle of the truncate adjacent to it,
   // never both. runOutput reads them as an if(skip)/else if(limit) chain, so a
   // malformed both-handles op would silently drop the limit; reject it here.
+  // One name per column, when the output carries names at all.
   let hasVerifier = 1;
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1315,6 +1315,14 @@ NLExecutor::~NLExecutor() {
 }
 
 void NLExecutor::run() {
+    NLOutputSink* const sink = _ctxt.getSink();
+    const std::span<const std::string_view> columnNames = _prog->columnNames();
+
+    const bool hasNamesToPublish = sink && !columnNames.empty();
+    if (hasNamesToPublish) {
+        sink->setColumnNames(columnNames);
+    }
+
     runBody(&_ctxt, _prog->getStmts());
 }
 

--- a/query/ir/interpreter/NLOutputSink.cpp
+++ b/query/ir/interpreter/NLOutputSink.cpp
@@ -4,3 +4,6 @@ using namespace db;
 
 NLOutputSink::~NLOutputSink() {
 }
+
+void NLOutputSink::setColumnNames(std::span<const std::string_view> names) {
+}

--- a/query/ir/interpreter/NLOutputSink.h
+++ b/query/ir/interpreter/NLOutputSink.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <span>
+#include <string_view>
 
 namespace db {
 
@@ -11,6 +12,12 @@ class Column;
 class NLOutputSink {
 public:
     virtual ~NLOutputSink();
+
+    // The name of each column appendChunks is about to receive, in that order. Called
+    // once before the first chunk, and not at all by a program naming no column - so an
+    // implementor labelling its output needs a fallback. The views last only for the
+    // call: an implementor keeping a name copies it.
+    virtual void setColumnNames(std::span<const std::string_view> names);
 
     // One call per chunk emission of the program. Only rows
     // [offset, offset + rowCount) of each chunk are part of the result - the rows

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -12,6 +12,10 @@ NLProgram::NLProgram() {
 NLProgram::~NLProgram() {
 }
 
+void NLProgram::setColumnNames(std::span<const std::string_view> names) {
+    _columnNames.assign(names.begin(), names.end());
+}
+
 void NLSortState::reset() {
     for (Column* buffer : _buffers) {
         buffer->clear();

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -2021,8 +2022,15 @@ public:
     size_t getChunkSize() const { return _chunkSize; }
     void setChunkSize(size_t chunkSize) { _chunkSize = chunkSize; }
 
+    std::span<const std::string_view> columnNames() const { return _columnNames; }
+    void setColumnNames(std::span<const std::string_view> names);
+
 private:
     size_t _chunkSize {ChunkConfig::CHUNK_SIZE};
+    // The result column names nl.output carried, one per emitted column, or empty when it
+    // named none. The views point into the MLIRContext's uniqued attribute storage, which
+    // outlives the module the names were read from.
+    std::vector<std::string_view> _columnNames;
     std::vector<std::unique_ptr<NLFunctionData>> _functionData;
     std::vector<std::unique_ptr<NLLimitState>> _limitStates;
     std::vector<std::unique_ptr<NLSkipState>> _skipStates;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <string_view>
 
 #include <spdlog/fmt/bundled/format.h>
 
@@ -9,6 +10,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Verifier.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include "columns/ColumnConst.h"
 #include "columns/ColumnMask.h"
@@ -1269,6 +1271,18 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
         }
 
         outputData->addOutputColumn(getColumn(column), !isConstant);
+    }
+
+    // The names label the result, not one emission of it, so they go on the program
+    // rather than the per-step output data the limit and skip handles sit on.
+    if (const mlir::ArrayAttr columnNames = output.getColumnNamesAttr()) {
+        llvm::SmallVector<std::string_view> names;
+        for (const mlir::Attribute name : columnNames) {
+            const llvm::StringRef nameText = mlir::cast<mlir::StringAttr>(name).getValue();
+            names.emplace_back(nameText.data(), nameText.size());
+        }
+
+        _program->setColumnNames(names);
     }
 
     body->emplaceStmt(&NLExecutor::runOutput, outputData);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1558,9 +1558,12 @@ void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         // The preceding nl.limit_update still sets that count. Drop the old output
         // and the now-unused truncate.
         _builder.setInsertionPoint(output);
-        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(),
-                                    truncate.getState(), mlir::Value(),
-                                    output.getCardinality());
+        _builder.create<nl::Output>(output.getLoc(),
+                                    truncate.getColumns(),
+                                    truncate.getState(),
+                                    mlir::Value(),
+                                    output.getCardinality(),
+                                    output.getColumnNamesAttr());
 
         output.erase();
         truncate.erase();
@@ -1621,8 +1624,12 @@ void DBLowering::foldSkipTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {
         // preceding nl.skip_update still sets that offset and count. Drop the old
         // output and the now-unused truncate.
         _builder.setInsertionPoint(output);
-        _builder.create<nl::Output>(output.getLoc(), truncate.getColumns(), mlir::Value(),
-                                    truncate.getState(), output.getCardinality());
+        _builder.create<nl::Output>(output.getLoc(),
+                                    truncate.getColumns(),
+                                    mlir::Value(),
+                                    truncate.getState(),
+                                    output.getCardinality(),
+                                    output.getColumnNamesAttr());
 
         output.erase();
         truncate.erase();
@@ -2224,8 +2231,12 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
     }
 
     setInsertionInto(anchorBlock);
-    _builder.create<nl::Output>(_builder.getUnknownLoc(), columns, mlir::Value(),
-                                mlir::Value(), cardinality);
+    _builder.create<nl::Output>(_builder.getUnknownLoc(),
+                                columns,
+                                mlir::Value(),
+                                mlir::Value(),
+                                cardinality,
+                                output.getColumnNamesAttr());
 }
 
 void DBLowering::buildLoopForSource(mlir::Value iterator, mlir::Operation* dbOp) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -345,6 +345,27 @@ target_link_libraries(test_query_ir_nested_aggregate_projection PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_nested_aggregate_projection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_output_column_names OutputColumnNamesTest.cpp)
+target_link_libraries(test_query_ir_output_column_names PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_output_column_names PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_wildcard_return WildcardReturnTest.cpp)
 target_link_libraries(test_query_ir_wildcard_return PRIVATE
         turing_db_s

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -187,6 +187,24 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (a) RETURN a AS person: the projection names the column it emits.
+const char* const namedOutputProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  db.output(%a) names ["person"] : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// Two names for one emitted column: the second names a column that is not there.
+const char* const mismatchedOutputNamesProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  db.output(%a) names ["person", "extra"] : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 // MATCH (n:Person) SET n.age = n.age
 const char* const setNodePropertyProgram = R"mlir(
 func.func @main() {
@@ -622,6 +640,61 @@ TEST_F(DBDialectTest, skipRoundTripsThroughTextualForm) {
     const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
     ASSERT_TRUE(reparsed);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, parsesOutputColumnNames) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(namedOutputProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Output output;
+    module.get().walk([&](mlir::db::Output op) {
+        output = op;
+    });
+    ASSERT_TRUE(output);
+
+    const mlir::ArrayAttr columnNames = output.getColumnNamesAttr();
+    ASSERT_TRUE(columnNames);
+    ASSERT_EQ(columnNames.size(), 1u);
+    EXPECT_EQ(mlir::cast<mlir::StringAttr>(columnNames[0]).getValue(), "person");
+}
+
+// The names are optional, so a program that names nothing carries no array at all -
+// which is what every hand-written db.output above relies on.
+TEST_F(DBDialectTest, parsesOutputWithoutColumnNames) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(limitProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Output output;
+    module.get().walk([&](mlir::db::Output op) {
+        output = op;
+    });
+    ASSERT_TRUE(output);
+
+    EXPECT_FALSE(output.getColumnNamesAttr());
+}
+
+TEST_F(DBDialectTest, outputColumnNamesRoundTripThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(namedOutputProgram);
+    ASSERT_TRUE(module);
+
+    // The names print after the `names` keyword and re-parse into a module that still
+    // verifies, so the printer and parser are inverses over them too.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    EXPECT_NE(printed.find("names [\"person\"]"), std::string::npos) << printed;
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, rejectsOutputNameCountMismatch) {
+    // One name per emitted column: the verifier rejects the extra name and the module
+    // fails to verify during parsing.
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(mismatchedOutputNamesProgram);
+    EXPECT_FALSE(module);
 }
 
 TEST_F(DBDialectTest, parsesSort) {

--- a/test/query/ir/OutputColumnNamesTest.cpp
+++ b/test/query/ir/OutputColumnNamesTest.cpp
@@ -1,0 +1,203 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/Column.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using ColumnNames = std::vector<std::string>;
+
+// Records the names the program published and the width of the chunks it then emitted,
+// so a test can hold the names against the columns they label.
+class ColumnNameSink : public NLOutputSink {
+public:
+    void setColumnNames(std::span<const std::string_view> names) override {
+        _names.assign(names.begin(), names.end());
+    }
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        _emittedColumnCount = chunks.size();
+        _rowCount += rowCount;
+    }
+
+    const ColumnNames& names() const { return _names; }
+    size_t getEmittedColumnCount() const { return _emittedColumnCount; }
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    ColumnNames _names;
+    size_t _emittedColumnCount {0};
+    size_t _rowCount {0};
+};
+
+}
+
+// A RETURN item's name - the alias it was given through AS, or the item spelled as it was
+// written - reaches the sink, which has no other way to label the columns it is fed: the
+// names ride the projection from db.output through the lowering to nl.output, and the
+// interpreter hands them over once before the first chunk.
+class OutputColumnNamesTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp moduleOp = module.get();
+
+        DBProgramGenerator generator(&moduleOp);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(moduleOp, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    void expectColumnNames(std::string_view query, const ColumnNames& expected) {
+        ColumnNameSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.names(), expected) << "query: " << query;
+
+        // A name labels a column the sink was handed, so a query that emitted rows names
+        // exactly as many columns as it emitted.
+        if (sink.getRowCount() > 0) {
+            EXPECT_EQ(sink.names().size(), sink.getEmittedColumnCount()) << "query: " << query;
+        }
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(OutputColumnNamesTest, namesAnAliasedProperty) {
+    expectColumnNames("MATCH (n:Person) RETURN n.name AS name", {"name"});
+}
+
+// An item without an alias is still named - it keeps the spelling it was written with.
+TEST_F(OutputColumnNamesTest, namesAnUnaliasedItemAsItWasWritten) {
+    expectColumnNames("MATCH (n:Person) RETURN n.name, n.age AS age", {"n.name", "age"});
+}
+
+TEST_F(OutputColumnNamesTest, namesAnAliasedTraversalVariable) {
+    expectColumnNames("MATCH (n:Person) RETURN n AS person", {"person"});
+}
+
+TEST_F(OutputColumnNamesTest, namesAnAliasedAggregate) {
+    expectColumnNames("MATCH (n:Person) RETURN count(n) AS total", {"total"});
+}
+
+// A wildcard names no item itself; the variables it stands for carry their own names.
+TEST_F(OutputColumnNamesTest, namesTheVariablesAWildcardStandsFor) {
+    expectColumnNames("MATCH (n:Person) RETURN *", {"n"});
+}
+
+// A constant projection has no per-row column, so its output is emitted nested in the
+// driving loop with a cardinality operand. The names travel with it all the same.
+TEST_F(OutputColumnNamesTest, namesAnAliasedConstant) {
+    expectColumnNames("MATCH (n:Person) RETURN 5 AS five", {"five"});
+}
+
+TEST_F(OutputColumnNamesTest, namesPastADistinct) {
+    expectColumnNames("MATCH (n:Person) RETURN DISTINCT n.age AS age", {"age"});
+}
+
+TEST_F(OutputColumnNamesTest, namesPastASortOnTheAlias) {
+    expectColumnNames("MATCH (n:Person) RETURN n.name AS name ORDER BY name", {"name"});
+}
+
+// A terminal LIMIT folds into the output, which is re-emitted over the untruncated
+// columns: the fold has to carry the names across, or the query that asks for a prefix
+// loses them.
+TEST_F(OutputColumnNamesTest, namesPastALimitFoldedIntoTheOutput) {
+    expectColumnNames("MATCH (n:Person) RETURN n.name AS name LIMIT 2", {"name"});
+}
+
+// The skip sibling of the limit fold, re-emitting the output over the surviving suffix.
+TEST_F(OutputColumnNamesTest, namesPastASkipFoldedIntoTheOutput) {
+    expectColumnNames("MATCH (n:Person) RETURN n.name AS name SKIP 6", {"name"});
+}
+
+TEST_F(OutputColumnNamesTest, namesEveryColumnOfAWiderProjection) {
+    expectColumnNames("MATCH (n:Person) RETURN n AS person, n.name AS name, n.age AS age",
+                      {"person", "name", "age"});
+}
+
+// A query matching nothing emits no chunk, yet the result still has named columns: the
+// names come off the program, not off a row.
+TEST_F(OutputColumnNamesTest, namesTheColumnsOfAnEmptyResult) {
+    ColumnNameSink sink;
+    runQuery("MATCH (n:Person) WHERE n.name = 'nobody' RETURN n.name AS name", &sink);
+
+    EXPECT_EQ(sink.getRowCount(), 0u);
+    EXPECT_EQ(sink.names(), ColumnNames {"name"});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -700,6 +700,10 @@ public:
     {
     }
 
+    void setColumnNames(std::span<const std::string_view> names) override {
+        _columnNames.assign(names.begin(), names.end());
+    }
+
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         if (_quiet) {
             _rowCount += rowCount;
@@ -709,7 +713,12 @@ public:
         if (_execCount == 0) {
             tabulate::RowStream headerRow;
             for (size_t columnIndex = 0; columnIndex < chunks.size(); columnIndex++) {
-                headerRow << ("$" + std::to_string(columnIndex));
+                const bool isNamed = columnIndex < _columnNames.size() && !_columnNames[columnIndex].empty();
+                if (isNamed) {
+                    headerRow << _columnNames[columnIndex];
+                } else {
+                    headerRow << ("$" + std::to_string(columnIndex));
+                }
             }
             _table.add_row(std::move(headerRow));
         }
@@ -732,6 +741,7 @@ public:
 
 private:
     tabulate::Table _table;
+    std::vector<std::string> _columnNames;
     size_t _execCount {0};
     size_t _rowCount {0};
     bool _quiet {false};


### PR DESCRIPTION
Transmit the AS alias names all the way to the output sink so that we see correct column names in #v3 TuringShell