### PR TITLE
MLIR: Add optimisation pass infra; `ScanNodesByLabel` optimisation implementation

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -441,7 +441,7 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
 
 void DBProgramGenerator::runPasses() {
     mlir::PassManager passManager(_mlirCtxt);
-    passManager.addPass(mlir::db::createGetOutEdgesDCE());
+    passManager.addPass(mlir::db::createFuseScanByLabel());
 
     if (mlir::failed(passManager.run(*_module))) {
         throw FatalException("DB pass pipeline failed");

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -19,11 +19,13 @@
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Pass/PassManager.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 #include "DBDialect.h"
 #include "DBOps.h"
+#include "DBPasses.h"
 #include "DBTypes.h"
 #include "StorageDialect.h"
 #include "StorageTypes.h"
@@ -433,6 +435,17 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
     generateOutput(ast);
 
     _opBuilder.create<mlir::func::ReturnOp>(uloc);
+
+    runPasses();
+}
+
+void DBProgramGenerator::runPasses() {
+    mlir::PassManager passManager(_mlirCtxt);
+    passManager.addPass(mlir::db::createGetOutEdgesDCE());
+
+    if (mlir::failed(passManager.run(*_module))) {
+        throw FatalException("DB pass pipeline failed");
+    }
 }
 
 void DBProgramGenerator::generateTraversal(const CypherAST* ast) {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -109,6 +109,8 @@ private:
     void translateDistinct(const Projection* projection,
                            llvm::SmallVectorImpl<mlir::Value>& projected);
 
+    void runPasses();
+
     // Reorders the projection with a Sort over @param projected, replacing each
     // projected column with its sorted counterpart
     void translateOrderBy(const Projection* projection,

--- a/query/ir/dialect/db/CMakeLists.txt
+++ b/query/ir/dialect/db/CMakeLists.txt
@@ -15,6 +15,9 @@ set(LLVM_TARGET_DEFINITIONS DBTypes.td)
 mlir_tablegen(DBTypes.h.inc      -gen-typedef-decls     -dialect db --typedefs-dialect db EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS} ${STORAGE_DIALECT_SOURCE_DIR})
 mlir_tablegen(DBTypes.cpp.inc    -gen-typedef-defs      -dialect db --typedefs-dialect db EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS} ${STORAGE_DIALECT_SOURCE_DIR})
 
+set (LLVM_TARGET_DEFINITIONS DBPasses.td)
+mlir_tablegen(DBPasses.h.inc     -gen-pass-decls    -name DB -dialect db  EXTRA_INCLUDES ${MLIR_INCLUDE_DIRS})
+
 # Creates CMAKE target with all included .inc files, the lib depends on this
 add_public_tablegen_target(DBDialectIncGen)
 
@@ -30,6 +33,7 @@ add_mlir_library(turing_db_ir_dbdialect_s
   DBDialect.cpp
   DBOps.cpp
   DBTypes.cpp
+  DBPasses.cpp
 
   DEPENDS
   DBDialectIncGen
@@ -37,6 +41,7 @@ add_mlir_library(turing_db_ir_dbdialect_s
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport
+  MLIRPass
   MLIRFuncDialect
   MLIRBuiltinToLLVMIRTranslation
   turing_db_ir_storagedialect_s

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -24,9 +24,6 @@ struct LabelScanChain {
     CheckLabelConstraint check;
 };
 
-// Matches `filter` against that chain, returning the three producing ops, or
-// nullopt when the filter is anything else - a different mask, more than one
-// filtered column, or a source that is not a plain scan.
 std::optional<LabelScanChain> matchLabelScanChain(FilterOp filter) {
     const Operation::operand_range columns = filter.getColumnsToFilter();
     if (columns.size() != 1) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,0 +1,27 @@
+#include "DBPasses.h"
+
+#include "mlir/IR/Operation.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+
+namespace mlir::db {
+
+#define GEN_PASS_DEF_GETOUTEDGESDCE
+#include "DBPasses.h.inc"
+
+namespace {
+
+struct GetOutEdgesDCE : public impl::GetOutEdgesDCEBase<GetOutEdgesDCE> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        root->walk([&](GetOutEdges op) {
+            // TODO: replace unused GetOutEdges results with null
+        });
+    }
+};
+
+}
+
+}

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,6 +1,7 @@
 #include "DBPasses.h"
 
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/ValueRange.h"
 
 #include "DBDialect.h"
 #include "DBOps.h"
@@ -17,7 +18,13 @@ struct GetOutEdgesDCE : public impl::GetOutEdgesDCEBase<GetOutEdgesDCE> {
         Operation* const root = getOperation();
 
         root->walk([&](GetOutEdges op) {
-            // TODO: replace unused GetOutEdges results with null
+            mlir::ValueRange results = op.getResults();
+            for (mlir::Value result : results) {
+                const size_t uses = result.getNumUses();
+                if (uses == 0) {
+                    // TODO replace with null
+                }
+            }
         });
     }
 };

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,31 +1,97 @@
 #include "DBPasses.h"
 
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
 
 #include "DBDialect.h"
 #include "DBOps.h"
 
 namespace mlir::db {
 
-#define GEN_PASS_DEF_GETOUTEDGESDCE
+#define GEN_PASS_DEF_FUSESCANBYLABEL
 #include "DBPasses.h.inc"
 
 namespace {
 
-struct GetOutEdgesDCE : public impl::GetOutEdgesDCEBase<GetOutEdgesDCE> {
+struct LabelScanChain {
+    ScanNodes scan;
+    GetNodeLabelSet labelSet;
+    CheckLabelConstraint check;
+};
+
+// Matches `filter` against that chain, returning the three producing ops, or
+// nullopt when the filter is anything else - a different mask, more than one
+// filtered column, or a source that is not a plain scan.
+std::optional<LabelScanChain> matchLabelScanChain(FilterOp filter) {
+    const Operation::operand_range columns = filter.getColumnsToFilter();
+    if (columns.size() != 1) {
+        return std::nullopt;
+    }
+
+    const Value scanColumn = columns[0];
+
+    auto check = filter.getMask().getDefiningOp<CheckLabelConstraint>();
+    if (!check) {
+        return std::nullopt;
+    }
+
+    auto labelSet = check.getLabelsetIds().getDefiningOp<GetNodeLabelSet>();
+    if (!labelSet || labelSet.getInputNodes() != scanColumn) {
+        return std::nullopt;
+    }
+
+    auto scan = scanColumn.getDefiningOp<ScanNodes>();
+    if (!scan) {
+        return std::nullopt;
+    }
+
+    return LabelScanChain {.scan = scan, .labelSet = labelSet, .check = check};
+}
+
+void eraseIfUnused(Operation* op) {
+    if (op && op->use_empty()) {
+        op->erase();
+    }
+}
+
+struct FuseScanByLabel : public impl::FuseScanByLabelBase<FuseScanByLabel> {
     void runOnOperation() override {
         Operation* const root = getOperation();
 
-        root->walk([&](GetOutEdges op) {
-            mlir::ValueRange results = op.getResults();
-            for (mlir::Value result : results) {
-                const size_t uses = result.getNumUses();
-                if (uses == 0) {
-                    // TODO replace with null
-                }
+        // Collect matches first: fusing erases ops, which would invalidate the walk.
+        llvm::SmallVector<FilterOp> filters;
+        root->walk([&](FilterOp filter) {
+            if (matchLabelScanChain(filter)) {
+                filters.push_back(filter);
             }
         });
+
+        mlir::OpBuilder builder(&getContext());
+        for (FilterOp filter : filters) {
+            std::optional<LabelScanChain> chain = matchLabelScanChain(filter);
+            if (!chain) {
+                continue;
+            }
+
+            builder.setInsertionPoint(filter);
+            auto scanByLabel = builder.create<ScanNodesByLabel>(filter.getLoc(),
+                                                                chain->scan.getResult().getType(),
+                                                                chain->check.getLabels());
+
+            Operation* const filterOp = filter.getOperation();
+            filterOp->getResult(0).replaceAllUsesWith(scanByLabel.getResult());
+            filterOp->erase();
+
+            // Drop the now-dead chain, consumer to producer, each only if unused.
+            eraseIfUnused(chain->check);
+            eraseIfUnused(chain->labelSet);
+            eraseIfUnused(chain->scan);
+        }
     }
 };
 

--- a/query/ir/dialect/db/DBPasses.h
+++ b/query/ir/dialect/db/DBPasses.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+#include "DBDialect.h"
+
+namespace mlir::db {
+
+#define GEN_PASS_DECL
+#include "DBPasses.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "DBPasses.h.inc"
+
+}

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -3,8 +3,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-def GetOutEdgesDCE : Pass<"get_out_edges_dce"> {
-    let summary = "Replaces unused variables in GetOutEdges with null";
+def FuseScanByLabel : Pass<"fuse_scan_by_label"> {
+    let summary = "Fuse a scan_nodes and its label-set filter into a scan_nodes_by_label";
     let dependentDialects = ["mlir::db::DB"];
 }
 

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -1,0 +1,11 @@
+#ifndef TURINGDB_PASSES
+#define TURINGDB_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def GetOutEdgesDCE : Pass<"get_out_edges_dce"> {
+    let summary = "Replaces unused variables in GetOutEdges with null";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
+#endif // TURINGDB_PASSES

--- a/samples/mlir/match_scan_nodes_by_label_hop.mlir
+++ b/samples/mlir/match_scan_nodes_by_label_hop.mlir
@@ -1,0 +1,8 @@
+// MATCH (n:Person:SoftwareEngineering)-->() RETURN  *
+
+func.func @main() {
+  %0 = db.scan_nodes_by_label(["Person", "SoftwareEngineering"]) : !db.column<!storage.node_id>
+  %1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%1) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_scan_nodes_by_label_hop.nl.mlir
+++ b/samples/mlir/match_scan_nodes_by_label_hop.nl.mlir
@@ -1,0 +1,12 @@
+// MATCH (n:Person:SoftwareEngineering)-->() RETURN  *
+
+func.func @main() {
+  %0 = nl.scan_nodes_by_label(["Person", "SoftwareEngineering"])
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %1 = nl.get_out_edges(%arg0, {})
+    nl.for %arg1, %arg2, %arg3, %arg4 in %1 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      nl.output(%arg1) names ["n"] : !nl.chunk<!storage.node_id>
+    }
+  }
+  return
+}

--- a/samples/mlir/match_scan_nodes_by_multi_label.mlir
+++ b/samples/mlir/match_scan_nodes_by_multi_label.mlir
@@ -1,0 +1,7 @@
+// MATCH (n:Person:SoftwareEngineering) RETURN  *
+
+func.func @main() {
+  %0 = db.scan_nodes_by_label(["Person", "SoftwareEngineering"]) : !db.column<!storage.node_id>
+  db.output(%0) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_scan_nodes_by_multi_label.nl.mlir
+++ b/samples/mlir/match_scan_nodes_by_multi_label.nl.mlir
@@ -1,0 +1,9 @@
+// MATCH (n:Person:SoftwareEngineering) RETURN  *
+
+func.func @main() {
+  %0 = nl.scan_nodes_by_label(["Person", "SoftwareEngineering"])
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%arg0) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/match_scan_nodes_by_single_label.mlir
+++ b/samples/mlir/match_scan_nodes_by_single_label.mlir
@@ -1,0 +1,7 @@
+// MATCH (n:Person) RETURN  *
+
+func.func @main() {
+  %0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  db.output(%0) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_scan_nodes_by_single_label.nl.mlir
+++ b/samples/mlir/match_scan_nodes_by_single_label.nl.mlir
@@ -1,0 +1,9 @@
+// MATCH (n:Person) RETURN  *
+
+func.func @main() {
+  %0 = nl.scan_nodes_by_label(["Person"])
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%arg0) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -9,9 +9,11 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
 
 #include "DBDialect.h"
 #include "DBOps.h"
+#include "DBPasses.h"
 #include "StorageDialect.h"
 #include "StorageTypes.h"
 
@@ -1471,6 +1473,62 @@ TEST_F(DBDialectTest, deleteEdgeRoundTripsThroughTextualForm) {
     const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
     ASSERT_TRUE(reparsed);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+// `MATCH (n:Person) RETURN n` with no optimisation applied
+const char* const labelScanChainProgram = R"mlir(
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_label_set(%0) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %2 = db.check_label_constraint(%1, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %3 = db.filter(%2, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%3) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(DBDialectTest, fuseScanByLabelCollapsesLabelFilterChain) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(labelScanChainProgram);
+    ASSERT_TRUE(module);
+
+    mlir::PassManager passManager(&_context);
+    passManager.addPass(mlir::db::createFuseScanByLabel());
+    ASSERT_TRUE(mlir::succeeded(passManager.run(*module)));
+
+    // The chain collapsed to one scan_nodes_by_label carrying the label.
+    mlir::db::ScanNodesByLabel scanByLabel;
+    module.get().walk([&](mlir::db::ScanNodesByLabel op) {
+        scanByLabel = op;
+    });
+    ASSERT_TRUE(scanByLabel);
+
+    const mlir::ArrayAttr labels = scanByLabel.getLabels();
+    ASSERT_EQ(labels.size(), 1u);
+    EXPECT_EQ(mlir::cast<mlir::StringAttr>(labels[0]).getValue(), "Person");
+
+    // None of the original chain survives.
+    size_t scans = 0;
+    size_t labelSets = 0;
+    size_t checks = 0;
+    size_t filters = 0;
+    module.get().walk([&](mlir::Operation* op) {
+        if (mlir::isa<mlir::db::ScanNodes>(op)) {
+            scans++;
+        } else if (mlir::isa<mlir::db::GetNodeLabelSet>(op)) {
+            labelSets++;
+        } else if (mlir::isa<mlir::db::CheckLabelConstraint>(op)) {
+            checks++;
+        } else if (mlir::isa<mlir::db::FilterOp>(op)) {
+            filters++;
+        }
+    });
+
+    EXPECT_EQ(scans, 0u);
+    EXPECT_EQ(labelSets, 0u);
+    EXPECT_EQ(checks, 0u);
+    EXPECT_EQ(filters, 0u);
+
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));
 }
 
 }


### PR DESCRIPTION
Integrate `DBPasses` into the MLIR build system.

As an example, implements a peephole optimisation which transforms a `ScanNodes` followed by a labelset-filter into a `ScanNodesByLabel`(Set) operation