### PR TITLE
MLIR: Implement the Cypher collect() aggregate, including lists of nodes and edges

### DIFF
--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -94,6 +94,16 @@ void FunctionDecls::initDefault() {
     collectBools->setReturnTypes({{EvaluatedType::List}});
     collectBools->setIsAggregate(true);
 
+    FunctionSignature* collectNodes = createFunction("collect");
+    collectNodes->setArguments({EvaluatedType::NodePattern});
+    collectNodes->setReturnTypes({{EvaluatedType::List}});
+    collectNodes->setIsAggregate(true);
+
+    FunctionSignature* collectEdges = createFunction("collect");
+    collectEdges->setArguments({EvaluatedType::EdgePattern});
+    collectEdges->setReturnTypes({{EvaluatedType::List}});
+    collectEdges->setIsAggregate(true);
+
     // count(null) is a query that can be asked: a null is never charged, so the tally is
     // zero, and the overload is what keeps the answer from being an argument error
     FunctionSignature* countNulls = createFunction("count");

--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -104,6 +104,13 @@ void FunctionDecls::initDefault() {
     collectEdges->setReturnTypes({{EvaluatedType::List}});
     collectEdges->setIsAggregate(true);
 
+    // collect(null) is a query that can be asked: every row's null is dropped, so the list
+    // comes out empty, and the overload is what keeps the answer from being an argument error
+    FunctionSignature* collectNulls = createFunction("collect");
+    collectNulls->setArguments({EvaluatedType::Null});
+    collectNulls->setReturnTypes({{EvaluatedType::List}});
+    collectNulls->setIsAggregate(true);
+
     // count(null) is a query that can be asked: a null is never charged, so the tally is
     // zero, and the overload is what keeps the answer from being an argument error
     FunctionSignature* countNulls = createFunction("count");

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -409,10 +409,11 @@ int64_t evaluateConstantInteger(const Expr* expr) {
     }
 }
 
-// Collect is only supported when it is the only aggregate in a return projection
+// Each collect drains through a loop of its own, and one emit cannot read two of them:
+// the second list is bound in a loop the output is not in. Every other aggregate
+// collapses to a single row above the drain, which the emit does read.
 void throwIfCollectUnsupported(const Projection* projection) {
     size_t collectCount = 0;
-    size_t aggregateCount = 0;
 
     for (const Projection::ReturnItem& returnItem : projection->items()) {
         Expr* const* itemPtr = std::get_if<Expr*>(&returnItem);
@@ -421,12 +422,6 @@ void throwIfCollectUnsupported(const Projection* projection) {
         }
 
         const Expr* item = *itemPtr;
-
-        if (!item->isAggregate()) {
-            continue;
-        }
-
-        aggregateCount++;
 
         const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
         if (!isInvocation) {
@@ -442,9 +437,8 @@ void throwIfCollectUnsupported(const Projection* projection) {
         }
     }
 
-    const bool mixesAggregates = collectCount > 0 && aggregateCount > 1;
-    if (mixesAggregates) {
-        throw TuringException("collect() may not yet be combined with another aggregate.");
+    if (collectCount > 1) {
+        throw TuringException("collect() may not yet be combined with another collect().");
     }
 }
 
@@ -3331,7 +3325,7 @@ void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
         _part._exprMap[expr] = _opBuilder.create<mlir::db::Avg>(loc, noneType, inputColumn, reducesDistinctValues).getResult();
     } else if (funcName == "collect") {
         mlir::db::Collect collectOp = createCollect({}, inputColumn, reducesDistinctValues);
-        _part._exprMap[expr] = collectOp.getResults().front();
+        _part._exprMap[expr] = collectOp.getResults().back();
     } else {
         throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
     }
@@ -3379,16 +3373,12 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
 
 mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
                                                     mlir::Value valueColumn,
-                                                    bool distinctValues) {
-    // A constant column is bound above the scan loop, so the collect would fold its one
-    // value once instead of once per row: the list would hold a single element where
-    // Cypher collects one per matched row.
-    if (yieldsConstantColumn(valueColumn)) {
-        throw TuringException("collect() of a constant expression is not yet supported.");
-    }
-
+                                                    bool distinctValues,
+                                                    llvm::ArrayRef<mlir::Value> aggregateColumns,
+                                                    llvm::ArrayRef<mlir::storage::GroupAggregateKind> aggregateKinds) {
     llvm::SmallVector<mlir::Value> columns(keyColumns.begin(), keyColumns.end());
     columns.push_back(valueColumn);
+    columns.append(aggregateColumns.begin(), aggregateColumns.end());
 
     llvm::SmallVector<mlir::Type> resultTypes;
     for (const mlir::Value keyColumn : keyColumns) {
@@ -3399,10 +3389,23 @@ mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> 
     const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, valueType.getType());
     resultTypes.push_back(allocColumnType(listType));
 
+    // An aggregate's result type is resolved during lowering, as db.group_aggregate's is.
+    const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
+    llvm::SmallVector<int64_t> kindValues;
+    for (const mlir::storage::GroupAggregateKind kind : aggregateKinds) {
+        kindValues.push_back(static_cast<int64_t>(kind));
+        resultTypes.push_back(noneType);
+    }
+
+    const mlir::DenseI64ArrayAttr kindsAttr = kindValues.empty()
+                                                  ? mlir::DenseI64ArrayAttr {}
+                                                  : _opBuilder.getDenseI64ArrayAttr(kindValues);
+
     return _opBuilder.create<mlir::db::Collect>(_opBuilder.getUnknownLoc(),
                                                 mlir::TypeRange {resultTypes},
                                                 mlir::ValueRange {columns},
                                                 static_cast<uint64_t>(keyColumns.size()),
+                                                kindsAttr,
                                                 distinctValues);
 }
 
@@ -3411,9 +3414,8 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         return;
     }
 
-    throwIfCollectUnsupported(projection);
-
     if (!projection->hasGroupingKeys()) {
+        throwIfCollectUnsupported(projection);
         return;
     }
 
@@ -3601,6 +3603,13 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     const size_t collectCount = collectInputColumns.size();
     bioassert(aggCount + collectCount > 0, "grouped aggregate with no aggregate columns.");
 
+    // Only the leading collect is built and only its list is mapped below, so a second
+    // collect would be dropped here - and reappear in generateOutput as an ungrouped
+    // collect of its own, next to this grouped one
+    if (collectCount > 1) {
+        throw TuringException("collect() may not yet be combined with another collect().");
+    }
+
     // Every non-aggregate item was constant, so nothing tells the matched rows apart:
     // the projection is one group, which is the scalar aggregate the projection
     // translates on its own - RETURN 1 AS x, count(n) counts the whole match
@@ -3613,19 +3622,16 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     mlir::Operation* aggregateOp = nullptr;
 
     if (isCollecting) {
-        // Only the leading collect is built and only the collect items are mapped below, so
-        // a second collect or a scalar aggregate would be dropped here - and reappear in
-        // generateOutput as an ungrouped aggregate of its own, next to this grouped one
-        bioassert(collectCount == 1 && aggCount == 0,
-                  "Collect lowered alongside {} other collects and {} scalar aggregates.",
-                  collectCount - 1,
-                  aggCount);
-
+        // One accumulator holds the groups both the list and the reductions read, so the
+        // collect carries the other aggregates rather than a second op grouping the same
+        // rows again.
         const FunctionInvocation* collectInvocation = collectFuncExprs.front()->getFunctionInvocation();
 
         mlir::db::Collect collectOp = createCollect(keyColumns,
                                                     collectInputColumns.front(),
-                                                    collectInvocation->isDistinct());
+                                                    collectInvocation->isDistinct(),
+                                                    aggInputColumns,
+                                                    aggKinds);
         aggregateOp = collectOp.getOperation();
     } else {
         llvm::SmallVector<mlir::Value> allColumns;
@@ -3707,7 +3713,14 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         }
     }
 
-    const llvm::SmallVector<const FunctionInvocationExpr*>& aggregateItems = isCollecting ? collectFuncExprs : aggFuncExprs;
+    // The results behind the keys are the collect's list then its reductions, or - with
+    // no collect - the reductions alone.
+    llvm::SmallVector<const FunctionInvocationExpr*> aggregateItems;
+    if (isCollecting) {
+        aggregateItems.push_back(collectFuncExprs.front());
+    }
+
+    aggregateItems.append(aggFuncExprs.begin(), aggFuncExprs.end());
 
     for (size_t i = 0; i < aggregateItems.size(); i++) {
         const FunctionInvocationExpr* aggregateItem = aggregateItems[i];

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -409,36 +409,42 @@ int64_t evaluateConstantInteger(const Expr* expr) {
     }
 }
 
-// Each collect drains through a loop of its own, and one emit cannot read two of them:
-// the second list is bound in a loop the output is not in. Every other aggregate
-// collapses to a single row above the drain, which the emit does read.
-void throwIfCollectUnsupported(const Projection* projection) {
-    size_t collectCount = 0;
+bool isCollectInvocation(const Expr* item) {
+    if (item->getKind() != Expr::Kind::FUNCTION_INVOCATION) {
+        return false;
+    }
 
+    const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(item);
+    const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
+
+    return invocation->getSignature()->getFullName() == "collect";
+}
+
+// The collects that dedupe, by their position among the collected columns: db.collect
+// names them that way rather than carrying a flag, since one projection may collect a
+// column both ways
+void collectDistinctValueIndices(llvm::ArrayRef<const FunctionInvocationExpr*> collects,
+                                 llvm::SmallVectorImpl<int64_t>& distinctValues) {
+    for (size_t collectIndex = 0; collectIndex < collects.size(); collectIndex++) {
+        const FunctionInvocation* invocation = collects[collectIndex]->getFunctionInvocation();
+
+        if (invocation->isDistinct()) {
+            distinctValues.push_back(static_cast<int64_t>(collectIndex));
+        }
+    }
+}
+
+void collectProjectedCollects(const Projection* projection,
+                              llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found) {
     for (const Projection::ReturnItem& returnItem : projection->items()) {
         Expr* const* itemPtr = std::get_if<Expr*>(&returnItem);
         if (!itemPtr) {
             continue;
         }
 
-        const Expr* item = *itemPtr;
-
-        const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
-        if (!isInvocation) {
-            continue;
+        if (isCollectInvocation(*itemPtr)) {
+            found.push_back(static_cast<const FunctionInvocationExpr*>(*itemPtr));
         }
-
-        const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(item);
-        const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
-        const std::string_view funcName = invocation->getSignature()->getFullName();
-
-        if (funcName == "collect") {
-            collectCount++;
-        }
-    }
-
-    if (collectCount > 1) {
-        throw TuringException("collect() may not yet be combined with another collect().");
     }
 }
 
@@ -3324,7 +3330,12 @@ void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
     } else if (funcName == "avg") {
         _part._exprMap[expr] = _opBuilder.create<mlir::db::Avg>(loc, noneType, inputColumn, reducesDistinctValues).getResult();
     } else if (funcName == "collect") {
-        mlir::db::Collect collectOp = createCollect({}, inputColumn, reducesDistinctValues);
+        llvm::SmallVector<int64_t> distinctValues;
+        if (reducesDistinctValues) {
+            distinctValues.push_back(0);
+        }
+
+        mlir::db::Collect collectOp = createCollect({}, {inputColumn}, distinctValues);
         _part._exprMap[expr] = collectOp.getResults().back();
     } else {
         throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
@@ -3372,12 +3383,12 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
 }
 
 mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
-                                                    mlir::Value valueColumn,
-                                                    bool distinctValues,
+                                                    llvm::ArrayRef<mlir::Value> valueColumns,
+                                                    llvm::ArrayRef<int64_t> distinctValues,
                                                     llvm::ArrayRef<mlir::Value> aggregateColumns,
                                                     llvm::ArrayRef<mlir::storage::GroupAggregateKind> aggregateKinds) {
     llvm::SmallVector<mlir::Value> columns(keyColumns.begin(), keyColumns.end());
-    columns.push_back(valueColumn);
+    columns.append(valueColumns.begin(), valueColumns.end());
     columns.append(aggregateColumns.begin(), aggregateColumns.end());
 
     llvm::SmallVector<mlir::Type> resultTypes;
@@ -3385,9 +3396,12 @@ mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> 
         resultTypes.push_back(keyColumn.getType());
     }
 
-    const mlir::db::ColumnType valueType = mlir::cast<mlir::db::ColumnType>(valueColumn.getType());
-    const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, valueType.getType());
-    resultTypes.push_back(allocColumnType(listType));
+    for (const mlir::Value valueColumn : valueColumns) {
+        const mlir::db::ColumnType valueType = mlir::cast<mlir::db::ColumnType>(valueColumn.getType());
+        const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, valueType.getType());
+
+        resultTypes.push_back(allocColumnType(listType));
+    }
 
     // An aggregate's result type is resolved during lowering, as db.group_aggregate's is.
     const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
@@ -3401,12 +3415,59 @@ mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> 
                                                   ? mlir::DenseI64ArrayAttr {}
                                                   : _opBuilder.getDenseI64ArrayAttr(kindValues);
 
+    const mlir::DenseI64ArrayAttr distinctAttr = distinctValues.empty()
+                                                     ? mlir::DenseI64ArrayAttr {}
+                                                     : _opBuilder.getDenseI64ArrayAttr(distinctValues);
+
     return _opBuilder.create<mlir::db::Collect>(_opBuilder.getUnknownLoc(),
                                                 mlir::TypeRange {resultTypes},
                                                 mlir::ValueRange {columns},
                                                 static_cast<uint64_t>(keyColumns.size()),
                                                 kindsAttr,
-                                                distinctValues);
+                                                distinctAttr);
+}
+
+void DBProgramGenerator::generateKeylessCollect(const Projection* projection) {
+    llvm::SmallVector<const FunctionInvocationExpr*> collectExprs;
+    collectProjectedCollects(projection, collectExprs);
+
+    // A lone collect is built by its own translation, keyless, as any other aggregate is
+    if (collectExprs.size() < 2) {
+        return;
+    }
+
+    VariableColumnMap variableColumns;
+    collectVariableColumns(variableColumns);
+
+    llvm::SmallVector<mlir::Value> valueColumns;
+    for (const FunctionInvocationExpr* collectExpr : collectExprs) {
+        const FunctionInvocation* invocation = collectExpr->getFunctionInvocation();
+
+        const ExprChain* args = invocation->getArguments();
+        bioassert(args && !args->empty(), "collect() with no arguments.");
+
+        valueColumns.push_back(translateAggregateInput(args->front(), &variableColumns));
+    }
+
+    llvm::SmallVector<int64_t> distinctValues;
+    collectDistinctValueIndices(collectExprs, distinctValues);
+
+    mlir::db::Collect collectOp = createCollect({}, valueColumns, distinctValues);
+    const mlir::ResultRange results = collectOp.getResults();
+
+    for (size_t collectIndex = 0; collectIndex < collectExprs.size(); collectIndex++) {
+        const FunctionInvocationExpr* collectExpr = collectExprs[collectIndex];
+        const mlir::Value listColumn = results[collectIndex];
+
+        _part._exprMap[collectExpr] = listColumn;
+
+        // The alias of a collect names its list, so a later item spelling that alias
+        // reads this column instead of collecting a second time
+        const VarDecl* collectDecl = collectExpr->getExprVarDecl();
+        if (collectDecl) {
+            _part._projectedColumns[collectDecl] = listColumn;
+        }
+    }
 }
 
 void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
@@ -3415,7 +3476,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     }
 
     if (!projection->hasGroupingKeys()) {
-        throwIfCollectUnsupported(projection);
+        generateKeylessCollect(projection);
         return;
     }
 
@@ -3603,13 +3664,6 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     const size_t collectCount = collectInputColumns.size();
     bioassert(aggCount + collectCount > 0, "grouped aggregate with no aggregate columns.");
 
-    // Only the leading collect is built and only its list is mapped below, so a second
-    // collect would be dropped here - and reappear in generateOutput as an ungrouped
-    // collect of its own, next to this grouped one
-    if (collectCount > 1) {
-        throw TuringException("collect() may not yet be combined with another collect().");
-    }
-
     // Every non-aggregate item was constant, so nothing tells the matched rows apart:
     // the projection is one group, which is the scalar aggregate the projection
     // translates on its own - RETURN 1 AS x, count(n) counts the whole match
@@ -3622,14 +3676,15 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     mlir::Operation* aggregateOp = nullptr;
 
     if (isCollecting) {
-        // One accumulator holds the groups both the list and the reductions read, so the
-        // collect carries the other aggregates rather than a second op grouping the same
-        // rows again.
-        const FunctionInvocation* collectInvocation = collectFuncExprs.front()->getFunctionInvocation();
+        // One accumulator holds the groups every list and every reduction reads, so the
+        // collects carry each other and the other aggregates rather than a second op
+        // grouping the same rows again.
+        llvm::SmallVector<int64_t> distinctCollects;
+        collectDistinctValueIndices(collectFuncExprs, distinctCollects);
 
         mlir::db::Collect collectOp = createCollect(keyColumns,
-                                                    collectInputColumns.front(),
-                                                    collectInvocation->isDistinct(),
+                                                    collectInputColumns,
+                                                    distinctCollects,
                                                     aggInputColumns,
                                                     aggKinds);
         aggregateOp = collectOp.getOperation();
@@ -3713,13 +3768,10 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         }
     }
 
-    // The results behind the keys are the collect's list then its reductions, or - with
+    // The results behind the keys are the collects' lists then the reductions, or - with
     // no collect - the reductions alone.
-    llvm::SmallVector<const FunctionInvocationExpr*> aggregateItems;
-    if (isCollecting) {
-        aggregateItems.push_back(collectFuncExprs.front());
-    }
-
+    llvm::SmallVector<const FunctionInvocationExpr*> aggregateItems(collectFuncExprs.begin(),
+                                                                    collectFuncExprs.end());
     aggregateItems.append(aggFuncExprs.begin(), aggFuncExprs.end());
 
     for (size_t i = 0; i < aggregateItems.size(); i++) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -422,12 +422,16 @@ void throwIfCollectUnsupported(const Projection* projection) {
 
         const Expr* item = *itemPtr;
 
-        const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
-        if (!item->isAggregate() || !isInvocation) {
+        if (!item->isAggregate()) {
             continue;
         }
 
         aggregateCount++;
+
+        const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
+        if (!isInvocation) {
+            continue;
+        }
 
         const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(item);
         const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
@@ -2286,15 +2290,20 @@ mlir::Value DBProgramGenerator::resolveColumnInScope(ColumnPredicate accept) con
     return mlir::Value {};
 }
 
-mlir::Value DBProgramGenerator::translateAggregateInput(const Expr* argExpr) {
+mlir::Value DBProgramGenerator::translateAggregateInput(const Expr* argExpr,
+                                                        const VariableColumnMap* variableColumns) {
     const EvaluatedType argType = argExpr->getType();
     const bool isEntity = argType == EvaluatedType::NodePattern || argType == EvaluatedType::EdgePattern;
 
     if (isEntity) {
-        VariableColumnMap variableColumns;
-        collectVariableColumns(variableColumns);
+        if (variableColumns) {
+            return getOrTranslateExprColumn(*variableColumns, argExpr);
+        }
 
-        return getOrTranslateExprColumn(variableColumns, argExpr);
+        VariableColumnMap ownColumns;
+        collectVariableColumns(ownColumns);
+
+        return getOrTranslateExprColumn(ownColumns, argExpr);
     } else if (argType != EvaluatedType::Wildcard) {
         translateExpr(argExpr);
         return _part._exprMap.at(argExpr);
@@ -3299,7 +3308,7 @@ void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
     bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
 
     const Expr* argExpr = args->front();
-    const mlir::Value inputColumn = translateAggregateInput(argExpr);
+    const mlir::Value inputColumn = translateAggregateInput(argExpr, nullptr);
 
     const bool isDistinct = invocation->isDistinct();
 
@@ -3550,7 +3559,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         const Expr* argExpr = args->front();
 
         if (funcName == "collect") {
-            const mlir::Value collectInput = translateAggregateInput(argExpr);
+            const mlir::Value collectInput = translateAggregateInput(argExpr, &variableColumns);
 
             collectInputColumns.push_back(collectInput);
             collectFuncExprs.push_back(funcExpr);
@@ -3580,7 +3589,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
             throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
         }
 
-        const mlir::Value inputColumn = translateAggregateInput(argExpr);
+        const mlir::Value inputColumn = translateAggregateInput(argExpr, &variableColumns);
 
         aggInputColumns.push_back(inputColumn);
         aggKinds.push_back(*kind);

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -409,6 +409,45 @@ int64_t evaluateConstantInteger(const Expr* expr) {
     }
 }
 
+// A collect and a scalar aggregate each lower to an accumulator of their own, drained by
+// an emit loop of their own, and the projection is output from a single loop: two of them
+// in one projection would have to be read from a loop the output is not in. Only top-level
+// items are counted: an aggregate nested into a map is not a function invocation, and is
+// rejected where the grouping keys are read
+void throwIfCollectUnsupported(const Projection* projection) {
+    size_t collectCount = 0;
+    size_t aggregateCount = 0;
+
+    for (const Projection::ReturnItem& returnItem : projection->items()) {
+        Expr* const* itemPtr = std::get_if<Expr*>(&returnItem);
+        if (!itemPtr) {
+            continue;
+        }
+
+        const Expr* item = *itemPtr;
+
+        const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
+        if (!item->isAggregate() || !isInvocation) {
+            continue;
+        }
+
+        aggregateCount++;
+
+        const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(item);
+        const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
+        const std::string_view funcName = invocation->getSignature()->getFullName();
+
+        if (funcName == "collect") {
+            collectCount++;
+        }
+    }
+
+    const bool mixesAggregates = collectCount > 0 && aggregateCount > 1;
+    if (mixesAggregates) {
+        throw TuringException("collect() may not yet be combined with another aggregate.");
+    }
+}
+
 }
 
 DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule)
@@ -3278,17 +3317,7 @@ void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
     } else if (funcName == "avg") {
         _part._exprMap[expr] = _opBuilder.create<mlir::db::Avg>(loc, noneType, inputColumn, reducesDistinctValues).getResult();
     } else if (funcName == "collect") {
-        // collect gathers values rather than reducing them, so it is db.collect rather
-        // than one of the reductions: with no grouping key it is the keyless form, whose
-        // one row holds the whole match's values as a list
-        const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, mlir::NoneType::get(_mlirCtxt));
-        const mlir::db::ColumnType listColumnType = allocColumnType(listType);
-
-        auto collectOp = _opBuilder.create<mlir::db::Collect>(loc,
-                                                             mlir::TypeRange {listColumnType},
-                                                             mlir::ValueRange {inputColumn},
-                                                             /*keyCount=*/0,
-                                                             reducesDistinctValues);
+        mlir::db::Collect collectOp = createCollect({}, inputColumn, reducesDistinctValues);
         _part._exprMap[expr] = collectOp.getResults().front();
     } else {
         throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
@@ -3335,8 +3364,43 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
     throw TuringException(fmt::format("Unsupported function: {}", funcName));
 }
 
+mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
+                                                    mlir::Value valueColumn,
+                                                    bool distinctValues) {
+    // A constant column is bound above the scan loop, so the collect would fold its one
+    // value once instead of once per row: the list would hold a single element where
+    // Cypher collects one per matched row.
+    if (yieldsConstantColumn(valueColumn)) {
+        throw TuringException("collect() of a constant expression is not yet supported.");
+    }
+
+    llvm::SmallVector<mlir::Value> columns(keyColumns.begin(), keyColumns.end());
+    columns.push_back(valueColumn);
+
+    llvm::SmallVector<mlir::Type> resultTypes;
+    for (const mlir::Value keyColumn : keyColumns) {
+        resultTypes.push_back(keyColumn.getType());
+    }
+
+    const mlir::db::ColumnType valueType = mlir::cast<mlir::db::ColumnType>(valueColumn.getType());
+    const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, valueType.getType());
+    resultTypes.push_back(allocColumnType(listType));
+
+    return _opBuilder.create<mlir::db::Collect>(_opBuilder.getUnknownLoc(),
+                                                mlir::TypeRange {resultTypes},
+                                                mlir::ValueRange {columns},
+                                                static_cast<uint64_t>(keyColumns.size()),
+                                                distinctValues);
+}
+
 void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
-    if (!projection->isAggregate() || !projection->hasGroupingKeys()) {
+    if (!projection->isAggregate()) {
+        return;
+    }
+
+    throwIfCollectUnsupported(projection);
+
+    if (!projection->hasGroupingKeys()) {
         return;
     }
 
@@ -3373,6 +3437,9 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     llvm::SmallVector<mlir::storage::GroupAggregateKind> aggKinds;
     llvm::SmallVector<const FunctionInvocationExpr*> aggFuncExprs;
     llvm::SmallVector<const FunctionInvocationExpr*> itemInvocations;
+
+    llvm::SmallVector<mlir::Value> collectInputColumns;
+    llvm::SmallVector<const FunctionInvocationExpr*> collectFuncExprs;
 
     const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
     const mlir::Location loc = _opBuilder.getUnknownLoc();
@@ -3480,11 +3547,17 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
         const std::string_view funcName = invocation->getSignature()->getFullName();
 
+        const ExprChain* args = invocation->getArguments();
+        bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
+
+        const Expr* argExpr = args->front();
+
         if (funcName == "collect") {
-            // db.collect groups on its own rather than being one function of a
-            // db.group_aggregate, so a collect beside a grouping key would need the two to
-            // be grouped together - the keyless form is what the frontend generates today
-            throw TuringException("collect() with grouping keys is not supported yet");
+            const mlir::Value collectInput = translateAggregateInput(argExpr);
+
+            collectInputColumns.push_back(collectInput);
+            collectFuncExprs.push_back(funcExpr);
+            continue;
         }
 
         // Dropping repeated values cannot move an extremum, so min(DISTINCT x) is min(x)
@@ -3494,10 +3567,6 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         const bool isExtremum = funcName == "min" || funcName == "max";
         const bool reducesDistinctValues = invocation->isDistinct() && !isExtremum;
 
-        const ExprChain* args = invocation->getArguments();
-        bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
-
-        const Expr* argExpr = args->front();
         const bool countsRows = argExpr->getType() == EvaluatedType::Wildcard;
 
         // count(*) reads no value, so a null of the column it is anchored on is a row
@@ -3523,7 +3592,8 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
 
     const size_t keyCount = keyColumns.size();
     const size_t aggCount = aggInputColumns.size();
-    bioassert(aggCount > 0, "grouped aggregate with no aggregate columns.");
+    const size_t collectCount = collectInputColumns.size();
+    bioassert(aggCount + collectCount > 0, "grouped aggregate with no aggregate columns.");
 
     // Every non-aggregate item was constant, so nothing tells the matched rows apart:
     // the projection is one group, which is the scalar aggregate the projection
@@ -3532,35 +3602,58 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         return;
     }
 
-    llvm::SmallVector<mlir::Value> allColumns;
-    for (const mlir::Value col : keyColumns) {
-        allColumns.push_back(col);
-    }
-    for (const mlir::Value col : aggInputColumns) {
-        allColumns.push_back(col);
+    const bool isCollecting = collectCount > 0;
+
+    mlir::Operation* aggregateOp = nullptr;
+
+    if (isCollecting) {
+        // Only the leading collect is built and only the collect items are mapped below, so
+        // a second collect or a scalar aggregate would be dropped here - and reappear in
+        // generateOutput as an ungrouped aggregate of its own, next to this grouped one
+        bioassert(collectCount == 1 && aggCount == 0,
+                  "Collect lowered alongside {} other collects and {} scalar aggregates.",
+                  collectCount - 1,
+                  aggCount);
+
+        const FunctionInvocation* collectInvocation = collectFuncExprs.front()->getFunctionInvocation();
+
+        mlir::db::Collect collectOp = createCollect(keyColumns,
+                                                    collectInputColumns.front(),
+                                                    collectInvocation->isDistinct());
+        aggregateOp = collectOp.getOperation();
+    } else {
+        llvm::SmallVector<mlir::Value> allColumns;
+        for (const mlir::Value col : keyColumns) {
+            allColumns.push_back(col);
+        }
+        for (const mlir::Value col : aggInputColumns) {
+            allColumns.push_back(col);
+        }
+
+        llvm::SmallVector<mlir::Type> resultTypes;
+        for (const mlir::Value col : keyColumns) {
+            resultTypes.push_back(col.getType());
+        }
+        for (size_t i = 0; i < aggCount; i++) {
+            resultTypes.push_back(noneType);
+        }
+
+        llvm::SmallVector<int64_t> aggKindValues;
+        for (const mlir::storage::GroupAggregateKind kind : aggKinds) {
+            aggKindValues.push_back(static_cast<int64_t>(kind));
+        }
+
+        mlir::db::GroupAggregate groupAgg = _opBuilder.create<mlir::db::GroupAggregate>(
+            loc,
+            mlir::TypeRange{resultTypes},
+            mlir::ValueRange{allColumns},
+            static_cast<uint64_t>(keyCount),
+            llvm::ArrayRef<int64_t>{aggKindValues});
+
+        aggregateOp = groupAgg.getOperation();
     }
 
-    llvm::SmallVector<mlir::Type> resultTypes;
-    for (const mlir::Value col : keyColumns) {
-        resultTypes.push_back(col.getType());
-    }
-    for (size_t i = 0; i < aggCount; i++) {
-        resultTypes.push_back(noneType);
-    }
-
-    llvm::SmallVector<int64_t> aggKindValues;
-    for (const mlir::storage::GroupAggregateKind kind : aggKinds) {
-        aggKindValues.push_back(static_cast<int64_t>(kind));
-    }
-
-    auto groupAgg = _opBuilder.create<mlir::db::GroupAggregate>(
-        loc,
-        mlir::TypeRange{resultTypes},
-        mlir::ValueRange{allColumns},
-        static_cast<uint64_t>(keyCount),
-        llvm::ArrayRef<int64_t>{aggKindValues});
-
-    const mlir::ResultRange results = groupAgg.getResults();
+    const mlir::ResultRange results = aggregateOp->getResults();
 
     GroupedColumns groupedColumns;
 
@@ -3608,14 +3701,18 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         }
     }
 
-    for (size_t i = 0; i < aggCount; i++) {
+    const llvm::SmallVector<const FunctionInvocationExpr*>& aggregateItems = isCollecting ? collectFuncExprs : aggFuncExprs;
+
+    for (size_t i = 0; i < aggregateItems.size(); i++) {
+        const FunctionInvocationExpr* aggregateItem = aggregateItems[i];
         const mlir::Value aggregateColumn = results[keyCount + i];
-        _part._exprMap[aggFuncExprs[i]] = aggregateColumn;
-        groupedColumns.emplace_back(aggFuncExprs[i], aggregateColumn);
+
+        _part._exprMap[aggregateItem] = aggregateColumn;
+        groupedColumns.emplace_back(aggregateItem, aggregateColumn);
 
         // The alias of an aggregate names its reduced column, so a key or a later item
         // spelling that alias reads this column instead of computing a second aggregate
-        const VarDecl* aggregateDecl = aggFuncExprs[i]->getExprVarDecl();
+        const VarDecl* aggregateDecl = aggregateItem->getExprVarDecl();
         if (aggregateDecl) {
             _part._projectedColumns[aggregateDecl] = aggregateColumn;
         }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2291,7 +2291,15 @@ mlir::Value DBProgramGenerator::resolveColumnInScope(ColumnPredicate accept) con
 }
 
 mlir::Value DBProgramGenerator::translateAggregateInput(const Expr* argExpr) {
-    if (argExpr->getType() != EvaluatedType::Wildcard) {
+    const EvaluatedType argType = argExpr->getType();
+    const bool isEntity = argType == EvaluatedType::NodePattern || argType == EvaluatedType::EdgePattern;
+
+    if (isEntity) {
+        VariableColumnMap variableColumns;
+        collectVariableColumns(variableColumns);
+
+        return getOrTranslateExprColumn(variableColumns, argExpr);
+    } else if (argType != EvaluatedType::Wildcard) {
         translateExpr(argExpr);
         return _part._exprMap.at(argExpr);
     }
@@ -3405,13 +3413,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     }
 
     VariableColumnMap variableColumns;
-    for (const auto& [cypherVar, mlirCol] : _part._varMap) {
-        variableColumns[cypherVar->getName()] = mlirCol.back();
-    }
-
-    for (const YieldedColumn& yieldedColumn : _part._yieldedColumns) {
-        variableColumns[yieldedColumn.first] = yieldedColumn.second;
-    }
+    collectVariableColumns(variableColumns);
 
     // An edge identity is carried by the traversal variable that produced it, under a
     // name of its own: the representative is where its column - and its grouped
@@ -3419,7 +3421,6 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     llvm::StringMap<const VariableDependency*> edgeIdentityVars;
     for (const auto& [name, vars] : _vdg.edgeIdentities()) {
         if (!vars.empty() && _part._varMap.contains(vars.front())) {
-            variableColumns[name] = _part._varMap.at(vars.front()).back();
             edgeIdentityVars[name] = vars.front();
         }
     }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -409,11 +409,7 @@ int64_t evaluateConstantInteger(const Expr* expr) {
     }
 }
 
-// A collect and a scalar aggregate each lower to an accumulator of their own, drained by
-// an emit loop of their own, and the projection is output from a single loop: two of them
-// in one projection would have to be read from a loop the output is not in. Only top-level
-// items are counted: an aggregate nested into a map is not a function invocation, and is
-// rejected where the grouping keys are read
+// Collect is only supported when it is the only aggregate in a return projection
 void throwIfCollectUnsupported(const Projection* projection) {
     size_t collectCount = 0;
     size_t aggregateCount = 0;

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -376,7 +376,9 @@ private:
 
     mlir::db::Collect createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
                                     mlir::Value valueColumn,
-                                    bool distinctValues);
+                                    bool distinctValues,
+                                    llvm::ArrayRef<mlir::Value> aggregateColumns = {},
+                                    llvm::ArrayRef<mlir::storage::GroupAggregateKind> aggregateKinds = {});
 
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -374,11 +374,17 @@ private:
     bool collectAggregateInvocations(const Expr* expr,
                                      llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found);
 
+    // One db.collect gathering every list the projection returns: the collects share the
+    // group table, so a second list is another value column rather than another op
     mlir::db::Collect createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
-                                    mlir::Value valueColumn,
-                                    bool distinctValues,
+                                    llvm::ArrayRef<mlir::Value> valueColumns,
+                                    llvm::ArrayRef<int64_t> distinctValues,
                                     llvm::ArrayRef<mlir::Value> aggregateColumns = {},
                                     llvm::ArrayRef<mlir::storage::GroupAggregateKind> aggregateKinds = {});
+
+    // The collects a keyless projection returns, built as one op so a single drain emits
+    // them all. One collect needs no help: its own translation is that op.
+    void generateKeylessCollect(const Projection* projection);
 
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -372,6 +372,10 @@ private:
     bool collectAggregateInvocations(const Expr* expr,
                                      llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found);
 
+    mlir::db::Collect createCollect(llvm::ArrayRef<mlir::Value> keyColumns,
+                                    mlir::Value valueColumn,
+                                    bool distinctValues);
+
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);
     void translateBinaryExpr(const Expr* expr, const BinaryExpr* binExpr);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -354,8 +354,10 @@ private:
     mlir::Value resolveWildcardColumn() const;
 
     // The column an aggregate folds over: the column count(*) counts, or the one its
-    // argument's translation computes
-    mlir::Value translateAggregateInput(const Expr* argExpr);
+    // argument's translation computes. @param variableColumns resolves an entity
+    // argument, and may be null, in which case a map is built to resolve it through
+    mlir::Value translateAggregateInput(const Expr* argExpr,
+                                        const VariableColumnMap* variableColumns);
 
     void generatePropertyConstraints(std::span<Stmt* const> stmts);
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -562,20 +562,25 @@ LogicalResult Collect::verify() {
     const Operation::result_range results = getResults();
     const uint64_t keyCount = getKeyCount();
 
-    // Exactly one collected column follows the grouping keys. Bound keyCount by the
-    // real column count first: summing keyCount + 1 could wrap in unsigned 64-bit and
-    // let a pathological keyCount slip past into out-of-bounds lowering.
+    // The collected column follows the grouping keys, and one aggregate input follows it
+    // per kind. Bound keyCount by the real column count first: summing keyCount + 1 could
+    // wrap in unsigned 64-bit and let a pathological keyCount slip past into
+    // out-of-bounds lowering.
     const size_t columnCount = columns.size();
-    if (keyCount >= columnCount || columnCount - keyCount != 1) {
+    const size_t aggregateCount = getKinds() ? getKinds()->size() : 0;
+    if (keyCount >= columnCount || columnCount - keyCount != 1 + aggregateCount) {
         return emitOpError("expects ") << keyCount
-                                       << " grouping-key columns and one collected column, but has "
+                                       << " grouping-key columns, one collected column and "
+                                       << aggregateCount
+                                       << " aggregate columns, but has "
                                        << columnCount;
     }
 
-    // One result per grouping key then the collected list.
+    // One result per grouping key, the collected list, then one per aggregate.
     if (results.size() != columnCount) {
         return emitOpError("expects ") << columnCount
-                                       << " results, one per grouping key plus the collected list, but has "
+                                       << " results, one per grouping key plus the collected list and the "
+                                          "aggregates, but has "
                                        << results.size();
     }
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -1,10 +1,13 @@
 #include "DBOps.h"
 #include "DBDialect.h"
 
+#include <optional>
+
 #include "llvm/ADT/SmallVector.h"
 
 #include "IRLiteralList.h"
 #include "StorageEnums.h"
+#include "ColumnIndicesFormat.h"
 #include "GroupAggregateKindsFormat.h"
 
 using namespace mlir;
@@ -562,24 +565,27 @@ LogicalResult Collect::verify() {
     const Operation::result_range results = getResults();
     const uint64_t keyCount = getKeyCount();
 
-    // The collected column follows the grouping keys, and one aggregate input follows it
-    // per kind. Bound keyCount by the real column count first: summing keyCount + 1 could
-    // wrap in unsigned 64-bit and let a pathological keyCount slip past into
-    // out-of-bounds lowering.
+    // The collected columns follow the grouping keys, and one aggregate input follows
+    // them per kind, so what is left over after the keys and the aggregates is the value
+    // columns - at least one. Bound keyCount by the real column count first: summing
+    // keyCount + aggregateCount could wrap in unsigned 64-bit and let a pathological
+    // keyCount slip past into out-of-bounds lowering.
     const size_t columnCount = columns.size();
     const size_t aggregateCount = getKinds() ? getKinds()->size() : 0;
-    if (keyCount >= columnCount || columnCount - keyCount != 1 + aggregateCount) {
+    if (keyCount >= columnCount || columnCount - keyCount <= aggregateCount) {
         return emitOpError("expects ") << keyCount
-                                       << " grouping-key columns, one collected column and "
+                                       << " grouping-key columns, at least one collected column and "
                                        << aggregateCount
                                        << " aggregate columns, but has "
                                        << columnCount;
     }
 
-    // One result per grouping key, the collected list, then one per aggregate.
+    const size_t valueCount = columnCount - keyCount - aggregateCount;
+
+    // One result per grouping key, one per collected list, then one per aggregate.
     if (results.size() != columnCount) {
         return emitOpError("expects ") << columnCount
-                                       << " results, one per grouping key plus the collected list and the "
+                                       << " results, one per grouping key plus the collected lists and the "
                                           "aggregates, but has "
                                        << results.size();
     }
@@ -594,19 +600,37 @@ LogicalResult Collect::verify() {
         }
     }
 
-    // The trailing result is the collected list: a column whose element type is a
-    // storage list.
-    const ColumnType listColumn = llvm::dyn_cast<ColumnType>(results[keyCount].getType());
-    if (!listColumn || !llvm::isa<storage::ListType>(listColumn.getType())) {
-        return emitOpError("collected result must be a list column");
+    // Each value's result is the list it collects into: a column whose element type is a
+    // storage list of that value column's type.
+    for (size_t valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+        const size_t position = keyCount + valueIndex;
+
+        const ColumnType listColumn = llvm::dyn_cast<ColumnType>(results[position].getType());
+        if (!listColumn || !llvm::isa<storage::ListType>(listColumn.getType())) {
+            return emitOpError("collected result ") << valueIndex << " must be a list column";
+        }
+
+        const ColumnType valueColumn = llvm::cast<ColumnType>(columns[position].getType());
+        const storage::ListType collectedList = llvm::cast<storage::ListType>(listColumn.getType());
+        if (collectedList.getElementType() != valueColumn.getType()) {
+            return emitOpError("collected result ") << valueIndex
+                                                    << " must be a list of "
+                                                    << valueColumn.getType()
+                                                    << ", the collected column's type, but collects "
+                                                    << collectedList.getElementType();
+        }
     }
 
-    const ColumnType valueColumn = llvm::cast<ColumnType>(columns[keyCount].getType());
-    const storage::ListType collectedList = llvm::cast<storage::ListType>(listColumn.getType());
-    if (collectedList.getElementType() != valueColumn.getType()) {
-        return emitOpError("collected result must be a list of ") << valueColumn.getType()
-                                                                  << ", the collected column's type, but collects "
-                                                                  << collectedList.getElementType();
+    // Every deduplicating value names one of the collected columns.
+    if (const std::optional<llvm::ArrayRef<int64_t>> distinctValues = getDistinctValues()) {
+        for (const int64_t valueIndex : *distinctValues) {
+            if (valueIndex < 0 || static_cast<size_t>(valueIndex) >= valueCount) {
+                return emitOpError("distinct value index ") << valueIndex
+                                                            << " is out of range for "
+                                                            << valueCount
+                                                            << " collected columns";
+            }
+        }
     }
 
     return success();

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1354,35 +1354,41 @@ def Collect : TuringOp<"collect", [Pure]> {
       %gcity, %names = db.collect(%city, %name) keys 1
                          : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
 
-    keyCount is how many leading columns are keys (0 = ungrouped); one value column
-    follows, and then one input per aggregate `aggregates` names - the reductions taken
-    over the same groups, as db.group_aggregate takes them. Results are the keys
-    (unchanged), the list column, then one column per aggregate.
+    keyCount is how many leading columns are keys (0 = ungrouped); the collected value
+    columns follow, one per list the projection returns, and then one input per aggregate
+    `aggregates` names - the reductions taken over the same groups, as db.group_aggregate
+    takes them. Results are the keys (unchanged), one list column per value, then one
+    column per aggregate. The value count is what is left over: columns minus the keys
+    and the aggregate inputs.
 
       %gcity, %names, %n = db.collect(%city, %name, %score) keys 1 aggregates [count]
                              : (...) -> (...)
 
-    `distinct` is Cypher's collect(DISTINCT x): a value repeated in a group is collected
-    once, so the list holds each of the group's distinct values. As on db.count the flag
-    stays on the one op, since the collection is the same over a deduplicated column.
+      %names, %ages = db.collect(%name, %age) keys 0
+                        : (...) -> (!db.column<!storage.list<none>>, !db.column<!storage.list<none>>)
 
-      %names = db.collect(%name) keys 0 distinct : (!db.column<none>) -> !db.column<!storage.list<none>>
+    `distinct` is Cypher's collect(DISTINCT x): a value repeated in a group is collected
+    once, so the list holds each of the group's distinct values. It names the value
+    columns that dedupe by index, since one projection may collect a column both ways.
+
+      %names = db.collect(%name) keys 0 distinct [0] : (!db.column<none>) -> !db.column<!storage.list<none>>
   }];
 
-  // keyCount grouping-key columns, one collected column, then one input per aggregate
-  // kinds names; keyCount is unsigned (never negative).
+  // keyCount grouping-key columns, one or more collected columns, then one input per
+  // aggregate kinds names; keyCount is unsigned (never negative).
   let arguments = (ins Variadic<Column>:$columns,
                        UI64Attr:$keyCount,
                        OptionalAttr<DenseI64ArrayAttr>:$kinds,
-                       UnitAttr:$distinct);
+                       OptionalAttr<DenseI64ArrayAttr>:$distinctValues);
   let results   = (outs Variadic<Column>:$results);
 
   let assemblyFormat = [{
     `(` $columns `)` `keys` $keyCount (`aggregates` custom<GroupAggregateKinds>($kinds)^)?
-    (`distinct` $distinct^)? attr-dict `:` functional-type(operands, results)
+    (`distinct` custom<ColumnIndices>($distinctValues)^)? attr-dict `:` functional-type(operands, results)
   }];
 
-  // keyCount + 1 columns; key results pass through; trailing result is a list column.
+  // At least one value column after the keys; key results pass through; one list result
+  // per value column.
   let hasVerifier = 1;
 }
 

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1354,8 +1354,13 @@ def Collect : TuringOp<"collect", [Pure]> {
       %gcity, %names = db.collect(%city, %name) keys 1
                          : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
 
-    keyCount is how many leading columns are keys (0 = ungrouped); exactly one value
-    column follows. Results are the keys (unchanged) then one list column.
+    keyCount is how many leading columns are keys (0 = ungrouped); one value column
+    follows, and then one input per aggregate `aggregates` names - the reductions taken
+    over the same groups, as db.group_aggregate takes them. Results are the keys
+    (unchanged), the list column, then one column per aggregate.
+
+      %gcity, %names, %n = db.collect(%city, %name, %score) keys 1 aggregates [count]
+                             : (...) -> (...)
 
     `distinct` is Cypher's collect(DISTINCT x): a value repeated in a group is collected
     once, so the list holds each of the group's distinct values. As on db.count the flag
@@ -1364,13 +1369,17 @@ def Collect : TuringOp<"collect", [Pure]> {
       %names = db.collect(%name) keys 0 distinct : (!db.column<none>) -> !db.column<!storage.list<none>>
   }];
 
-  // keyCount grouping-key columns then one collected column; unsigned (never negative).
-  let arguments = (ins Variadic<Column>:$columns, UI64Attr:$keyCount, UnitAttr:$distinct);
+  // keyCount grouping-key columns, one collected column, then one input per aggregate
+  // kinds names; keyCount is unsigned (never negative).
+  let arguments = (ins Variadic<Column>:$columns,
+                       UI64Attr:$keyCount,
+                       OptionalAttr<DenseI64ArrayAttr>:$kinds,
+                       UnitAttr:$distinct);
   let results   = (outs Variadic<Column>:$results);
 
   let assemblyFormat = [{
-    `(` $columns `)` `keys` $keyCount (`distinct` $distinct^)? attr-dict `:`
-    functional-type(operands, results)
+    `(` $columns `)` `keys` $keyCount (`aggregates` custom<GroupAggregateKinds>($kinds)^)?
+    (`distinct` $distinct^)? attr-dict `:` functional-type(operands, results)
   }];
 
   // keyCount + 1 columns; key results pass through; trailing result is a list column.

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -6,6 +6,7 @@
 
 #include "IRLiteralList.h"
 #include "StorageEnums.h"
+#include "ColumnIndicesFormat.h"
 #include "GroupAggregateKindsFormat.h"
 
 using namespace mlir;

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1614,11 +1614,16 @@ def CollectBuffer : NLOp<"collect_buffer", []> {
   }];
 
   // keyCount is unsigned; 0 is a valid ungrouped collect, so nothing to verify here
-  // (the one-value-column split is checked during translation).
-  let arguments = (ins UI64Attr:$keyCount, UnitAttr:$distinct);
+  // (the value-column split is checked during translation). kinds names the reductions
+  // taken over the same groups as the list, one per aggregate input the update carries
+  // after the value column, and is absent when the collect reduces nothing beside it.
+  let arguments = (ins UI64Attr:$keyCount, OptionalAttr<DenseI64ArrayAttr>:$kinds, UnitAttr:$distinct);
   let results   = (outs NLCollectState:$state);
 
-  let assemblyFormat = "`keys` $keyCount (`distinct` $distinct^)? attr-dict";
+  let assemblyFormat = [{
+    `keys` $keyCount (`aggregates` custom<GroupAggregateKinds>($kinds)^)?
+    (`distinct` $distinct^)? attr-dict
+  }];
 }
 
 /**

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1604,25 +1604,31 @@ def CollectBuffer : NLOp<"collect_buffer", []> {
   let description = [{
     Hoisted above the loops; produces the !nl.collect_state handle nl.collect_update
     appends to and the drain reads. `keys` is how many collected columns are grouping
-    keys (0 = one global list); the column types are recovered from the update.
+    keys (0 = one global list); the column types, and how many value columns follow the
+    keys, are recovered from the update.
 
       %buf = nl.collect_buffer keys 1
 
     `distinct` makes the accumulator charge each of a group's values once - Cypher's
-    collect(DISTINCT x). It sits on the buffer rather than the update because it is part
-    of what the accumulator is, as its key count is: the update carries no spec of its own.
+    collect(DISTINCT x) - naming the value columns that dedupe by index. It sits on the
+    buffer rather than the update because it is part of what the accumulator is, as its
+    key count is: the update carries no spec of its own.
+
+      %buf = nl.collect_buffer keys 0 distinct [1]
   }];
 
   // keyCount is unsigned; 0 is a valid ungrouped collect, so nothing to verify here
   // (the value-column split is checked during translation). kinds names the reductions
   // taken over the same groups as the list, one per aggregate input the update carries
-  // after the value column, and is absent when the collect reduces nothing beside it.
-  let arguments = (ins UI64Attr:$keyCount, OptionalAttr<DenseI64ArrayAttr>:$kinds, UnitAttr:$distinct);
+  // after the value columns, and is absent when the collect reduces nothing beside it.
+  let arguments = (ins UI64Attr:$keyCount,
+                       OptionalAttr<DenseI64ArrayAttr>:$kinds,
+                       OptionalAttr<DenseI64ArrayAttr>:$distinctValues);
   let results   = (outs NLCollectState:$state);
 
   let assemblyFormat = [{
     `keys` $keyCount (`aggregates` custom<GroupAggregateKinds>($kinds)^)?
-    (`distinct` $distinct^)? attr-dict
+    (`distinct` custom<ColumnIndices>($distinctValues)^)? attr-dict
   }];
 }
 
@@ -1633,9 +1639,9 @@ def CollectBuffer : NLOp<"collect_buffer", []> {
 def CollectUpdate : NLOp<"collect_update", []> {
   let summary = "Append this step's rows to the per-group value lists";
   let description = [{
-    Assigns each row to its group by the grouping-key tuple and appends its value to
-    that group's list. Columns are the grouping keys then the single value column, per
-    the buffer's `keys`; nulls are dropped (Cypher collect ignores them).
+    Assigns each row to its group by the grouping-key tuple and appends its values to
+    that group's lists. Columns are the grouping keys then the value columns, per the
+    buffer's `keys`; nulls are dropped (Cypher collect ignores them).
 
       nl.collect_update %buf, (%city, %name) : !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<!storage.string>>
   }];
@@ -1677,10 +1683,11 @@ def UnwindCollect : NLOp<"unwind_collect", [Pure]> {
 def Collect : NLOp<"collect", [Pure]> {
   let summary = "Create a database iterator that drains a collect accumulator, one row per group carrying the whole list";
   let description = [{
-    Per-group drain of an nl.collect_state: one row per group - the key values then a
-    list cell (a ListView over the group's elements). An empty group yields an empty
-    list (unlike nl.unwind_collect). The iterator chunk types (keys then the list cell) are
-    spelled after the colon, and it is placed after the producing loop.
+    Per-group drain of an nl.collect_state: one row per group - the key values then one
+    list cell per value column (a ListView over the group's elements). An empty group
+    yields an empty list (unlike nl.unwind_collect). The iterator chunk types (the keys
+    then the list cells) are spelled after the colon, and it is placed after the
+    producing loop.
 
       %rows = nl.collect(%buf) : !nl.iter<!nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.list<!storage.string>>>
   }];

--- a/query/ir/dialect/storage/CMakeLists.txt
+++ b/query/ir/dialect/storage/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_library(turing_db_ir_storagedialect_s
   StorageDialect.cpp
   StorageTypes.cpp
   GroupAggregateKindsFormat.cpp
+  ColumnIndicesFormat.cpp
 
   DEPENDS
   StorageDialectIncGen

--- a/query/ir/dialect/storage/ColumnIndicesFormat.cpp
+++ b/query/ir/dialect/storage/ColumnIndicesFormat.cpp
@@ -1,0 +1,41 @@
+#include "ColumnIndicesFormat.h"
+
+#include <stdint.h>
+
+#include "mlir/IR/Builders.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+ParseResult mlir::parseColumnIndices(OpAsmParser& parser, DenseI64ArrayAttr& indices) {
+    llvm::SmallVector<int64_t> values;
+
+    const auto parseIndex = [&]() -> ParseResult {
+        int64_t value = 0;
+        if (parser.parseInteger(value)) {
+            return failure();
+        }
+
+        values.push_back(value);
+        return success();
+    };
+
+    if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Square, parseIndex)) {
+        return failure();
+    }
+
+    indices = parser.getBuilder().getDenseI64ArrayAttr(values);
+    return success();
+}
+
+void mlir::printColumnIndices(OpAsmPrinter& printer, Operation* op, DenseI64ArrayAttr indices) {
+    printer << "[";
+
+    llvm::interleaveComma(indices.asArrayRef(), printer, [&](int64_t index) {
+        printer << index;
+    });
+
+    printer << "]";
+}

--- a/query/ir/dialect/storage/ColumnIndicesFormat.h
+++ b/query/ir/dialect/storage/ColumnIndicesFormat.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace mlir {
+
+// Custom assembly-format directive shared by db.collect and nl.collect_buffer for the
+// indices naming which of their value columns dedupe. It prints and parses the list in
+// brackets - `[0, 2]` - rather than the builtin `array<i64: 0, 2>` spelling, so it reads
+// like the aggregate-kind list beside it while the ops still store a DenseI64ArrayAttr.
+ParseResult parseColumnIndices(OpAsmParser& parser, DenseI64ArrayAttr& indices);
+
+void printColumnIndices(OpAsmPrinter& printer, Operation* op, DenseI64ArrayAttr indices);
+
+}

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -860,6 +860,18 @@ void distinctAppendElementBytes(std::string& key, const ListElementView element)
             return;
         break;
 
+        case ListBufferTypeTag::NodeID:
+            key.push_back(static_cast<char>(tag));
+            distinctAppendValueBytes(key, element.getAs<NodeID>().getValue());
+            return;
+        break;
+
+        case ListBufferTypeTag::EdgeID:
+            key.push_back(static_cast<char>(tag));
+            distinctAppendValueBytes(key, element.getAs<EdgeID>().getValue());
+            return;
+        break;
+
         case ListBufferTypeTag::Embedding:
             throw IRException("cannot dedup by an embedding element");
         break;
@@ -1509,6 +1521,51 @@ void collectFoldDistinct(Column* values,
 
         const size_t position = valuesRaw.size();
         valuesRaw.push_back(*value);
+        groupPositions[group].push_back(position);
+    }
+}
+
+// The entity sibling of collectFold: an ID chunk has no null rows, so every row of the
+// input joins its group's list.
+template <typename IDType>
+void collectEntityFold(Column* values,
+                       const Column* input,
+                       const std::vector<size_t>& groups,
+                       std::vector<std::vector<size_t>>& groupPositions,
+                       NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
+        groupPositions[groups[row]].push_back(position);
+    }
+}
+
+// The entity sibling of collectFoldDistinct: an entity repeated within its group joins
+// the list once, keyed by the ID's underlying integer.
+template <typename IDType>
+void collectEntityFoldDistinct(Column* values,
+                               const Column* input,
+                               const std::vector<size_t>& groups,
+                               std::vector<std::vector<size_t>>& groupPositions,
+                               NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const size_t group = groups[row];
+
+        distinct.beginKey(group);
+        distinctAppendValueBytes(distinct.getKey(), inputRaw[row].getValue());
+
+        if (!distinct.insertIfNew()) {
+            continue;
+        }
+
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
         groupPositions[group].push_back(position);
     }
 }
@@ -3265,6 +3322,54 @@ NLCollectListEmitFunction NLExecutor::selectCollectListEmit(ValueType valueType)
     }
 
     return nullptr;
+}
+
+NLCollectFoldFunction NLExecutor::selectCollectEntityFold(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &collectEntityFold<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &collectEntityFold<EdgeID>;
+        break;
+
+        default:
+            throw IRException("collect does not support this chunk kind");
+        break;
+    }
+}
+
+NLCollectFoldFunction NLExecutor::selectCollectEntityDistinctFold(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &collectEntityFoldDistinct<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &collectEntityFoldDistinct<EdgeID>;
+        break;
+
+        default:
+            throw IRException("collect does not support this chunk kind");
+        break;
+    }
+}
+
+NLCollectListEmitFunction NLExecutor::selectCollectEntityListEmit(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &collectListEmit<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &collectListEmit<EdgeID>;
+        break;
+
+        default:
+            throw IRException("collect does not support this chunk kind");
+        break;
+    }
 }
 
 void NLExecutor::runUnwindCollectLoop(NLExecutionContext* context, NLFunctionData* data) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1551,10 +1551,11 @@ void collectEntityFold(Column* values,
     auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
     const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
 
+    const size_t base = valuesRaw.size();
+    valuesRaw.insert(valuesRaw.end(), inputRaw.begin(), inputRaw.end());
+
     for (size_t row = 0; row < inputRaw.size(); row++) {
-        const size_t position = valuesRaw.size();
-        valuesRaw.push_back(inputRaw[row]);
-        groupPositions[groups[row]].push_back(position);
+        groupPositions[groups[row]].push_back(base + row);
     }
 }
 
@@ -1632,6 +1633,17 @@ void collectListEmit(const Column* values,
 
         outputRaw.push_back(listBuffer.insert(elements));
     }
+}
+
+// The fold and the list emit an entity collect of this ID reads. The list emits through
+// the value path's template - its elements are the IDs the fold appended - so there is
+// no entity emit of its own.
+template <typename IDType>
+void selectCollectIDHandlers(bool distinctValues,
+                             NLCollectFoldFunction& fold,
+                             NLCollectListEmitFunction& listEmit) {
+    fold = distinctValues ? &collectEntityFoldDistinct<IDType> : &collectEntityFold<IDType>;
+    listEmit = &collectListEmit<IDType>;
 }
 
 // Emit a sum/min/max slice: the accumulator holds each group's reduced value in the
@@ -3168,6 +3180,12 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
     bioassert(valueInput->size() == rowCount,
               "nl.collect_update value column must be row-aligned with the grouping keys");
 
+    std::vector<NLGroupAggregateState::Aggregate>& aggregates = state->aggregates();
+    for (const NLGroupAggregateState::Aggregate& aggregate : aggregates) {
+        bioassert(aggregate._input->size() == rowCount,
+                  "nl.collect_update aggregate inputs must be row-aligned with the grouping keys");
+    }
+
     if (rowCount == 0) {
         return;
     }
@@ -3211,6 +3229,20 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
     groupPositions.resize(groupCount);
 
     state->getFold()(state->getValues(), valueInput, groupIndices, groupPositions, state->distinct());
+
+    // The reductions taken over the same groups fold beside the list, off the group
+    // assignment computed once above, exactly as nl.group_aggregate_update folds them.
+    for (NLGroupAggregateState::Aggregate& aggregate : aggregates) {
+        aggregate._grow(aggregate._accumulator, aggregate._counts, groupCount);
+    }
+
+    for (NLGroupAggregateState::Aggregate& aggregate : aggregates) {
+        aggregate._fold(aggregate._accumulator,
+                        aggregate._counts,
+                        aggregate._input,
+                        groupIndices,
+                        aggregate._distinct);
+    }
 }
 
 // Only the scalar value types are collectable for now; an embedding column (a span of
@@ -3339,46 +3371,17 @@ NLCollectListEmitFunction NLExecutor::selectCollectListEmit(ValueType valueType)
     return nullptr;
 }
 
-NLCollectFoldFunction NLExecutor::selectCollectEntityFold(NLChunkKind kind) {
+void NLExecutor::selectCollectEntityHandlers(NLChunkKind kind,
+                                             bool distinctValues,
+                                             NLCollectFoldFunction& fold,
+                                             NLCollectListEmitFunction& listEmit) {
     switch (kind) {
         case NLChunkKind::NodeID:
-            return &collectEntityFold<NodeID>;
+            return selectCollectIDHandlers<NodeID>(distinctValues, fold, listEmit);
         break;
 
         case NLChunkKind::EdgeID:
-            return &collectEntityFold<EdgeID>;
-        break;
-
-        default:
-            throw IRException("collect does not support this chunk kind");
-        break;
-    }
-}
-
-NLCollectFoldFunction NLExecutor::selectCollectEntityDistinctFold(NLChunkKind kind) {
-    switch (kind) {
-        case NLChunkKind::NodeID:
-            return &collectEntityFoldDistinct<NodeID>;
-        break;
-
-        case NLChunkKind::EdgeID:
-            return &collectEntityFoldDistinct<EdgeID>;
-        break;
-
-        default:
-            throw IRException("collect does not support this chunk kind");
-        break;
-    }
-}
-
-NLCollectListEmitFunction NLExecutor::selectCollectEntityListEmit(NLChunkKind kind) {
-    switch (kind) {
-        case NLChunkKind::NodeID:
-            return &collectListEmit<NodeID>;
-        break;
-
-        case NLChunkKind::EdgeID:
-            return &collectListEmit<EdgeID>;
+            return selectCollectIDHandlers<EdgeID>(distinctValues, fold, listEmit);
         break;
 
         default:
@@ -3474,6 +3477,10 @@ void NLExecutor::runCollectLoop(NLExecutionContext* context, NLFunctionData* dat
                              stepGroups,
                              state->listBuffer(),
                              state->getValueOutput());
+
+        for (const NLGroupAggregateState::Aggregate& aggregate : state->aggregates()) {
+            aggregate._emit(aggregate._accumulator, aggregate._counts, offset, stepGroups, aggregate._output);
+        }
 
         runBody(context, loopBody);
     }

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -3382,6 +3382,10 @@ NLGatherFunction NLExecutor::selectCountGatherFunction() {
     return &gatherColumn<uint64_t>;
 }
 
+NLGatherFunction NLExecutor::selectListGatherFunction() {
+    return &gatherColumn<ListView>;
+}
+
 NLMaskSurvivorFunction NLExecutor::selectMaskSurvivorFunction(bool nullable) {
     if (nullable) {
         return &collectOptMaskSurvivors;
@@ -3535,6 +3539,10 @@ NLAppendFunction NLExecutor::selectAppendFunction(NLChunkKind kind) {
 
 NLAppendFunction NLExecutor::selectCountAppendFunction() {
     return &appendColumn<uint64_t>;
+}
+
+NLAppendFunction NLExecutor::selectListAppendFunction() {
+    return &appendColumn<ListView>;
 }
 
 // A nullable value chunk is a ColumnOptVector<Primitive> - that is,

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -682,6 +682,21 @@ int compareListElementColumn(const Column* column, size_t a, size_t b) {
     return 0;
 }
 
+// 3-way compare two rows of a collected list column. Two lists order lexicographically
+// on the element order above, so a list can be the key the rows are sorted on.
+int compareListColumn(const Column* column, size_t a, size_t b) {
+    const auto& raw = static_cast<const ColumnVector<ListView>*>(column)->getRaw();
+    const std::strong_ordering order = raw[a] <=> raw[b];
+
+    if (order == std::strong_ordering::less) {
+        return -1;
+    } else if (order == std::strong_ordering::greater) {
+        return 1;
+    }
+
+    return 0;
+}
+
 // Append the raw bytes of a present property value to a distinct row key. The key
 // is a std::string used purely as a growable byte buffer - not text - so the value
 // is appended verbatim: a trivially-copyable primitive copies its object bytes; a
@@ -3602,6 +3617,10 @@ NLCopyFunction NLExecutor::selectListElementCopyFunction() {
 
 NLBroadcastFunction NLExecutor::selectListBlockRepeatFunction() {
     return &blockRepeatColumn<ListView>;
+}
+
+NLCompareFunction NLExecutor::selectListCompareFunction() {
+    return &compareListColumn;
 }
 
 NLCopyFunction NLExecutor::selectListCopyFunction() {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -3160,11 +3160,12 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
     NLCollectState* state = update->getState();
 
     std::vector<NLCollectState::KeyColumn>& keyColumns = state->keyColumns();
+    std::vector<NLCollectState::ValueColumn>& valueColumns = state->valueColumns();
 
     // Every column is row-aligned. With grouping keys the first key sizes this step's
-    // rows; ungrouped (no key), the collected value column sizes it.
-    const Column* valueInput = state->getValueInput();
-    const size_t rowCount = keyColumns.empty() ? valueInput->size() : keyColumns.front()._input->size();
+    // rows; ungrouped (no key), the first collected value column sizes it.
+    const size_t rowCount = keyColumns.empty() ? valueColumns.front()._input->size()
+                                               : keyColumns.front()._input->size();
 
     // That alignment is this step's precondition, not a property of the op's types:
     // the group assignment is computed once per key row, then indexed by the fold as it
@@ -3177,8 +3178,10 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
                   "nl.collect_update grouping keys must be row-aligned");
     }
 
-    bioassert(valueInput->size() == rowCount,
-              "nl.collect_update value column must be row-aligned with the grouping keys");
+    for (const NLCollectState::ValueColumn& valueColumn : valueColumns) {
+        bioassert(valueColumn._input->size() == rowCount,
+                  "nl.collect_update value columns must be row-aligned with the grouping keys");
+    }
 
     std::vector<NLGroupAggregateState::Aggregate>& aggregates = state->aggregates();
     for (const NLGroupAggregateState::Aggregate& aggregate : aggregates) {
@@ -3225,10 +3228,15 @@ void NLExecutor::runCollectUpdate(NLExecutionContext* context, NLFunctionData* d
         keyColumn._gatherAppend(keyColumn._input, newGroupRows, keyColumn._buffer);
     }
 
-    std::vector<std::vector<size_t>>& groupPositions = state->groupPositions();
-    groupPositions.resize(groupCount);
+    for (NLCollectState::ValueColumn& valueColumn : valueColumns) {
+        valueColumn._groupPositions.resize(groupCount);
 
-    state->getFold()(state->getValues(), valueInput, groupIndices, groupPositions, state->distinct());
+        valueColumn._fold(valueColumn._buffer,
+                          valueColumn._input,
+                          groupIndices,
+                          valueColumn._groupPositions,
+                          valueColumn._distinct);
+    }
 
     // The reductions taken over the same groups fold beside the list, off the group
     // assignment computed once above, exactly as nl.group_aggregate_update folds them.
@@ -3398,7 +3406,8 @@ void NLExecutor::runUnwindCollectLoop(NLExecutionContext* context, NLFunctionDat
     const NLStmtContainer* loopBody = loopData->getStmts();
 
     std::vector<NLCollectState::KeyColumn>& keyColumns = state->keyColumns();
-    const std::vector<std::vector<size_t>>& groupPositions = state->groupPositions();
+    NLCollectState::ValueColumn& unwound = state->unwoundColumn();
+    const std::vector<std::vector<size_t>>& groupPositions = unwound._groupPositions;
     const size_t totalGroups = groupPositions.size();
 
     ColumnVector<size_t>* groupIndices = loopData->getGroupIndices();
@@ -3442,7 +3451,7 @@ void NLExecutor::runUnwindCollectLoop(NLExecutionContext* context, NLFunctionDat
             keyColumn._gather(keyColumn._buffer, groupIndices, keyColumn._output);
         }
 
-        state->getUnwindCollectEmit()(state->getValues(), positions, state->getValueOutput());
+        unwound._unwindCollectEmit(unwound._buffer, positions, unwound._output);
 
         runBody(context, loopBody);
     }
@@ -3471,12 +3480,14 @@ void NLExecutor::runCollectLoop(NLExecutionContext* context, NLFunctionData* dat
             keyColumn._emitCopy(keyColumn._buffer, offset, stepGroups, keyColumn._output);
         }
 
-        state->getListEmit()(state->getValues(),
-                             state->groupPositions(),
-                             offset,
-                             stepGroups,
-                             state->listBuffer(),
-                             state->getValueOutput());
+        for (NLCollectState::ValueColumn& valueColumn : state->valueColumns()) {
+            valueColumn._listEmit(valueColumn._buffer,
+                                  valueColumn._groupPositions,
+                                  offset,
+                                  stepGroups,
+                                  state->listBuffer(),
+                                  valueColumn._output);
+        }
 
         for (const NLGroupAggregateState::Aggregate& aggregate : state->aggregates()) {
             aggregate._emit(aggregate._accumulator, aggregate._counts, offset, stepGroups, aggregate._output);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -417,6 +417,12 @@ public:
     static NLUnwindCollectValueEmitFunction selectUnwindCollectValueEmit(ValueType valueType);
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
 
+    // The fold and list-emit for an entity chunk of this kind, whose elements carry a
+    // node or edge ID. An edge-type ID is no entity, so both reject that kind.
+    static NLCollectFoldFunction selectCollectEntityFold(NLChunkKind kind);
+    static NLCollectFoldFunction selectCollectEntityDistinctFold(NLChunkKind kind);
+    static NLCollectListEmitFunction selectCollectEntityListEmit(NLChunkKind kind);
+
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization
     // from the resolved property and stores it as the statement's handler; only

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -275,6 +275,10 @@ public:
     static NLCompareFunction selectCompareFunction(NLChunkKind kind);
     static NLCompareFunction selectOptCompareFunction(ValueType valueType);
 
+    // The 3-way row comparator for a collected list chunk, ordering two lists
+    // lexicographically over their elements.
+    static NLCompareFunction selectListCompareFunction();
+
     // The handlers of a plain value column - a ColumnVector<Primitive> rather than the
     // nullable ColumnOptVector a property fetch yields. A tally comes out this way, and so
     // does an expression over one: both are present in every row. Numeric only, since

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -254,6 +254,10 @@ public:
     // Gather for the count result chunk: one non-nullable uint64 tally per row.
     static NLGatherFunction selectCountGatherFunction();
 
+    // Gather for a collected list chunk: one ListView per row, each spanning its
+    // group's run in the collect accumulator's list buffer, which outlives the sort.
+    static NLGatherFunction selectListGatherFunction();
+
     // The mask survivor collector for an nl.filter, chosen by the mask chunk's
     // nullability: a nullable mask drops null rows as well as false ones.
     static NLMaskSurvivorFunction selectMaskSurvivorFunction(bool nullable);
@@ -263,6 +267,7 @@ public:
     static NLAppendFunction selectAppendFunction(NLChunkKind kind);
     static NLAppendFunction selectOptAppendFunction(ValueType valueType);
     static NLAppendFunction selectCountAppendFunction();
+    static NLAppendFunction selectListAppendFunction();
 
     // The 3-way row comparator for an ID key column of this kind / a nullable
     // value key column of this value type. The value-type selector throws for a

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -422,10 +422,11 @@ public:
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
 
     // The fold and list-emit for an entity chunk of this kind, whose elements carry a
-    // node or edge ID. An edge-type ID is no entity, so both reject that kind.
-    static NLCollectFoldFunction selectCollectEntityFold(NLChunkKind kind);
-    static NLCollectFoldFunction selectCollectEntityDistinctFold(NLChunkKind kind);
-    static NLCollectListEmitFunction selectCollectEntityListEmit(NLChunkKind kind);
+    // node or edge ID. An edge-type ID is no entity, so the kind is rejected.
+    static void selectCollectEntityHandlers(NLChunkKind kind,
+                                            bool distinctValues,
+                                            NLCollectFoldFunction& fold,
+                                            NLCollectListEmitFunction& listEmit);
 
     // The with-null property fetch handler for an ID type (NodeID/EdgeID) and a
     // value type (types::Double, ...). The translator picks the specialization

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -162,19 +162,30 @@ void NLGroupAggregateState::reset() {
     }
 }
 
+NLCollectState::ValueColumn& NLCollectState::unwoundColumn() {
+    if (_valueColumns.size() != 1) {
+        throw IRException("nl.unwind_collect must drain an accumulator holding a single collected column");
+    }
+
+    return _valueColumns.front();
+}
+
 void NLCollectState::reset() {
     _groupTable.clear();
-    _distinct.clear();
 
     for (KeyColumn& key : _keyColumns) {
         key._buffer->clear();
     }
 
-    if (_values) {
-        _values->clear();
+    for (ValueColumn& value : _valueColumns) {
+        if (value._buffer) {
+            value._buffer->clear();
+        }
+
+        value._distinct.clear();
+        value._groupPositions.clear();
     }
 
-    _groupPositions.clear();
     _listBuffer.clear();
 
     for (NLGroupAggregateState::Aggregate& aggregate : _aggregates) {
@@ -194,7 +205,10 @@ void NLCollectState::reset() {
     if (_keyColumns.empty()) {
         _key.clear();
         _groupTable.assign(_key);
-        _groupPositions.resize(1);
+
+        for (ValueColumn& value : _valueColumns) {
+            value._groupPositions.resize(1);
+        }
     }
 }
 

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -177,6 +177,15 @@ void NLCollectState::reset() {
     _groupPositions.clear();
     _listBuffer.clear();
 
+    for (NLGroupAggregateState::Aggregate& aggregate : _aggregates) {
+        if (aggregate._accumulator) {
+            aggregate._accumulator->clear();
+        }
+
+        aggregate._counts.clear();
+        aggregate._distinct.clear();
+    }
+
     // An ungrouped collect has exactly one group - the empty key tuple - and that group
     // exists whether or not a row ever arrives: collect() over no row is the empty list,
     // not the absence of a row. Creating it here rather than on the first update keeps

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1843,6 +1843,12 @@ public:
     // group's values once. Left empty by a plain collect.
     NLGroupDistinctTally& distinct() { return _distinct; }
 
+    // The reductions taken over the same groups as the list - Cypher's collect(x) beside
+    // count(y) - each folded and emitted exactly as a grouped aggregation does, since one
+    // accumulator holds the groups both read.
+    void addAggregate(const NLGroupAggregateState::Aggregate& aggregate) { _aggregates.push_back(aggregate); }
+    std::vector<NLGroupAggregateState::Aggregate>& aggregates() { return _aggregates; }
+
     // The drain's output loop variable: the unwound value column (nl.unwind_collect) or the
     // per-group list column (nl.collect). Set at loop translation. A state feeds one
     // drain, so a single slot holds whichever it is.
@@ -1889,6 +1895,8 @@ private:
     NLUnwindCollectValueEmitFunction _unwindCollectEmit {nullptr};
     NLCollectListEmitFunction _listEmit {nullptr};
     ListBuffer<> _listBuffer;
+
+    std::vector<NLGroupAggregateState::Aggregate> _aggregates;
 
     NLGroupTable _groupTable;
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1823,25 +1823,35 @@ public:
         NLGatherFunction _gather {nullptr};
     };
 
+    // One collected column - Cypher's collect(x). The update reads the incoming chunk
+    // _input and appends its present values to _buffer through _fold, recording where
+    // each group's elements landed in _groupPositions; _distinct holds the (group,
+    // value) pairs already charged, so collect(DISTINCT x) takes each once and a plain
+    // collect leaves it empty. The drain fills _output - the per-group list cell
+    // through _listEmit, or the unwound value through _unwindCollectEmit.
+    struct ValueColumn {
+        const Column* _input {nullptr};
+        Column* _buffer {nullptr};
+        Column* _output {nullptr};
+        NLCollectFoldFunction _fold {nullptr};
+        NLCollectListEmitFunction _listEmit {nullptr};
+        NLUnwindCollectValueEmitFunction _unwindCollectEmit {nullptr};
+        NLGroupDistinctTally _distinct;
+        std::vector<std::vector<size_t>> _groupPositions;
+    };
+
     void addKeyColumn(const KeyColumn& key) { _keyColumns.push_back(key); }
     std::vector<KeyColumn>& keyColumns() { return _keyColumns; }
 
     NLGroupTable& groupTable() { return _groupTable; }
 
-    // The incoming value chunk (a loop variable, refilled each step), the flat buffer
-    // its present values accumulate into, and the fold that appends them. Set once by
-    // the update translation.
-    const Column* getValueInput() const { return _valueInput; }
-    void setValueInput(const Column* input) { _valueInput = input; }
-    Column* getValues() { return _values; }
-    const Column* getValues() const { return _values; }
-    void setValues(Column* values) { _values = values; }
-    NLCollectFoldFunction getFold() const { return _fold; }
-    void setFold(NLCollectFoldFunction fold) { _fold = fold; }
+    void addValueColumn(const ValueColumn& value) { _valueColumns.push_back(value); }
+    std::vector<ValueColumn>& valueColumns() { return _valueColumns; }
+    const std::vector<ValueColumn>& valueColumns() const { return _valueColumns; }
 
-    // The values already collected per group, so collect(DISTINCT x) charges each of a
-    // group's values once. Left empty by a plain collect.
-    NLGroupDistinctTally& distinct() { return _distinct; }
+    // An nl.unwind_collect drain reads exactly one collected column, so it names it
+    // rather than indexing the list every caller would otherwise have to bound.
+    ValueColumn& unwoundColumn();
 
     // The reductions taken over the same groups as the list - Cypher's collect(x) beside
     // count(y) - each folded and emitted exactly as a grouped aggregation does, since one
@@ -1849,26 +1859,10 @@ public:
     void addAggregate(const NLGroupAggregateState::Aggregate& aggregate) { _aggregates.push_back(aggregate); }
     std::vector<NLGroupAggregateState::Aggregate>& aggregates() { return _aggregates; }
 
-    // The drain's output loop variable: the unwound value column (nl.unwind_collect) or the
-    // per-group list column (nl.collect). Set at loop translation. A state feeds one
-    // drain, so a single slot holds whichever it is.
-    Column* getValueOutput() const { return _valueOutput; }
-    void setValueOutput(Column* output) { _valueOutput = output; }
-
-    // The per-element (unwind) and per-group (collect) emit handlers, both baked from
-    // the value type at update time; the drain loop uses whichever it needs.
-    NLUnwindCollectValueEmitFunction getUnwindCollectEmit() const { return _unwindCollectEmit; }
-    void setUnwindCollectEmit(NLUnwindCollectValueEmitFunction emit) { _unwindCollectEmit = emit; }
-    NLCollectListEmitFunction getListEmit() const { return _listEmit; }
-    void setListEmit(NLCollectListEmitFunction emit) { _listEmit = emit; }
-
     // The query-scoped list buffer the nl.collect drain materializes per-group runs
-    // into; the ListViews it hands out span it and stay valid for the whole run.
+    // into; the ListViews it hands out span it and stay valid for the whole run. Every
+    // collected column shares it, since each run is contiguous per insert.
     ListBuffer<>& listBuffer() { return _listBuffer; }
-
-    // Per group, the positions of its elements in the flat value buffer, in append
-    // order. Grown to the group count each update step.
-    std::vector<std::vector<size_t>>& groupPositions() { return _groupPositions; }
 
     // Scratch reused per update step: the row key being built, the per-row group index
     // map, and the incoming rows that created a new group this step.
@@ -1876,7 +1870,7 @@ public:
     std::vector<size_t>& groupIndicesScratch() { return _groupIndices; }
     std::vector<size_t>& newGroupRowsScratch() { return _newGroupRows; }
 
-    // Empty the group table, key buffers, value buffer and per-group positions, so the
+    // Empty the group table, key buffers, value buffers and per-group positions, so the
     // collect starts fresh. Runs each time nl.collect_buffer's block runs. An ungrouped
     // collect comes back with its single empty group already created, since that group
     // does not depend on any row arriving.
@@ -1885,15 +1879,8 @@ public:
 private:
     std::vector<KeyColumn> _keyColumns;
 
-    const Column* _valueInput {nullptr};
-    Column* _values {nullptr};
-    NLCollectFoldFunction _fold {nullptr};
-    NLGroupDistinctTally _distinct;
-    std::vector<std::vector<size_t>> _groupPositions;
+    std::vector<ValueColumn> _valueColumns;
 
-    Column* _valueOutput {nullptr};
-    NLUnwindCollectValueEmitFunction _unwindCollectEmit {nullptr};
-    NLCollectListEmitFunction _listEmit {nullptr};
     ListBuffer<> _listBuffer;
 
     std::vector<NLGroupAggregateState::Aggregate> _aggregates;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -321,7 +321,10 @@ bool isConstantColumn(const Column* column) {
 // second one means malformed IR - the accumulate side rejects a second
 // nl.collect_update the same way.
 void throwIfAlreadyDrained(const NLCollectState* state) {
-    if (state->getValueOutput()) {
+    const std::vector<NLCollectState::ValueColumn>& valueColumns = state->valueColumns();
+    const bool isDrained = !valueColumns.empty() && valueColumns.front()._output;
+
+    if (isDrained) {
         throw IRException("an nl.collect_buffer must be drained by a single nl.collect or nl.unwind_collect");
     }
 }
@@ -2159,10 +2162,10 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
         throw IRException("collect_update state must come from nl.collect_buffer");
     }
 
-    // The key buffers and the value buffer are allocated once, by the single update
+    // The key buffers and the value buffers are allocated once, by the single update
     // feeding an accumulator. Generated IR has exactly one update per accumulator; a
     // second would append the same rows twice, so it is rejected here.
-    if (!state->keyColumns().empty() || state->getValues()) {
+    if (!state->keyColumns().empty() || !state->valueColumns().empty()) {
         throw IRException("an nl.collect_buffer must be fed by a single nl.collect_update");
     }
 
@@ -2170,11 +2173,16 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
     const size_t keyCount = buffer.getKeyCount();
     const llvm::ArrayRef<int64_t> kinds = buffer.getKinds().value_or(llvm::ArrayRef<int64_t> {});
 
-    // The collected columns are the grouping keys, the one value column, then one input
-    // per aggregate reduced over the same groups.
-    if (columns.size() != keyCount + 1 + kinds.size()) {
-        throw IRException("collect collects one value column after the grouping keys, then one column per aggregate");
+    // The collected columns are the grouping keys, the value columns, then one input per
+    // aggregate reduced over the same groups: what the keys and the aggregates leave is
+    // what the collect gathers, and it gathers at least one.
+    if (columns.size() <= keyCount + kinds.size()) {
+        throw IRException("collect collects at least one value column after the grouping keys, then one column per aggregate");
     }
+
+    const size_t valueCount = columns.size() - keyCount - kinds.size();
+
+    const llvm::ArrayRef<int64_t> distinctValues = buffer.getDistinctValues().value_or(llvm::ArrayRef<int64_t> {});
 
     NLCollectUpdateData* data = _program->allocFunctionData<NLCollectUpdateData>(state);
 
@@ -2194,36 +2202,41 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
         state->addKeyColumn(key);
     }
 
-    // The collected value column is either a nullable value chunk (a property fetch),
-    // whose present values accumulate in a flat buffer of the same primitive with nulls
+    // Each collected column is either a nullable value chunk (a property fetch), whose
+    // present values accumulate in a flat buffer of the same primitive with nulls
     // dropped to match Cypher collect, or an entity chunk, whose every row carries an
     // ID. The fold (append) and the drain emit handlers are baked from that type here,
     // so whichever drain the query uses reads a ready handler off the state.
-    const mlir::Value valueColumn = columns[keyCount];
-    const mlir::Type valueElement = mlir::cast<nl::ChunkType>(valueColumn.getType()).getElementType();
+    for (size_t valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+        const mlir::Value column = columns[keyCount + valueIndex];
+        const mlir::Type element = mlir::cast<nl::ChunkType>(column.getType()).getElementType();
 
-    state->setValueInput(getColumn(valueColumn));
+        const bool isDistinct = llvm::is_contained(distinctValues, static_cast<int64_t>(valueIndex));
 
-    const bool isDistinct = buffer.getDistinct();
+        NLCollectState::ValueColumn value;
+        value._input = getColumn(column);
 
-    if (mlir::isa<storage::NullableType>(valueElement)) {
-        const ValueType valueType = nullableChunkValueType(valueColumn.getType());
+        if (mlir::isa<storage::NullableType>(element)) {
+            const ValueType valueType = nullableChunkValueType(column.getType());
 
-        state->setValues(allocValueColumnForValueType(valueType));
-        state->setFold(isDistinct ? NLExecutor::selectCollectDistinctFold(valueType)
-                                  : NLExecutor::selectCollectFold(valueType));
-        state->setUnwindCollectEmit(NLExecutor::selectUnwindCollectValueEmit(valueType));
-        state->setListEmit(NLExecutor::selectCollectListEmit(valueType));
-    } else {
-        const NLChunkKind kind = getChunkKind(valueColumn.getType());
+            value._buffer = allocValueColumnForValueType(valueType);
+            value._fold = isDistinct ? NLExecutor::selectCollectDistinctFold(valueType)
+                                     : NLExecutor::selectCollectFold(valueType);
+            value._unwindCollectEmit = NLExecutor::selectUnwindCollectValueEmit(valueType);
+            value._listEmit = NLExecutor::selectCollectListEmit(valueType);
+        } else {
+            const NLChunkKind kind = getChunkKind(column.getType());
 
-        NLCollectFoldFunction fold = nullptr;
-        NLCollectListEmitFunction listEmit = nullptr;
-        NLExecutor::selectCollectEntityHandlers(kind, isDistinct, fold, listEmit);
+            NLCollectFoldFunction fold = nullptr;
+            NLCollectListEmitFunction listEmit = nullptr;
+            NLExecutor::selectCollectEntityHandlers(kind, isDistinct, fold, listEmit);
 
-        state->setValues(allocColumnForKind(kind));
-        state->setFold(fold);
-        state->setListEmit(listEmit);
+            value._buffer = allocColumnForKind(kind);
+            value._fold = fold;
+            value._listEmit = listEmit;
+        }
+
+        state->addValueColumn(value);
     }
 
     // The reductions taken beside the list read the same groups, so their accumulators
@@ -2232,7 +2245,7 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
         const storage::GroupAggregateKind aggregateKind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
 
         NLGroupAggregateState::Aggregate aggregate;
-        buildGroupAggregate(aggregateKind, columns[keyCount + 1 + aggregateIndex], aggregate);
+        buildGroupAggregate(aggregateKind, columns[keyCount + valueCount + aggregateIndex], aggregate);
 
         state->addAggregate(aggregate);
     }
@@ -2261,7 +2274,8 @@ void NLTranslator::translateUnwindCollectLoop(const IteratorConfig& config,
 
     // Only a value collect bakes an unwind emit handler; an entity collect leaves it
     // unset, so its list can be returned but not yet unwound element by element.
-    if (!state->getUnwindCollectEmit()) {
+    NLCollectState::ValueColumn& unwound = state->unwoundColumn();
+    if (!unwound._unwindCollectEmit) {
         throw IRException("unwinding a collected entity list is not supported");
     }
 
@@ -2292,7 +2306,7 @@ void NLTranslator::translateUnwindCollectLoop(const IteratorConfig& config,
     const mlir::Value valueVariable = loopBody.getArgument(static_cast<unsigned>(keyCount));
     Column* valueOutput = allocColumnForResultChunkType(valueVariable.getType());
     _valueSlots[valueVariable] = valueOutput;
-    state->setValueOutput(valueOutput);
+    unwound._output = valueOutput;
 
     body->emplaceStmt(&NLExecutor::runUnwindCollectLoop, loopData);
 
@@ -2309,12 +2323,13 @@ void NLTranslator::translateCollectLoop(const IteratorConfig& config,
 
     throwIfAlreadyDrained(state);
 
-    // The collect iterator's chunks are the grouping keys, the list cell, then one per
-    // aggregate reduced over the same groups.
+    // The collect iterator's chunks are the grouping keys, one list cell per collected
+    // column, then one per aggregate reduced over the same groups.
     const size_t keyCount = state->keyColumns().size();
+    std::vector<NLCollectState::ValueColumn>& valueColumns = state->valueColumns();
     std::vector<NLGroupAggregateState::Aggregate>& aggregates = state->aggregates();
-    if (loopBody.getNumArguments() != keyCount + 1 + aggregates.size()) {
-        throw IRException("nl.collect loop must bind one variable per grouping key, the list, and one per aggregate");
+    if (loopBody.getNumArguments() != keyCount + valueColumns.size() + aggregates.size()) {
+        throw IRException("nl.collect loop must bind one variable per grouping key, one per list, and one per aggregate");
     }
 
     NLCollectLoopData* loopData = _program->allocFunctionData<NLCollectLoopData>(state);
@@ -2329,16 +2344,19 @@ void NLTranslator::translateCollectLoop(const IteratorConfig& config,
         state->keyColumns()[keyIndex]._output = output;
     }
 
-    // Then the per-group list cell (a ColumnVector<ListView>).
-    const mlir::Value listVariable = loopBody.getArgument(static_cast<unsigned>(keyCount));
-    Column* listOutput = allocColumnForResultChunkType(listVariable.getType());
-    _valueSlots[listVariable] = listOutput;
-    state->setValueOutput(listOutput);
+    // Then one per-group list cell per collected column (a ColumnVector<ListView>).
+    for (size_t valueIndex = 0; valueIndex < valueColumns.size(); valueIndex++) {
+        const mlir::Value listVariable = loopBody.getArgument(static_cast<unsigned>(keyCount + valueIndex));
+
+        Column* listOutput = allocColumnForResultChunkType(listVariable.getType());
+        _valueSlots[listVariable] = listOutput;
+        valueColumns[valueIndex]._output = listOutput;
+    }
 
     // The remaining variables take the reductions, one per aggregate, filled from the
-    // same group window the list is sliced over.
+    // same group window the lists are sliced over.
     for (size_t aggregateIndex = 0; aggregateIndex < aggregates.size(); aggregateIndex++) {
-        const unsigned argumentIndex = static_cast<unsigned>(keyCount + 1 + aggregateIndex);
+        const unsigned argumentIndex = static_cast<unsigned>(keyCount + valueColumns.size() + aggregateIndex);
         const mlir::Value loopVariable = loopBody.getArgument(argumentIndex);
 
         Column* output = allocColumnForResultChunkType(loopVariable.getType());

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2703,10 +2703,8 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
         return NLExecutor::selectPlainCompareFunction(valueTypeFromElementType(elementType));
     }
 
-    // A list is carried through the sort row-aligned with the keys, but two lists have no
-    // order between them, so one can never be the key the rows are compared on.
     if (llvm::isa<storage::ListType>(elementType)) {
-        throw IRException("a list column cannot be a sort key");
+        return NLExecutor::selectListCompareFunction();
     }
 
     return NLExecutor::selectCompareFunction(chunkKindFromElementType(elementType));

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -50,6 +50,30 @@ namespace storage = mlir::storage;
 
 namespace {
 
+// A chunk holding the single row a reduction collapsed the whole relation to, or a
+// computation over such rows and constants: like a constant, it holds one value for
+// every row of the step that reads it, whichever loop that step belongs to.
+bool yieldsReducedRowChunk(mlir::Value column) {
+    mlir::Operation* const definingOp = column.getDefiningOp();
+    if (!definingOp) {
+        return false;
+    }
+
+    if (mlir::isa<nl::CountResult, nl::AggregateResult>(definingOp)) {
+        return true;
+    }
+
+    if (!definingOp->hasTrait<mlir::OpTrait::ConstantThroughOperands>()) {
+        return false;
+    }
+
+    const bool readsAReducedRow = llvm::any_of(definingOp->getOperands(), yieldsReducedRowChunk);
+
+    return readsAReducedRow && llvm::all_of(definingOp->getOperands(), [](mlir::Value operand) {
+        return yieldsReducedRowChunk(operand) || yieldsConstantColumn(operand);
+    });
+}
+
 using NLUnaryFunctionSelector = NLUnaryFunctionKernel (*)(const Column* input, bool inputNullable, LocalMemory* memory, Column*& result);
 
 const std::unordered_map<std::string_view, NLUnaryFunctionSelector> unaryFunctionSelectors = {
@@ -1313,9 +1337,9 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
     // scope. Either way its per-row columns must be bound in the output's own block,
     // which the per-column check below enforces: a loop variable of this loop, or a
     // chunk materialized in this block (a property fetch, or nl.count_result at
-    // function scope). The sole cross-scope exception is a constant, which is
-    // loop-invariant and broadcasts; any other chunk from an outer or sibling loop
-    // fails the check.
+    // function scope). Two chunks cross that scope: a constant, and the single row a
+    // reduction collapsed to - both hold one value for every row of the step. Any
+    // other chunk from an outer or sibling loop fails the check.
     mlir::Block* outputBlock = output->getBlock();
 
     NLOutputData* outputData = _program->allocFunctionData<NLOutputData>();
@@ -1336,10 +1360,11 @@ void NLTranslator::translateOutput(nl::Output output, NLStmtContainer* body) {
         const bool isProducedInThisBlock = definingOp && definingOp->getBlock() == outputBlock;
 
         const bool isConstant = yieldsConstantColumn(column);
+        const bool isReducedRow = yieldsReducedRowChunk(column);
 
-        if (!isInnermostLoopVariable && !isProducedInThisBlock && !isConstant) {
+        if (!isInnermostLoopVariable && !isProducedInThisBlock && !isConstant && !isReducedRow) {
             throw IRException("nl.output columns must be a loop variable of the enclosing "
-                              "nl.for, produced in this block, or a constant");
+                              "nl.for, produced in this block, a constant, or a reduced row");
         }
 
         outputData->addOutputColumn(getColumn(column), !isConstant);
@@ -1895,6 +1920,104 @@ void NLTranslator::translateGroupAggregateBuffer(nl::GroupAggregateBuffer buffer
     body->addStmt(NLFunctionDescriptor {&NLExecutor::runGroupAggregateReset, resetData});
 }
 
+void NLTranslator::buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKind,
+                                       mlir::Value column,
+                                       NLGroupAggregateState::Aggregate& aggregate) {
+    const GroupAggregateKind kind = toRuntimeGroupAggregateKind(mlirKind);
+    const mlir::Type chunkType = column.getType();
+
+    aggregate._input = getColumn(column);
+
+    // A switch (not an if/else) over every kind so a new one is a compile error
+    // here rather than silently taking the value-reduction path.
+    switch (kind) {
+        case GroupAggregateKind::Count: {
+            // count tallies rows, so it keeps no reduced value (a null
+            // accumulator, only the per-group tally). count(*) over an ID chunk
+            // charges every row; count(x) over a nullable value chunk charges
+            // only the present values.
+            aggregate._accumulator = nullptr;
+            aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
+            aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
+
+            const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+            const mlir::Type countElementType = chunk.getElementType();
+            const auto nullable = mlir::dyn_cast<storage::NullableType>(countElementType);
+            if (nullable) {
+                const ValueType valueType = valueTypeFromElementType(nullable.getValueType());
+                aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, valueType);
+            } else if (mlir::isa<storage::ListElementType>(countElementType)) {
+                aggregate._fold = NLExecutor::selectGroupCountListElementFold();
+            } else if (llvm::isa<storage::ListType>(countElementType)) {
+                // No row of a list chunk is null, so a group's tally is its whole row
+                // count, as it is for count(*).
+                aggregate._fold = NLExecutor::selectGroupCountAllFold();
+            } else {
+                // A non-nullable chunk holds no null to skip - an ID chunk of
+                // count(*), or a column a CALL yielded - so every row is charged.
+                aggregate._fold = NLExecutor::selectGroupCountAllFold();
+            }
+        }
+        break;
+
+        case GroupAggregateKind::CountRows: {
+            // count(*) charges every row of the group and reads no value, so the
+            // chunk it is anchored on needs no type dispatch at all
+            aggregate._accumulator = nullptr;
+            aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
+            aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
+            aggregate._fold = NLExecutor::selectGroupCountAllFold();
+        }
+        break;
+
+        case GroupAggregateKind::CountDistinct: {
+            // count(DISTINCT x) keeps the same per-group tally as count, charged
+            // once per distinct value instead of once per row, so it shares count's
+            // grow and emit and differs only in the fold. count(DISTINCT n) over an
+            // ID chunk keys on the ID; count(DISTINCT x) over a nullable value chunk
+            // keys on the value and skips the nulls.
+            aggregate._accumulator = nullptr;
+            aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
+            aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
+
+            const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+            const auto nullable = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
+            if (nullable) {
+                const ValueType valueType = valueTypeFromElementType(nullable.getValueType());
+                aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, valueType);
+            } else if (mlir::isa<storage::ListElementType>(chunk.getElementType())) {
+                aggregate._fold = NLExecutor::selectGroupCountDistinctListElementFold();
+            } else {
+                aggregate._fold = NLExecutor::selectGroupCountDistinctChunkFold(getChunkKind(chunkType));
+            }
+        }
+        break;
+
+        case GroupAggregateKind::Sum:
+        case GroupAggregateKind::SumDistinct:
+        case GroupAggregateKind::Min:
+        case GroupAggregateKind::Max:
+        case GroupAggregateKind::Avg:
+        case GroupAggregateKind::AvgDistinct: {
+            // sum/min/max/avg reduce the values themselves, so the input must be a
+            // nullable value chunk; avg accumulates as f64, the rest in the input's
+            // own type. nullableChunkValueType rejects an ID chunk here. The distinct
+            // kinds keep the shape of the kind they mirror and differ only in the
+            // fold, which charges each of a group's values once.
+            const ValueType inputType = nullableChunkValueType(chunkType);
+            const bool accumulatesAsDouble = (kind == GroupAggregateKind::Avg)
+                                          || (kind == GroupAggregateKind::AvgDistinct);
+            const ValueType accumulatorType = accumulatesAsDouble ? ValueType::Double : inputType;
+
+            aggregate._accumulator = allocOptColumnForValueType(accumulatorType);
+            aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, accumulatorType);
+            aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, inputType);
+            aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, accumulatorType);
+        }
+        break;
+    }
+}
+
 void NLTranslator::translateGroupAggregateUpdate(nl::GroupAggregateUpdate update, NLStmtContainer* body) {
     const mlir::Value updateState = update.getState();
     NLGroupAggregateState* state = groupAggregateStateFor(updateState);
@@ -1945,102 +2068,10 @@ void NLTranslator::translateGroupAggregateUpdate(nl::GroupAggregateUpdate update
     // One per-group accumulator per aggregate, with the grow/fold/emit handlers baked
     // from the kind and the input value type.
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
-        const storage::GroupAggregateKind mlirKind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
-        const GroupAggregateKind kind = toRuntimeGroupAggregateKind(mlirKind);
-        const mlir::Value column = columns[keyCount + aggregateIndex];
-        const mlir::Type chunkType = column.getType();
+        const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
 
         NLGroupAggregateState::Aggregate aggregate;
-        aggregate._input = getColumn(column);
-
-        // A switch (not an if/else) over every kind so a new one is a compile error
-        // here rather than silently taking the value-reduction path.
-        switch (kind) {
-            case GroupAggregateKind::Count: {
-                // count tallies rows, so it keeps no reduced value (a null
-                // accumulator, only the per-group tally). count(*) over an ID chunk
-                // charges every row; count(x) over a nullable value chunk charges
-                // only the present values.
-                aggregate._accumulator = nullptr;
-                aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
-                aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
-
-                const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
-                const mlir::Type countElementType = chunk.getElementType();
-                const auto nullable = mlir::dyn_cast<storage::NullableType>(countElementType);
-                if (nullable) {
-                    const ValueType valueType = valueTypeFromElementType(nullable.getValueType());
-                    aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, valueType);
-                } else if (mlir::isa<storage::ListElementType>(countElementType)) {
-                    aggregate._fold = NLExecutor::selectGroupCountListElementFold();
-                } else if (llvm::isa<storage::ListType>(countElementType)) {
-                    // No row of a list chunk is null, so a group's tally is its whole row
-                    // count, as it is for count(*).
-                    aggregate._fold = NLExecutor::selectGroupCountAllFold();
-                } else {
-                    // A non-nullable chunk holds no null to skip - an ID chunk of
-                    // count(*), or a column a CALL yielded - so every row is charged.
-                    aggregate._fold = NLExecutor::selectGroupCountAllFold();
-                }
-            }
-            break;
-
-            case GroupAggregateKind::CountRows: {
-                // count(*) charges every row of the group and reads no value, so the
-                // chunk it is anchored on needs no type dispatch at all
-                aggregate._accumulator = nullptr;
-                aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
-                aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
-                aggregate._fold = NLExecutor::selectGroupCountAllFold();
-            }
-            break;
-
-            case GroupAggregateKind::CountDistinct: {
-                // count(DISTINCT x) keeps the same per-group tally as count, charged
-                // once per distinct value instead of once per row, so it shares count's
-                // grow and emit and differs only in the fold. count(DISTINCT n) over an
-                // ID chunk keys on the ID; count(DISTINCT x) over a nullable value chunk
-                // keys on the value and skips the nulls.
-                aggregate._accumulator = nullptr;
-                aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, ValueType::Int64);
-                aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, ValueType::Int64);
-
-                const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
-                const auto nullable = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
-                if (nullable) {
-                    const ValueType valueType = valueTypeFromElementType(nullable.getValueType());
-                    aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, valueType);
-                } else if (mlir::isa<storage::ListElementType>(chunk.getElementType())) {
-                    aggregate._fold = NLExecutor::selectGroupCountDistinctListElementFold();
-                } else {
-                    aggregate._fold = NLExecutor::selectGroupCountDistinctChunkFold(getChunkKind(chunkType));
-                }
-            }
-            break;
-
-            case GroupAggregateKind::Sum:
-            case GroupAggregateKind::SumDistinct:
-            case GroupAggregateKind::Min:
-            case GroupAggregateKind::Max:
-            case GroupAggregateKind::Avg:
-            case GroupAggregateKind::AvgDistinct: {
-                // sum/min/max/avg reduce the values themselves, so the input must be a
-                // nullable value chunk; avg accumulates as f64, the rest in the input's
-                // own type. nullableChunkValueType rejects an ID chunk here. The distinct
-                // kinds keep the shape of the kind they mirror and differ only in the
-                // fold, which charges each of a group's values once.
-                const ValueType inputType = nullableChunkValueType(chunkType);
-                const bool accumulatesAsDouble = (kind == GroupAggregateKind::Avg)
-                                              || (kind == GroupAggregateKind::AvgDistinct);
-                const ValueType accumulatorType = accumulatesAsDouble ? ValueType::Double : inputType;
-
-                aggregate._accumulator = allocOptColumnForValueType(accumulatorType);
-                aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, accumulatorType);
-                aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, inputType);
-                aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, accumulatorType);
-            }
-            break;
-        }
+        buildGroupAggregate(kind, columns[keyCount + aggregateIndex], aggregate);
 
         state->addAggregate(aggregate);
     }
@@ -2137,10 +2168,12 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
 
     const mlir::OperandRange columns = update.getColumns();
     const size_t keyCount = buffer.getKeyCount();
+    const llvm::ArrayRef<int64_t> kinds = buffer.getKinds().value_or(llvm::ArrayRef<int64_t> {});
 
-    // The collected columns are the grouping keys followed by exactly one value column.
-    if (columns.size() != keyCount + 1) {
-        throw IRException("collect collects one value column after the grouping keys");
+    // The collected columns are the grouping keys, the one value column, then one input
+    // per aggregate reduced over the same groups.
+    if (columns.size() != keyCount + 1 + kinds.size()) {
+        throw IRException("collect collects one value column after the grouping keys, then one column per aggregate");
     }
 
     NLCollectUpdateData* data = _program->allocFunctionData<NLCollectUpdateData>(state);
@@ -2184,10 +2217,24 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
     } else {
         const NLChunkKind kind = getChunkKind(valueColumn.getType());
 
+        NLCollectFoldFunction fold = nullptr;
+        NLCollectListEmitFunction listEmit = nullptr;
+        NLExecutor::selectCollectEntityHandlers(kind, isDistinct, fold, listEmit);
+
         state->setValues(allocColumnForKind(kind));
-        state->setFold(isDistinct ? NLExecutor::selectCollectEntityDistinctFold(kind)
-                                  : NLExecutor::selectCollectEntityFold(kind));
-        state->setListEmit(NLExecutor::selectCollectEntityListEmit(kind));
+        state->setFold(fold);
+        state->setListEmit(listEmit);
+    }
+
+    // The reductions taken beside the list read the same groups, so their accumulators
+    // live on this state and are wired exactly as a grouped aggregation's are.
+    for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
+        const storage::GroupAggregateKind aggregateKind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
+
+        NLGroupAggregateState::Aggregate aggregate;
+        buildGroupAggregate(aggregateKind, columns[keyCount + 1 + aggregateIndex], aggregate);
+
+        state->addAggregate(aggregate);
     }
 
     body->emplaceStmt(&NLExecutor::runCollectUpdate, data);
@@ -2262,11 +2309,12 @@ void NLTranslator::translateCollectLoop(const IteratorConfig& config,
 
     throwIfAlreadyDrained(state);
 
-    // The collect iterator's chunks are the grouping keys then the list cell, so the
-    // loop takes one variable per grouping key plus one for the list.
+    // The collect iterator's chunks are the grouping keys, the list cell, then one per
+    // aggregate reduced over the same groups.
     const size_t keyCount = state->keyColumns().size();
-    if (loopBody.getNumArguments() != keyCount + 1) {
-        throw IRException("nl.collect loop must bind one variable per grouping key plus the list");
+    std::vector<NLGroupAggregateState::Aggregate>& aggregates = state->aggregates();
+    if (loopBody.getNumArguments() != keyCount + 1 + aggregates.size()) {
+        throw IRException("nl.collect loop must bind one variable per grouping key, the list, and one per aggregate");
     }
 
     NLCollectLoopData* loopData = _program->allocFunctionData<NLCollectLoopData>(state);
@@ -2281,11 +2329,22 @@ void NLTranslator::translateCollectLoop(const IteratorConfig& config,
         state->keyColumns()[keyIndex]._output = output;
     }
 
-    // The last loop variable is the per-group list cell (a ColumnVector<ListView>).
+    // Then the per-group list cell (a ColumnVector<ListView>).
     const mlir::Value listVariable = loopBody.getArgument(static_cast<unsigned>(keyCount));
     Column* listOutput = allocColumnForResultChunkType(listVariable.getType());
     _valueSlots[listVariable] = listOutput;
     state->setValueOutput(listOutput);
+
+    // The remaining variables take the reductions, one per aggregate, filled from the
+    // same group window the list is sliced over.
+    for (size_t aggregateIndex = 0; aggregateIndex < aggregates.size(); aggregateIndex++) {
+        const unsigned argumentIndex = static_cast<unsigned>(keyCount + 1 + aggregateIndex);
+        const mlir::Value loopVariable = loopBody.getArgument(argumentIndex);
+
+        Column* output = allocColumnForResultChunkType(loopVariable.getType());
+        _valueSlots[loopVariable] = output;
+        aggregates[aggregateIndex]._output = output;
+    }
 
     body->emplaceStmt(&NLExecutor::runCollectLoop, loopData);
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2639,6 +2639,10 @@ NLAppendFunction NLTranslator::selectAppendForChunkType(mlir::Type chunkType) {
         return NLExecutor::selectPlainAppendFunction(valueTypeFromElementType(elementType));
     }
 
+    if (llvm::isa<storage::ListType>(elementType)) {
+        return NLExecutor::selectListAppendFunction();
+    }
+
     return NLExecutor::selectAppendFunction(chunkKindFromElementType(elementType));
 }
 
@@ -2657,6 +2661,10 @@ NLGatherFunction NLTranslator::selectGatherForChunkType(mlir::Type chunkType) {
         return NLExecutor::selectPlainGatherFunction(valueTypeFromElementType(elementType));
     }
 
+    if (llvm::isa<storage::ListType>(elementType)) {
+        return NLExecutor::selectListGatherFunction();
+    }
+
     return NLExecutor::selectGatherFunction(chunkKindFromElementType(elementType));
 }
 
@@ -2673,6 +2681,12 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
 
     if (isPlainValueElementType(elementType)) {
         return NLExecutor::selectPlainCompareFunction(valueTypeFromElementType(elementType));
+    }
+
+    // A list is carried through the sort row-aligned with the keys, but two lists have no
+    // order between them, so one can never be the key the rows are compared on.
+    if (llvm::isa<storage::ListType>(elementType)) {
+        throw IRException("a list column cannot be a sort key");
     }
 
     return NLExecutor::selectCompareFunction(chunkKindFromElementType(elementType));

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2161,20 +2161,34 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
         state->addKeyColumn(key);
     }
 
-    // The collected value column is a nullable value chunk (a property fetch). Its
-    // present values accumulate in a flat buffer of the same primitive; nulls are
-    // dropped, matching Cypher collect. nullableChunkValueType rejects an ID chunk.
-    // The fold (append) and both drain emit handlers are baked from the value type
-    // here, so whichever drain the query uses reads a ready handler off the state.
+    // The collected value column is either a nullable value chunk (a property fetch),
+    // whose present values accumulate in a flat buffer of the same primitive with nulls
+    // dropped to match Cypher collect, or an entity chunk, whose every row carries an
+    // ID. The fold (append) and the drain emit handlers are baked from that type here,
+    // so whichever drain the query uses reads a ready handler off the state.
     const mlir::Value valueColumn = columns[keyCount];
-    const ValueType valueType = nullableChunkValueType(valueColumn.getType());
+    const mlir::Type valueElement = mlir::cast<nl::ChunkType>(valueColumn.getType()).getElementType();
 
     state->setValueInput(getColumn(valueColumn));
-    state->setValues(allocValueColumnForValueType(valueType));
-    state->setFold(buffer.getDistinct() ? NLExecutor::selectCollectDistinctFold(valueType)
-                                       : NLExecutor::selectCollectFold(valueType));
-    state->setUnwindCollectEmit(NLExecutor::selectUnwindCollectValueEmit(valueType));
-    state->setListEmit(NLExecutor::selectCollectListEmit(valueType));
+
+    const bool isDistinct = buffer.getDistinct();
+
+    if (mlir::isa<storage::NullableType>(valueElement)) {
+        const ValueType valueType = nullableChunkValueType(valueColumn.getType());
+
+        state->setValues(allocValueColumnForValueType(valueType));
+        state->setFold(isDistinct ? NLExecutor::selectCollectDistinctFold(valueType)
+                                  : NLExecutor::selectCollectFold(valueType));
+        state->setUnwindCollectEmit(NLExecutor::selectUnwindCollectValueEmit(valueType));
+        state->setListEmit(NLExecutor::selectCollectListEmit(valueType));
+    } else {
+        const NLChunkKind kind = getChunkKind(valueColumn.getType());
+
+        state->setValues(allocColumnForKind(kind));
+        state->setFold(isDistinct ? NLExecutor::selectCollectEntityDistinctFold(kind)
+                                  : NLExecutor::selectCollectEntityFold(kind));
+        state->setListEmit(NLExecutor::selectCollectEntityListEmit(kind));
+    }
 
     body->emplaceStmt(&NLExecutor::runCollectUpdate, data);
 }
@@ -2197,6 +2211,12 @@ void NLTranslator::translateUnwindCollectLoop(const IteratorConfig& config,
     }
 
     throwIfAlreadyDrained(state);
+
+    // Only a value collect bakes an unwind emit handler; an entity collect leaves it
+    // unset, so its list can be returned but not yet unwound element by element.
+    if (!state->getUnwindCollectEmit()) {
+        throw IRException("unwinding a collected entity list is not supported");
+    }
 
     // For::verify binds one loop variable per iterator chunk; the unwind iterator's
     // chunks are the grouping keys then the element value, so the loop takes one

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -349,6 +349,13 @@ private:
     // (by the keyCount / kinds on the producing nl.group_aggregate_buffer), allocate
     // each key buffer and each aggregate's per-group state with its grow/fold/emit
     // handlers, and record the per-step fold statement.
+    // The per-group accumulator one aggregate kind needs over a column: the grow, fold
+    // and emit handlers baked from the kind and the input's value type. Shared by the
+    // grouped aggregation and the collect that reduces beside its list.
+    void buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKind,
+                             mlir::Value column,
+                             NLGroupAggregateState::Aggregate& aggregate);
+
     void translateGroupAggregateUpdate(mlir::nl::GroupAggregateUpdate update, NLStmtContainer* body);
 
     // Translate the nl.for over an nl.group_aggregate iterator: allocate one loop

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1547,7 +1547,8 @@ void DBLowering::lowerCount(mlir::db::Count count) {
     // The update sits in the innermost producing loop body, where the counted
     // column is bound (the same block db.output would emit from), and charges each
     // step's non-null rows against the tally.
-    setInsertionInto(ownerBlock(inputChunk));
+    mlir::Block* const producingBlock = ownerBlock(inputChunk);
+    setInsertionInto(producingBlock);
 
     mlir::Value countedChunk = inputChunk;
     if (distinctState) {
@@ -1560,15 +1561,15 @@ void DBLowering::lowerCount(mlir::db::Count count) {
     // COUNT is a pipeline breaker: the tally is final only once every row has been
     // seen. Since it collapses to exactly one row there is nothing to iterate, so -
     // unlike db.sort - it opens no emit loop: nl.count_result materializes the tally
-    // chunk in place at function scope (after the producing loop, before the
-    // func.return), and db.output consumes it there. The chunk is the single-row
-    // count as an unsigned i64 (!nl.chunk<ui64>) - a non-negative tally that is
-    // never null, so no nullable wrapper.
+    // chunk in place at function scope, right after the producing loop, and db.output
+    // consumes it there. The chunk is the single-row count as an unsigned i64
+    // (!nl.chunk<ui64>) - a non-negative tally that is never null, so no nullable
+    // wrapper.
     mlir::MLIRContext* const context = _builder.getContext();
     const mlir::Type countElementType = _builder.getIntegerType(64, /*isSigned=*/false);
     const nl::ChunkType countChunkType = nl::ChunkType::get(context, countElementType);
 
-    setInsertionInto(_entryBlock);
+    setInsertionAfterProducingLoop(producingBlock);
     nl::CountResult result = _builder.create<nl::CountResult>(loc, countChunkType, state);
 
     // db.count's result maps to that chunk, so the db.output that follows lowers
@@ -1613,7 +1614,8 @@ void DBLowering::lowerAggregate(mlir::Value input, mlir::Value result, storage::
     // The update sits in the innermost producing loop body, where the aggregated
     // column is bound (the same block db.output would emit from), and folds each
     // step's non-null values into the accumulator.
-    setInsertionInto(ownerBlock(inputChunk));
+    mlir::Block* const producingBlock = ownerBlock(inputChunk);
+    setInsertionInto(producingBlock);
 
     mlir::Value reducedChunk = inputChunk;
     if (distinctState) {
@@ -1625,13 +1627,13 @@ void DBLowering::lowerAggregate(mlir::Value input, mlir::Value result, storage::
 
     // Like db.count, an aggregate is a pipeline breaker that collapses to one row,
     // so it opens no emit loop: nl.aggregate_result materializes the reduced value
-    // in place at function scope (after the producing loop, before the func.return).
-    // The result is a single-row nullable value chunk - an aggregate can be null
-    // (min/max/avg of no non-null row), and sum rides the same representation.
+    // in place at function scope, right after the producing loop. The result is a
+    // single-row nullable value chunk - an aggregate can be null (min/max/avg of no
+    // non-null row), and sum rides the same representation.
     const storage::NullableType resultNullable = storage::NullableType::get(context, resultElement);
     const nl::ChunkType resultChunkType = nl::ChunkType::get(context, resultNullable);
 
-    setInsertionInto(_entryBlock);
+    setInsertionAfterProducingLoop(producingBlock);
     nl::AggregateResult aggregateResult = _builder.create<nl::AggregateResult>(loc, resultChunkType, state, kind);
 
     // The db aggregate's result maps to that chunk, so the db.output that follows
@@ -1749,6 +1751,15 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
         throw IRException("db.collect requires at least one column");
     }
 
+    // A constant collected column is folded over the rows of the group it falls in, not
+    // over the single row it is, so it is laid out over the chunk the grouping keys are
+    // read from - the driving relation when the collect has no keys. The aggregate
+    // inputs beside it are laid out the same way, as lowerGroupAggregate lays its own.
+    const mlir::Value cardinality = keyCount > 0 ? chunks.front() : _innermostCardinality;
+    for (size_t inputIndex = keyCount; inputIndex < chunks.size(); inputIndex++) {
+        chunks[inputIndex] = rowAlignedChunk(chunks[inputIndex], cardinality);
+    }
+
     // An entity column collects as the IDs it carries, which every row holds: only a
     // scalar value column is read as nullable, the way a property fetch is.
     const mlir::Type collectedElement = mlir::cast<nl::ChunkType>(chunks[keyCount].getType()).getElementType();
@@ -1758,13 +1769,28 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
         chunks[keyCount] = nullableValueChunk(chunks[keyCount]);
     }
 
+    // A reduction beside the list reads its input as a nullable value chunk, as it does
+    // under a grouped aggregation; a count tallies rows and takes the chunk as it is.
+    const llvm::ArrayRef<int64_t> kinds = collect.getKinds().value_or(llvm::ArrayRef<int64_t> {});
+    for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
+        const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
+
+        if (reducesValues(kind)) {
+            const size_t chunkIndex = keyCount + 1 + aggregateIndex;
+            chunks[chunkIndex] = nullableValueChunk(chunks[chunkIndex]);
+        }
+    }
+
     const mlir::Location loc = _builder.getUnknownLoc();
 
     // The accumulator is hoisted to the top of the entry block, above every loop, so
     // the group table exists before the producing loop fills it and the handle
     // dominates the update. The collect sibling of lowerGroupAggregate's buffer.
     _builder.setInsertionPointToStart(_entryBlock);
-    nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc, keyCount, collect.getDistinct());
+    nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc,
+                                                                    keyCount,
+                                                                    collect.getKindsAttr(),
+                                                                    collect.getDistinct());
     const mlir::Value state = bufferOp.getState();
 
     // The update folds each step's chunk of every column into the per-group lists. It
@@ -1796,6 +1822,16 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
     const nl::ChunkType listChunk = nl::ChunkType::get(context, storage::ListType::get(context, listElement));
     chunkTypes.push_back(listChunk);
 
+    const mlir::Type ui64Element = _builder.getIntegerType(64, /*isSigned=*/false);
+    const nl::ChunkType countChunkType = nl::ChunkType::get(context, ui64Element);
+
+    for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
+        const storage::GroupAggregateKind kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
+        const mlir::Value inputChunk = chunks[keyCount + 1 + aggregateIndex];
+
+        chunkTypes.push_back(groupAggregateResultChunkType(_builder, kind, inputChunk, countChunkType));
+    }
+
     const nl::IteratorType iteratorType = nl::IteratorType::get(context, chunkTypes);
 
     setInsertionInto(_entryBlock);
@@ -1826,7 +1862,10 @@ void DBLowering::lowerUnwindCollect(mlir::db::UnwindCollect unwindCollect) {
     // The accumulate phase is identical to lowerCollect: a hoisted nl.collect_buffer
     // and an nl.collect_update in the producing loop body.
     _builder.setInsertionPointToStart(_entryBlock);
-    nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc, keyCount, /*distinct=*/false);
+    nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc,
+                                                                    keyCount,
+                                                                    mlir::DenseI64ArrayAttr {},
+                                                                    /*distinct=*/false);
     const mlir::Value state = bufferOp.getState();
 
     const mlir::Value representative = chunks.front();
@@ -2691,6 +2730,20 @@ void DBLowering::setInsertionInto(mlir::Block* block) {
     // or a loop body's implicit nl.yield - so the next op goes just before it,
     // after any siblings already lowered here.
     _builder.setInsertionPoint(block->getTerminator());
+}
+
+void DBLowering::setInsertionAfterProducingLoop(mlir::Block* updateBlock) {
+    if (updateBlock == _entryBlock) {
+        setInsertionInto(_entryBlock);
+        return;
+    }
+
+    mlir::Operation* enclosing = updateBlock->getParentOp();
+    while (enclosing->getBlock() != _entryBlock) {
+        enclosing = enclosing->getBlock()->getParentOp();
+    }
+
+    _builder.setInsertionPointAfter(enclosing);
 }
 
 void DBLowering::setInsertionForBinaryOp(mlir::Value lhs, mlir::Value rhs) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1749,7 +1749,14 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
         throw IRException("db.collect requires at least one column");
     }
 
-    chunks[keyCount] = nullableValueChunk(chunks[keyCount]);
+    // An entity column collects as the IDs it carries, which every row holds: only a
+    // scalar value column is read as nullable, the way a property fetch is.
+    const mlir::Type collectedElement = mlir::cast<nl::ChunkType>(chunks[keyCount].getType()).getElementType();
+    const bool collectsEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(collectedElement);
+
+    if (!collectsEntity) {
+        chunks[keyCount] = nullableValueChunk(chunks[keyCount]);
+    }
 
     const mlir::Location loc = _builder.getUnknownLoc();
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1737,19 +1737,24 @@ void DBLowering::lowerGroupAggregate(mlir::db::GroupAggregate groupAggregate) {
 void DBLowering::lowerCollect(mlir::db::Collect collect) {
     const mlir::OperandRange columns = collect.getColumns();
     const uint64_t keyCount = collect.getKeyCount();
+    const llvm::ArrayRef<int64_t> kinds = collect.getKinds().value_or(llvm::ArrayRef<int64_t> {});
 
-    // The nl chunks the columns lowered to: the grouping keys first, then the single
-    // collected value column. nl.collect_update appends these to the per-group lists.
+    // The nl chunks the columns lowered to: the grouping keys first, then the collected
+    // value columns, then the aggregate inputs. nl.collect_update appends these to the
+    // per-group lists.
     llvm::SmallVector<mlir::Value, 4> chunks;
     for (const mlir::Value column : columns) {
         chunks.push_back(mapValue(column));
     }
 
-    // Collect::verify guarantees columns.size() == keyCount + 1, so an empty column set
-    // here means unverified IR - a defensive backstop, as in lowerGroupAggregate.
+    // Collect::verify guarantees at least one value column after the keys, so an empty
+    // column set here means unverified IR - a defensive backstop, as in
+    // lowerGroupAggregate.
     if (chunks.empty()) {
         throw IRException("db.collect requires at least one column");
     }
+
+    const size_t valueCount = chunks.size() - keyCount - kinds.size();
 
     // A constant collected column is folded over the rows of the group it falls in, not
     // over the single row it is, so it is laid out over the chunk the grouping keys are
@@ -1762,21 +1767,23 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
 
     // An entity column collects as the IDs it carries, which every row holds: only a
     // scalar value column is read as nullable, the way a property fetch is.
-    const mlir::Type collectedElement = mlir::cast<nl::ChunkType>(chunks[keyCount].getType()).getElementType();
-    const bool collectsEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(collectedElement);
+    for (size_t valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+        const size_t chunkIndex = keyCount + valueIndex;
+        const mlir::Type collectedElement = mlir::cast<nl::ChunkType>(chunks[chunkIndex].getType()).getElementType();
+        const bool collectsEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(collectedElement);
 
-    if (!collectsEntity) {
-        chunks[keyCount] = nullableValueChunk(chunks[keyCount]);
+        if (!collectsEntity) {
+            chunks[chunkIndex] = nullableValueChunk(chunks[chunkIndex]);
+        }
     }
 
-    // A reduction beside the list reads its input as a nullable value chunk, as it does
+    // A reduction beside the lists reads its input as a nullable value chunk, as it does
     // under a grouped aggregation; a count tallies rows and takes the chunk as it is.
-    const llvm::ArrayRef<int64_t> kinds = collect.getKinds().value_or(llvm::ArrayRef<int64_t> {});
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
         const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
 
         if (reducesValues(kind)) {
-            const size_t chunkIndex = keyCount + 1 + aggregateIndex;
+            const size_t chunkIndex = keyCount + valueCount + aggregateIndex;
             chunks[chunkIndex] = nullableValueChunk(chunks[chunkIndex]);
         }
     }
@@ -1790,7 +1797,7 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
     nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc,
                                                                     keyCount,
                                                                     collect.getKindsAttr(),
-                                                                    collect.getDistinct());
+                                                                    collect.getDistinctValuesAttr());
     const mlir::Value state = bufferOp.getState();
 
     // The update folds each step's chunk of every column into the per-group lists. It
@@ -1802,10 +1809,10 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
     _builder.create<nl::CollectUpdate>(loc, state, chunks);
 
     // The emit phase: an nl.collect source iterator yielding one row per group - the
-    // key columns then the per-group list cell - drained by an nl.for after the
-    // producing loop. The list chunk's element is the resolved value type (unwrapped
-    // from the collected column's nullable) wrapped in a storage list; the key chunks
-    // keep their input types.
+    // key columns then one per-group list cell per collected column - drained by an
+    // nl.for after the producing loop. Each list chunk's element is the resolved value
+    // type (unwrapped from the collected column's nullable) wrapped in a storage list;
+    // the key chunks keep their input types.
     mlir::MLIRContext* const context = _builder.getContext();
 
     llvm::SmallVector<mlir::Type, 4> chunkTypes;
@@ -1813,21 +1820,23 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
         chunkTypes.push_back(chunks[keyIndex].getType());
     }
 
-    const mlir::Type valueElement = mlir::cast<nl::ChunkType>(chunks[keyCount].getType()).getElementType();
-    mlir::Type listElement = valueElement;
-    if (const auto nullable = mlir::dyn_cast<storage::NullableType>(valueElement)) {
-        listElement = nullable.getValueType();
-    }
+    for (size_t valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+        const mlir::Type valueElement = mlir::cast<nl::ChunkType>(chunks[keyCount + valueIndex].getType()).getElementType();
 
-    const nl::ChunkType listChunk = nl::ChunkType::get(context, storage::ListType::get(context, listElement));
-    chunkTypes.push_back(listChunk);
+        mlir::Type listElement = valueElement;
+        if (const auto nullable = mlir::dyn_cast<storage::NullableType>(valueElement)) {
+            listElement = nullable.getValueType();
+        }
+
+        chunkTypes.push_back(nl::ChunkType::get(context, storage::ListType::get(context, listElement)));
+    }
 
     const mlir::Type ui64Element = _builder.getIntegerType(64, /*isSigned=*/false);
     const nl::ChunkType countChunkType = nl::ChunkType::get(context, ui64Element);
 
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
         const storage::GroupAggregateKind kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
-        const mlir::Value inputChunk = chunks[keyCount + 1 + aggregateIndex];
+        const mlir::Value inputChunk = chunks[keyCount + valueCount + aggregateIndex];
 
         chunkTypes.push_back(groupAggregateResultChunkType(_builder, kind, inputChunk, countChunkType));
     }
@@ -1865,7 +1874,7 @@ void DBLowering::lowerUnwindCollect(mlir::db::UnwindCollect unwindCollect) {
     nl::CollectBuffer bufferOp = _builder.create<nl::CollectBuffer>(loc,
                                                                     keyCount,
                                                                     mlir::DenseI64ArrayAttr {},
-                                                                    /*distinct=*/false);
+                                                                    mlir::DenseI64ArrayAttr {});
     const mlir::Value state = bufferOp.getState();
 
     const mlir::Value representative = chunks.front();

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -380,6 +380,12 @@ private:
     // lowered op belongs
     void setInsertionInto(mlir::Block* block);
 
+    // Point the builder just after the loop nest that @param updateBlock belongs to,
+    // where an accumulator filled from that block holds its final value. A drain loop
+    // lowered before this one sits further down the entry block and may read the
+    // result, so the end of the entry block is too late a home for it.
+    void setInsertionAfterProducingLoop(mlir::Block* updateBlock);
+
     // Point the builder at the right place for an op consuming lhs and rhs.
     void setInsertionForBinaryOp(mlir::Value lhs, mlir::Value rhs);
 

--- a/samples/mlir/collect_aggregates.mlir
+++ b/samples/mlir/collect_aggregates.mlir
@@ -1,0 +1,36 @@
+module {
+  func.func @main() {
+    // MATCH (a) WITH a.dob AS dob, collect(a.name) AS names, count(a.age) AS n,
+    // min(a.age) AS low, max(a.age) AS high RETURN dob, names, n, low, high: one
+    // accumulator holds a group's collected list and the reductions over the same
+    // rows, so the aggregates ride the collect rather than a second op grouping those
+    // rows again.
+    //
+    // The operands are the keyCount grouping keys, then the one collected column, then
+    // one input per kind the `aggregates` list names - the same inputs, in the same
+    // order, that db.group_aggregate takes. The results mirror them: the keys
+    // unchanged, the list, then one column per kind.
+    //
+    // Nothing keeps a reduction off the collected column, and nothing makes the three
+    // read different columns: all three here reduce the same "age". Their result types
+    // are resolved during lowering, as db.group_aggregate's are - count is a non-null
+    // ui64 per group, min and max keep the reduced column's type, so they are left
+    // !db.column<none> here.
+    //
+    // "dob", "name" and "age" are simpledb properties; swap them for properties your
+    // graph has.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %dob = db.get_node_properties(%a, "dob") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %gdob, %names, %n, %low, %high = db.collect(%dob, %name, %age, %age, %age) keys 1 aggregates [count, min, max] : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<ui64>, !db.column<none>, !db.column<none>)
+
+    db.output(%gdob, %names, %n, %low, %high) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<ui64>, !db.column<none>, !db.column<none>
+
+    return
+  }
+}

--- a/samples/mlir/collect_aggregates.nl.mlir
+++ b/samples/mlir/collect_aggregates.nl.mlir
@@ -1,0 +1,35 @@
+// Generated nl-dialect lowering of collect_aggregates.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered collect_aggregates.mlir -graph <graph>
+// This is the DBLowering output; edit collect_aggregates.mlir, not this file.
+//
+// The kinds ride the accumulator: nl.collect_buffer carries `aggregates [count, min,
+// max]`, so it holds a per-group reduction beside the per-group list, and one
+// nl.collect_update appends to the list and charges the three reductions from the same
+// chunk. The nl.collect source then yields one chunk per column - the key, the list,
+// then the three reductions - which is why the aggregates ride the collect rather than
+// a db.group_aggregate of their own over the same rows.
+//
+// Needs -graph: every chunk element type here is resolved during lowering. "dob" and
+// "name" are Strings and "age" is an Int64, so the key and the list are String-shaped
+// and the reductions read a !storage.nullable<i64> chunk. count emits a non-null ui64
+// and min and max keep the reduced column's nullable i64.
+module {
+  func.func @main() {
+    %0 = nl.collect_buffer keys 1 aggregates [count, min, max]
+    %1 = nl.get_property_type("age")
+    %2 = nl.get_property_type("name")
+    %3 = nl.get_property_type("dob")
+    %4 = nl.scan_nodes()
+    nl.for %arg0 in %4 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %6 = nl.get_node_properties(%arg0, %3) : !nl.chunk<!storage.nullable<!storage.string>>
+      %7 = nl.get_node_properties(%arg0, %2) : !nl.chunk<!storage.nullable<!storage.string>>
+      %8 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<i64>>
+      nl.collect_update %0, (%6, %7, %8, %8, %8) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<i64>>
+    }
+    %5 = nl.collect(%0) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<ui64>, !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<i64>>>
+    nl.for %arg0, %arg1, %arg2, %arg3, %arg4 in %5 : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<ui64>, !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<i64>>> {
+      nl.output(%arg0, %arg1, %arg2, %arg3, %arg4) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<ui64>, !nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<i64>>
+    }
+    return
+  }
+}

--- a/samples/mlir/collect_distinct.mlir
+++ b/samples/mlir/collect_distinct.mlir
@@ -29,7 +29,7 @@ module {
 
     %name = db.get_node_properties(%src, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
 
-    %gname, %targets = db.collect(%name, %tgt) keys 1 distinct : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
+    %gname, %targets = db.collect(%name, %tgt) keys 1 distinct [0] : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
 
     db.output(%gname, %targets) : !db.column<none>, !db.column<!storage.list<!storage.node_id>>
 

--- a/samples/mlir/collect_distinct.mlir
+++ b/samples/mlir/collect_distinct.mlir
@@ -1,0 +1,38 @@
+module {
+  func.func @main() {
+    // MATCH (a)-->(b) WITH a.name AS name, collect(DISTINCT b) AS targets RETURN name,
+    // targets: group each source's out-edge rows by its "name" and gather the different
+    // nodes that source points at. `distinct` collects a value a group has already
+    // collected once, so a node reached over several edges is one element - where the
+    // plain form appends one element per edge row. It is Cypher's collect(DISTINCT x),
+    // and the sibling of the count_distinct kind db.group_aggregate takes: same
+    // dedupe, one gathering the values and the other tallying them. The two forms part
+    // exactly when a group repeats a value, which simpledb - where no source reaches one
+    // target twice - does not.
+    //
+    // As on db.count the flag stays on the one op rather than becoming a kind of its
+    // own: the collection is the same over a deduplicated column. What changes is the
+    // fold, which keys each row on its (group, value) pair and appends only the first
+    // time it sees one - so the list holds the group's distinct values in first-seen
+    // order. The dedupe tally lives in the hoisted accumulator, so it spans the chunks
+    // the producing loop steps through.
+    //
+    // The collected column here is the target node ID, so the list is a
+    // !storage.list<!storage.node_id>: the element type is the collected column's,
+    // whatever that is. Only the grouping key is resolved during the db -> nl lowering
+    // (hence -graph), baked from the "name" property.
+    //
+    // "name" is a simpledb property; swap it for a property your graph has.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %src, %edge, %type, %tgt = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    %name = db.get_node_properties(%src, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %gname, %targets = db.collect(%name, %tgt) keys 1 distinct : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
+
+    db.output(%gname, %targets) : !db.column<none>, !db.column<!storage.list<!storage.node_id>>
+
+    return
+  }
+}

--- a/samples/mlir/collect_distinct.nl.mlir
+++ b/samples/mlir/collect_distinct.nl.mlir
@@ -1,0 +1,33 @@
+// Generated nl-dialect lowering of collect_distinct.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered collect_distinct.mlir -graph <graph>
+// This is the DBLowering output; edit collect_distinct.mlir, not this file.
+//
+// The flag rides the accumulator: nl.collect_buffer carries `distinct`, so the fold
+// nl.collect_update runs is the deduplicating one. Nothing else about the shape moves -
+// the same hoisted buffer, the same update inside the loop nest, the same nl.collect
+// source draining one row per group - which is why collect(DISTINCT x) is a flag rather
+// than an op of its own.
+//
+// Needs -graph: the grouping key's chunk element type is resolved from the "name"
+// property during lowering, so it is a !storage.nullable<!storage.string> chunk. The
+// collected column is already a node ID, so the list cell is a
+// !storage.list<!storage.node_id> chunk whatever the schema says.
+module {
+  func.func @main() {
+    %0 = nl.collect_buffer keys 1 distinct
+    %1 = nl.get_property_type("name")
+    %2 = nl.scan_nodes()
+    nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %4 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        %5 = nl.get_node_properties(%arg1, %1) : !nl.chunk<!storage.nullable<!storage.string>>
+        nl.collect_update %0, (%5, %arg4) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>
+      }
+    }
+    %3 = nl.collect(%0) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.node_id>>>
+    nl.for %arg0, %arg1 in %3 : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.node_id>>> {
+      nl.output(%arg0, %arg1) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.node_id>>
+    }
+    return
+  }
+}

--- a/samples/mlir/collect_distinct.nl.mlir
+++ b/samples/mlir/collect_distinct.nl.mlir
@@ -2,7 +2,7 @@
 // Reproduce with: mlir -dump-lowered collect_distinct.mlir -graph <graph>
 // This is the DBLowering output; edit collect_distinct.mlir, not this file.
 //
-// The flag rides the accumulator: nl.collect_buffer carries `distinct`, so the fold
+// The flag rides the accumulator: nl.collect_buffer names the deduping value column, so the fold
 // nl.collect_update runs is the deduplicating one. Nothing else about the shape moves -
 // the same hoisted buffer, the same update inside the loop nest, the same nl.collect
 // source draining one row per group - which is why collect(DISTINCT x) is a flag rather
@@ -14,7 +14,7 @@
 // !storage.list<!storage.node_id> chunk whatever the schema says.
 module {
   func.func @main() {
-    %0 = nl.collect_buffer keys 1 distinct
+    %0 = nl.collect_buffer keys 1 distinct [0]
     %1 = nl.get_property_type("name")
     %2 = nl.scan_nodes()
     nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {

--- a/samples/mlir/collect_multi.mlir
+++ b/samples/mlir/collect_multi.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @main() {
+    // MATCH (a) WITH a.dob AS dob, collect(a.name) AS names, collect(DISTINCT a.age) AS
+    // ages RETURN dob, names, ages: one accumulator holds every list a group collects,
+    // so a second collect is another value column rather than a second op grouping the
+    // same rows again - and a second drain the one output could not read.
+    //
+    // The operands are the keyCount grouping keys, then the collected columns, then one
+    // input per kind the `aggregates` list names. What the keys and the aggregates leave
+    // over is the value count, so it is not spelled out: two columns follow the one key
+    // here. The results mirror them: the keys unchanged, then one list per value.
+    //
+    // `distinct` names the value columns that dedupe by index rather than being a flag on
+    // the op, because one projection may collect a column both ways: here value 1 (the
+    // ages) takes each of a group's values once and value 0 (the names) keeps every row.
+    //
+    // "dob", "name" and "age" are simpledb properties; swap them for properties your
+    // graph has.
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+
+    %dob = db.get_node_properties(%a, "dob") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    %gdob, %names, %ages = db.collect(%dob, %name, %age) keys 1 distinct [1] : (!db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<!storage.list<none>>)
+
+    db.output(%gdob, %names, %ages) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<!storage.list<none>>
+
+    return
+  }
+}

--- a/samples/mlir/collect_multi.nl.mlir
+++ b/samples/mlir/collect_multi.nl.mlir
@@ -1,0 +1,36 @@
+// Generated nl-dialect lowering of collect_multi.mlir (db dialect).
+// Reproduce with: mlir -dump-lowered collect_multi.mlir -graph <graph>
+// This is the DBLowering output; edit collect_multi.mlir, not this file.
+//
+// Both lists ride the accumulator: nl.collect_buffer holds a per-group value buffer per
+// collected column, so one nl.collect_update appends a row's name and its age from the
+// same chunk, and the nl.collect source yields one chunk per column - the key, then a
+// list per value. That is what keeps a second collect out of a drain loop of its own,
+// which the single nl.output could not read from.
+//
+// `distinct [1]` names the deduping value column by index, so the ages take each of a
+// group's values once while the names beside them keep every row.
+//
+// Needs -graph: every chunk element type here is resolved during lowering. "dob" and
+// "name" are Strings and "age" is an Int64, so the key and the first list are
+// String-shaped and the second list collects i64.
+module {
+  func.func @main() {
+    %0 = nl.collect_buffer keys 1 distinct [1]
+    %1 = nl.get_property_type("age")
+    %2 = nl.get_property_type("name")
+    %3 = nl.get_property_type("dob")
+    %4 = nl.scan_nodes()
+    nl.for %arg0 in %4 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %6 = nl.get_node_properties(%arg0, %3) : !nl.chunk<!storage.nullable<!storage.string>>
+      %7 = nl.get_node_properties(%arg0, %2) : !nl.chunk<!storage.nullable<!storage.string>>
+      %8 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<i64>>
+      nl.collect_update %0, (%6, %7, %8) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<i64>>
+    }
+    %5 = nl.collect(%0) : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<!storage.list<i64>>>
+    nl.for %arg0, %arg1, %arg2 in %5 : !nl.iter<!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<!storage.list<i64>>> {
+      nl.output(%arg0, %arg1, %arg2) : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.list<!storage.string>>, !nl.chunk<!storage.list<i64>>
+    }
+    return
+  }
+}

--- a/samples/mlir/main.cpp
+++ b/samples/mlir/main.cpp
@@ -458,6 +458,14 @@ private:
                 std::cout << "null";
             break;
 
+            case ListBufferTypeTag::NodeID:
+                std::cout << element.getAs<NodeID>().getValue();
+            break;
+
+            case ListBufferTypeTag::EdgeID:
+                std::cout << element.getAs<EdgeID>().getValue();
+            break;
+
             case ListBufferTypeTag::INVALID:
                 std::cout << "?";
             break;

--- a/storage/list/ListBuffer.h
+++ b/storage/list/ListBuffer.h
@@ -12,6 +12,8 @@
 #include "ListView.h"
 #include "ListWriteCursor.h"
 
+#include "ID.h"
+
 #include "metadata/PropertyNull.h"
 #include "metadata/PropertyType.h"
 
@@ -22,7 +24,7 @@ using ListableTypesImpl =
     std::tuple<db::types::Int64::Primitive, db::types::UInt64::Primitive,
                db::types::Double::Primitive, db::types::String::Primitive,
                db::types::Bool::Primitive, db::types::Embedding::Primitive, db::ListView,
-               db::PropertyNull>;
+               db::PropertyNull, db::NodeID, db::EdgeID>;
 }
 
 namespace db {

--- a/storage/list/ListBufferTypeTag.h
+++ b/storage/list/ListBufferTypeTag.h
@@ -14,6 +14,8 @@ enum class ListBufferTypeTag : uint8_t {
     Embedding,
     ListView,
     Null,
+    NodeID,
+    EdgeID,
 
     INVALID,
 };

--- a/storage/list/ListByteBuffer.cpp
+++ b/storage/list/ListByteBuffer.cpp
@@ -119,4 +119,6 @@ template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const types:
 template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const types::Embedding::Primitive&);
 template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const ListView&);
 template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const PropertyNull&);
+template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const NodeID&);
+template ListElementView ListByteBuffer<>::write(ListBufferTypeTag, const EdgeID&);
 }

--- a/storage/list/ListElementOrder.cpp
+++ b/storage/list/ListElementOrder.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "ID.h"
 #include "ListBufferTypeTag.h"
 
 #include "metadata/PropertyType.h"
@@ -19,7 +20,9 @@ namespace {
 
 // The class a tagged element sorts in, ascending.
 enum class ListElementOrderClass {
-    List = 0,
+    Node = 0,
+    Edge,
+    List,
     String,
     Bool,
     Number,
@@ -28,6 +31,14 @@ enum class ListElementOrderClass {
 
 ListElementOrderClass orderClassOf(ListBufferTypeTag tag) {
     switch (tag) {
+        case ListBufferTypeTag::NodeID:
+            return ListElementOrderClass::Node;
+        break;
+
+        case ListBufferTypeTag::EdgeID:
+            return ListElementOrderClass::Edge;
+        break;
+
         case ListBufferTypeTag::ListView:
             return ListElementOrderClass::List;
         break;
@@ -176,6 +187,14 @@ std::strong_ordering db::operator<=>(const ListElementView lhs, const ListElemen
     }
 
     switch (lhsClass) {
+        case ListElementOrderClass::Node:
+            return lhs.getAs<NodeID>() <=> rhs.getAs<NodeID>();
+        break;
+
+        case ListElementOrderClass::Edge:
+            return lhs.getAs<EdgeID>() <=> rhs.getAs<EdgeID>();
+        break;
+
         case ListElementOrderClass::List:
             return compareLists(lhs.getAs<ListView>(), rhs.getAs<ListView>());
         break;

--- a/storage/list/ListElementOrder.cpp
+++ b/storage/list/ListElementOrder.cpp
@@ -159,23 +159,6 @@ bool elementEqualsNumber(const ListElementView element, const Value value) {
     }
 }
 
-// Two lists compare lexicographically: pairwise from the front, then the shorter list
-// first when one is a prefix of the other.
-std::strong_ordering compareLists(const ListView lhs, const ListView rhs) {
-    const std::span<const ListElementView> lhsElements = lhs.elements();
-    const std::span<const ListElementView> rhsElements = rhs.elements();
-    const size_t common = std::min(lhsElements.size(), rhsElements.size());
-
-    for (size_t index = 0; index < common; index++) {
-        const std::strong_ordering order = lhsElements[index] <=> rhsElements[index];
-        if (order != std::strong_ordering::equal) {
-            return order;
-        }
-    }
-
-    return lhsElements.size() <=> rhsElements.size();
-}
-
 }
 
 std::strong_ordering db::operator<=>(const ListElementView lhs, const ListElementView rhs) {
@@ -196,7 +179,7 @@ std::strong_ordering db::operator<=>(const ListElementView lhs, const ListElemen
         break;
 
         case ListElementOrderClass::List:
-            return compareLists(lhs.getAs<ListView>(), rhs.getAs<ListView>());
+            return lhs.getAs<ListView>() <=> rhs.getAs<ListView>();
         break;
 
         case ListElementOrderClass::String:
@@ -221,6 +204,25 @@ std::strong_ordering db::operator<=>(const ListElementView lhs, const ListElemen
 }
 
 bool db::operator==(const ListElementView lhs, const ListElementView rhs) {
+    return (lhs <=> rhs) == std::strong_ordering::equal;
+}
+
+std::strong_ordering db::operator<=>(const ListView lhs, const ListView rhs) {
+    const std::span<const ListElementView> lhsElements = lhs.elements();
+    const std::span<const ListElementView> rhsElements = rhs.elements();
+    const size_t common = std::min(lhsElements.size(), rhsElements.size());
+
+    for (size_t index = 0; index < common; index++) {
+        const std::strong_ordering order = lhsElements[index] <=> rhsElements[index];
+        if (order != std::strong_ordering::equal) {
+            return order;
+        }
+    }
+
+    return lhsElements.size() <=> rhsElements.size();
+}
+
+bool db::operator==(const ListView lhs, const ListView rhs) {
     return (lhs <=> rhs) == std::strong_ordering::equal;
 }
 

--- a/storage/list/ListElementOrder.h
+++ b/storage/list/ListElementOrder.h
@@ -12,10 +12,10 @@ namespace db {
 /**
  * @brief Orders two elements of a @ref ListByteBuffer, which need not share a type.
  *
- * Follows Cypher's orderability across types - LIST < STRING < BOOLEAN < NUMBER < NULL -
- * so a null sorts after every value and two elements of one type compare by their own
- * order: numbers numerically whatever they are tagged as, strings lexicographically,
- * lists element-wise. An embedding has no order and throws.
+ * Follows Cypher's orderability across types - NODE < EDGE < LIST < STRING < BOOLEAN <
+ * NUMBER < NULL - so a null sorts after every value and two elements of one type compare
+ * by their own order: entities by their ID, numbers numerically whatever they are tagged
+ * as, strings lexicographically, lists element-wise. An embedding has no order and throws.
  */
 std::strong_ordering operator<=>(ListElementView lhs, ListElementView rhs);
 bool operator==(ListElementView lhs, ListElementView rhs);

--- a/storage/list/ListElementOrder.h
+++ b/storage/list/ListElementOrder.h
@@ -21,6 +21,16 @@ std::strong_ordering operator<=>(ListElementView lhs, ListElementView rhs);
 bool operator==(ListElementView lhs, ListElementView rhs);
 
 /**
+ * @brief Orders two lists of a @ref ListByteBuffer lexicographically.
+ *
+ * Compares pairwise from the front on the element order above, then puts the shorter
+ * list first when one is a prefix of the other - Cypher's order over lists, and the
+ * order a nested list element is compared on.
+ */
+std::strong_ordering operator<=>(ListView lhs, ListView rhs);
+bool operator==(ListView lhs, ListView rhs);
+
+/**
  * @brief Compares an element of a @ref ListByteBuffer against a value of a known type.
  *
  * Equal only when the element holds that value: a number compares numerically whatever

--- a/storage/list/ListUtils.h
+++ b/storage/list/ListUtils.h
@@ -3,6 +3,8 @@
 #include "ListView.h"
 #include "ListBufferTypeTag.h"
 
+#include "ID.h"
+
 #include "metadata/PropertyNull.h"
 #include "metadata/PropertyType.h"
 
@@ -37,6 +39,12 @@ struct ListTagDispatcher {
             break;
             case ListBufferTypeTag::Null:
                 return executor.template operator()<PropertyNull>(view);
+            break;
+            case ListBufferTypeTag::NodeID:
+                return executor.template operator()<NodeID>(view);
+            break;
+            case ListBufferTypeTag::EdgeID:
+                return executor.template operator()<EdgeID>(view);
             break;
 
             case ListBufferTypeTag::INVALID:
@@ -88,6 +96,16 @@ struct TypeToListBufferTag<ListView> {
 template <>
 struct TypeToListBufferTag<PropertyNull> {
     static constexpr ListBufferTypeTag Tag = ListBufferTypeTag::Null;
+};
+
+template <>
+struct TypeToListBufferTag<NodeID> {
+    static constexpr ListBufferTypeTag Tag = ListBufferTypeTag::NodeID;
+};
+
+template <>
+struct TypeToListBufferTag<EdgeID> {
+    static constexpr ListBufferTypeTag Tag = ListBufferTypeTag::EdgeID;
 };
 
 }

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -925,6 +925,17 @@ target_link_libraries(test_query_ir_with_collect PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_with_collect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_cypher_multi_collect CypherMultiCollectTest.cpp)
+target_link_libraries(test_query_ir_cypher_multi_collect PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_cypher_multi_collect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with_scope WithScopeTest.cpp)
 target_link_libraries(test_query_ir_with_scope PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -34,6 +34,9 @@ target_link_libraries(test_query_ir_group_aggregate PRIVATE
         turing_db_interpreter_v3_s)
 add_ir_tests(test_query_ir_collect CollectTest.cpp)
 
+# The chunked collect tests force the collect fold to span chunk boundaries.
+add_ir_tests(test_query_ir_collect_chunked CollectChunkedTest.cpp)
+
 # The collect row-alignment and drain tests run against the shared SimpleGraph fixture.
 add_ir_tests(test_query_ir_collect_row_alignment CollectRowAlignmentTest.cpp)
 target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_examples_s)
@@ -186,6 +189,34 @@ target_link_libraries(test_query_ir_db_procedures PRIVATE
 # The Cypher-level collect tests drive queries end to end through QueryInterpreterV3.
 add_ir_tests(test_query_ir_cypher_collect CypherCollectTest.cpp)
 target_link_libraries(test_query_ir_cypher_collect PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_interpreter_v3_s)
+
+add_ir_tests(test_query_ir_cypher_collect_distinct_entity CypherCollectDistinctEntityTest.cpp)
+target_link_libraries(test_query_ir_cypher_collect_distinct_entity PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_interpreter_v3_s)
+
+add_ir_tests(test_query_ir_cypher_collect_element_type CypherCollectElementTypeTest.cpp)
+target_link_libraries(test_query_ir_cypher_collect_element_type PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_interpreter_v3_s)
+
+add_ir_tests(test_query_ir_cypher_collect_aggregate CypherCollectAggregateTest.cpp)
+target_link_libraries(test_query_ir_cypher_collect_aggregate PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_interpreter_v3_s)
+
+add_ir_tests(test_query_ir_cypher_collect_input CypherCollectInputTest.cpp)
+target_link_libraries(test_query_ir_cypher_collect_input PRIVATE
         turing_db_s
         turing_testenv_s
         turing_db_system_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -914,6 +914,17 @@ target_link_libraries(test_query_ir_with_cut PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_with_cut PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_with_collect WithCollectTest.cpp)
+target_link_libraries(test_query_ir_with_collect PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_with_collect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with_scope WithScopeTest.cpp)
 target_link_libraries(test_query_ir_with_scope PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -183,6 +183,14 @@ target_link_libraries(test_query_ir_db_procedures PRIVATE
         turing_db_frontend_cypher_s
         turing_db_ir_codegen_s)
 
+# The Cypher-level collect tests drive queries end to end through QueryInterpreterV3.
+add_ir_tests(test_query_ir_cypher_collect CypherCollectTest.cpp)
+target_link_libraries(test_query_ir_cypher_collect PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_interpreter_v3_s)
+
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)

--- a/test/query/ir/CollectChunkedTest.cpp
+++ b/test/query/ir/CollectChunkedTest.cpp
@@ -1,0 +1,632 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+#include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Names = std::vector<std::string>;
+using Values = std::vector<int64_t>;
+using NodeIDs = std::vector<uint64_t>;
+using OptInt64 = std::optional<int64_t>;
+using OptDouble = std::optional<double>;
+
+// Reads one list cell as a vector of strings.
+void readStringList(const ListView& view, Names& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(std::string(element.getAs<std::string_view>()));
+    }
+}
+
+// Reads one list cell as a vector of int64s.
+void readInt64List(const ListView& view, Values& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(element.getAs<int64_t>());
+    }
+}
+
+// Reads one list cell as a vector of node ids, asserting the node tag.
+void readNodeIDList(const ListView& view, NodeIDs& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::NodeID);
+        out.push_back(element.getAs<NodeID>().getValue());
+    }
+}
+
+// Collects the (team, [values]) rows a grouped collect emits, reading each list cell
+// with the reader for the collected element type.
+template <typename Element, void (*Reader)(const ListView&, std::vector<Element>&)>
+class KeyedListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<Element>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<Element> values;
+            Reader(listRaw[row], values);
+
+            _rows.push_back({key, values});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+using KeyedValueListSink = KeyedListSink<int64_t, readInt64List>;
+using KeyedNameListSink = KeyedListSink<std::string, readStringList>;
+using KeyedNodeListSink = KeyedListSink<uint64_t, readNodeIDList>;
+
+// Collects the single [values] row an ungrouped collect emits.
+class ValueListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Values values;
+            readInt64List(listRaw[row], values);
+
+            _rows.push_back(values);
+        }
+    }
+
+    const std::vector<Values>& rows() const { return _rows; }
+
+private:
+    std::vector<Values> _rows;
+};
+
+// Collects the (team, [values], count, sum, min, max) rows a collect carrying the four
+// plain reductions emits.
+class KeyedListAndReductionsSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, Values, uint64_t, OptInt64, OptInt64, OptInt64>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 6u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[2]);
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[3]);
+        const auto* minima = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[4]);
+        const auto* maxima = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[5]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(counts, nullptr);
+        ASSERT_NE(sums, nullptr);
+        ASSERT_NE(minima, nullptr);
+        ASSERT_NE(maxima, nullptr);
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& countRaw = counts->getRaw();
+        const auto& sumRaw = sums->getRaw();
+        const auto& minimumRaw = minima->getRaw();
+        const auto& maximumRaw = maxima->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Values values;
+            readInt64List(listRaw[row], values);
+
+            _rows.push_back({key, values, countRaw[row], sumRaw[row], minimumRaw[row], maximumRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (team, [values], count_distinct, sum_distinct, avg_distinct) rows a
+// collect carrying the three distinct reductions emits.
+class KeyedListAndDistinctReductionsSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, Values, uint64_t, OptInt64, OptDouble>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 5u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[2]);
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[3]);
+        const auto* averages = dynamic_cast<const ColumnOptVector<double>*>(chunks[4]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(counts, nullptr);
+        ASSERT_NE(sums, nullptr);
+        ASSERT_NE(averages, nullptr);
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& countRaw = counts->getRaw();
+        const auto& sumRaw = sums->getRaw();
+        const auto& averageRaw = averages->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Values values;
+            readInt64List(listRaw[row], values);
+
+            _rows.push_back({key, values, countRaw[row], sumRaw[row], averageRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// MATCH (a) RETURN a.team, collect(DISTINCT a.score).
+constexpr const char* distinctScoresProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %scores = db.collect(%team, %score) keys 1 distinct : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
+  db.output(%gteam, %scores) : !db.column<none>, !db.column<!storage.list<none>>
+  return
+}
+)mlir";
+
+// The same collect without the flag: the bag the distinct form deduplicates.
+constexpr const char* everyScoreProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %scores = db.collect(%team, %score) keys 1 : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
+  db.output(%gteam, %scores) : !db.column<none>, !db.column<!storage.list<none>>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN collect(DISTINCT a.score): one group over the whole scan, so every
+// chunk folds into the same distinct tally.
+constexpr const char* distinctScoresKeylessProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %scores = db.collect(%score) keys 0 distinct : (!db.column<none>) -> !db.column<!storage.list<none>>
+  db.output(%scores) : !db.column<!storage.list<none>>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN a.team, collect(DISTINCT a.name): the String fold, which keys a
+// group on the bytes of the value rather than on a scalar.
+constexpr const char* distinctNamesProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %names = db.collect(%team, %name) keys 1 distinct : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
+  db.output(%gteam, %names) : !db.column<none>, !db.column<!storage.list<none>>
+  return
+}
+)mlir";
+
+// MATCH (a)-->(b) RETURN a.team, collect(DISTINCT b): the entity fold. A node reached
+// over two edges is one element, and at chunk size one the two edges are two steps.
+constexpr const char* distinctTargetsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %src, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %team = db.get_node_properties(%src, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %targets = db.collect(%team, %b) keys 1 distinct : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
+  db.output(%gteam, %targets) : !db.column<none>, !db.column<!storage.list<!storage.node_id>>
+  return
+}
+)mlir";
+
+// MATCH (a) RETURN a.team, collect(a.score), count(a.score), sum(a.score),
+// min(a.score), max(a.score): four accumulators folded over the same groups as the list.
+constexpr const char* reductionsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %scores, %n, %total, %low, %high = db.collect(%team, %score, %score, %score, %score, %score) keys 1 aggregates [count, sum, min, max] : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>)
+  db.output(%gteam, %scores, %n, %total, %low, %high) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+// The distinct reductions beside a plain list: each keeps a tally of the values its
+// group has already charged, which every chunk of the group folds into.
+constexpr const char* distinctReductionsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %scores, %n, %total, %mean = db.collect(%team, %score, %score, %score, %score) keys 1 aggregates [count_distinct, sum_distinct, avg_distinct] : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>)
+  db.output(%gteam, %scores, %n, %total, %mean) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+// The distinct reductions beside a distinct list: the list and the reductions dedupe
+// the same column through tallies of their own, so both must survive the chunking.
+constexpr const char* distinctReductionsAndListProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gteam, %scores, %n, %total, %mean = db.collect(%team, %score, %score, %score, %score) keys 1 aggregates [count_distinct, sum_distinct, avg_distinct] distinct : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>)
+  db.output(%gteam, %scores, %n, %total, %mean) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+}
+
+// collect(DISTINCT x) and the reductions a collect carries both accumulate in state
+// hoisted above the producing loop, which nl.collect_update folds one chunk at a time.
+// Every test here runs its program at a chunk size that splits the fixture and at the
+// production one, against a single expectation: a tally or an accumulator that did not
+// survive a chunk boundary parts the two.
+class CollectChunkedTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // Seven nodes over three teams, each with an optional "name" (String) and "score"
+    // (Int64), and four edges of two types:
+    //   n0 red   name=Ann  score=10   -> n2 (KNOWS), -> n2 (LIKES), so n2 twice
+    //   n1 red   name=Bob  score=20   -> n5 (KNOWS)
+    //   n2 blue  name=Cara score=100  -> n0 (KNOWS)
+    //   n3 red   name=Ann  score=10   repeats red's name and score three rows on
+    //   n4 blue  name=Dee  score=100  repeats blue's score, -> n0 (KNOWS)
+    //   n5 red   name=Eve  score=30
+    //   n6 green (no name, no score)  the group holding no value at all
+    //
+    // Every repeat is several rows away from what it repeats, so a chunk size of two or
+    // three puts the two occurrences in different chunks.
+    std::unique_ptr<Graph> buildRepeatingGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        metadata.getOrCreateLabel("0");
+        const PropertyTypeID teamID = metadata.getOrCreatePropertyType("team", ValueType::String)._id;
+        const PropertyTypeID nameID = metadata.getOrCreatePropertyType("name", ValueType::String)._id;
+        const PropertyTypeID scoreID = metadata.getOrCreatePropertyType("score", ValueType::Int64)._id;
+        const EdgeTypeID knows = metadata.getOrCreateEdgeType("KNOWS");
+        const EdgeTypeID likes = metadata.getOrCreateEdgeType("LIKES");
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const NodeID red1 = builder.addNode(labelset);
+        const NodeID red2 = builder.addNode(labelset);
+        const NodeID blue1 = builder.addNode(labelset);
+        const NodeID red3 = builder.addNode(labelset);
+        const NodeID blue2 = builder.addNode(labelset);
+        const NodeID red4 = builder.addNode(labelset);
+        const NodeID green1 = builder.addNode(labelset);
+
+        builder.addNodeProperty<types::String>(red1, teamID, "red");
+        builder.addNodeProperty<types::String>(red2, teamID, "red");
+        builder.addNodeProperty<types::String>(blue1, teamID, "blue");
+        builder.addNodeProperty<types::String>(red3, teamID, "red");
+        builder.addNodeProperty<types::String>(blue2, teamID, "blue");
+        builder.addNodeProperty<types::String>(red4, teamID, "red");
+        builder.addNodeProperty<types::String>(green1, teamID, "green");
+
+        builder.addNodeProperty<types::String>(red1, nameID, "Ann");
+        builder.addNodeProperty<types::String>(red2, nameID, "Bob");
+        builder.addNodeProperty<types::String>(blue1, nameID, "Cara");
+        builder.addNodeProperty<types::String>(red3, nameID, "Ann");
+        builder.addNodeProperty<types::String>(blue2, nameID, "Dee");
+        builder.addNodeProperty<types::String>(red4, nameID, "Eve");
+
+        builder.addNodeProperty<types::Int64>(red1, scoreID, 10);
+        builder.addNodeProperty<types::Int64>(red2, scoreID, 20);
+        builder.addNodeProperty<types::Int64>(blue1, scoreID, 100);
+        builder.addNodeProperty<types::Int64>(red3, scoreID, 10);
+        builder.addNodeProperty<types::Int64>(blue2, scoreID, 100);
+        builder.addNodeProperty<types::Int64>(red4, scoreID, 30);
+
+        builder.addEdge(knows, red1, blue1);
+        builder.addEdge(likes, red1, blue1);
+        builder.addEdge(knows, red2, red4);
+        builder.addEdge(knows, blue1, red1);
+        builder.addEdge(knows, blue2, red1);
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
+    // Parses a db-dialect program, lowers it to nl with DBLowering, and runs the lowered
+    // function against the graph view at this chunk size.
+    void runLoweredProgram(const char* programText,
+                           const GraphView& view,
+                           NLOutputSink& sink,
+                           size_t chunkSize) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule);
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+    }
+
+    // One row per chunk, then two and three rows per chunk - each splitting the seven
+    // nodes and the five edges differently - and last the production size, which holds
+    // the whole fixture in one chunk.
+    const std::vector<size_t> _chunkSizes {1, 2, 3, ChunkConfig::CHUNK_SIZE};
+
+    std::unique_ptr<JobSystem> _jobSystem;
+};
+
+TEST_F(CollectChunkedTest, collectsDistinctScoresPerGroup) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedValueListSink::Row> expected {
+        {"blue", {100}},
+        {"green", {}},
+        {"red", {10, 20, 30}},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedValueListSink sink;
+        runLoweredProgram(distinctScoresProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedValueListSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, collectsEveryScorePerGroup) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedValueListSink::Row> expected {
+        {"blue", {100, 100}},
+        {"green", {}},
+        {"red", {10, 20, 10, 30}},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedValueListSink sink;
+        runLoweredProgram(everyScoreProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedValueListSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, collectsDistinctScoresOverTheWholeScan) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const Values expected {10, 20, 100, 30};
+
+    for (const size_t chunkSize : _chunkSizes) {
+        ValueListSink sink;
+        runLoweredProgram(distinctScoresKeylessProgram, reader.getView(), sink, chunkSize);
+
+        ASSERT_EQ(sink.rows().size(), 1u) << "at chunk size " << chunkSize;
+        EXPECT_EQ(sink.rows().front(), expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, collectsDistinctNamesPerGroup) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedNameListSink::Row> expected {
+        {"blue", {"Cara", "Dee"}},
+        {"green", {}},
+        {"red", {"Ann", "Bob", "Eve"}},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedNameListSink sink;
+        runLoweredProgram(distinctNamesProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedNameListSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, collectsDistinctTargetsPerGroup) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedNodeListSink::Row> expected {
+        {"blue", {0}},
+        {"red", {2, 5}},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedNodeListSink sink;
+        runLoweredProgram(distinctTargetsProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedNodeListSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, reducesEveryPlainKindBesideTheList) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedListAndReductionsSink::Row> expected {
+        {"blue", {100, 100}, 2, 200, 100, 100},
+        {"green", {}, 0, 0, std::nullopt, std::nullopt},
+        {"red", {10, 20, 10, 30}, 4, 70, 10, 30},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedListAndReductionsSink sink;
+        runLoweredProgram(reductionsProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedListAndReductionsSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, reducesDistinctValuesBesideTheList) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedListAndDistinctReductionsSink::Row> expected {
+        {"blue", {100, 100}, 1, 100, 100.0},
+        {"green", {}, 0, 0, std::nullopt},
+        {"red", {10, 20, 10, 30}, 3, 60, 20.0},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedListAndDistinctReductionsSink sink;
+        runLoweredProgram(distinctReductionsProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedListAndDistinctReductionsSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CollectChunkedTest, reducesDistinctValuesBesideADistinctList) {
+    auto graph = buildRepeatingGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    const std::vector<KeyedListAndDistinctReductionsSink::Row> expected {
+        {"blue", {100}, 1, 100, 100.0},
+        {"green", {}, 0, 0, std::nullopt},
+        {"red", {10, 20, 30}, 3, 60, 20.0},
+    };
+
+    for (const size_t chunkSize : _chunkSizes) {
+        KeyedListAndDistinctReductionsSink sink;
+        runLoweredProgram(distinctReductionsAndListProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<KeyedListAndDistinctReductionsSink::Row> rows;
+        sink.sortedRows(rows);
+        EXPECT_EQ(rows, expected) << "at chunk size " << chunkSize;
+    }
+}

--- a/test/query/ir/CollectChunkedTest.cpp
+++ b/test/query/ir/CollectChunkedTest.cpp
@@ -250,7 +250,7 @@ func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
   %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %gteam, %scores = db.collect(%team, %score) keys 1 distinct : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
+  %gteam, %scores = db.collect(%team, %score) keys 1 distinct [0] : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
   db.output(%gteam, %scores) : !db.column<none>, !db.column<!storage.list<none>>
   return
 }
@@ -274,7 +274,7 @@ constexpr const char* distinctScoresKeylessProgram = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %scores = db.collect(%score) keys 0 distinct : (!db.column<none>) -> !db.column<!storage.list<none>>
+  %scores = db.collect(%score) keys 0 distinct [0] : (!db.column<none>) -> !db.column<!storage.list<none>>
   db.output(%scores) : !db.column<!storage.list<none>>
   return
 }
@@ -287,7 +287,7 @@ func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
   %name = db.get_node_properties(%a, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %gteam, %names = db.collect(%team, %name) keys 1 distinct : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
+  %gteam, %names = db.collect(%team, %name) keys 1 distinct [0] : (!db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>)
   db.output(%gteam, %names) : !db.column<none>, !db.column<!storage.list<none>>
   return
 }
@@ -300,7 +300,7 @@ func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %src, %eids, %etypes, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
   %team = db.get_node_properties(%src, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %gteam, %targets = db.collect(%team, %b) keys 1 distinct : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
+  %gteam, %targets = db.collect(%team, %b) keys 1 distinct [0] : (!db.column<none>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.list<!storage.node_id>>)
   db.output(%gteam, %targets) : !db.column<none>, !db.column<!storage.list<!storage.node_id>>
   return
 }
@@ -339,7 +339,7 @@ func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %team = db.get_node_properties(%a, "team") : (!db.column<!storage.node_id>) -> !db.column<none>
   %score = db.get_node_properties(%a, "score") : (!db.column<!storage.node_id>) -> !db.column<none>
-  %gteam, %scores, %n, %total, %mean = db.collect(%team, %score, %score, %score, %score) keys 1 aggregates [count_distinct, sum_distinct, avg_distinct] distinct : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>)
+  %gteam, %scores, %n, %total, %mean = db.collect(%team, %score, %score, %score, %score) keys 1 aggregates [count_distinct, sum_distinct, avg_distinct] distinct [0] : (!db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>, !db.column<none>) -> (!db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>)
   db.output(%gteam, %scores, %n, %total, %mean) : !db.column<none>, !db.column<!storage.list<none>>, !db.column<none>, !db.column<none>, !db.column<none>
   return
 }

--- a/test/query/ir/CypherCollectAggregateTest.cpp
+++ b/test/query/ir/CypherCollectAggregateTest.cpp
@@ -1,0 +1,467 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+
+#include "LocalMemory.h"
+#include "NLOutputSink.h"
+#include "QueryConfig.h"
+#include "QueryInterpreterV3.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Names = std::vector<std::string>;
+using OptInt64 = std::optional<int64_t>;
+using OptDouble = std::optional<double>;
+
+// Reads one list cell as a vector of strings.
+void readStringList(const ListView& view, Names& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(std::string(element.getAs<std::string_view>()));
+    }
+}
+
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+// Collects the (team, [names], reduction) rows a grouped collect emits beside one
+// reduction, reading the reduction column as the type its kind produces: a count is an
+// unsigned tally, a sum or an extremum is a nullable Int64, an average a nullable Double.
+template <typename ReductionColumn, typename Reduction>
+class KeyedListAndReductionSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, Names, Reduction>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* reductions = dynamic_cast<const ReductionColumn*>(chunks[2]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(reductions, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& reductionRaw = reductions->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key, names, reductionRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+    // The rows as the sink saw them, for the ORDER BY test: the emit order is the result.
+    void rowsInEmitOrder(std::vector<Row>& rows) const {
+        rows = _rows;
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+using KeyedListAndCountSink = KeyedListAndReductionSink<ColumnVector<uint64_t>, uint64_t>;
+using KeyedListAndInt64Sink = KeyedListAndReductionSink<ColumnOptVector<int64_t>, OptInt64>;
+using KeyedListAndDoubleSink = KeyedListAndReductionSink<ColumnOptVector<double>, OptDouble>;
+
+// Collects the (team, [names], count(*), count(score), sum, min, max, avg) rows one
+// collect carrying every non-distinct reduction emits.
+class KeyedListAndEveryReductionSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, Names, uint64_t, uint64_t, OptInt64, OptInt64, OptInt64, OptDouble>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 8u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* rowCounts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[2]);
+        const auto* valueCounts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[3]);
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[4]);
+        const auto* minima = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[5]);
+        const auto* maxima = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[6]);
+        const auto* averages = dynamic_cast<const ColumnOptVector<double>*>(chunks[7]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(rowCounts, nullptr);
+        ASSERT_NE(valueCounts, nullptr);
+        ASSERT_NE(sums, nullptr);
+        ASSERT_NE(minima, nullptr);
+        ASSERT_NE(maxima, nullptr);
+        ASSERT_NE(averages, nullptr);
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& rowCountRaw = rowCounts->getRaw();
+        const auto& valueCountRaw = valueCounts->getRaw();
+        const auto& sumRaw = sums->getRaw();
+        const auto& minimumRaw = minima->getRaw();
+        const auto& maximumRaw = maxima->getRaw();
+        const auto& averageRaw = averages->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key,
+                             names,
+                             rowCountRaw[row],
+                             valueCountRaw[row],
+                             sumRaw[row],
+                             minimumRaw[row],
+                             maximumRaw[row],
+                             averageRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the ([names], min, avg) row an ungrouped collect emits beside two scalar
+// aggregates of its own.
+class ListAndTwoReductionsSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        const auto* minima = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[1]);
+        const auto* averages = dynamic_cast<const ColumnOptVector<double>*>(chunks[2]);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(minima, nullptr);
+        ASSERT_NE(averages, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            readStringList(listRaw[row], _names);
+
+            _min = minima->getRaw()[row];
+            _average = averages->getRaw()[row];
+            _rowCount++;
+        }
+    }
+
+    const Names& getNames() const { return _names; }
+    OptInt64 getMin() const { return _min; }
+    OptDouble getAverage() const { return _average; }
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    Names _names;
+    OptInt64 _min;
+    OptDouble _average;
+    size_t _rowCount {0};
+};
+
+}
+
+// One accumulator holds a group's collected list and its reductions, so every
+// GroupAggregateKind has to come out beside the list it was folded with. This suite runs
+// the whole matrix: count, sum, min, max, avg and the distinct forms of count, sum and
+// avg, one per test, then all the non-distinct ones on a single collect.
+class CypherCollectAggregateTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interp3 = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        system.createGraph(_graphName);
+    }
+
+    // Runs a CREATE query in its own change and submits it.
+    void create(std::string_view query) {
+        ChangeID changeID;
+        {
+            SystemAccessor system = _env->getSystemManager().accessUnique();
+            const auto res = system.newChange(_graphName);
+            ASSERT_TRUE(res);
+            changeID = res.value()->id();
+        }
+
+        NullSink discardSink;
+        QueryStatus createStatus;
+        _interp3->execute(createStatus, query, _graphName, CommitHash::head(), changeID, &_env->getMem(), &discardSink);
+        ASSERT_TRUE(createStatus.isOk()) << "CREATE failed: " << createStatus.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+        const QueryState submitState(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a read-only MATCH query against the committed head.
+    void match(std::string_view query, NLOutputSink& sink) {
+        QueryStatus status;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << "MATCH failed: " << status.getError();
+    }
+
+    // Inserts 6 nodes over three teams. red repeats the score 10 so the distinct forms
+    // part from the plain ones, blue holds one score beside a node with none, and grey
+    // holds no score at all - the group every reduction reads over no value.
+    void buildTeamGraph() {
+        create(R"(CREATE (:Node {team: "red", name: "alice", score: 10}), (:Node {team: "red", name: "carol", score: 10}), (:Node {team: "red", name: "erin", score: 40}))");
+        create(R"(CREATE (:Node {team: "blue", name: "bob", score: 100}), (:Node {team: "blue", name: "dan"}), (:Node {team: "grey", name: "gus"}))");
+    }
+
+    const std::string _graphName = "teamGraph";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interp3;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideACountOfRows) {
+    buildTeamGraph();
+
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(*)", sink);
+
+    std::vector<KeyedListAndCountSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"bob", "dan"}, 2},
+        {"grey", {"gus"}, 1},
+        {"red", {"alice", "carol", "erin"}, 3},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideACountOfValues) {
+    buildTeamGraph();
+
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(n.score)", sink);
+
+    std::vector<KeyedListAndCountSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"bob", "dan"}, 1},
+        {"grey", {"gus"}, 0},
+        {"red", {"alice", "carol", "erin"}, 3},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideASum) {
+    buildTeamGraph();
+
+    KeyedListAndInt64Sink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score)", sink);
+
+    std::vector<KeyedListAndInt64Sink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndInt64Sink::Row> expected {
+        {"blue", {"bob", "dan"}, 100},
+        {"grey", {"gus"}, 0},
+        {"red", {"alice", "carol", "erin"}, 60},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideAMinimum) {
+    buildTeamGraph();
+
+    KeyedListAndInt64Sink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), min(n.score)", sink);
+
+    std::vector<KeyedListAndInt64Sink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndInt64Sink::Row> expected {
+        {"blue", {"bob", "dan"}, 100},
+        {"grey", {"gus"}, std::nullopt},
+        {"red", {"alice", "carol", "erin"}, 10},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideAMaximum) {
+    buildTeamGraph();
+
+    KeyedListAndInt64Sink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), max(n.score)", sink);
+
+    std::vector<KeyedListAndInt64Sink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndInt64Sink::Row> expected {
+        {"blue", {"bob", "dan"}, 100},
+        {"grey", {"gus"}, std::nullopt},
+        {"red", {"alice", "carol", "erin"}, 40},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideAnAverage) {
+    buildTeamGraph();
+
+    KeyedListAndDoubleSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), avg(n.score)", sink);
+
+    std::vector<KeyedListAndDoubleSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndDoubleSink::Row> expected {
+        {"blue", {"bob", "dan"}, 100.0},
+        {"grey", {"gus"}, std::nullopt},
+        {"red", {"alice", "carol", "erin"}, 20.0},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideACountOfDistinctValues) {
+    buildTeamGraph();
+
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(DISTINCT n.score)", sink);
+
+    std::vector<KeyedListAndCountSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"bob", "dan"}, 1},
+        {"grey", {"gus"}, 0},
+        {"red", {"alice", "carol", "erin"}, 2},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideASumOfDistinctValues) {
+    buildTeamGraph();
+
+    KeyedListAndInt64Sink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), sum(DISTINCT n.score)", sink);
+
+    std::vector<KeyedListAndInt64Sink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndInt64Sink::Row> expected {
+        {"blue", {"bob", "dan"}, 100},
+        {"grey", {"gus"}, 0},
+        {"red", {"alice", "carol", "erin"}, 50},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideAnAverageOfDistinctValues) {
+    buildTeamGraph();
+
+    KeyedListAndDoubleSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), avg(DISTINCT n.score)", sink);
+
+    std::vector<KeyedListAndDoubleSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndDoubleSink::Row> expected {
+        {"blue", {"bob", "dan"}, 100.0},
+        {"grey", {"gus"}, std::nullopt},
+        {"red", {"alice", "carol", "erin"}, 25.0},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, groupedCollectBesideEveryReduction) {
+    buildTeamGraph();
+
+    KeyedListAndEveryReductionSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(*), count(n.score), sum(n.score), min(n.score), max(n.score), avg(n.score)", sink);
+
+    std::vector<KeyedListAndEveryReductionSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndEveryReductionSink::Row> expected {
+        {"blue", {"bob", "dan"}, 2, 1, 100, 100, 100, 100.0},
+        {"grey", {"gus"}, 1, 0, 0, std::nullopt, std::nullopt, std::nullopt},
+        {"red", {"alice", "carol", "erin"}, 3, 3, 60, 10, 40, 20.0},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// Ordering on a reduction the collect carries: the key of the sort is a column of the
+// same drain the list comes out of. A null extremum is the largest value, so descending
+// puts the group holding no score first.
+TEST_F(CypherCollectAggregateTest, groupedCollectOrderedByAMinimum) {
+    buildTeamGraph();
+
+    KeyedListAndInt64Sink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), min(n.score) ORDER BY min(n.score) DESC", sink);
+
+    std::vector<KeyedListAndInt64Sink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedListAndInt64Sink::Row> expected {
+        {"grey", {"gus"}, std::nullopt},
+        {"blue", {"bob", "dan"}, 100},
+        {"red", {"alice", "carol", "erin"}, 10},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectAggregateTest, ungroupedCollectBesideAMinimumAndAnAverage) {
+    buildTeamGraph();
+
+    ListAndTwoReductionsSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name), min(n.score), avg(n.score)", sink);
+
+    EXPECT_EQ(sink.getRowCount(), 1u);
+    EXPECT_EQ(sink.getNames(), (Names {"alice", "carol", "erin", "bob", "dan", "gus"}));
+    EXPECT_EQ(sink.getMin(), OptInt64 {10});
+    EXPECT_EQ(sink.getAverage(), OptDouble {40.0});
+}

--- a/test/query/ir/CypherCollectDistinctEntityTest.cpp
+++ b/test/query/ir/CypherCollectDistinctEntityTest.cpp
@@ -1,0 +1,295 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+
+#include "LocalMemory.h"
+#include "NLOutputSink.h"
+#include "QueryConfig.h"
+#include "QueryInterpreterV3.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Reads one list cell as a vector of node ids, asserting each element carries the node
+// tag rather than a bare integer.
+void readNodeIDList(const ListView& view, std::vector<uint64_t>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::NodeID);
+        out.push_back(element.getAs<NodeID>().getValue());
+    }
+}
+
+// Reads one list cell as a vector of edge ids, asserting the edge tag.
+void readEdgeIDList(const ListView& view, std::vector<uint64_t>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::EdgeID);
+        out.push_back(element.getAs<EdgeID>().getValue());
+    }
+}
+
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+// Collects the single [ids] row an ungrouped entity collect emits.
+template <void (*Reader)(const ListView&, std::vector<uint64_t>&)>
+class IDListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<uint64_t> ids;
+            Reader(listRaw[row], ids);
+
+            _rows.push_back(ids);
+        }
+    }
+
+    const std::vector<std::vector<uint64_t>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<uint64_t>> _rows;
+};
+
+using NodeListSink = IDListSink<readNodeIDList>;
+using EdgeListSink = IDListSink<readEdgeIDList>;
+
+// Collects the (name, [ids]) rows a grouped entity collect emits.
+template <void (*Reader)(const ListView&, std::vector<uint64_t>&)>
+class KeyedIDListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<uint64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<uint64_t> ids;
+            Reader(listRaw[row], ids);
+
+            _rows.push_back({key, ids});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+using KeyedNodeListSink = KeyedIDListSink<readNodeIDList>;
+using KeyedEdgeListSink = KeyedIDListSink<readEdgeIDList>;
+
+}
+
+// collect(DISTINCT n) and collect(DISTINCT e) over a match that repeats an entity: the
+// distinct fold keys a group on the ID it already buffered, which the plain fold beside
+// each test pins as the shape it deduplicates.
+class CypherCollectDistinctEntityTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interp3 = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        system.createGraph(_graphName);
+    }
+
+    // Runs a CREATE query in its own change and submits it.
+    void create(std::string_view query) {
+        ChangeID changeID;
+        {
+            SystemAccessor system = _env->getSystemManager().accessUnique();
+            const auto res = system.newChange(_graphName);
+            ASSERT_TRUE(res);
+            changeID = res.value()->id();
+        }
+
+        NullSink discardSink;
+        QueryStatus createStatus;
+        _interp3->execute(createStatus, query, _graphName, CommitHash::head(), changeID, &_env->getMem(), &discardSink);
+        ASSERT_TRUE(createStatus.isOk()) << "CREATE failed: " << createStatus.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+        const QueryState submitState(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a read-only MATCH query against the committed head.
+    void match(std::string_view query, NLOutputSink& sink) {
+        QueryStatus status;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << "MATCH failed: " << status.getError();
+    }
+
+    // Inserts alice (0), bob (1) and carol (2), with alice reaching bob over two edges of
+    // different types - KNOWS (0) and LIKES (1) - and carol over a third (2). An untyped
+    // edge pattern then matches bob twice, so a group repeats both alice and bob.
+    void buildFollowGraph() {
+        create(R"(CREATE (:Person {name: "alice"}), (:Person {name: "bob"}), (:Person {name: "carol"}))");
+        create(R"(MATCH (a:Person {name: "alice"}), (b:Person {name: "bob"}) CREATE (a)-[:KNOWS]->(b))");
+        create(R"(MATCH (a:Person {name: "alice"}), (b:Person {name: "bob"}) CREATE (a)-[:LIKES]->(b))");
+        create(R"(MATCH (a:Person {name: "alice"}), (c:Person {name: "carol"}) CREATE (a)-[:KNOWS]->(c))");
+    }
+
+    const std::string _graphName = "followGraph";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interp3;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CypherCollectDistinctEntityTest, collectsARepeatedSourceOncePerMatch) {
+    buildFollowGraph();
+
+    NodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN collect(a)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {0, 0, 0}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, collectsADistinctRepeatedSourceOnce) {
+    buildFollowGraph();
+
+    NodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN collect(DISTINCT a)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {0}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, collectsARepeatedTargetOncePerMatch) {
+    buildFollowGraph();
+
+    NodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN collect(b)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {1, 1, 2}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, collectsDistinctTargets) {
+    buildFollowGraph();
+
+    NodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN collect(DISTINCT b)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {1, 2}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, groupedCollectKeepsRepeatedTargets) {
+    buildFollowGraph();
+
+    KeyedNodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN a.name, collect(b)", sink);
+
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {{"alice", {1, 1, 2}}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectDistinctEntityTest, groupedCollectOfDistinctTargets) {
+    buildFollowGraph();
+
+    KeyedNodeListSink sink;
+    match("MATCH (a:Person)-[]->(b:Person) RETURN a.name, collect(DISTINCT b)", sink);
+
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {{"alice", {1, 2}}};
+    EXPECT_EQ(rows, expected);
+}
+
+// A cross product repeats every edge once per crossed node, which is what gives the edge
+// collect a group to deduplicate: an edge is matched once per row of the pattern alone.
+TEST_F(CypherCollectDistinctEntityTest, collectsARepeatedEdgeOncePerMatch) {
+    buildFollowGraph();
+
+    EdgeListSink sink;
+    match("MATCH (a:Person)-[e]->(b:Person), (c:Person) RETURN collect(e)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {0, 0, 0, 1, 1, 1, 2, 2, 2}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, collectsDistinctEdges) {
+    buildFollowGraph();
+
+    EdgeListSink sink;
+    match("MATCH (a:Person)-[e]->(b:Person), (c:Person) RETURN collect(DISTINCT e)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<uint64_t> {0, 1, 2}));
+}
+
+TEST_F(CypherCollectDistinctEntityTest, groupedCollectOfDistinctEdges) {
+    buildFollowGraph();
+
+    KeyedEdgeListSink sink;
+    match("MATCH (a:Person)-[e]->(b:Person), (c:Person) RETURN c.name, collect(DISTINCT e)", sink);
+
+    std::vector<KeyedEdgeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedEdgeListSink::Row> expected {
+        {"alice", {0, 1, 2}},
+        {"bob", {0, 1, 2}},
+        {"carol", {0, 1, 2}},
+    };
+    EXPECT_EQ(rows, expected);
+}

--- a/test/query/ir/CypherCollectElementTypeTest.cpp
+++ b/test/query/ir/CypherCollectElementTypeTest.cpp
@@ -1,0 +1,294 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+#include "metadata/PropertyType.h"
+
+#include "LocalMemory.h"
+#include "NLOutputSink.h"
+#include "QueryConfig.h"
+#include "QueryInterpreterV3.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Reads one list cell as a vector of doubles, asserting each element carries the double
+// tag: the tag is what tells a renderer a number apart from an entity id.
+void readDoubleList(const ListView& view, std::vector<double>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::Double);
+        out.push_back(element.getAs<types::Double::Primitive>());
+    }
+}
+
+// Reads one list cell as a vector of booleans, asserting the boolean tag.
+void readBoolList(const ListView& view, std::vector<bool>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::Bool);
+        out.push_back(static_cast<bool>(element.getAs<types::Bool::Primitive>()));
+    }
+}
+
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+// Collects the (team, [values]) rows a grouped collect of this element type emits.
+template <typename Element, void (*Reader)(const ListView&, std::vector<Element>&)>
+class KeyedListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<Element>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<Element> values;
+            Reader(listRaw[row], values);
+
+            _rows.push_back({key, values});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the single [values] row an ungrouped collect of this element type emits.
+template <typename Element, void (*Reader)(const ListView&, std::vector<Element>&)>
+class ListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<Element> values;
+            Reader(listRaw[row], values);
+
+            _rows.push_back(values);
+        }
+    }
+
+    const std::vector<std::vector<Element>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<Element>> _rows;
+};
+
+using KeyedDoubleListSink = KeyedListSink<double, readDoubleList>;
+using KeyedBoolListSink = KeyedListSink<bool, readBoolList>;
+using DoubleListSink = ListSink<double, readDoubleList>;
+using BoolListSink = ListSink<bool, readBoolList>;
+
+}
+
+// collect() over the two scalar element types no other suite gathers - a Double and a
+// Bool property - plain and DISTINCT, grouped and ungrouped. Each element type has a fold
+// and a list emit of its own selected off the column's value type.
+class CypherCollectElementTypeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interp3 = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        system.createGraph(_graphName);
+    }
+
+    // Runs a CREATE query in its own change and submits it.
+    void create(std::string_view query) {
+        ChangeID changeID;
+        {
+            SystemAccessor system = _env->getSystemManager().accessUnique();
+            const auto res = system.newChange(_graphName);
+            ASSERT_TRUE(res);
+            changeID = res.value()->id();
+        }
+
+        NullSink discardSink;
+        QueryStatus createStatus;
+        _interp3->execute(createStatus, query, _graphName, CommitHash::head(), changeID, &_env->getMem(), &discardSink);
+        ASSERT_TRUE(createStatus.isOk()) << "CREATE failed: " << createStatus.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+        const QueryState submitState(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a read-only MATCH query against the committed head.
+    void match(std::string_view query, NLOutputSink& sink) {
+        QueryStatus status;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << "MATCH failed: " << status.getError();
+    }
+
+    // Inserts 6 nodes over three teams: red repeats a weight and a flag so DISTINCT has
+    // something to drop, blue carries one of each beside a node holding neither, and grey
+    // holds neither - the group whose every value is null.
+    void buildSampleGraph() {
+        create(R"(CREATE (:Node {team: "red", name: "alice", weight: 1.5, flag: true}), (:Node {team: "red", name: "carol", weight: 2.5, flag: false}), (:Node {team: "red", name: "erin", weight: 1.5, flag: true}))");
+        create(R"(CREATE (:Node {team: "blue", name: "bob", weight: 3.5, flag: false}), (:Node {team: "blue", name: "dan"}), (:Node {team: "grey", name: "gus"}))");
+    }
+
+    const std::string _graphName = "sampleGraph";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interp3;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CypherCollectElementTypeTest, groupedCollectOfDoubles) {
+    buildSampleGraph();
+
+    KeyedDoubleListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.weight)", sink);
+
+    std::vector<KeyedDoubleListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedDoubleListSink::Row> expected {
+        {"blue", {3.5}},
+        {"grey", {}},
+        {"red", {1.5, 2.5, 1.5}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectElementTypeTest, groupedCollectOfDistinctDoubles) {
+    buildSampleGraph();
+
+    KeyedDoubleListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(DISTINCT n.weight)", sink);
+
+    std::vector<KeyedDoubleListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedDoubleListSink::Row> expected {
+        {"blue", {3.5}},
+        {"grey", {}},
+        {"red", {1.5, 2.5}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectElementTypeTest, ungroupedCollectOfDoubles) {
+    buildSampleGraph();
+
+    DoubleListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.weight)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<double> {1.5, 2.5, 1.5, 3.5}));
+}
+
+TEST_F(CypherCollectElementTypeTest, ungroupedCollectOfDistinctDoubles) {
+    buildSampleGraph();
+
+    DoubleListSink sink;
+    match("MATCH (n:Node) RETURN collect(DISTINCT n.weight)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<double> {1.5, 2.5, 3.5}));
+}
+
+TEST_F(CypherCollectElementTypeTest, groupedCollectOfBooleans) {
+    buildSampleGraph();
+
+    KeyedBoolListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.flag)", sink);
+
+    std::vector<KeyedBoolListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedBoolListSink::Row> expected {
+        {"blue", {false}},
+        {"grey", {}},
+        {"red", {true, false, true}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectElementTypeTest, groupedCollectOfDistinctBooleans) {
+    buildSampleGraph();
+
+    KeyedBoolListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(DISTINCT n.flag)", sink);
+
+    std::vector<KeyedBoolListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedBoolListSink::Row> expected {
+        {"blue", {false}},
+        {"grey", {}},
+        {"red", {true, false}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectElementTypeTest, ungroupedCollectOfBooleans) {
+    buildSampleGraph();
+
+    BoolListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.flag)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<bool> {true, false, true, false}));
+}
+
+TEST_F(CypherCollectElementTypeTest, ungroupedCollectOfDistinctBooleans) {
+    buildSampleGraph();
+
+    BoolListSink sink;
+    match("MATCH (n:Node) RETURN collect(DISTINCT n.flag)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (std::vector<bool> {true, false}));
+}

--- a/test/query/ir/CypherCollectInputTest.cpp
+++ b/test/query/ir/CypherCollectInputTest.cpp
@@ -1,0 +1,559 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+
+#include "LocalMemory.h"
+#include "NLOutputSink.h"
+#include "QueryConfig.h"
+#include "QueryInterpreterV3.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Names = std::vector<std::string>;
+using Values = std::vector<int64_t>;
+using NodeIDs = std::vector<uint64_t>;
+
+// Reads one list cell as a vector of strings.
+void readStringList(const ListView& view, Names& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(std::string(element.getAs<std::string_view>()));
+    }
+}
+
+// Reads one list cell as a vector of int64s.
+void readInt64List(const ListView& view, Values& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(element.getAs<int64_t>());
+    }
+}
+
+// Reads one list cell as a vector of node ids, asserting the node tag.
+void readNodeIDList(const ListView& view, NodeIDs& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::NodeID);
+        out.push_back(element.getAs<NodeID>().getValue());
+    }
+}
+
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+// Collects the (string key, [names]) rows a collect grouped on one string key emits.
+class KeyedNameListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, Names>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key, names});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (team, score, [names]) rows a collect grouped on two keys emits.
+class TwoKeyNameListSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, std::optional<int64_t>, Names>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* teams = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* scores = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[1]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[2]);
+        ASSERT_NE(teams, nullptr);
+        ASSERT_NE(scores, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(teams->size(), lists->size());
+        ASSERT_EQ(scores->size(), lists->size());
+
+        const auto& teamRaw = teams->getRaw();
+        const auto& scoreRaw = scores->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> team;
+            if (teamRaw[row]) {
+                team = std::string(*teamRaw[row]);
+            }
+
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({team, scoreRaw[row], names});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (score, [names]) rows a collect grouped on a nullable Int64 key emits.
+class Int64KeyedNameListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<int64_t>, Names>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({keyRaw[row], names});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (team, [values]) rows a grouped collect of an Int64 expression emits.
+class KeyedValueListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, Values>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            Values values;
+            readInt64List(listRaw[row], values);
+
+            _rows.push_back({key, values});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (name, [ids]) rows a grouped collect of nodes emits.
+class KeyedNodeListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, NodeIDs>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            NodeIDs ids;
+            readNodeIDList(listRaw[row], ids);
+
+            _rows.push_back({key, ids});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the single [names] row an ungrouped collect of strings emits.
+class NameListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Names names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back(names);
+        }
+    }
+
+    const std::vector<Names>& rows() const { return _rows; }
+
+private:
+    std::vector<Names> _rows;
+};
+
+// Collects the single [values] row an ungrouped collect of Int64s emits.
+class ValueListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Values values;
+            readInt64List(listRaw[row], values);
+
+            _rows.push_back(values);
+        }
+    }
+
+    const std::vector<Values>& rows() const { return _rows; }
+
+private:
+    std::vector<Values> _rows;
+};
+
+}
+
+// The shapes a collect's input and grouping keys come in: several keys, a nullable key,
+// an expression computed per row, a two-hop traversal, the cells of an UNWIND, and a
+// filtered match.
+class CypherCollectInputTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interp3 = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        system.createGraph(_graphName);
+    }
+
+    // Runs a CREATE query in its own change and submits it.
+    void create(std::string_view query) {
+        ChangeID changeID;
+        {
+            SystemAccessor system = _env->getSystemManager().accessUnique();
+            const auto res = system.newChange(_graphName);
+            ASSERT_TRUE(res);
+            changeID = res.value()->id();
+        }
+
+        NullSink discardSink;
+        QueryStatus createStatus;
+        _interp3->execute(createStatus, query, _graphName, CommitHash::head(), changeID, &_env->getMem(), &discardSink);
+        ASSERT_TRUE(createStatus.isOk()) << "CREATE failed: " << createStatus.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+        const QueryState submitState(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a read-only MATCH query against the committed head.
+    void match(std::string_view query, NLOutputSink& sink) {
+        QueryStatus status;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << "MATCH failed: " << status.getError();
+    }
+
+    // Inserts 6 nodes over three teams: red holds the score 10 twice and 40 once, blue
+    // holds 100 beside a node with no score, and grey holds no score either. The (team,
+    // score) pairs make four groups over two keys, and two nodes share the null score.
+    void buildTeamGraph() {
+        create(R"(CREATE (:Node {team: "red", name: "alice", score: 10}), (:Node {team: "red", name: "carol", score: 10}), (:Node {team: "red", name: "erin", score: 40}))");
+        create(R"(CREATE (:Node {team: "blue", name: "bob", score: 100}), (:Node {team: "blue", name: "dan"}), (:Node {team: "grey", name: "gus"}))");
+    }
+
+    // Inserts two disjoint two-hop chains out of alice (0): alice -> bob (1) -> carol (2)
+    // and alice -> dave (3) -> erin (4).
+    void buildChainGraph() {
+        create(R"(CREATE (:Person {name: "alice"}), (:Person {name: "bob"}), (:Person {name: "carol"}), (:Person {name: "dave"}), (:Person {name: "erin"}))");
+        create(R"(MATCH (a:Person {name: "alice"}), (b:Person {name: "bob"}) CREATE (a)-[:KNOWS]->(b))");
+        create(R"(MATCH (b:Person {name: "bob"}), (c:Person {name: "carol"}) CREATE (b)-[:KNOWS]->(c))");
+        create(R"(MATCH (a:Person {name: "alice"}), (d:Person {name: "dave"}) CREATE (a)-[:KNOWS]->(d))");
+        create(R"(MATCH (d:Person {name: "dave"}), (e:Person {name: "erin"}) CREATE (d)-[:KNOWS]->(e))");
+    }
+
+    const std::string _graphName = "inputGraph";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interp3;
+    QueryConfig _queryConfig;
+};
+
+// A group is the key pair, so the two nodes holding no score stay apart under the teams
+// they belong to - where the single-key test below collects them together.
+TEST_F(CypherCollectInputTest, groupsOnTwoKeys) {
+    buildTeamGraph();
+
+    TwoKeyNameListSink sink;
+    match("MATCH (n:Node) RETURN n.team, n.score, collect(n.name)", sink);
+
+    std::vector<TwoKeyNameListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<TwoKeyNameListSink::Row> expected {
+        {"blue", std::nullopt, {"dan"}},
+        {"blue", 100, {"bob"}},
+        {"grey", std::nullopt, {"gus"}},
+        {"red", 10, {"alice", "carol"}},
+        {"red", 40, {"erin"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// A null key is a group of its own rather than a dropped row, and one group: the two
+// nodes holding no score collect together.
+TEST_F(CypherCollectInputTest, groupsOnANullableKey) {
+    buildTeamGraph();
+
+    Int64KeyedNameListSink sink;
+    match("MATCH (n:Node) RETURN n.score, collect(n.name)", sink);
+
+    std::vector<Int64KeyedNameListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<Int64KeyedNameListSink::Row> expected {
+        {std::nullopt, {"dan", "gus"}},
+        {10, {"alice", "carol"}},
+        {40, {"erin"}},
+        {100, {"bob"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsARowVaryingExpressionPerGroup) {
+    buildTeamGraph();
+
+    KeyedValueListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.score * 2)", sink);
+
+    std::vector<KeyedValueListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedValueListSink::Row> expected {
+        {"blue", {200}},
+        {"grey", {}},
+        {"red", {20, 20, 80}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsARowVaryingExpressionOverTheWholeMatch) {
+    buildTeamGraph();
+
+    ValueListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.score + 1)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (Values {11, 11, 41, 101}));
+}
+
+TEST_F(CypherCollectInputTest, collectsTheTargetOfATwoHopPattern) {
+    buildChainGraph();
+
+    KeyedNameListSink sink;
+    match("MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) RETURN a.name, collect(c.name)", sink);
+
+    std::vector<KeyedNameListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNameListSink::Row> expected {{"alice", {"carol", "erin"}}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsTheMiddleNodeOfATwoHopPattern) {
+    buildChainGraph();
+
+    KeyedNodeListSink sink;
+    match("MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) RETURN a.name, collect(b)", sink);
+
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {{"alice", {1, 3}}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, groupsOnTheMiddleOfATwoHopPattern) {
+    buildChainGraph();
+
+    KeyedNameListSink sink;
+    match("MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) RETURN b.name, collect(c.name)", sink);
+
+    std::vector<KeyedNameListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNameListSink::Row> expected {
+        {"bob", {"carol"}},
+        {"dave", {"erin"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsTheCellsOfAnUnwoundList) {
+    ValueListSink sink;
+    match("UNWIND [10, 20, 20] AS v RETURN collect(v)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (Values {10, 20, 20}));
+}
+
+TEST_F(CypherCollectInputTest, collectsTheDistinctCellsOfAnUnwoundList) {
+    ValueListSink sink;
+    match("UNWIND [10, 20, 20] AS v RETURN collect(DISTINCT v)", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (Values {10, 20}));
+}
+
+// The UNWIND crosses the match, so each group collects its own nodes' worth of cells.
+TEST_F(CypherCollectInputTest, collectsAnUnwoundListPerGroup) {
+    buildTeamGraph();
+
+    KeyedValueListSink sink;
+    match("MATCH (n:Node) UNWIND [1, 2] AS v RETURN n.team, collect(v)", sink);
+
+    std::vector<KeyedValueListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedValueListSink::Row> expected {
+        {"blue", {1, 2, 1, 2}},
+        {"grey", {1, 2}},
+        {"red", {1, 2, 1, 2, 1, 2}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsOnlyTheRowsAFilterKept) {
+    buildTeamGraph();
+
+    KeyedNameListSink sink;
+    match("MATCH (n:Node) WHERE n.score > 15 RETURN n.team, collect(n.name)", sink);
+
+    std::vector<KeyedNameListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNameListSink::Row> expected {
+        {"blue", {"bob"}},
+        {"red", {"erin"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectInputTest, collectsTheWholeMatchAFilterKept) {
+    buildTeamGraph();
+
+    NameListSink sink;
+    match(R"(MATCH (n:Node) WHERE n.team = "red" RETURN collect(n.name))", sink);
+
+    ASSERT_EQ(sink.rows().size(), 1u);
+    EXPECT_EQ(sink.rows().front(), (Names {"alice", "carol", "erin"}));
+}
+
+// A grouped collect folds no row, so it emits no group - where the ungrouped form emits
+// one empty list.
+TEST_F(CypherCollectInputTest, emitsNoGroupWhenTheFilterKeepsNothing) {
+    buildTeamGraph();
+
+    KeyedNameListSink sink;
+    match("MATCH (n:Node) WHERE n.score > 1000 RETURN n.team, collect(n.name)", sink);
+
+    std::vector<KeyedNameListSink::Row> rows;
+    sink.sortedRows(rows);
+    EXPECT_TRUE(rows.empty());
+}

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -268,6 +268,40 @@ private:
 };
 
 
+// Collects the (node, [names]) rows a collect keyed on a node alias emits.
+class NodeKeyedStringListSink : public NLOutputSink {
+public:
+    using Row = std::pair<uint64_t, std::vector<std::string>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnVector<NodeID>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({keyRaw[row].getValue(), names});
+        }
+    }
+
+    // The rows as the sink saw them, for the ORDER BY tests: the emit order is the result.
+    void rowsInEmitOrder(std::vector<Row>& rows) const {
+        rows = _rows;
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+
 // Collects the ([ids]) rows an ungrouped entity collect emits: a single list cell chunk.
 class NodeListSink : public NLOutputSink {
 public:
@@ -612,6 +646,24 @@ TEST_F(CypherCollectTest, groupedCollectWithOrderByDescending) {
     const std::vector<KeyedStringListSink::Row> expected {
         {"red", {"alice", "carol"}},
         {"blue", {"bob", "dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectWithOrderByOverTheReturnedNode) {
+    buildTeamGraph();
+
+    NodeKeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n, collect(n.name) ORDER BY n.name", sink);
+
+    std::vector<NodeKeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<NodeKeyedStringListSink::Row> expected {
+        {0, {"alice"}},
+        {2, {"bob"}},
+        {1, {"carol"}},
+        {3, {"dan"}},
     };
     EXPECT_EQ(rows, expected);
 }

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -874,11 +874,28 @@ TEST_F(CypherCollectTest, collectOfNodesWithOrderByAndSkipLimit) {
     }
 }
 
-TEST_F(CypherCollectTest, rejectsCollectDistinct) {
+TEST_F(CypherCollectTest, ungroupedCollectDistinct) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN collect(DISTINCT n.name)", status);
+    StringListSink sink;
+    match("MATCH (n:Node) RETURN collect(DISTINCT n.team)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PARSE_ERROR);
+    const std::vector<std::vector<std::string>> expected {{"red", "blue"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectDistinct) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(DISTINCT n.team)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"blue"}},
+        {"red", {"red"}},
+    };
+    EXPECT_EQ(rows, expected);
 }

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -68,6 +68,9 @@ void readEdgeIDList(const ListView& view, std::vector<uint64_t>& out) {
     }
 }
 
+const std::string_view droppedKeyReason =
+    "ORDER BY with an aggregate may only order by expressions over the returned columns";
+
 // Discards output: used by the CREATE queries building the fixture and by the queries
 // that are rejected before producing rows.
 class NullSink : public NLOutputSink {
@@ -307,7 +310,8 @@ private:
 
 
 // Collects the ([ids]) rows an ungrouped entity collect emits: a single list cell chunk.
-class NodeListSink : public NLOutputSink {
+template <void (*Reader)(const ListView&, std::vector<uint64_t>&)>
+class IDListSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
@@ -318,7 +322,7 @@ public:
         const auto& listRaw = lists->getRaw();
         for (size_t row = offset; row < offset + rowCount; row++) {
             std::vector<uint64_t> ids;
-            readNodeIDList(listRaw[row], ids);
+            Reader(listRaw[row], ids);
             _rows.push_back(ids);
         }
     }
@@ -327,6 +331,212 @@ public:
 
 private:
     std::vector<std::vector<uint64_t>> _rows;
+};
+
+using NodeListSink = IDListSink<readNodeIDList>;
+using EdgeListSink = IDListSink<readEdgeIDList>;
+
+// Collects the ([scores]) rows an ungrouped collect over an Int64 value emits.
+class Int64ListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<int64_t> scores;
+            readInt64List(listRaw[row], scores);
+            _rows.push_back(scores);
+        }
+    }
+
+    const std::vector<std::vector<int64_t>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<int64_t>> _rows;
+};
+
+// Collects the (team, [names], count) rows a grouped collect emits beside a tally.
+class KeyedListAndCountSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, std::vector<std::string>, uint64_t>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[2]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(counts, nullptr);
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& countRaw = counts->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key, names, countRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+    void rowsInEmitOrder(std::vector<Row>& rows) const {
+        rows = _rows;
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (team, [names], sum) rows a grouped collect emits beside a reduction.
+class KeyedListAndSumSink : public NLOutputSink {
+public:
+    using Row = std::tuple<std::optional<std::string>, std::vector<std::string>, std::optional<int64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[2]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(sums, nullptr);
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        const auto& sumRaw = sums->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key, names, sumRaw[row]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the ([names], count) row a collect emits beside a tally, reading each column
+// by its type so both projection orders share one sink.
+class ListAndCountSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::vector<std::string>, uint64_t>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const ColumnVector<ListView>* lists = nullptr;
+        const ColumnVector<uint64_t>* counts = nullptr;
+        for (const Column* chunk : chunks) {
+            const ColumnVector<ListView>* list = dynamic_cast<const ColumnVector<ListView>*>(chunk);
+            if (list) {
+                lists = list;
+                continue;
+            }
+
+            const ColumnVector<uint64_t>* count = dynamic_cast<const ColumnVector<uint64_t>*>(chunk);
+            if (count) {
+                counts = count;
+            }
+        }
+
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(counts, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        const auto& countRaw = counts->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({names, countRaw[row]});
+        }
+    }
+
+    const std::vector<Row>& rows() const { return _rows; }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the ([names], sum) row a collect emits beside a value reduction.
+class ListAndSumSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::vector<std::string>, std::optional<int64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[1]);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_NE(sums, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        const auto& sumRaw = sums->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({names, sumRaw[row]});
+        }
+    }
+
+    const std::vector<Row>& rows() const { return _rows; }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the list cell a projection ends with, for the shapes carrying a column beside
+// the list that the assert does not read.
+class TrailingInt64ListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_FALSE(chunks.empty());
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks.back());
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<int64_t> scores;
+            readInt64List(listRaw[row], scores);
+            _rows.push_back(scores);
+        }
+    }
+
+    const std::vector<std::vector<int64_t>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<int64_t>> _rows;
 };
 
 // Collects the ([names]) rows an ungrouped collect emits: a single list cell chunk.
@@ -491,6 +701,45 @@ TEST_F(CypherCollectTest, groupedCollectDropsNulls) {
     EXPECT_EQ(rows, expected);
 }
 
+// The literal every row collects is the one collect drops, so each group's list comes out
+// empty however many rows folded into it.
+TEST_F(CypherCollectTest, groupedCollectOfNull) {
+    buildTeamGraph();
+
+    KeyedInt64ListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(null)", sink);
+
+    std::vector<KeyedInt64ListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedInt64ListSink::Row> expected {
+        {"blue", {}},
+        {"red", {}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, ungroupedCollectOfNull) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match("MATCH (n:Node) RETURN collect(null)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// No match drives the projection, so the collect folds the single row a bare RETURN is.
+TEST_F(CypherCollectTest, collectOfNullWithoutAMatch) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match("RETURN collect(null)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
 TEST_F(CypherCollectTest, ungroupedCollect) {
     buildTeamGraph();
 
@@ -518,20 +767,13 @@ TEST_F(CypherCollectTest, groupedCollectWithLimit) {
     match("MATCH (n:Node) RETURN n.team, collect(n.name) LIMIT 1", sink);
 
     // One group row survives the cut, and it is a whole group: the limit budgets the
-    // drain, not the rows folded into it.
+    // drain, not the rows folded into it. Which group it is separates the limit from the
+    // skip below, so it is pinned rather than taken either way.
     std::vector<KeyedStringListSink::Row> rows;
-    sink.sortedRows(rows);
+    sink.rowsInEmitOrder(rows);
 
-    ASSERT_EQ(rows.size(), 1u);
-    const KeyedStringListSink::Row& row = rows.front();
-    ASSERT_TRUE(row.first);
-
-    if (*row.first == "red") {
-        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
-    } else {
-        EXPECT_EQ(*row.first, "blue");
-        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
-    }
+    const std::vector<KeyedStringListSink::Row> expected {{"red", {"alice", "carol"}}};
+    EXPECT_EQ(rows, expected);
 }
 
 TEST_F(CypherCollectTest, groupedCollectWithSkipAndLimit) {
@@ -541,18 +783,10 @@ TEST_F(CypherCollectTest, groupedCollectWithSkipAndLimit) {
     match("MATCH (n:Node) RETURN n.team, collect(n.name) SKIP 1 LIMIT 1", sink);
 
     std::vector<KeyedStringListSink::Row> rows;
-    sink.sortedRows(rows);
+    sink.rowsInEmitOrder(rows);
 
-    ASSERT_EQ(rows.size(), 1u);
-    const KeyedStringListSink::Row& row = rows.front();
-    ASSERT_TRUE(row.first);
-
-    if (*row.first == "red") {
-        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
-    } else {
-        EXPECT_EQ(*row.first, "blue");
-        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
-    }
+    const std::vector<KeyedStringListSink::Row> expected {{"blue", {"bob", "dan"}}};
+    EXPECT_EQ(rows, expected);
 }
 
 TEST_F(CypherCollectTest, groupedCollectWithSkip) {
@@ -562,60 +796,223 @@ TEST_F(CypherCollectTest, groupedCollectWithSkip) {
     match("MATCH (n:Node) RETURN n.team, collect(n.name) SKIP 1", sink);
 
     std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {{"blue", {"bob", "dan"}}};
+    EXPECT_EQ(rows, expected);
+}
+
+// One accumulator holds both: the group's list and the tally of the same rows, so the
+// drain emits them beside the key they belong to.
+TEST_F(CypherCollectTest, groupedCollectBesideACount) {
+    buildTeamGraph();
+
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(*)", sink);
+
+    std::vector<KeyedListAndCountSink::Row> rows;
     sink.sortedRows(rows);
 
-    ASSERT_EQ(rows.size(), 1u);
-    const KeyedStringListSink::Row& row = rows.front();
-    ASSERT_TRUE(row.first);
-
-    if (*row.first == "red") {
-        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
-    } else {
-        EXPECT_EQ(*row.first, "blue");
-        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
-    }
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"bob", "dan"}, 2},
+        {"red", {"alice", "carol"}, 2},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
-TEST_F(CypherCollectTest, rejectsCollectWithAnotherAggregate) {
+// The tally counts non-null rows, so it need not be the length of the list beside it:
+// dan has no score, and collect drops the null the count skips.
+TEST_F(CypherCollectTest, groupedCollectBesideACountOfANullableProperty) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name), count(*)", status);
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(n.score)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+    std::vector<KeyedListAndCountSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"bob", "dan"}, 1},
+        {"red", {"alice", "carol"}, 2},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
-TEST_F(CypherCollectTest, rejectsUngroupedCollectWithCount) {
+// Several reductions beside the list, each with its own per-group accumulator on the
+// state the list is collected into.
+TEST_F(CypherCollectTest, groupedCollectBesideTwoAggregates) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN collect(n.name), count(*)", status);
+    KeyedListAndCountSink counts;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), count(*)", counts);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+    KeyedListAndSumSink sums;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score)", sums);
+
+    std::vector<KeyedListAndCountSink::Row> countRows;
+    counts.sortedRows(countRows);
+
+    const std::vector<KeyedListAndCountSink::Row> expectedCounts {
+        {"blue", {"bob", "dan"}, 2},
+        {"red", {"alice", "carol"}, 2},
+    };
+    EXPECT_EQ(countRows, expectedCounts);
+
+    std::vector<KeyedListAndSumSink::Row> sumRows;
+    sums.sortedRows(sumRows);
+
+    const std::vector<KeyedListAndSumSink::Row> expectedSums {
+        {"blue", {"bob", "dan"}, 100},
+        {"red", {"alice", "carol"}, 30},
+    };
+    EXPECT_EQ(sumRows, expectedSums);
 }
 
-TEST_F(CypherCollectTest, rejectsUngroupedCollectWithAWrappedAggregate) {
+// Each dedups against a tally of its own: the collect charges a group's distinct names
+// once, and the count a group's distinct scores.
+TEST_F(CypherCollectTest, groupedCollectDistinctBesideACountDistinct) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN collect(n.name), count(n) + 1", status);
+    KeyedListAndCountSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(DISTINCT n.team), count(DISTINCT n.score)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+    std::vector<KeyedListAndCountSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndCountSink::Row> expected {
+        {"blue", {"blue"}, 1},
+        {"red", {"red"}, 2},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
-TEST_F(CypherCollectTest, rejectsGroupedCollectWithAWrappedAggregate) {
+// The key orders the groups by an aggregate the projection does not return, which the
+// same accumulator computes: blue scores once, red twice.
+TEST_F(CypherCollectTest, groupedCollectOrderedByACount) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score) + 0", status);
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY count(n.score)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
+TEST_F(CypherCollectTest, groupedCollectOrderedByACountDescending) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY count(n.score) DESC", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"red", {"alice", "carol"}},
+        {"blue", {"bob", "dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// Two pipeline breakers over one match, each collapsing to one row: the collect drains its
+// single group in a loop of its own, and the tally is a single-row chunk bound above that
+// loop - loop-invariant, as a constant is, so the emit reads it beside the list.
+TEST_F(CypherCollectTest, ungroupedCollectBesideACount) {
+    buildTeamGraph();
+
+    ListAndCountSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name), count(*)", sink);
+
+    const std::vector<ListAndCountSink::Row> expected {{{"alice", "carol", "bob", "dan"}, 4}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The tally ahead of the list: the emit is anchored in the drain loop whichever order the
+// projection names them in.
+TEST_F(CypherCollectTest, ungroupedCountBesideACollect) {
+    buildTeamGraph();
+
+    ListAndCountSink sink;
+    match("MATCH (n:Node) RETURN count(*), collect(n.name)", sink);
+
+    const std::vector<ListAndCountSink::Row> expected {{{"alice", "carol", "bob", "dan"}, 4}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The value reduction beside a collect: dan has no score, so the sum is over the three
+// that have one.
+TEST_F(CypherCollectTest, ungroupedCollectBesideASum) {
+    buildTeamGraph();
+
+    ListAndSumSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name), sum(n.score)", sink);
+
+    const std::vector<ListAndSumSink::Row> expected {{{"alice", "carol", "bob", "dan"}, 130}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The aggregate wrapped in an expression is computed off the same single-row chunk.
+TEST_F(CypherCollectTest, ungroupedCollectBesideAWrappedAggregate) {
+    buildTeamGraph();
+
+    ListAndSumSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name), sum(n.score) + 1", sink);
+
+    const std::vector<ListAndSumSink::Row> expected {{{"alice", "carol", "bob", "dan"}, 131}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The reduction beside a collect, wrapped in an expression computed off its grouped
+// column: red scores 30, and blue 100 - dan has none.
+TEST_F(CypherCollectTest, groupedCollectBesideAWrappedAggregate) {
+    buildTeamGraph();
+
+    KeyedListAndSumSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score) + 0", sink);
+
+    std::vector<KeyedListAndSumSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedListAndSumSink::Row> expected {
+        {"blue", {"bob", "dan"}, 100},
+        {"red", {"alice", "carol"}, 30},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// With no grouping key the projection is one row, and the key reducing a second aggregate
+// over the same match is one value beside it: the sort has a row to order, so the query
+// runs rather than needing the collect and the count to share an accumulator.
+TEST_F(CypherCollectTest, ungroupedCollectOrderedByACount) {
+    buildTeamGraph();
+
+    StringListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name) ORDER BY count(n)", sink);
+
+    const std::vector<std::vector<std::string>> expected {{"alice", "carol", "bob", "dan"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The value reduction of the same shape, whose result is materialized the same way
+TEST_F(CypherCollectTest, ungroupedCollectOrderedByASum) {
+    buildTeamGraph();
+
+    StringListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name) ORDER BY sum(n.score) DESC", sink);
+
+    const std::vector<std::vector<std::string>> expected {{"alice", "carol", "bob", "dan"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// Each collect drains through a loop of its own, and the emit sits in one of them: the
+// other list is bound in a loop the output is not in, so this is the pair that is still
+// turned away.
 TEST_F(CypherCollectTest, rejectsTwoCollects) {
     buildTeamGraph();
 
@@ -623,7 +1020,7 @@ TEST_F(CypherCollectTest, rejectsTwoCollects) {
     runQuery("MATCH (n:Node) RETURN collect(n.name), collect(n.team)", status);
 
     EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another collect().");
 }
 
 // The sort orders the group rows the drain emits, carrying each group's list along with
@@ -676,6 +1073,31 @@ TEST_F(CypherCollectTest, groupedCollectWithOrderByOverTheReturnedNode) {
         {3, {"dan"}},
     };
     EXPECT_EQ(rows, expected);
+}
+
+// The other side of the line the test above stands on: n is returned there, so n.name is
+// one name per group, while grouping on n.team drops n and leaves one name per matched
+// row - four of them against two groups, lining up with no row the drain emits.
+TEST_F(CypherCollectTest, rejectsOrderByOverAVariableTheGroupingDropped) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY n.name", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+    EXPECT_NE(status.getError().find(droppedKeyReason), std::string::npos) << status.getError();
+}
+
+// An ungrouped collect keeps no variable at all, so there is not even a group for the key
+// to hold one value of.
+TEST_F(CypherCollectTest, rejectsOrderByOverADroppedVariableUnderAnUngroupedCollect) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(n.name) ORDER BY n.name", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+    EXPECT_NE(status.getError().find(droppedKeyReason), std::string::npos) << status.getError();
 }
 
 // ORDER BY ... LIMIT fuses into a top-K accumulator, which trims the buffers by gathering
@@ -814,33 +1236,120 @@ TEST_F(CypherCollectTest, distinctOverTheCollectedList) {
     EXPECT_EQ(rows, expected);
 }
 
-TEST_F(CypherCollectTest, rejectsCollectOfConstant) {
+// A constant is bound above the loop the matched rows are read in, so it is laid out over
+// those rows before the fold reads it: what is collected is one element per row of the
+// group, not the single row the constant is.
+TEST_F(CypherCollectTest, groupedCollectOfAConstant) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN n.team, collect(1)", status);
+    KeyedInt64ListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(1)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() of a constant expression is not yet supported.");
+    std::vector<KeyedInt64ListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedInt64ListSink::Row> expected {
+        {"blue", {1, 1}},
+        {"red", {1, 1}},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
-// The alias is what makes the collected column look row-carrying: what it names is still
-// the constant, bound above the loop the matched rows are read in, so both spellings must
-// reach the same rejection.
-TEST_F(CypherCollectTest, rejectsCollectOfAConstantAlias) {
+TEST_F(CypherCollectTest, ungroupedCollectOfAConstant) {
     buildTeamGraph();
 
-    QueryStatus groupedStatus;
-    runQuery("MATCH (n:Node) RETURN n.team, 1 AS x, collect(x)", groupedStatus);
+    Int64ListSink sink;
+    match("MATCH (n:Node) RETURN collect(1)", sink);
 
-    EXPECT_EQ(groupedStatus.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(groupedStatus.getError(), "collect() of a constant expression is not yet supported.");
+    const std::vector<std::vector<int64_t>> expected {{1, 1, 1, 1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
 
-    QueryStatus ungroupedStatus;
-    runQuery("MATCH (n:Node) RETURN 1 AS x, collect(x)", ungroupedStatus);
+// The arithmetic is computed once, above the rows, and the value it holds is what every
+// row contributes.
+TEST_F(CypherCollectTest, ungroupedCollectOfConstantArithmetic) {
+    buildTeamGraph();
 
-    EXPECT_EQ(ungroupedStatus.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(ungroupedStatus.getError(), "collect() of a constant expression is not yet supported.");
+    Int64ListSink sink;
+    match("MATCH (n:Node) RETURN collect(2 + 3)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{5, 5, 5, 5}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(CypherCollectTest, ungroupedCollectOfAConstantString) {
+    buildTeamGraph();
+
+    StringListSink sink;
+    match(R"(MATCH (n:Node) RETURN collect("x"))", sink);
+
+    const std::vector<std::vector<std::string>> expected {{"x", "x", "x", "x"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// Every row holds the same value, so dropping the repeats leaves the one element.
+TEST_F(CypherCollectTest, ungroupedCollectDistinctOfAConstant) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match("MATCH (n:Node) RETURN collect(DISTINCT 1)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// No match drives the projection, so the rows the constant is laid out over are the single
+// row a bare RETURN is.
+TEST_F(CypherCollectTest, collectOfAConstantWithoutAMatch) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match("RETURN collect(1)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The rows the constant is laid out over are the rows the query left standing, so a
+// filter is what the list is sized by: two of the four nodes are red.
+TEST_F(CypherCollectTest, ungroupedCollectOfAConstantUnderAFilter) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match(R"(MATCH (n:Node) WHERE n.team = "red" RETURN collect(1))", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{1, 1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The driving relation need not be a match: an unwound list drives the rows here, and the
+// constant is laid out over its cells.
+TEST_F(CypherCollectTest, ungroupedCollectOfAConstantOverAnUnwind) {
+    buildTeamGraph();
+
+    Int64ListSink sink;
+    match("UNWIND [10, 20] AS v RETURN collect(1)", sink);
+
+    const std::vector<std::vector<int64_t>> expected {{1, 1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// An alias of a constant names that constant, so it is laid out the same way - grouped,
+// once per row of each group, and ungrouped, once per matched row.
+TEST_F(CypherCollectTest, collectOfAConstantAlias) {
+    buildTeamGraph();
+
+    TrailingInt64ListSink groupedSink;
+    match("MATCH (n:Node) RETURN n.team, 1 AS x, collect(x)", groupedSink);
+
+    const std::vector<std::vector<int64_t>> grouped {{1, 1}, {1, 1}};
+    EXPECT_EQ(groupedSink.rows(), grouped);
+
+    TrailingInt64ListSink ungroupedSink;
+    match("MATCH (n:Node) RETURN 1 AS x, collect(x)", ungroupedSink);
+
+    const std::vector<std::vector<int64_t>> ungrouped {{1, 1, 1, 1}};
+    EXPECT_EQ(ungroupedSink.rows(), ungrouped);
 }
 
 // An aliased item is a non-aggregate item like any other, so it groups the rows too: each
@@ -956,6 +1465,36 @@ TEST_F(CypherCollectTest, groupedCollectOfEdges) {
     EXPECT_EQ(rows, expected);
 }
 
+// Grouping on the other end of the traversal: the key is a property of the target rather
+// than of the source the two edges share, so each edge lands in a group of its own.
+TEST_F(CypherCollectTest, groupedCollectOfEdgesOnTheTraversalTarget) {
+    buildKnowsGraph();
+
+    KeyedEdgeListSink sink;
+    match("MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN b.name, collect(e)", sink);
+
+    std::vector<KeyedEdgeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedEdgeListSink::Row> expected {
+        {"bob", {0}},
+        {"carol", {1}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// With no grouping key there is no key column to resolve the edge beside, so the argument
+// is resolved through the edge identity's representative alone.
+TEST_F(CypherCollectTest, ungroupedCollectOfEdges) {
+    buildKnowsGraph();
+
+    EdgeListSink sink;
+    match("MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN collect(e)", sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
 // The list carries entities through the same buffers a value list does, so the sort and
 // the skip/limit copies need no entity case of their own.
 TEST_F(CypherCollectTest, collectOfNodesWithOrderByAndSkipLimit) {
@@ -965,30 +1504,22 @@ TEST_F(CypherCollectTest, collectOfNodesWithOrderByAndSkipLimit) {
     match("MATCH (n:Node) RETURN n.team, collect(n) ORDER BY n.team DESC", orderedSink);
 
     std::vector<KeyedNodeListSink::Row> orderedRows;
-    orderedSink.sortedRows(orderedRows);
+    orderedSink.rowsInEmitOrder(orderedRows);
 
-    const std::vector<KeyedNodeListSink::Row> expected {
-        {"blue", {2, 3}},
+    const std::vector<KeyedNodeListSink::Row> ordered {
         {"red", {0, 1}},
+        {"blue", {2, 3}},
     };
-    EXPECT_EQ(orderedRows, expected);
+    EXPECT_EQ(orderedRows, ordered);
 
     KeyedNodeListSink cutSink;
     match("MATCH (n:Node) RETURN n.team, collect(n) SKIP 1 LIMIT 1", cutSink);
 
     std::vector<KeyedNodeListSink::Row> cutRows;
-    cutSink.sortedRows(cutRows);
+    cutSink.rowsInEmitOrder(cutRows);
 
-    ASSERT_EQ(cutRows.size(), 1u);
-    const KeyedNodeListSink::Row& row = cutRows.front();
-    ASSERT_TRUE(row.first);
-
-    if (*row.first == "red") {
-        EXPECT_EQ(row.second, std::vector<uint64_t>({0, 1}));
-    } else {
-        EXPECT_EQ(*row.first, "blue");
-        EXPECT_EQ(row.second, std::vector<uint64_t>({2, 3}));
-    }
+    const std::vector<KeyedNodeListSink::Row> cut {{"blue", {2, 3}}};
+    EXPECT_EQ(cutRows, cut);
 }
 
 TEST_F(CypherCollectTest, ungroupedCollectDistinct) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -338,6 +338,48 @@ TEST_F(CypherCollectTest, groupedCollectWithLimit) {
     }
 }
 
+TEST_F(CypherCollectTest, groupedCollectWithSkipAndLimit) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) SKIP 1 LIMIT 1", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    ASSERT_EQ(rows.size(), 1u);
+    const KeyedStringListSink::Row& row = rows.front();
+    ASSERT_TRUE(row.first);
+
+    if (*row.first == "red") {
+        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
+    } else {
+        EXPECT_EQ(*row.first, "blue");
+        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
+    }
+}
+
+TEST_F(CypherCollectTest, groupedCollectWithSkip) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) SKIP 1", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    ASSERT_EQ(rows.size(), 1u);
+    const KeyedStringListSink::Row& row = rows.front();
+    ASSERT_TRUE(row.first);
+
+    if (*row.first == "red") {
+        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
+    } else {
+        EXPECT_EQ(*row.first, "blue");
+        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
+    }
+}
+
 TEST_F(CypherCollectTest, rejectsCollectWithAnotherAggregate) {
     buildTeamGraph();
 

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -1,0 +1,462 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+
+#include "LocalMemory.h"
+#include "NLOutputSink.h"
+#include "QueryConfig.h"
+#include "QueryInterpreterV3.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Reads one list cell (a ColumnVector<ListView> row) as a vector of strings.
+void readStringList(const ListView& view, std::vector<std::string>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(std::string(element.getAs<std::string_view>()));
+    }
+}
+
+// Reads one list cell as a vector of int64s.
+void readInt64List(const ListView& view, std::vector<int64_t>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        out.push_back(element.getAs<int64_t>());
+    }
+}
+
+// Discards output: used by the CREATE queries building the fixture and by the queries
+// that are rejected before producing rows.
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+// Collects the (team, [names]) rows a grouped collect emits: a nullable string key chunk
+// and a per-group list cell chunk. The list keeps its append order; the row set is
+// captured for an order-independent assert.
+class KeyedStringListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<std::string>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+
+            _rows.push_back({key, names});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+    // The rows as the sink saw them, for the ORDER BY tests: the emit order is the result.
+    void rowsInEmitOrder(std::vector<Row>& rows) const {
+        rows = _rows;
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the (team, [scores]) rows a grouped collect over an Int64 value emits.
+class KeyedInt64ListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<int64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<int64_t> scores;
+            readInt64List(listRaw[row], scores);
+
+            _rows.push_back({key, scores});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+// Collects the ([names]) rows an ungrouped collect emits: a single list cell chunk.
+class StringListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<std::string> names;
+            readStringList(listRaw[row], names);
+            _rows.push_back(names);
+        }
+    }
+
+    const std::vector<std::vector<std::string>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<std::string>> _rows;
+};
+
+}
+
+// End-to-end tests driving collect() from Cypher text through parsing, analysis,
+// DBProgramGenerator codegen, NL lowering and NLInterpreter execution.
+class CypherCollectTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interp3 = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        system.createGraph(_graphName);
+    }
+
+    // Runs a CREATE query in its own change and submits it.
+    void create(std::string_view query) {
+        ChangeID changeID;
+        {
+            SystemAccessor system = _env->getSystemManager().accessUnique();
+            const auto res = system.newChange(_graphName);
+            ASSERT_TRUE(res);
+            changeID = res.value()->id();
+        }
+
+        NullSink discardSink;
+        QueryStatus createStatus;
+        _interp3->execute(createStatus, query, _graphName, CommitHash::head(), changeID, &_env->getMem(), &discardSink);
+        ASSERT_TRUE(createStatus.isOk()) << "CREATE failed: " << createStatus.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+        const QueryState submitState(_graphName, &_env->getMem(), &_queryConfig, &callbacks, CommitHash::head(), changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a read-only MATCH query against the committed head.
+    void match(std::string_view query, NLOutputSink& sink) {
+        QueryStatus status;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << "MATCH failed: " << status.getError();
+    }
+
+    // Runs a query expected to be rejected, and hands back the status carrying the reason.
+    void runQuery(std::string_view query, QueryStatus& status) {
+        NullSink sink;
+        _interp3->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+    }
+
+    // Inserts 4 nodes: red/alice/10, red/carol/20, blue/bob/100, blue/dan (no score).
+    void buildTeamGraph() {
+        create(R"(CREATE (:Node {team: "red", name: "alice", score: 10}), (:Node {team: "red", name: "carol", score: 20}), (:Node {team: "blue", name: "bob", score: 100}))");
+        create(R"(CREATE (:Node {team: "blue", name: "dan"}))");
+    }
+
+    // Inserts alice, who KNOWS both bob and carol.
+    void buildKnowsGraph() {
+        create(R"(CREATE (:Person {name: "alice"}), (:Person {name: "bob"}), (:Person {name: "carol"}))");
+        create(R"(MATCH (a:Person {name: "alice"}), (b:Person {name: "bob"}) CREATE (a)-[:KNOWS]->(b))");
+        create(R"(MATCH (a:Person {name: "alice"}), (c:Person {name: "carol"}) CREATE (a)-[:KNOWS]->(c))");
+    }
+
+    const std::string _graphName = "teamGraph";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interp3;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CypherCollectTest, groupedCollectStrings) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectWithAliases) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team AS team, collect(n.name) AS names", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// The grouping key is bound by the outer loop and the collected values by the inner one,
+// so the per-group appends must happen where the traversal binds the target.
+TEST_F(CypherCollectTest, groupedCollectOverTraversal) {
+    buildKnowsGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, collect(b.name)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {{"alice", {"bob", "carol"}}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectDropsNulls) {
+    buildTeamGraph();
+
+    KeyedInt64ListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.score)", sink);
+
+    // dan has no score, so the blue group collects the one score it has: Cypher's
+    // collect ignores nulls.
+    std::vector<KeyedInt64ListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedInt64ListSink::Row> expected {
+        {"blue", {100}},
+        {"red", {10, 20}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, ungroupedCollect) {
+    buildTeamGraph();
+
+    StringListSink sink;
+    match("MATCH (n:Node) RETURN collect(n.name)", sink);
+
+    const std::vector<std::vector<std::string>> expected {{"alice", "carol", "bob", "dan"}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(CypherCollectTest, ungroupedCollectOverNoRow) {
+    buildTeamGraph();
+
+    StringListSink sink;
+    match(R"(MATCH (n:Node {team: "green"}) RETURN collect(n.name))", sink);
+
+    const std::vector<std::vector<std::string>> expected {{}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectWithLimit) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) LIMIT 1", sink);
+
+    // One group row survives the cut, and it is a whole group: the limit budgets the
+    // drain, not the rows folded into it.
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    ASSERT_EQ(rows.size(), 1u);
+    const KeyedStringListSink::Row& row = rows.front();
+    ASSERT_TRUE(row.first);
+
+    if (*row.first == "red") {
+        EXPECT_EQ(row.second, std::vector<std::string>({"alice", "carol"}));
+    } else {
+        EXPECT_EQ(*row.first, "blue");
+        EXPECT_EQ(row.second, std::vector<std::string>({"bob", "dan"}));
+    }
+}
+
+TEST_F(CypherCollectTest, rejectsCollectWithAnotherAggregate) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name), count(*)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+}
+
+TEST_F(CypherCollectTest, rejectsUngroupedCollectWithCount) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(n.name), count(*)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+}
+
+TEST_F(CypherCollectTest, rejectsTwoCollects) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(n.name), collect(n.team)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+}
+
+// The sort orders the group rows the drain emits, carrying each group's list along with
+// the key it belongs to.
+TEST_F(CypherCollectTest, groupedCollectWithOrderBy) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY n.team", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectWithOrderByDescending) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY n.team DESC", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"red", {"alice", "carol"}},
+        {"blue", {"bob", "dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// ORDER BY ... LIMIT fuses into a top-K accumulator, which trims the buffers by gathering
+// the surviving rows - the list column included.
+TEST_F(CypherCollectTest, groupedCollectWithOrderByAndLimit) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY n.team LIMIT 1", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {{"blue", {"bob", "dan"}}};
+    EXPECT_EQ(rows, expected);
+}
+
+// A list is carried through the sort but never compared, so it cannot be the key. The
+// analyzer already turns every aggregate ORDER BY key away, alias or spelled out.
+TEST_F(CypherCollectTest, rejectsOrderByOnTheCollectedList) {
+    buildTeamGraph();
+
+    QueryStatus aliasStatus;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names", aliasStatus);
+    EXPECT_EQ(aliasStatus.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+
+    QueryStatus spelledOutStatus;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY collect(n.name)", spelledOutStatus);
+    EXPECT_EQ(spelledOutStatus.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+}
+
+TEST_F(CypherCollectTest, rejectsCollectOfConstant) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(1)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() of a constant expression is not yet supported.");
+}
+
+// An entity has no list element representation, so no collect overload takes one and the
+// analyzer rejects the call.
+TEST_F(CypherCollectTest, rejectsCollectOfEntity) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(n)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+}
+
+TEST_F(CypherCollectTest, rejectsCollectDistinct) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(DISTINCT n.name)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PARSE_ERROR);
+}

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -49,6 +49,25 @@ void readInt64List(const ListView& view, std::vector<int64_t>& out) {
     }
 }
 
+// Reads one list cell as a vector of node ids, asserting each element carries the node
+// tag rather than a bare integer.
+void readNodeIDList(const ListView& view, std::vector<uint64_t>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::NodeID);
+        out.push_back(element.getAs<NodeID>().getValue());
+    }
+}
+
+// Reads one list cell as a vector of edge ids, asserting the edge tag.
+void readEdgeIDList(const ListView& view, std::vector<uint64_t>& out) {
+    out.clear();
+    for (const ListElementView& element : view) {
+        ASSERT_EQ(element.getTag(), ListBufferTypeTag::EdgeID);
+        out.push_back(element.getAs<EdgeID>().getValue());
+    }
+}
+
 // Discards output: used by the CREATE queries building the fixture and by the queries
 // that are rejected before producing rows.
 class NullSink : public NLOutputSink {
@@ -137,6 +156,72 @@ public:
 
 private:
     std::vector<Row> _rows;
+};
+
+// Collects the (key, [ids]) rows a grouped entity collect emits, reading each list cell
+// with the tag-checking reader for the collected entity kind.
+template <void (*Reader)(const ListView&, std::vector<uint64_t>&)>
+class KeyedIDListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<uint64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<std::string_view>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key;
+            if (keyRaw[row]) {
+                key = std::string(*keyRaw[row]);
+            }
+
+            std::vector<uint64_t> ids;
+            Reader(listRaw[row], ids);
+
+            _rows.push_back({key, ids});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+using KeyedNodeListSink = KeyedIDListSink<readNodeIDList>;
+using KeyedEdgeListSink = KeyedIDListSink<readEdgeIDList>;
+
+// Collects the ([ids]) rows an ungrouped entity collect emits: a single list cell chunk.
+class NodeListSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[0]);
+        ASSERT_NE(lists, nullptr);
+
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<uint64_t> ids;
+            readNodeIDList(listRaw[row], ids);
+            _rows.push_back(ids);
+        }
+    }
+
+    const std::vector<std::vector<uint64_t>>& rows() const { return _rows; }
+
+private:
+    std::vector<std::vector<uint64_t>> _rows;
 };
 
 // Collects the ([names]) rows an ungrouped collect emits: a single list cell chunk.
@@ -485,13 +570,94 @@ TEST_F(CypherCollectTest, rejectsCollectOfConstant) {
 
 // An entity has no list element representation, so no collect overload takes one and the
 // analyzer rejects the call.
-TEST_F(CypherCollectTest, rejectsCollectOfEntity) {
+TEST_F(CypherCollectTest, groupedCollectOfNodes) {
     buildTeamGraph();
 
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN collect(n)", status);
+    KeyedNodeListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n)", sink);
 
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {
+        {"blue", {2, 3}},
+        {"red", {0, 1}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, ungroupedCollectOfNodes) {
+    buildTeamGraph();
+
+    NodeListSink sink;
+    match("MATCH (n:Node) RETURN collect(n)", sink);
+
+    const std::vector<std::vector<uint64_t>> expected {{0, 1, 2, 3}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(CypherCollectTest, collectOfNodesOnUnlabelledMatch) {
+    buildTeamGraph();
+
+    KeyedNodeListSink sink;
+    match("match (n) return n.team, collect(n)", sink);
+
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {
+        {"blue", {2, 3}},
+        {"red", {0, 1}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectOfEdges) {
+    buildKnowsGraph();
+
+    KeyedEdgeListSink sink;
+    match("MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN a.name, collect(e)", sink);
+
+    std::vector<KeyedEdgeListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedEdgeListSink::Row> expected {{"alice", {0, 1}}};
+    EXPECT_EQ(rows, expected);
+}
+
+// The list carries entities through the same buffers a value list does, so the sort and
+// the skip/limit copies need no entity case of their own.
+TEST_F(CypherCollectTest, collectOfNodesWithOrderByAndSkipLimit) {
+    buildTeamGraph();
+
+    KeyedNodeListSink orderedSink;
+    match("MATCH (n:Node) RETURN n.team, collect(n) ORDER BY n.team DESC", orderedSink);
+
+    std::vector<KeyedNodeListSink::Row> orderedRows;
+    orderedSink.sortedRows(orderedRows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {
+        {"blue", {2, 3}},
+        {"red", {0, 1}},
+    };
+    EXPECT_EQ(orderedRows, expected);
+
+    KeyedNodeListSink cutSink;
+    match("MATCH (n:Node) RETURN n.team, collect(n) SKIP 1 LIMIT 1", cutSink);
+
+    std::vector<KeyedNodeListSink::Row> cutRows;
+    cutSink.sortedRows(cutRows);
+
+    ASSERT_EQ(cutRows.size(), 1u);
+    const KeyedNodeListSink::Row& row = cutRows.front();
+    ASSERT_TRUE(row.first);
+
+    if (*row.first == "red") {
+        EXPECT_EQ(row.second, std::vector<uint64_t>({0, 1}));
+    } else {
+        EXPECT_EQ(*row.first, "blue");
+        EXPECT_EQ(row.second, std::vector<uint64_t>({2, 3}));
+    }
 }
 
 TEST_F(CypherCollectTest, rejectsCollectDistinct) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -568,6 +568,25 @@ TEST_F(CypherCollectTest, rejectsCollectOfConstant) {
     EXPECT_EQ(status.getError(), "collect() of a constant expression is not yet supported.");
 }
 
+// The alias is what makes the collected column look row-carrying: what it names is still
+// the constant, bound above the loop the matched rows are read in, so both spellings must
+// reach the same rejection.
+TEST_F(CypherCollectTest, rejectsCollectOfAConstantAlias) {
+    buildTeamGraph();
+
+    QueryStatus groupedStatus;
+    runQuery("MATCH (n:Node) RETURN n.team, 1 AS x, collect(x)", groupedStatus);
+
+    EXPECT_EQ(groupedStatus.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(groupedStatus.getError(), "collect() of a constant expression is not yet supported.");
+
+    QueryStatus ungroupedStatus;
+    runQuery("MATCH (n:Node) RETURN 1 AS x, collect(x)", ungroupedStatus);
+
+    EXPECT_EQ(ungroupedStatus.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(ungroupedStatus.getError(), "collect() of a constant expression is not yet supported.");
+}
+
 // An entity has no list element representation, so no collect overload takes one and the
 // analyzer rejects the call.
 TEST_F(CypherCollectTest, groupedCollectOfNodes) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -796,6 +796,24 @@ TEST_F(CypherCollectTest, groupedCollectOfNodesOrderedByTheList) {
     EXPECT_EQ(rows, expected);
 }
 
+// An aggregate projection emits one row per group, so no two of its rows can be equal:
+// the dedup is elided and DISTINCT beside a collect returns the groups untouched.
+TEST_F(CypherCollectTest, distinctOverTheCollectedList) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN DISTINCT n.team, collect(n.name)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
 TEST_F(CypherCollectTest, rejectsCollectOfConstant) {
     buildTeamGraph();
 

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -1010,19 +1010,6 @@ TEST_F(CypherCollectTest, ungroupedCollectOrderedByASum) {
     EXPECT_EQ(sink.rows(), expected);
 }
 
-// Each collect drains through a loop of its own, and the emit sits in one of them: the
-// other list is bound in a loop the output is not in, so this is the pair that is still
-// turned away.
-TEST_F(CypherCollectTest, rejectsTwoCollects) {
-    buildTeamGraph();
-
-    QueryStatus status;
-    runQuery("MATCH (n:Node) RETURN collect(n.name), collect(n.team)", status);
-
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another collect().");
-}
-
 // The sort orders the group rows the drain emits, carrying each group's list along with
 // the key it belongs to.
 TEST_F(CypherCollectTest, groupedCollectWithOrderBy) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -683,18 +683,20 @@ TEST_F(CypherCollectTest, groupedCollectWithOrderByAndLimit) {
     EXPECT_EQ(rows, expected);
 }
 
-// A list is carried through the sort but never compared, so it cannot be the key. The
-// analyzer already turns every aggregate ORDER BY key away, alias or spelled out.
+// A list is carried through the sort row-aligned with the keys but never compared, so it
+// cannot be the key the rows are ordered on - alias or spelled out.
 TEST_F(CypherCollectTest, rejectsOrderByOnTheCollectedList) {
     buildTeamGraph();
 
     QueryStatus aliasStatus;
     runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names", aliasStatus);
-    EXPECT_EQ(aliasStatus.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+    EXPECT_EQ(aliasStatus.getStatus(), QueryStatus::Status::EXEC_ERROR);
+    EXPECT_EQ(aliasStatus.getError(), "a list column cannot be a sort key");
 
     QueryStatus spelledOutStatus;
     runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY collect(n.name)", spelledOutStatus);
-    EXPECT_EQ(spelledOutStatus.getStatus(), QueryStatus::Status::ANALYZE_ERROR);
+    EXPECT_EQ(spelledOutStatus.getStatus(), QueryStatus::Status::EXEC_ERROR);
+    EXPECT_EQ(spelledOutStatus.getError(), "a list column cannot be a sort key");
 }
 
 TEST_F(CypherCollectTest, rejectsCollectOfConstant) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -227,6 +227,10 @@ public:
         std::sort(rows.begin(), rows.end());
     }
 
+    void rowsInEmitOrder(std::vector<Row>& rows) const {
+        rows = _rows;
+    }
+
 private:
     std::vector<Row> _rows;
 };
@@ -401,6 +405,12 @@ protected:
     void buildTeamGraph() {
         create(R"(CREATE (:Node {team: "red", name: "alice", score: 10}), (:Node {team: "red", name: "carol", score: 20}), (:Node {team: "blue", name: "bob", score: 100}))");
         create(R"(CREATE (:Node {team: "blue", name: "dan"}))");
+    }
+
+    // Inserts 3 nodes so that one group's collected list is a prefix of the other's:
+    // solo collects ["ann"], duo ["ann", "bob"].
+    void buildPrefixTeamGraph() {
+        create(R"(CREATE (:Node {team: "duo", name: "ann"}), (:Node {team: "solo", name: "ann"}), (:Node {team: "duo", name: "bob"}))");
     }
 
     // Inserts alice, who KNOWS both bob and carol.
@@ -683,20 +693,107 @@ TEST_F(CypherCollectTest, groupedCollectWithOrderByAndLimit) {
     EXPECT_EQ(rows, expected);
 }
 
-// A list is carried through the sort row-aligned with the keys but never compared, so it
-// cannot be the key the rows are ordered on - alias or spelled out.
-TEST_F(CypherCollectTest, rejectsOrderByOnTheCollectedList) {
+// Two lists order lexicographically, so the collected list can be the sort key: red's
+// ["alice", "carol"] sorts before blue's ["bob", "dan"] on the first element.
+TEST_F(CypherCollectTest, groupedCollectOrderedByTheList) {
     buildTeamGraph();
 
-    QueryStatus aliasStatus;
-    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names", aliasStatus);
-    EXPECT_EQ(aliasStatus.getStatus(), QueryStatus::Status::EXEC_ERROR);
-    EXPECT_EQ(aliasStatus.getError(), "a list column cannot be a sort key");
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names", sink);
 
-    QueryStatus spelledOutStatus;
-    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY collect(n.name)", spelledOutStatus);
-    EXPECT_EQ(spelledOutStatus.getStatus(), QueryStatus::Status::EXEC_ERROR);
-    EXPECT_EQ(spelledOutStatus.getError(), "a list column cannot be a sort key");
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"red", {"alice", "carol"}},
+        {"blue", {"bob", "dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, groupedCollectOrderedByTheListDescending) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names DESC", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"blue", {"bob", "dan"}},
+        {"red", {"alice", "carol"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// The key need not be the alias: spelling the aggregate out again reads the same
+// collected column rather than collecting a second one.
+TEST_F(CypherCollectTest, groupedCollectOrderedBySpelledOutCollect) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY collect(n.name)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"red", {"alice", "carol"}},
+        {"blue", {"bob", "dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// Element-wise comparison runs out of elements before it finds a difference, so the
+// shorter list - the prefix - sorts first.
+TEST_F(CypherCollectTest, groupedCollectOrderedByListPrefix) {
+    buildPrefixTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"solo", {"ann"}},
+        {"duo", {"ann", "bob"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// ORDER BY ... LIMIT fuses into a top-K accumulator, which trims by gathering the
+// surviving rows - so the list is both the key compared and a column gathered.
+TEST_F(CypherCollectTest, groupedCollectOrderedByTheListWithLimit) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names LIMIT 1", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {{"red", {"alice", "carol"}}};
+    EXPECT_EQ(rows, expected);
+}
+
+// A list of entities orders by its elements' IDs: red collects nodes 0 and 1, blue 2
+// and 3, so red sorts first.
+TEST_F(CypherCollectTest, groupedCollectOfNodesOrderedByTheList) {
+    buildTeamGraph();
+
+    KeyedNodeListSink sink;
+    match("MATCH (n:Node) RETURN n.team, collect(n) AS nodes ORDER BY nodes", sink);
+
+    std::vector<KeyedNodeListSink::Row> rows;
+    sink.rowsInEmitOrder(rows);
+
+    const std::vector<KeyedNodeListSink::Row> expected {
+        {"red", {0, 1}},
+        {"blue", {2, 3}},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
 TEST_F(CypherCollectTest, rejectsCollectOfConstant) {

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -158,6 +158,39 @@ private:
     std::vector<Row> _rows;
 };
 
+// Collects the (score, [scores]) rows a collect keyed on a nullable Int64 alias emits.
+class Int64KeyedListSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<int64_t>, std::vector<int64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<int64_t> scores;
+            readInt64List(listRaw[row], scores);
+
+            _rows.push_back({keyRaw[row], scores});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
 // Collects the (key, [ids]) rows a grouped entity collect emits, reading each list cell
 // with the tag-checking reader for the collected entity kind.
 template <void (*Reader)(const ListView&, std::vector<uint64_t>&)>
@@ -200,6 +233,40 @@ private:
 
 using KeyedNodeListSink = KeyedIDListSink<readNodeIDList>;
 using KeyedEdgeListSink = KeyedIDListSink<readEdgeIDList>;
+
+// Collects the (node, [nodes]) rows a collect keyed on a node alias emits.
+class NodeKeyedListSink : public NLOutputSink {
+public:
+    using Row = std::pair<uint64_t, std::vector<uint64_t>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnVector<NodeID>*>(chunks[0]);
+        const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(lists, nullptr);
+        ASSERT_EQ(keys->size(), lists->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& listRaw = lists->getRaw();
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::vector<uint64_t> ids;
+            readNodeIDList(listRaw[row], ids);
+
+            _rows.push_back({keyRaw[row].getValue(), ids});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
 
 // Collects the ([ids]) rows an ungrouped entity collect emits: a single list cell chunk.
 class NodeListSink : public NLOutputSink {
@@ -585,6 +652,64 @@ TEST_F(CypherCollectTest, rejectsCollectOfAConstantAlias) {
 
     EXPECT_EQ(ungroupedStatus.getStatus(), QueryStatus::Status::PLAN_ERROR);
     EXPECT_EQ(ungroupedStatus.getError(), "collect() of a constant expression is not yet supported.");
+}
+
+// An aliased item is a non-aggregate item like any other, so it groups the rows too: each
+// list holds the one value its group is, not the values of the whole match.
+TEST_F(CypherCollectTest, collectOverAPropertyAlias) {
+    buildTeamGraph();
+
+    KeyedStringListSink sink;
+    match("MATCH (n:Node) RETURN n.name AS nm, collect(nm)", sink);
+
+    std::vector<KeyedStringListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<KeyedStringListSink::Row> expected {
+        {"alice", {"alice"}},
+        {"bob", {"bob"}},
+        {"carol", {"carol"}},
+        {"dan", {"dan"}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+// dan has no score, so the null keys a group of its own - and collect drops the null it
+// would have collected there, leaving that group's list empty.
+TEST_F(CypherCollectTest, collectOverANullablePropertyAlias) {
+    buildTeamGraph();
+
+    Int64KeyedListSink sink;
+    match("MATCH (n:Node) RETURN n.score AS s, collect(s)", sink);
+
+    std::vector<Int64KeyedListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<Int64KeyedListSink::Row> expected {
+        {std::nullopt, {}},
+        {10, {10}},
+        {20, {20}},
+        {100, {100}},
+    };
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(CypherCollectTest, collectOverAnEntityAlias) {
+    buildTeamGraph();
+
+    NodeKeyedListSink sink;
+    match("MATCH (n:Node) RETURN n AS m, collect(m)", sink);
+
+    std::vector<NodeKeyedListSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<NodeKeyedListSink::Row> expected {
+        {0, {0}},
+        {1, {1}},
+        {2, {2}},
+        {3, {3}},
+    };
+    EXPECT_EQ(rows, expected);
 }
 
 // An entity has no list element representation, so no collect overload takes one and the

--- a/test/query/ir/CypherCollectTest.cpp
+++ b/test/query/ir/CypherCollectTest.cpp
@@ -552,6 +552,26 @@ TEST_F(CypherCollectTest, rejectsUngroupedCollectWithCount) {
     EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
 }
 
+TEST_F(CypherCollectTest, rejectsUngroupedCollectWithAWrappedAggregate) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN collect(n.name), count(n) + 1", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+}
+
+TEST_F(CypherCollectTest, rejectsGroupedCollectWithAWrappedAggregate) {
+    buildTeamGraph();
+
+    QueryStatus status;
+    runQuery("MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score) + 0", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "collect() may not yet be combined with another aggregate.");
+}
+
 TEST_F(CypherCollectTest, rejectsTwoCollects) {
     buildTeamGraph();
 
@@ -712,8 +732,6 @@ TEST_F(CypherCollectTest, collectOverAnEntityAlias) {
     EXPECT_EQ(rows, expected);
 }
 
-// An entity has no list element representation, so no collect overload takes one and the
-// analyzer rejects the call.
 TEST_F(CypherCollectTest, groupedCollectOfNodes) {
     buildTeamGraph();
 

--- a/test/query/ir/CypherMultiCollectTest.cpp
+++ b/test/query/ir/CypherMultiCollectTest.cpp
@@ -1,0 +1,207 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// More than one collect() in the same projection. Each is a value column of the one
+// accumulator, so the lists come out of a single drain: the group table, the keys and
+// the reductions beside them are shared, and only the per-group value buffers multiply.
+class CypherMultiCollectTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// Two lists over the whole match: one row, holding both. The names and the identities
+// are the same ten interests, collected as values and as entities
+TEST_F(CypherMultiCollectTest, collectsTwoValuesOverTheWholeMatch) {
+    expectRows("MATCH (i:Interest) RETURN collect(i.name), collect(i)",
+               {{"[Computers, Eighties, Bio, Cooking, Ghosts, Padel, Animals, Gym, Travel, JiuJitsu]",
+                 "[2, 3, 4, 5, 6, 7, 10, 13, 14, 16]"}});
+}
+
+TEST_F(CypherMultiCollectTest, collectsTwoValuesPerGroup) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.name, collect(i.name), collect(i)",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]"},
+                {"Luc", "[Animals, Computers]", "[10, 2]"},
+                {"Martina", "[Cooking]", "[5]"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]"},
+                {"Doruk", "[Gym]", "[13]"}});
+}
+
+TEST_F(CypherMultiCollectTest, collectsThreeValuesPerGroup) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.name, collect(i.name), collect(i), collect(p)",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]", "[0, 0, 0]"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]", "[1, 1]"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]", "[8, 8]"},
+                {"Luc", "[Animals, Computers]", "[10, 2]", "[9, 9]"},
+                {"Martina", "[Cooking]", "[5]", "[11]"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]", "[12, 12]"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]", "[15, 15]"},
+                {"Doruk", "[Gym]", "[13]", "[17]"}});
+}
+
+// The DISTINCT rides the value column it is written on, so the plain list beside it keeps
+// every row: a person repeats in a group once per interest they hold
+TEST_F(CypherMultiCollectTest, dedupesOneListAndNotTheOneBesideIt) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.hasPhD, collect(DISTINCT p.name), collect(p.name)",
+               {{"true", "[Remy, Adam, Luc, Martina]", "[Remy, Remy, Remy, Adam, Adam, Luc, Luc, Martina]"},
+                {"false", "[Maxime, Cyrus, Suhas, Doruk]", "[Maxime, Maxime, Cyrus, Cyrus, Suhas, Suhas, Doruk]"}});
+}
+
+TEST_F(CypherMultiCollectTest, dedupesBothListsIndependently) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.hasPhD, collect(DISTINCT p.name), collect(DISTINCT i.name)",
+               {{"true", "[Remy, Adam, Luc, Martina]", "[Ghosts, Computers, Eighties, Bio, Cooking, Animals]"},
+                {"false", "[Maxime, Cyrus, Suhas, Doruk]", "[Bio, Padel, Gym, Travel, JiuJitsu]"}});
+}
+
+// The reductions read the same group table the lists do, so they ride the one op beside
+// them rather than grouping the rows a second time
+TEST_F(CypherMultiCollectTest, reducesBesideTwoLists) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.name, collect(i.name), collect(i), count(*)",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]", "3"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]", "2"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]", "2"},
+                {"Luc", "[Animals, Computers]", "[10, 2]", "2"},
+                {"Martina", "[Cooking]", "[5]", "1"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]", "2"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]", "2"},
+                {"Doruk", "[Gym]", "[13]", "1"}});
+}
+
+TEST_F(CypherMultiCollectTest, aliasesBothLists) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN p.name AS person, collect(i.name) AS names, collect(i) AS nodes",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]"},
+                {"Luc", "[Animals, Computers]", "[10, 2]"},
+                {"Martina", "[Cooking]", "[5]"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]"},
+                {"Doruk", "[Gym]", "[13]"}});
+}
+
+// The sort reads one of the two lists as its key, and carries the other along with it
+TEST_F(CypherMultiCollectTest, ordersTheGroupsByOneOfTwoLists) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "RETURN p.name, collect(i.name) AS names, collect(i) AS nodes ORDER BY names",
+                      {{"Luc", "[Animals, Computers]", "[10, 2]"},
+                       {"Adam", "[Bio, Cooking]", "[4, 5]"},
+                       {"Maxime", "[Bio, Padel]", "[4, 7]"},
+                       {"Martina", "[Cooking]", "[5]"},
+                       {"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]"},
+                       {"Doruk", "[Gym]", "[13]"},
+                       {"Suhas", "[Gym, JiuJitsu]", "[13, 16]"},
+                       {"Cyrus", "[Gym, Travel]", "[13, 14]"}});
+}
+
+TEST_F(CypherMultiCollectTest, cutsTheGroupsCarryingTwoLists) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "RETURN p.name AS person, collect(i.name) AS names, collect(i) AS nodes "
+                      "ORDER BY person SKIP 1 LIMIT 2",
+                      {{"Cyrus", "[Gym, Travel]", "[13, 14]"},
+                       {"Doruk", "[Gym]", "[13]"}});
+}
+
+// A constant collected column is folded over the rows of the group it falls in, not over
+// the single row it is, so it lands one element per row beside a column that varies
+TEST_F(CypherMultiCollectTest, collectsAConstantBesideAVaryingColumn) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "RETURN collect(1), collect(i.name)",
+               {{"[1, 1]", "[Bio, Cooking]"}});
+}
+
+// A collected list is a value like any other, so DISTINCT over the projected rows reads
+// two of them the way it reads two scalars
+TEST_F(CypherMultiCollectTest, dedupesTheRowsTwoListsProject) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN DISTINCT p.name, collect(i.name), collect(i)",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]"},
+                {"Luc", "[Animals, Computers]", "[10, 2]"},
+                {"Martina", "[Cooking]", "[5]"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]"},
+                {"Doruk", "[Gym]", "[13]"}});
+}

--- a/test/query/ir/IRTestRows.cpp
+++ b/test/query/ir/IRTestRows.cpp
@@ -19,6 +19,7 @@
 #include "list/ListElementView.h"
 #include "list/ListView.h"
 #include "metadata/PropertyNull.h"
+#include "metadata/PropertyType.h"
 
 #include "ID.h"
 
@@ -101,24 +102,25 @@ void renderList(const ListView& list, std::string& out) {
 }
 
 template <typename T>
+void renderValue(const T& value, std::string& out) {
+    if constexpr (std::is_same_v<T, std::string_view>) {
+        out = std::string(value);
+    } else if constexpr (std::is_same_v<T, types::Bool::Primitive>) {
+        out = value ? "true" : "false";
+    } else {
+        out = std::to_string(value);
+    }
+}
+
+template <typename T>
 bool renderValueCell(const Column* column, size_t row, std::string& out) {
     if (const auto* constCol = dynamic_cast<const ColumnConst<T>*>(column)) {
-        const T value = constCol->at(0);
-        if constexpr (std::is_same_v<T, std::string_view>) {
-            out = std::string(value);
-        } else {
-            out = std::to_string(value);
-        }
+        renderValue<T>(constCol->at(0), out);
         return true;
     }
 
     if (const auto* plain = dynamic_cast<const ColumnVector<T>*>(column)) {
-        const T value = (*plain)[row];
-        if constexpr (std::is_same_v<T, std::string_view>) {
-            out = std::string(value);
-        } else {
-            out = std::to_string(value);
-        }
+        renderValue<T>((*plain)[row], out);
         return true;
     }
 
@@ -133,11 +135,7 @@ bool renderValueCell(const Column* column, size_t row, std::string& out) {
         return true;
     }
 
-    if constexpr (std::is_same_v<T, std::string_view>) {
-        out = std::string(*value);
-    } else {
-        out = std::to_string(*value);
-    }
+    renderValue<T>(*value, out);
 
     return true;
 }
@@ -159,6 +157,7 @@ void turing::test::renderCell(const Column* column, size_t row, std::string& out
     } else if (renderValueCell<int64_t>(column, row, out)
                || renderValueCell<uint64_t>(column, row, out)
                || renderValueCell<double>(column, row, out)
+               || renderValueCell<types::Bool::Primitive>(column, row, out)
                || renderValueCell<std::string_view>(column, row, out)) {
         // Rendered by the helper for whichever value type matched
     } else {

--- a/test/query/ir/IRTestRows.cpp
+++ b/test/query/ir/IRTestRows.cpp
@@ -15,12 +15,90 @@
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
 #include "dataframe/NamedColumn.h"
+#include "list/ListBufferTypeTag.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
 #include "metadata/PropertyNull.h"
+
+#include "ID.h"
 
 using namespace db;
 using namespace turing::test;
 
 namespace {
+
+void renderList(const ListView& list, std::string& out);
+
+void renderListElement(const ListElementView& element, std::string& out) {
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            out += std::to_string(element.getAs<int64_t>());
+            return;
+        break;
+
+        case ListBufferTypeTag::UInt:
+            out += std::to_string(element.getAs<uint64_t>());
+            return;
+        break;
+
+        case ListBufferTypeTag::Double:
+            out += std::to_string(element.getAs<double>());
+            return;
+        break;
+
+        case ListBufferTypeTag::Bool:
+            out += element.getAs<bool>() ? "true" : "false";
+            return;
+        break;
+
+        case ListBufferTypeTag::String:
+            out += element.getAs<std::string_view>();
+            return;
+        break;
+
+        case ListBufferTypeTag::ListView:
+            renderList(element.getAs<ListView>(), out);
+            return;
+        break;
+
+        case ListBufferTypeTag::Null:
+            out += "null";
+            return;
+        break;
+
+        case ListBufferTypeTag::NodeID:
+            out += std::to_string(element.getAs<NodeID>().getValue());
+            return;
+        break;
+
+        case ListBufferTypeTag::EdgeID:
+            out += std::to_string(element.getAs<EdgeID>().getValue());
+            return;
+        break;
+
+        case ListBufferTypeTag::Embedding:
+        case ListBufferTypeTag::INVALID:
+        break;
+    }
+
+    throw std::runtime_error("IRTestRows: unsupported list element tag");
+}
+
+void renderList(const ListView& list, std::string& out) {
+    out += '[';
+
+    bool isFirst = true;
+    for (const ListElementView& element : list) {
+        if (!isFirst) {
+            out += ", ";
+        }
+
+        isFirst = false;
+        renderListElement(element, out);
+    }
+
+    out += ']';
+}
 
 template <typename T>
 bool renderValueCell(const Column* column, size_t row, std::string& out) {
@@ -75,6 +153,9 @@ void turing::test::renderCell(const Column* column, size_t row, std::string& out
         out = std::to_string((*edgeTypes)[row].getValue());
     } else if (dynamic_cast<const ColumnConst<PropertyNull>*>(column)) {
         out = "null";
+    } else if (const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(column)) {
+        out.clear();
+        renderList((*lists)[row], out);
     } else if (renderValueCell<int64_t>(column, row, out)
                || renderValueCell<uint64_t>(column, row, out)
                || renderValueCell<double>(column, row, out)

--- a/test/query/ir/StringRowSink.cpp
+++ b/test/query/ir/StringRowSink.cpp
@@ -66,6 +66,14 @@ std::string elementText(const ListElementView& element) {
             return "null";
         break;
 
+        case ListBufferTypeTag::NodeID:
+            return fmt::format("{}", element.getAs<NodeID>().getValue());
+        break;
+
+        case ListBufferTypeTag::EdgeID:
+            return fmt::format("{}", element.getAs<EdgeID>().getValue());
+        break;
+
         case ListBufferTypeTag::Embedding:
         case ListBufferTypeTag::ListView:
         case ListBufferTypeTag::INVALID:

--- a/test/query/ir/WithCollectTest.cpp
+++ b/test/query/ir/WithCollectTest.cpp
@@ -78,15 +78,6 @@ protected:
         EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
     }
 
-    void expectRejected(std::string_view query, QueryStatus::Status stage, std::string_view reason) {
-        RowSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
-
-        EXPECT_EQ(status.getStatus(), stage) << "query: " << query;
-        EXPECT_EQ(status.getError(), reason) << "query: " << query;
-    }
-
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
     std::unique_ptr<QueryInterpreterV3> _interpreter;
@@ -238,12 +229,17 @@ TEST_F(WithCollectTest, collectsOnlyTheRowsTheBarrierLeft) {
                {{"[Adam, Cyrus, Doruk]"}});
 }
 
-// Each collect drains through a loop of its own and one emit cannot read two of them, at
-// a barrier as in a projection
-TEST_F(WithCollectTest, rejectsTwoCollectsAtTheBarrier) {
-    expectRejected("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
-                   "WITH p.name AS person, collect(i.name) AS interests, collect(i) AS nodes "
-                   "RETURN person, interests, nodes",
-                   QueryStatus::Status::PLAN_ERROR,
-                   "collect() may not yet be combined with another collect().");
+// One accumulator carries both lists, so a barrier publishes them side by side
+TEST_F(WithCollectTest, publishesTwoListsAtTheBarrier) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests, collect(i) AS nodes "
+               "RETURN person, interests, nodes",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "[6, 2, 3]"},
+                {"Adam", "[Bio, Cooking]", "[4, 5]"},
+                {"Maxime", "[Bio, Padel]", "[4, 7]"},
+                {"Luc", "[Animals, Computers]", "[10, 2]"},
+                {"Martina", "[Cooking]", "[5]"},
+                {"Suhas", "[Gym, JiuJitsu]", "[13, 16]"},
+                {"Cyrus", "[Gym, Travel]", "[13, 14]"},
+                {"Doruk", "[Gym]", "[13]"}});
 }

--- a/test/query/ir/WithCollectTest.cpp
+++ b/test/query/ir/WithCollectTest.cpp
@@ -1,0 +1,249 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// collect() taken at a WITH barrier: the list a part publishes, what the part after it
+// reads back, and the ORDER BY, cut, filter and reductions that sit beside it.
+class WithCollectTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    // The rows in the order the query emits them, which is what a barrier's ORDER BY is
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRejected(std::string_view query, QueryStatus::Status stage, std::string_view reason) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
+
+        EXPECT_EQ(status.getStatus(), stage) << "query: " << query;
+        EXPECT_EQ(status.getError(), reason) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(WithCollectTest, publishesAGroupedListAtTheBarrier) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "RETURN person, interests",
+               {{"Remy", "[Ghosts, Computers, Eighties]"},
+                {"Adam", "[Bio, Cooking]"},
+                {"Maxime", "[Bio, Padel]"},
+                {"Luc", "[Animals, Computers]"},
+                {"Martina", "[Cooking]"},
+                {"Suhas", "[Gym, JiuJitsu]"},
+                {"Cyrus", "[Gym, Travel]"},
+                {"Doruk", "[Gym]"}});
+}
+
+TEST_F(WithCollectTest, publishesTheWholeMatchAsOneListAtTheBarrier) {
+    expectRows("MATCH (i:Interest) WITH collect(i.name) AS names RETURN names",
+               {{"[Computers, Eighties, Bio, Cooking, Ghosts, Padel, Animals, Gym, Travel, JiuJitsu]"}});
+}
+
+// The list rides past the barrier untouched while the key beside it is filtered on, the
+// HAVING a WITH reads as
+TEST_F(WithCollectTest, filtersTheGroupedRowsAfterTheBarrier) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "WHERE person = 'Adam' "
+               "RETURN person, interests",
+               {{"Adam", "[Bio, Cooking]"}});
+}
+
+TEST_F(WithCollectTest, ordersTheGroupedRowsAtTheBarrier) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "WITH p.name AS person, collect(i.name) AS interests ORDER BY person "
+                      "RETURN person, interests",
+                      {{"Adam", "[Bio, Cooking]"},
+                       {"Cyrus", "[Gym, Travel]"},
+                       {"Doruk", "[Gym]"},
+                       {"Luc", "[Animals, Computers]"},
+                       {"Martina", "[Cooking]"},
+                       {"Maxime", "[Bio, Padel]"},
+                       {"Remy", "[Ghosts, Computers, Eighties]"},
+                       {"Suhas", "[Gym, JiuJitsu]"}});
+}
+
+TEST_F(WithCollectTest, cutsTheGroupedRowsAtTheBarrier) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "WITH p.name AS person, collect(i.name) AS interests "
+                      "ORDER BY person SKIP 1 LIMIT 2 "
+                      "RETURN person, interests",
+                      {{"Cyrus", "[Gym, Travel]"}, {"Doruk", "[Gym]"}});
+}
+
+TEST_F(WithCollectTest, reducesBesideTheListAtTheBarrier) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests, count(i) AS interestCount "
+               "RETURN person, interests, interestCount",
+               {{"Remy", "[Ghosts, Computers, Eighties]", "3"},
+                {"Adam", "[Bio, Cooking]", "2"},
+                {"Maxime", "[Bio, Padel]", "2"},
+                {"Luc", "[Animals, Computers]", "2"},
+                {"Martina", "[Cooking]", "1"},
+                {"Suhas", "[Gym, JiuJitsu]", "2"},
+                {"Cyrus", "[Gym, Travel]", "2"},
+                {"Doruk", "[Gym]", "1"}});
+}
+
+// One person contributes as many rows as they have interests, so the barrier collects a
+// name per row unless the DISTINCT drops the repeats
+TEST_F(WithCollectTest, collectsDistinctValuesAtTheBarrier) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(DISTINCT p.name) AS people "
+               "RETURN people",
+               {{"[Remy, Adam, Maxime, Luc, Martina, Cyrus, Suhas, Doruk]"}});
+}
+
+// The collected column is one an earlier barrier published, not one the traversal bound
+TEST_F(WithCollectTest, collectsWhatAnEarlierBarrierPublished) {
+    expectRows("MATCH (p:Person) WITH p.name AS person "
+               "WITH collect(person) AS people "
+               "RETURN people",
+               {{"[Remy, Adam, Maxime, Luc, Martina, Suhas, Cyrus, Doruk]"}});
+}
+
+// A list of node identities rather than of values: Computers is 2, Eighties 3, Bio 4,
+// Cooking 5, Ghosts 6, Padel 7, Animals 10, Gym 13, Travel 14, JiuJitsu 16
+TEST_F(WithCollectTest, collectsTheEntitiesTheBarrierGroups) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i) AS interests "
+               "RETURN person, interests",
+               {{"Remy", "[6, 2, 3]"},
+                {"Adam", "[4, 5]"},
+                {"Maxime", "[4, 7]"},
+                {"Luc", "[10, 2]"},
+                {"Martina", "[5]"},
+                {"Suhas", "[13, 16]"},
+                {"Cyrus", "[13, 14]"},
+                {"Doruk", "[13]"}});
+}
+
+// Grouping on the node itself leaves the part after the barrier reading a property off
+// the grouped column, not off the traversal variable the barrier dropped
+TEST_F(WithCollectTest, groupsOnTheNodeTheBarrierPublishes) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p, collect(i.name) AS interests "
+               "RETURN p.name, interests",
+               {{"Remy", "[Ghosts, Computers, Eighties]"},
+                {"Adam", "[Bio, Cooking]"},
+                {"Maxime", "[Bio, Padel]"},
+                {"Luc", "[Animals, Computers]"},
+                {"Martina", "[Cooking]"},
+                {"Suhas", "[Gym, JiuJitsu]"},
+                {"Cyrus", "[Gym, Travel]"},
+                {"Doruk", "[Gym]"}});
+}
+
+// The collect is taken in the part after the barrier, over a traversal rooted on the node
+// the barrier published
+TEST_F(WithCollectTest, collectsAfterTraversingFromWhatTheBarrierPublished) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) WITH p AS remy "
+               "MATCH (remy)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN collect(i.name)",
+               {{"[Ghosts, Computers, Eighties]"}});
+}
+
+// The barrier's sort key is the list itself, ordered element by element with the shorter
+// of two common prefixes first
+TEST_F(WithCollectTest, ordersTheBarrierRowsByTheCollectedList) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "WITH p.name AS person, collect(i.name) AS interests ORDER BY interests "
+                      "RETURN person, interests",
+                      {{"Luc", "[Animals, Computers]"},
+                       {"Adam", "[Bio, Cooking]"},
+                       {"Maxime", "[Bio, Padel]"},
+                       {"Martina", "[Cooking]"},
+                       {"Remy", "[Ghosts, Computers, Eighties]"},
+                       {"Doruk", "[Gym]"},
+                       {"Suhas", "[Gym, JiuJitsu]"},
+                       {"Cyrus", "[Gym, Travel]"}});
+}
+
+// The collect folds the rows the barrier published, not the ones its cut dropped
+TEST_F(WithCollectTest, collectsOnlyTheRowsTheBarrierLeft) {
+    expectRows("MATCH (p:Person) WITH p.name AS name ORDER BY name LIMIT 3 "
+               "RETURN collect(name)",
+               {{"[Adam, Cyrus, Doruk]"}});
+}
+
+// Each collect drains through a loop of its own and one emit cannot read two of them, at
+// a barrier as in a projection
+TEST_F(WithCollectTest, rejectsTwoCollectsAtTheBarrier) {
+    expectRejected("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                   "WITH p.name AS person, collect(i.name) AS interests, collect(i) AS nodes "
+                   "RETURN person, interests, nodes",
+                   QueryStatus::Status::PLAN_ERROR,
+                   "collect() may not yet be combined with another collect().");
+}

--- a/test/storage/CMakeLists.txt
+++ b/test/storage/CMakeLists.txt
@@ -33,6 +33,7 @@ add_storage_tests(test_storage_metadatarebaser versioning/MetadataRebaserTest.cp
 add_storage_tests(test_storage_datapartmerger versioning/DatapartMergerTest.cpp)
 
 add_storage_tests(test_storage_stringindex StringIndexTest.cpp)
+add_storage_tests(test_storage_listorder ListOrderTest.cpp)
 
 add_storage_tests(test_storage_dump_propertycontainerdumper dump/PropertyContainerDumperTest.cpp)
 add_storage_tests(test_storage_dump_propertydumpformat dump/PropertyDumpFormatTest.cpp)

--- a/test/storage/ListOrderTest.cpp
+++ b/test/storage/ListOrderTest.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <compare>
+#include <limits>
+#include <string_view>
+#include <vector>
+
+#include "list/ListBuffer.h"
+#include "list/ListElementOrder.h"
+#include "list/ListView.h"
+
+#include "ID.h"
+
+using namespace db;
+
+namespace {
+
+class ListOrderTest : public testing::Test {
+protected:
+    ListView list(std::vector<ListBuffer<>::ListItemVariant> elements) {
+        return _buffer.insert(elements);
+    }
+
+    ListBuffer<> _buffer;
+};
+
+}
+
+TEST_F(ListOrderTest, comparesOnTheFirstDifferingElement) {
+    const ListView lhs = list({int64_t {1}, int64_t {2}, int64_t {9}});
+    const ListView rhs = list({int64_t {1}, int64_t {3}, int64_t {0}});
+
+    EXPECT_EQ(lhs <=> rhs, std::strong_ordering::less);
+    EXPECT_EQ(rhs <=> lhs, std::strong_ordering::greater);
+}
+
+TEST_F(ListOrderTest, aPrefixSortsBeforeTheLongerList) {
+    const ListView prefix = list({int64_t {1}, int64_t {2}});
+    const ListView longer = list({int64_t {1}, int64_t {2}, int64_t {3}});
+
+    EXPECT_EQ(prefix <=> longer, std::strong_ordering::less);
+    EXPECT_EQ(longer <=> prefix, std::strong_ordering::greater);
+}
+
+TEST_F(ListOrderTest, theEmptyListSortsFirst) {
+    const ListView empty = list({});
+    const ListView single = list({int64_t {-1}});
+
+    EXPECT_EQ(empty <=> single, std::strong_ordering::less);
+    EXPECT_EQ(empty <=> empty, std::strong_ordering::equal);
+}
+
+TEST_F(ListOrderTest, listsOfEqualElementsTie) {
+    const ListView lhs = list({std::string_view {"a"}, int64_t {2}});
+    const ListView rhs = list({std::string_view {"a"}, int64_t {2}});
+
+    EXPECT_EQ(lhs <=> rhs, std::strong_ordering::equal);
+    EXPECT_TRUE(lhs == rhs);
+}
+
+// The element order carries into the list order, so a pair of elements of different
+// types decides the two lists by the classes those types sort in.
+TEST_F(ListOrderTest, comparesElementsOfDifferentTypesByTheirClass) {
+    const ListView strings = list({std::string_view {"zzz"}});
+    const ListView numbers = list({int64_t {0}});
+
+    EXPECT_EQ(strings <=> numbers, std::strong_ordering::less);
+}
+
+// A null element sorts after every value, so a list holding one sorts after a list
+// holding a value in that position - however small the value.
+TEST_F(ListOrderTest, aNullElementSortsAfterAValue) {
+    const ListView withNull = list({int64_t {1}, PropertyNull {}});
+    const ListView withValue = list({int64_t {1}, std::numeric_limits<int64_t>::min()});
+
+    EXPECT_EQ(withValue <=> withNull, std::strong_ordering::less);
+}
+
+TEST_F(ListOrderTest, comparesEntityElementsByTheirID) {
+    const ListView lowNode = list({NodeID {1}});
+    const ListView highNode = list({NodeID {2}});
+    const ListView edge = list({EdgeID {0}});
+
+    EXPECT_EQ(lowNode <=> highNode, std::strong_ordering::less);
+
+    // A node sorts before an edge whatever the IDs are, since the classes decide first.
+    EXPECT_EQ(highNode <=> edge, std::strong_ordering::less);
+}
+
+// A nested list element compares on this same order, so the outer lists are decided by
+// comparing the inner ones element-wise.
+TEST_F(ListOrderTest, comparesNestedListsElementWise) {
+    const ListView innerLow = list({int64_t {1}, int64_t {2}});
+    const ListView innerHigh = list({int64_t {1}, int64_t {3}});
+
+    const ListView lhs = list({innerLow});
+    const ListView rhs = list({innerHigh});
+
+    EXPECT_EQ(lhs <=> rhs, std::strong_ordering::less);
+}
+
+TEST_F(ListOrderTest, mixedNumericTagsCompareNumerically) {
+    const ListView integer = list({int64_t {2}});
+    const ListView floating = list({2.5});
+
+    EXPECT_EQ(integer <=> floating, std::strong_ordering::less);
+}

--- a/test/storage/ListOrderTest.cpp
+++ b/test/storage/ListOrderTest.cpp
@@ -87,6 +87,25 @@ TEST_F(ListOrderTest, comparesEntityElementsByTheirID) {
     EXPECT_EQ(highNode <=> edge, std::strong_ordering::less);
 }
 
+// The class an element sorts in is decided before its value is read, so one element of
+// each class puts the lists in the declared order however large the values are.
+TEST_F(ListOrderTest, ordersTheElementClassesAheadOfTheValues) {
+    const std::vector<ListView> ascending {
+        list({NodeID {9}}),
+        list({EdgeID {9}}),
+        list({list({int64_t {9}})}),
+        list({std::string_view {"zzz"}}),
+        list({CustomBool {true}}),
+        list({std::numeric_limits<int64_t>::max()}),
+        list({PropertyNull {}}),
+    };
+
+    for (size_t index = 1; index < ascending.size(); index++) {
+        EXPECT_EQ(ascending[index - 1] <=> ascending[index], std::strong_ordering::less) << "at index " << index;
+        EXPECT_EQ(ascending[index] <=> ascending[index - 1], std::strong_ordering::greater) << "at index " << index;
+    }
+}
+
 // A nested list element compares on this same order, so the outer lists are decided by
 // comparing the inner ones element-wise.
 TEST_F(ListOrderTest, comparesNestedListsElementWise) {


### PR DESCRIPTION
Implement the Cypher collect() aggregate.

```Cypher
MATCH (n:Node) RETURN collect(n.name)
MATCH (n:Node) RETURN collect(DISTINCT n.team)
MATCH (n:Node) RETURN collect(n)
MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN collect(e)
UNWIND [10, 20, 20] AS v RETURN collect(DISTINCT v)

MATCH (n:Node) RETURN n.team, collect(n.name)
MATCH (n:Node) RETURN n.team AS team, collect(n.name) AS names
MATCH (n:Node) RETURN n.team, collect(DISTINCT n.name)
MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, collect(b)
MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN a.name, collect(e)
MATCH (n:Node) RETURN DISTINCT n.team, collect(n.name)

MATCH (n:Node) RETURN n.team, collect(n.name), count(*)
MATCH (n:Node) RETURN n.team, collect(n.name), count(DISTINCT n.score)
MATCH (n:Node) RETURN n.team, collect(n.name), sum(n.score), min(n.score), max(n.score), avg(n.score)
MATCH (n:Node) RETURN collect(n.name), sum(n.score) + 1

MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY n.team SKIP 1 LIMIT 1
MATCH (n:Node) RETURN n.team, collect(n.name) AS names ORDER BY names DESC
MATCH (n:Node) RETURN n.team, collect(n) AS nodes ORDER BY nodes
MATCH (n:Node) RETURN n.team, collect(n.name) ORDER BY count(n.score) DESC

MATCH (i:Interest) WITH collect(i.name) AS names RETURN names

MATCH (p:Person)-[:INTERESTED_IN]->(i) 
WITH p.name AS person, collect(i.name) AS interests 
RETURN person, interests

MATCH (p:Person)-[:INTERESTED_IN]->(i) 
WITH p, collect(i.name) AS interests
RETURN p.name, interests

MATCH (p:Person)-[:INTERESTED_IN]->(i) 
WITH p.name AS person, collect(i.name) AS names WHERE person = 'Adam' 
RETURN person, names

MATCH (p:Person) 
WITH p.name AS name ORDER BY name LIMIT 3 
RETURN collect(name)
```
