### PR TITLE
MLIR: Fix edge variables being unregistered

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1767,11 +1767,9 @@ void DBProgramGenerator::translateExpr(const Expr* expr) {
             if (projectedIt != end(_projectedColumns)) {
                 _exprMap[expr] = projectedIt->second;
             } else {
-                for (const auto& [var, values] : _varMap) {
-                    if (var->getName() == varName) {
-                        _exprMap[expr] = values.back();
-                        break;
-                    }
+                const mlir::Value entityColumn = resolveEntityColumn(varName);
+                if (entityColumn) {
+                    _exprMap[expr] = entityColumn;
                 }
             }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -65,7 +65,6 @@ private:
     // Maps each edge VDG var to its MLIR type column
     std::unordered_map<const VariableDependency*, mlir::Value> _edgeTypeMap;
 
-    // Maps each WHERE clause expression to the MLIR value it produces
     ExprValueMap _exprMap;
 
     // Maps each projected item to the column it produced, under the declaration the

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -400,6 +400,9 @@ TEST_F(EquivalenceTest, eqFilters) {
 
     expectEquivalent("MATCH (n)-->(a)-->(m) WHERE n = m RETURN n, a, m");
 
+    expectEquivalent("MATCH ()-[e]->(n) WHERE e = 0 RETURN n");
+    expectEquivalent("MATCH (n)-[e]->(m) WHERE e = e RETURN n");
+
     // Disabled due to suspected v2 bug
     // expectEquivalent("MATCH (n)-->(a)-->(m), (a)-->(b) WHERE b = n RETURN n, a, m, b");
 


### PR DESCRIPTION
Fixes bugs in queries such as `match ()-[e]->(n) where e = 0 return n` where `e` would be unregistered.