### PR TITLE
MLIR: Generate label and edge type constraints immediately on traversal

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -412,8 +412,6 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
     generateTraversal(ast);
     resolveEdgeIdentities();
     generatePropertyConstraints(ast);
-    generateLabelConstraints(ast);
-    generateEdgeTypeConstraints(ast);
     generateFilters(ast);
     generateGroupAggregate(ast);
     generateCreate(ast);
@@ -666,6 +664,7 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
     }
 
     markDefined(root);
+    applyConstraints(root);
 
     // Forms the "carried set" for this connected component
     std::vector<const VariableDependency*> carriedSet;
@@ -712,6 +711,7 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
         if (!haveTriple) {
             if (pred && pred->isMetaEdge()) {
                 addMergeFilter(var, carriedSet);
+                applyConstraints(var);
             }
 
             markDefined(var);
@@ -785,6 +785,9 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
         markDefined(src);
         markDefined(edge);
         markDefined(tgt);
+
+        applyConstraints(edge);
+        applyConstraints(tgt);
 
         carriedSet.push_back(src);
         carriedSet.push_back(edge);
@@ -1509,183 +1512,73 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
     }
 }
 
-void DBProgramGenerator::generateLabelConstraints(const CypherAST* ast) {
-    const CypherAST::QueryCommands& queries = ast->queries();
-    if (queries.size() != 1) {
-        throw TuringException("Multiple queries not yet supported.");
-    }
-
-    const QueryCommand* query = queries.front();
-
-    const SinglePartQuery* sglPart = dynamic_cast<const SinglePartQuery*>(query);
-    if (!sglPart) {
+void DBProgramGenerator::applyConstraints(const VariableDependency* var) {
+    const std::optional<VariableDependency::Constraint>& constraints = var->constraints();
+    if (!constraints) {
         return;
     }
 
-    const StmtContainer* stmtsContainer = sglPart->getReadStmts();
-    if (!stmtsContainer) {
-        return;
-    }
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
 
-    using NodeDataPair = std::pair<const NodePattern*, const NodePatternData*>;
-    std::vector<NodeDataPair> labelConstrainedNodes;
+    const auto applyLabelConstraint = [&](const VariableDependency::LabelNames& labels) {
+        const auto findIt = _varMap.find(var);
+        const bool registered = findIt != _varMap.end() && !findIt->second.empty();
+        bioassert(registered, "Label-constrained node not registered: {}", var->getName());
+        const mlir::Value nodeColumn = findIt->second.back();
 
-    for (const Stmt* stmt : stmtsContainer->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::MATCH) {
-            continue;
+        const mlir::db::ColumnType labelSetIDType =
+            allocColumnType(mlir::storage::LabelSetIDType::get(_mlirCtxt));
+
+        const mlir::Value labelSetIDColumn = _opBuilder.create<mlir::db::GetNodeLabelSet>(
+            loc,
+            labelSetIDType,
+            nodeColumn).getResult();
+
+        llvm::SmallVector<llvm::StringRef> labelNames;
+        for (const std::string_view label : labels) {
+            labelNames.push_back(llvm::StringRef(label.data(), label.size()));
         }
 
-        const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
-        const Pattern* pattern = matchStmt->getPattern();
+        const mlir::ArrayAttr labelsAttr = _opBuilder.getStrArrayAttr(labelNames);
+        const mlir::Value labelMask = _opBuilder.create<mlir::db::CheckLabelConstraint>(
+            loc,
+            boolType,
+            labelSetIDColumn,
+            labelsAttr).getResult();
 
-        labelConstrainedNodes.clear();
+        filterAllColumns(labelMask);
+    };
 
-        for (const PatternElement* element : pattern->elements()) {
-            const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
-            const NodePatternData* rootData = rootNode->getData();
-
-            if (rootData && !rootData->labelConstraints().empty()) {
-                labelConstrainedNodes.emplace_back(rootNode, rootData);
-            }
-
-            for (auto [edgePattern, nodePattern] : element->getElementChain()) {
-                const NodePatternData* nodeData = nodePattern->getData();
-                if (nodeData && !nodeData->labelConstraints().empty()) {
-                    labelConstrainedNodes.emplace_back(nodePattern, nodeData);
-                }
-            }
-        }
-
-        if (labelConstrainedNodes.empty()) {
-            continue;
-        }
-
-        const mlir::Location loc = _opBuilder.getUnknownLoc();
-        const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
-        const mlir::db::ColumnType labelSetIDType = allocColumnType(
-            mlir::storage::LabelSetIDType::get(_mlirCtxt));
-
-        mlir::Value combinedPredicate;
-
-        for (auto [nodePattern, nodeData] : labelConstrainedNodes) {
-            const VarDecl* vardecl = nodePattern->getDecl();
-            bioassert(vardecl, "Null variable declaration.");
-            const std::string_view nodeName = vardecl->getName();
-
-            mlir::Value nodeColumn;
-            for (const auto& [var, values] : _varMap) {
-                if (var->getName() == nodeName) {
-                    nodeColumn = values.back();
-                    break;
-                }
-            }
-
-            bioassert(nodeColumn, "Label-constrained node not found in variable map: {}", nodeName);
-
-            const mlir::Value labelSetIDColumn = _opBuilder.create<mlir::db::GetNodeLabelSet>(
-                loc,
-                labelSetIDType,
-                nodeColumn).getResult();
-
-            llvm::SmallVector<llvm::StringRef> labelNames;
-            for (const std::string_view label : nodeData->labelConstraints()) {
-                labelNames.push_back(llvm::StringRef(label.data(), label.size()));
-            }
-
-            const mlir::ArrayAttr labelsAttr = _opBuilder.getStrArrayAttr(labelNames);
-            const mlir::Value labelMask = _opBuilder.create<mlir::db::CheckLabelConstraint>(
-                loc,
-                boolType,
-                labelSetIDColumn,
-                labelsAttr).getResult();
-
-            if (!combinedPredicate) {
-                combinedPredicate = labelMask;
-            } else {
-                combinedPredicate = _opBuilder.create<mlir::db::AndOp>(
-                    loc, boolType, combinedPredicate, labelMask).getResult();
-            }
-        }
-
-        filterAllColumns(combinedPredicate);
-    }
-}
-
-void DBProgramGenerator::generateEdgeTypeConstraints(const CypherAST* ast) {
-    const CypherAST::QueryCommands& queries = ast->queries();
-    if (queries.size() != 1) {
-        throw TuringException("Multiple queries not yet supported.");
-    }
-
-    const QueryCommand* query = queries.front();
-
-    const SinglePartQuery* sglPart = dynamic_cast<const SinglePartQuery*>(query);
-    if (!sglPart) {
-        return;
-    }
-
-    const StmtContainer* stmtsContainer = sglPart->getReadStmts();
-    if (!stmtsContainer) {
-        return;
-    }
-
-    const VariableDependencyGraph::EdgeIdentityMap& edgeIdentities = _vdg.edgeIdentities();
-
-    for (const Stmt* stmt : stmtsContainer->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::MATCH) {
-            continue;
-        }
-
-        const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
-        const Pattern* pattern = matchStmt->getPattern();
-
-        mlir::Value combinedPredicate;
+    const auto applyEdgeTypeConstraint = [&](const VariableDependency::EdgeType& type) {
+        const auto findIt = _edgeTypeMap.find(var);
+        bioassert(findIt != _edgeTypeMap.end(),
+                  "Type-constrained edge without a type column: {}", var->getName());
+        const mlir::Value edgeTypeColumn = findIt->second;
 
         llvm::SmallVector<llvm::StringRef> typeNames;
-        for (const PatternElement* element : pattern->elements()) {
-            for (auto [edgePattern, nodePattern] : element->getElementChain()) {
-                const EdgePatternData* edgeData = edgePattern->getData();
-                if (!edgeData || edgeData->edgeTypeConstraints().empty()) {
-                    continue;
-                }
+        typeNames.push_back(llvm::StringRef(type.data(), type.size()));
 
-                const std::string_view cypherName = edgePattern->getDecl()->getName();
-                const auto identityIt = edgeIdentities.find(std::string(cypherName));
-                bioassert(identityIt != edgeIdentities.end(),
-                          "Edge variable not found in identity map: {}", cypherName);
+        const mlir::ArrayAttr edgeTypesAttr = _opBuilder.getStrArrayAttr(typeNames);
+        const mlir::Value edgeTypeMask = _opBuilder.create<mlir::db::CheckEdgeTypeConstraint>(
+            loc,
+            boolType,
+            edgeTypeColumn,
+            edgeTypesAttr).getResult();
 
-                const VariableDependency* edgeVar = identityIt->second.front();
-                const auto edgeTypeIt = _edgeTypeMap.find(edgeVar);
-                bioassert(edgeTypeIt != _edgeTypeMap.end(),
-                          "Edge type column not found for variable: {}", cypherName);
+        filterAllColumns(edgeTypeMask);
+    };
 
-                const mlir::Value edgeTypeColumn = edgeTypeIt->second;
-
-                const mlir::Location loc = _opBuilder.getUnknownLoc();
-                const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
-
-                typeNames.clear();
-                for (const std::string_view typeName : edgeData->edgeTypeConstraints()) {
-                    typeNames.push_back(llvm::StringRef(typeName.data(), typeName.size()));
-                }
-
-                const mlir::ArrayAttr edgeTypesAttr = _opBuilder.getStrArrayAttr(typeNames);
-                const mlir::Value edgeTypeMask = _opBuilder.create<mlir::db::CheckEdgeTypeConstraint>(
-                    loc, boolType, edgeTypeColumn, edgeTypesAttr).getResult();
-
-                if (!combinedPredicate) {
-                    combinedPredicate = edgeTypeMask;
-                } else {
-                    combinedPredicate = _opBuilder.create<mlir::db::AndOp>(
-                        loc, boolType, combinedPredicate, edgeTypeMask).getResult();
-                }
-            }
+    std::visit([&](auto&& constraint) {
+        using T = std::decay_t<decltype(constraint)>;
+        if constexpr (std::is_same_v<T, VariableDependency::LabelNames>) {
+            applyLabelConstraint(constraint);
+        } else if constexpr (std::is_same_v<T, VariableDependency::EdgeType>) {
+            applyEdgeTypeConstraint(constraint);
+        } else {
+            static_assert(false, "Unhandled constraint type.");
         }
-
-        if (combinedPredicate) {
-            filterAllColumns(combinedPredicate);
-        }
-    }
+    }, *constraints);
 }
 
 void DBProgramGenerator::generateFilters(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1514,7 +1514,7 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
 
 void DBProgramGenerator::applyConstraints(const VariableDependency* var) {
     const std::optional<VariableDependency::Constraint>& constraints = var->constraints();
-    if (!constraints) {
+    if (!constraints.has_value()) {
         return;
     }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -123,8 +123,6 @@ private:
     mlir::Value resolveEntityColumn(std::string_view varName);
 
     void generatePropertyConstraints(const CypherAST* ast);
-    void generateLabelConstraints(const CypherAST* ast);
-    void generateEdgeTypeConstraints(const CypherAST* ast);
     void generateFilters(const CypherAST* ast);
 
     void generateGroupAggregate(const CypherAST* ast);
@@ -150,6 +148,12 @@ private:
     // from the graph's nodes
     void addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind);
     void filterAllColumns(mlir::Value predicate);
+
+    // Filters a freshly produced variable by its own constraint right where it is
+    // scanned or traversed - a label-set filter for a node, an edge-type filter for
+    // an edge - so it narrows before the next hop and before any cross product.
+    // No-op for an unconstrained variable.
+    void applyConstraints(const VariableDependency* var);
 
     void addMergeFilter(const VariableDependency* var,
                         std::vector<const VariableDependency*>& carriedSet);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -149,10 +149,6 @@ private:
     void addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind);
     void filterAllColumns(mlir::Value predicate);
 
-    // Filters a freshly produced variable by its own constraint right where it is
-    // scanned or traversed - a label-set filter for a node, an edge-type filter for
-    // an edge - so it narrows before the next hop and before any cross product.
-    // No-op for an unconstrained variable.
     void applyConstraints(const VariableDependency* var);
 
     void addMergeFilter(const VariableDependency* var,

--- a/query/ir/frontend/cypher/VariableDependency.cpp
+++ b/query/ir/frontend/cypher/VariableDependency.cpp
@@ -1,5 +1,10 @@
 #include "VariableDependency.h"
 
+#include <algorithm>
+#include <variant>
+
+#include "BioAssert.h"
+
 using namespace db;
 
 void VariableDependency::addIncoming(DependencyEdge* newEdge) {
@@ -8,4 +13,40 @@ void VariableDependency::addIncoming(DependencyEdge* newEdge) {
 
 void VariableDependency::addOutgoing(DependencyEdge* newEdge) {
     _outgoing.push_back(newEdge);
+}
+
+void VariableDependency::addLabelConstraints(std::span<const std::string_view> labels) {
+    if (labels.empty()) {
+        return;
+    }
+
+    if (_constraints) {
+        bioassert(!std::holds_alternative<EdgeType>(*_constraints), "Have edge type");
+    }
+
+    if (!_constraints) {
+        _constraints = LabelNames {};
+    }
+
+    LabelNames& labelNames = std::get<LabelNames>(*_constraints);
+
+    for (const std::string_view label : labels) {
+        const bool alreadyPresent =
+            std::ranges::find(labelNames, label) != labelNames.end();
+        if (alreadyPresent) {
+            continue;
+        }
+
+        labelNames.push_back(label);
+    }
+}
+
+void VariableDependency::setEdgeTypeConstraint(std::string_view type) {
+    if (type.empty()) {
+        return;
+    }
+
+    bioassert(!_constraints.has_value(), "Multiple edge types.");
+
+    _constraints = EdgeType {type};
 }

--- a/query/ir/frontend/cypher/VariableDependency.h
+++ b/query/ir/frontend/cypher/VariableDependency.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <optional>
+#include <span>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 #include <range/v3/view/concat.hpp>
@@ -23,6 +26,10 @@ class VariableDependency {
 public:
     using Edges = std::vector<DependencyEdge*>;
 
+    using LabelNames = std::vector<std::string_view>;
+    using EdgeType = std::string_view;
+    using Constraint = std::variant<LabelNames, EdgeType>;
+
     explicit VariableDependency(std::string_view name)
         : _name(name)
     {
@@ -34,6 +41,8 @@ public:
 
     std::string_view getName() const { return _name; }
 
+    const std::optional<Constraint>& constraints() const { return _constraints; }
+
     bool isIsolated() const { return edges().empty(); }
 
     void setName(std::string_view name) { _name = name; }
@@ -44,11 +53,16 @@ public:
     void addIncoming(DependencyEdge* newEdge);
     void addOutgoing(DependencyEdge* newEdge);
 
+    void addLabelConstraints(std::span<const std::string_view> labels);
+    void setEdgeTypeConstraint(std::string_view type);
+
 private:
     friend VariableDependencyGraph;
 
     Edges _incoming;
     Edges _outgoing;
+
+    std::optional<Constraint> _constraints;
 
     std::string _name;
 };

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -159,15 +159,15 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
         edgeOccurrences.push_back(edgeVar);
 
         const EdgePatternData* edgeData = edge->getData();
-        std::string_view edgeType;
+        std::string_view edgeTypeConstraint;
         if (edgeData) {
             const std::span<const std::string_view> types = edgeData->edgeTypeConstraints();
             bioassert(types.size() <= 1, "Edge pattern with more than one type; disjunction unsupported");
             if (!types.empty()) {
-                edgeType = types.front();
+                edgeTypeConstraint = types.front();
             }
         }
-        edgeVar->setEdgeTypeConstraint(edgeType);
+        edgeVar->setEdgeTypeConstraint(edgeTypeConstraint);
 
         addDirected(src, edgeVar, EdgeMetadata {edgeType});
         addDirected(edgeVar, tgt, EdgeMetadata {otherType});

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <ranges>
 #include <set>
+#include <span>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -12,6 +13,7 @@
 
 #include "EdgePattern.h"
 #include "EntityPattern.h"
+#include "NodePattern.h"
 #include "VariableDependencyGraphDumper.h"
 #include "CypherAST.h"
 #include "SinglePartQuery.h"
@@ -21,6 +23,7 @@
 #include "stmt/MatchStmt.h"
 #include "stmt/StmtContainer.h"
 #include "stmt/UnwindStmt.h"
+#include "decl/PatternData.h"
 #include "decl/VarDecl.h"
 
 #include "DependencyEdge.h"
@@ -155,6 +158,17 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
         VariableDependency* edgeVar = newVariable(anonymousName);
         edgeOccurrences.push_back(edgeVar);
 
+        const EdgePatternData* edgeData = edge->getData();
+        std::string_view edgeType;
+        if (edgeData) {
+            const std::span<const std::string_view> types = edgeData->edgeTypeConstraints();
+            bioassert(types.size() <= 1, "Edge pattern with more than one type; disjunction unsupported");
+            if (!types.empty()) {
+                edgeType = types.front();
+            }
+        }
+        edgeVar->setEdgeTypeConstraint(edgeType);
+
         addDirected(src, edgeVar, EdgeMetadata {edgeType});
         addDirected(edgeVar, tgt, EdgeMetadata {otherType});
 
@@ -190,7 +204,17 @@ VariableDependency* VariableDependencyGraph::getOrCreateVariable(const EntityPat
     const auto foundIt = std::ranges::find_if(_vars, match);
     const bool exists  = foundIt != _vars.end();
 
-    return exists ? &*foundIt : newVariable(entity);
+    VariableDependency* var = exists ? &*foundIt : newVariable(entity);
+
+    const NodePattern* node = dynamic_cast<const NodePattern*>(entity);
+    if (node) {
+        const NodePatternData* data = node->getData();
+        if (data) {
+            var->addLabelConstraints(data->labelConstraints());
+        }
+    }
+
+    return var;
 }
 
 void VariableDependencyGraph::computeCycleBasis(std::vector<Cycle>& cycles) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -50,6 +50,21 @@ llvm::StringRef edgeTypeName(mlir::Value handle) {
     return handleOp.getName();
 }
 
+bool sameCardinality(mlir::Value first, mlir::Value second) {
+    const mlir::BlockArgument firstArg = mlir::dyn_cast<mlir::BlockArgument>(first);
+    const mlir::BlockArgument secondArg = mlir::dyn_cast<mlir::BlockArgument>(second);
+
+    if (firstArg && secondArg) {
+        return firstArg.getOwner() == secondArg.getOwner();
+    }
+
+    if (!firstArg && !secondArg) {
+        return first.getDefiningOp() == second.getDefiningOp();
+    }
+
+    return false;
+}
+
 // The with-null fetch handler for a property's value type, on the node side
 // when isNode is true and the edge side otherwise. Selecting it here keeps the
 // value-type dispatch with the rest of translation; the handler bodies live in
@@ -700,21 +715,12 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
     loopData->getIndices()->reserve(_program->getChunkSize());
 
     // Allocate carried columns in the carried set
-    const auto inputArgument = mlir::dyn_cast<mlir::BlockArgument>(config._inputNodes);
     const size_t carriedCount = config._carriedColumns.size();
     for (size_t carriedIndex = 0; carriedIndex < carriedCount; carriedIndex++) {
         const mlir::Value carriedValue = config._carriedColumns[carriedIndex];
 
-        // A carried chunk is filtered through the same indices as the input,
-        // so its rows must belong to the same loop step: it must be a loop
-        // variable of the nl.for that binds input_nodes. The ops constrain
-        // only types, so a cross-loop carry passes MLIR verification and has
-        // to be rejected here, before it can misalign the gathers at runtime.
-        const auto carriedArgument = mlir::dyn_cast<mlir::BlockArgument>(carriedValue);
-        const bool boundBySameLoop = inputArgument && carriedArgument
-                                     && carriedArgument.getOwner() == inputArgument.getOwner();
-        if (!boundBySameLoop) {
-            throw IRException("Carried columns must be loop variables of the same nl.for as the input chunk");
+        if (!sameCardinality(config._inputNodes, carriedValue)) {
+            throw IRException("Carried column is not row-aligned with the input chunk");
         }
 
         const NLChunkKind kind = getChunkKind(carriedValue.getType());


### PR DESCRIPTION
Should facilitate easier pattern rewriting to `ScanNodesByLabel`, `ScanEdgesByType`, etc.