### PR TITLE
MLIR: Split filters to be maximally granular

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -218,6 +218,19 @@ mlir::Value findVarOrThrow(const DBProgramGenerator::VariableIdentityMap& map,
     return identities.back();
 }
 
+void flattenConjuncts(const Expr* expr, std::vector<const Expr*>& conjuncts) {
+    if (expr->getKind() == Expr::Kind::BINARY) {
+        const BinaryExpr* binaryExpr = static_cast<const BinaryExpr*>(expr);
+        if (binaryExpr->getOperator() == BinaryOperator::And) {
+            flattenConjuncts(binaryExpr->getLHS(), conjuncts);
+            flattenConjuncts(binaryExpr->getRHS(), conjuncts);
+            return;
+        }
+    }
+
+    conjuncts.push_back(expr);
+}
+
 }
 
 DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
@@ -1428,6 +1441,13 @@ mlir::Value DBProgramGenerator::getOrTranslateExprColumn(const VariableColumnMap
     return _exprMap.at(expr);
 }
 
+void DBProgramGenerator::applyPredicateFilters(std::span<const Expr* const> predicates) {
+    for (const Expr* predicate : predicates) {
+        translateExpr(predicate);
+        filterAllColumns(_exprMap.at(predicate));
+    }
+}
+
 void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
     const CypherAST::QueryCommands& queries = ast->queries();
     if (queries.size() != 1) {
@@ -1485,30 +1505,7 @@ void DBProgramGenerator::generatePropertyConstraints(const CypherAST* ast) {
             }
         }
 
-        if (constraintExprs.empty()) {
-            continue;
-        }
-
-        const mlir::Location loc = _opBuilder.getUnknownLoc();
-        const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
-
-        mlir::Value combinedPredicate;
-
-        for (const Expr* constraintExpr : constraintExprs) {
-            translateExpr(constraintExpr);
-            const mlir::Value predicate = _exprMap.at(constraintExpr);
-
-            if (!combinedPredicate) {
-                combinedPredicate = predicate;
-            } else {
-                combinedPredicate = _opBuilder
-                                        .create<mlir::db::AndOp>(
-                                            loc, boolType, combinedPredicate, predicate)
-                                        .getResult();
-            }
-        }
-
-        filterAllColumns(combinedPredicate);
+        applyPredicateFilters(constraintExprs);
     }
 }
 
@@ -1599,6 +1596,7 @@ void DBProgramGenerator::generateFilters(const CypherAST* ast) {
         return;
     }
 
+    std::vector<const Expr*> conjuncts;
     for (const Stmt* stmt : stmtsContainer->stmts()) {
         if (stmt->getKind() != Stmt::Kind::MATCH) {
             continue;
@@ -1611,14 +1609,10 @@ void DBProgramGenerator::generateFilters(const CypherAST* ast) {
             continue;
         }
 
-        const Expr* predicateExpr = where->getExpr();
-        translateExpr(predicateExpr);
+        conjuncts.clear();
+        flattenConjuncts(where->getExpr(), conjuncts);
 
-        const auto findIt = _exprMap.find(predicateExpr);
-        bioassert(findIt != end(_exprMap), "Failed to get value for expr");
-        const mlir::Value predicateVal = findIt->second;
-
-        filterAllColumns(predicateVal);
+        applyPredicateFilters(conjuncts);
     }
 }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -123,6 +124,8 @@ private:
 
     void generatePropertyConstraints(const CypherAST* ast);
     void generateFilters(const CypherAST* ast);
+
+    void applyPredicateFilters(std::span<const Expr* const> predicates);
 
     void generateGroupAggregate(const CypherAST* ast);
 

--- a/samples/mlir/match_split_filter.mlir
+++ b/samples/mlir/match_split_filter.mlir
@@ -1,0 +1,15 @@
+// MATCH (n) WHERE n.age = 32 AND n.isFrench = true RETURN *
+
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_properties(%0, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.constant(32 : i64)
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %4 = db.filter(%3, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %5 = db.get_node_properties(%4, "isFrench") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %6 = db.constant(true)
+  %7 = db.eq %5, %6 : (!db.column<none>, !db.column<i1>) -> !db.column<!storage.bool>
+  %8 = db.filter(%7, {%4}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%8) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_split_filter.nl.mlir
+++ b/samples/mlir/match_split_filter.nl.mlir
@@ -1,0 +1,19 @@
+// MATCH (n) WHERE n.age = 32 AND n.isFrench = true RETURN *
+
+func.func @main() {
+  %0 = nl.constant(true)
+  %1 = nl.get_property_type("isFrench")
+  %2 = nl.constant(32 : i64)
+  %3 = nl.get_property_type("age")
+  %4 = nl.scan_nodes()
+  nl.for %arg0 in %4 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %5 = nl.get_node_properties(%arg0, %3) : !nl.chunk<!storage.nullable<i64>>
+    %6 = nl.eq %5, %2 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %7 = nl.filter %6, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %8 = nl.get_node_properties(%7, %1) : !nl.chunk<!storage.nullable<i1>>
+    %9 = nl.eq %8, %0 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<i1>) -> !nl.chunk<!storage.nullable<i1>>
+    %10 = nl.filter %9, (%7) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%10) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}


### PR DESCRIPTION
Splitting each predicate (separated by `AND` clauses) into its own filter operation.

Motivations:

- short circuiting (cardinality reduction reduces row count for subsequent filters)
- more malleable code for predicate pushdown/peephole optimisations