### PR TITLE
ci: drop the Prepare SimpleDB step — nothing reads $HOME/.turing

### DIFF
--- a/.github/actions/clean-self-hosted-runner/action.yml
+++ b/.github/actions/clean-self-hosted-runner/action.yml
@@ -18,8 +18,9 @@ runs:
 
         # 1) Container writable-layer growth. These live inside the container
         #    (not on a bind-mount) and are recreated by the job when needed:
-        #    .local/.cache are uv/pip caches; .turing is the graph output the
-        #    "Prepare SimpleDB" step writes. /tmp is per-container scratch.
+        #    .local/.cache are uv/pip caches; .turing is created (empty) by
+        #    turingdb's default config — the "Prepare SimpleDB" step writes to
+        #    RUNNER_TEMP instead. /tmp is per-container scratch.
         rm -rf "${HOME:?}/.local" "${HOME:?}/.cache" "${HOME:?}/.turing" 2>/dev/null
         sudo rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null
 

--- a/.github/actions/clean-self-hosted-runner/action.yml
+++ b/.github/actions/clean-self-hosted-runner/action.yml
@@ -19,8 +19,8 @@ runs:
         # 1) Container writable-layer growth. These live inside the container
         #    (not on a bind-mount) and are recreated by the job when needed:
         #    .local/.cache are uv/pip caches; .turing is created (empty) by
-        #    turingdb's default config — the "Prepare SimpleDB" step writes to
-        #    RUNNER_TEMP instead. /tmp is per-container scratch.
+        #    turingdb's default config — no CI step seeds graphs there
+        #    anymore. /tmp is per-container scratch.
         rm -rf "${HOME:?}/.local" "${HOME:?}/.cache" "${HOME:?}/.turing" 2>/dev/null
         sudo rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -212,15 +212,6 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python_version }}
         VERSION_OVERRIDE: ${{ steps.version.outputs.version }}
 
-    # There is deliberately no "Prepare SimpleDB" step here. Nothing reads a
-    # pre-seeded $HOME/.turing/graphs/simpledb: every test suite builds
-    # simpledb itself (unit/query suites in-memory via TuringTestEnv, each
-    # regress test into its own -turing-dir). The old step's cp -r into
-    # $HOME/.turing merged fresh-hash commits/dataparts on every run, and on
-    # the persistent macOS minis — where nothing cleans $HOME between jobs —
-    # that grew to 194GB and filled the macos15 host disk. Don't reintroduce a
-    # shared on-disk graph; give any future consumer a per-job dir instead
-    # (e.g. under RUNNER_TEMP, which the runner empties between jobs).
     - name: Run unit tests
       run: |
         cd build

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -212,12 +212,19 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python_version }}
         VERSION_OVERRIDE: ${{ steps.version.outputs.version }}
 
+    # The prepared graph goes under RUNNER_TEMP, not $HOME/.turing: the runner
+    # empties RUNNER_TEMP between jobs, while on the persistent self-hosted
+    # macOS minis $HOME/.turing survives forever and is cleaned by nothing
+    # (clean-self-hosted-runner below is Linux-only). ./simpledb names each
+    # run's commits and dataparts with fresh hashes, so cp -r into a surviving
+    # graph dir merges them without bound — this grew to 194GB and filled the
+    # macos15 host disk.
     - name: Prepare SimpleDB
       run: |
         cd build/samples/simpledb
         ./simpledb
-        mkdir -p $HOME/.turing/graphs
-        cp -r simpledb.out/simpledb $HOME/.turing/graphs
+        mkdir -p "$RUNNER_TEMP/.turing/graphs"
+        cp -r simpledb.out/simpledb "$RUNNER_TEMP/.turing/graphs"
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -212,20 +212,15 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python_version }}
         VERSION_OVERRIDE: ${{ steps.version.outputs.version }}
 
-    # The prepared graph goes under RUNNER_TEMP, not $HOME/.turing: the runner
-    # empties RUNNER_TEMP between jobs, while on the persistent self-hosted
-    # macOS minis $HOME/.turing survives forever and is cleaned by nothing
-    # (clean-self-hosted-runner below is Linux-only). ./simpledb names each
-    # run's commits and dataparts with fresh hashes, so cp -r into a surviving
-    # graph dir merges them without bound — this grew to 194GB and filled the
-    # macos15 host disk.
-    - name: Prepare SimpleDB
-      run: |
-        cd build/samples/simpledb
-        ./simpledb
-        mkdir -p "$RUNNER_TEMP/.turing/graphs"
-        cp -r simpledb.out/simpledb "$RUNNER_TEMP/.turing/graphs"
-
+    # There is deliberately no "Prepare SimpleDB" step here. Nothing reads a
+    # pre-seeded $HOME/.turing/graphs/simpledb: every test suite builds
+    # simpledb itself (unit/query suites in-memory via TuringTestEnv, each
+    # regress test into its own -turing-dir). The old step's cp -r into
+    # $HOME/.turing merged fresh-hash commits/dataparts on every run, and on
+    # the persistent macOS minis — where nothing cleans $HOME between jobs —
+    # that grew to 194GB and filled the macos15 host disk. Don't reintroduce a
+    # shared on-disk graph; give any future consumer a per-job dir instead
+    # (e.g. under RUNNER_TEMP, which the runner empties between jobs).
     - name: Run unit tests
       run: |
         cd build


### PR DESCRIPTION
## Problem

The `Prepare SimpleDB` step copied the generated graph into `$HOME/.turing/graphs` on every job. Each run generates the graph's commits/dataparts under fresh hash names, so every `cp -r` **merged** new files into the surviving graph dir. On the persistent self-hosted macOS minis nothing cleans `$HOME/.turing` between jobs (`clean-self-hosted-runner` is Linux-only), so on macos15-runner this accumulated 4,794 commits / 4,195 dataparts totalling **194GB**, filled the 460GB disk completely, and left macOS CI jobs hanging on GitHub with blank/broken logs (this morning's cancelled runs, e.g. 31686789966).

## Fix

Delete the step. Verified nothing consumes its output:

- **Unit tests (`make test`)**: every ctest suite builds simpledb in-memory in its own per-test out-dir via `TuringTestEnv::create(outDir)` + `createSimpleGraph` — including the remote query suite, whose in-process `TuringServer` is rooted at the test's out-dir on an ephemeral port.
- **Regress**: every `regress/*/run.sh` generates its own `simpledb.out` and starts the daemon with `-turing-dir $SCRIPT_DIR/.turing` — none falls back to `$HOME`.
- **Other workflows**: `ci_release`, `ci_full_matrix_build`, `ci_macos14_manual`, `ci_docker` all call `ci_build.yml` via `workflow_call`; none has its own copy step.
- **Python**: no Python tests run in CI (the wheel check only runs `turingdb --help`), so the embedded client's `$HOME/.turing` default is never exercised.
- Nothing reads `build/samples/simpledb/simpledb.out` either — regress regenerates its own.

The stale comment in `clean-self-hosted-runner` is updated (it still deletes `$HOME/.turing` as defense-in-depth: turingdb's default config creates it empty).

The minis were cleaned manually today (macos15: 100% → 43% disk); this PR prevents the recurrence.
