### PR TITLE
MLIR: fix SKIP & LIMIT over a projection of constants

### DIFF
--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -344,6 +344,13 @@ void blockRepeatColumn(const Column* input, size_t factor, size_t outputRowCount
     }
 }
 
+// Block-repeat for a constant chunk. A constant already stands for every row of
+// the step, so there is nothing to repeat: all the cut leaves in question is
+// whether a row survived, and assignFromLine empties the output when none did.
+void blockRepeatConstColumn(const Column* input, size_t factor, size_t outputRowCount, Column* output) {
+    output->assignFromLine(input, 0, outputRowCount);
+}
+
 // Tile: the whole input chunk is emitted back to back, so input row j lands at
 // output indices j, j+M, j+2M, ... This lays out an inner column of a cross
 // product, where the inner chunk repeats once per outer row. The fill stops at
@@ -2555,6 +2562,10 @@ NLBroadcastFunction NLExecutor::selectBlockRepeatFunction(NLChunkKind kind) {
 
 NLBroadcastFunction NLExecutor::selectCountBlockRepeatFunction() {
     return &blockRepeatColumn<uint64_t>;
+}
+
+NLBroadcastFunction NLExecutor::selectConstBlockRepeatFunction() {
+    return &blockRepeatConstColumn;
 }
 
 NLBroadcastFunction NLExecutor::selectTileFunction(NLChunkKind kind) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -386,6 +386,14 @@ void copyRangeColumn(const Column* input, size_t inputOffset, size_t rowCount, C
     std::copy(first, first + rowCount, outputRaw.begin());
 }
 
+// Range copy for a constant chunk. A constant holds one value standing for every
+// row of the step, so the window that lands in the output is a row count and not a
+// range: assignFromLine keeps the value when the window kept a row and empties the
+// output when it kept none.
+void copyRangeConstColumn(const Column* input, size_t inputOffset, size_t rowCount, Column* output) {
+    output->assignFromLine(input, inputOffset, rowCount);
+}
+
 // Append every row of an input chunk onto the tail of a growing buffer of the
 // same element type. nl.sort_collect calls this once per producing-loop step, so
 // the buffer accumulates every row across all chunks, row-aligned with the other
@@ -2622,6 +2630,10 @@ NLCopyFunction NLExecutor::selectCopyFunction(NLChunkKind kind) {
 
 NLCopyFunction NLExecutor::selectCountCopyFunction() {
     return &copyRangeColumn<uint64_t>;
+}
+
+NLCopyFunction NLExecutor::selectConstCopyFunction() {
+    return &copyRangeConstColumn;
 }
 
 // A nullable value chunk gathers the same way an ID chunk does - copy the indexed

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -344,9 +344,6 @@ void blockRepeatColumn(const Column* input, size_t factor, size_t outputRowCount
     }
 }
 
-// Block-repeat for a constant chunk. A constant already stands for every row of
-// the step, so there is nothing to repeat: all the cut leaves in question is
-// whether a row survived, and assignFromLine empties the output when none did.
 void blockRepeatConstColumn(const Column* input, size_t factor, size_t outputRowCount, Column* output) {
     output->assignFromLine(input, 0, outputRowCount);
 }
@@ -393,10 +390,6 @@ void copyRangeColumn(const Column* input, size_t inputOffset, size_t rowCount, C
     std::copy(first, first + rowCount, outputRaw.begin());
 }
 
-// Range copy for a constant chunk. A constant holds one value standing for every
-// row of the step, so the window that lands in the output is a row count and not a
-// range: assignFromLine keeps the value when the window kept a row and empties the
-// output when it kept none.
 void copyRangeConstColumn(const Column* input, size_t inputOffset, size_t rowCount, Column* output) {
     output->assignFromLine(input, inputOffset, rowCount);
 }

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -246,6 +246,10 @@ public:
     // Block-repeat for the count result chunk, which a limit truncates with factor 1.
     static NLBroadcastFunction selectCountBlockRepeatFunction();
 
+    // Block-repeat for a constant chunk, which a limit over a projection of
+    // constants alone cuts down to the one row it holds or to no row at all.
+    static NLBroadcastFunction selectConstBlockRepeatFunction();
+
     // Tile for an ID chunk of this kind (inner column).
     static NLBroadcastFunction selectTileFunction(NLChunkKind kind);
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -266,6 +266,10 @@ public:
     // Range copy for the count result chunk, which a skip lifts to a chunk front.
     static NLCopyFunction selectCountCopyFunction();
 
+    // Range copy for a constant chunk, which a skip over a projection of constants
+    // alone cuts down to the one row it holds or to no row at all.
+    static NLCopyFunction selectConstCopyFunction();
+
     // Range copy for a nullable value chunk of this value type (skip suffix copy).
     static NLCopyFunction selectOptCopyFunction(ValueType valueType);
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1353,9 +1353,6 @@ void NLTranslator::addTruncateColumn(mlir::Value inputValue,
     Column* output = nullptr;
     NLBroadcastFunction copyPrefix = nullptr;
 
-    // A projection of constants alone charges its cut to the constants themselves,
-    // and a constant is a ColumnConst whatever its element type says - a nullable
-    // one included - so the defining op tells it from the families below.
     if (isConstantLike(inputValue)) {
         output = _memory->allocSame(input);
         copyPrefix = NLExecutor::selectConstBlockRepeatFunction();
@@ -1449,9 +1446,6 @@ void NLTranslator::addSkipColumn(mlir::Value inputValue,
     Column* output = nullptr;
     NLCopyFunction copySuffix = nullptr;
 
-    // A projection of constants alone charges its cut to the constants themselves,
-    // and a constant is a ColumnConst whatever its element type says - a nullable
-    // one included - so the defining op tells it from the families below.
     if (isConstantLike(inputValue)) {
         output = _memory->allocSame(input);
         copySuffix = NLExecutor::selectConstCopyFunction();

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1353,7 +1353,13 @@ void NLTranslator::addTruncateColumn(mlir::Value inputValue,
     Column* output = nullptr;
     NLBroadcastFunction copyPrefix = nullptr;
 
-    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+    // A projection of constants alone charges its cut to the constants themselves,
+    // and a constant is a ColumnConst whatever its element type says - a nullable
+    // one included - so the defining op tells it from the families below.
+    if (isConstantLike(inputValue)) {
+        output = _memory->allocSame(input);
+        copyPrefix = NLExecutor::selectConstBlockRepeatFunction();
+    } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         output = allocOptColumnForValueType(valueType);
         copyPrefix = NLExecutor::selectOptBlockRepeatFunction(valueType);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1443,7 +1443,13 @@ void NLTranslator::addSkipColumn(mlir::Value inputValue,
     Column* output = nullptr;
     NLCopyFunction copySuffix = nullptr;
 
-    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+    // A projection of constants alone charges its cut to the constants themselves,
+    // and a constant is a ColumnConst whatever its element type says - a nullable
+    // one included - so the defining op tells it from the families below.
+    if (isConstantLike(inputValue)) {
+        output = _memory->allocSame(input);
+        copySuffix = NLExecutor::selectConstCopyFunction();
+    } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         output = allocOptColumnForValueType(valueType);
         copySuffix = NLExecutor::selectOptCopyFunction(valueType);

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -366,6 +366,27 @@ target_link_libraries(test_query_ir_output_column_names PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_output_column_names PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_limit_skip LimitSkipTest.cpp)
+target_link_libraries(test_query_ir_limit_skip PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_limit_skip PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_wildcard_return WildcardReturnTest.cpp)
 target_link_libraries(test_query_ir_wildcard_return PRIVATE
         turing_db_s

--- a/test/query/ir/LimitSkipTest.cpp
+++ b/test/query/ir/LimitSkipTest.cpp
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnConst.h"
+#include "columns/ColumnIDs.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using ValueRow = std::vector<int64_t>;
+using ValueRows = std::vector<ValueRow>;
+
+int64_t readValue(const Column* column, size_t row) {
+    if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
+        return static_cast<int64_t>((*nodeIDs)[row].getValue());
+    } else if (const auto* constants = dynamic_cast<const ColumnConst<int64_t>*>(column)) {
+        return (*constants)[row];
+    }
+
+    throw std::runtime_error("LimitSkipTest: unsupported output column type");
+}
+
+void describeRows(const ValueRows& rows, std::string& out) {
+    out.clear();
+    for (const ValueRow& row : rows) {
+        out += "        {";
+        for (size_t index = 0; index < row.size(); index++) {
+            if (index > 0) {
+                out += ", ";
+            }
+
+            out += std::to_string(row[index]);
+        }
+
+        out += "},\n";
+    }
+}
+
+// Keeps the rows in the order the sink sees them: a SKIP and a LIMIT cut a window out of
+// that order, and sorting them would hide which window came out.
+class CollectingValueSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            ValueRow& row = _rows.emplace_back();
+            for (const Column* column : chunks) {
+                row.push_back(readValue(column, rowIndex));
+            }
+        }
+    }
+
+    const ValueRows& rows() const { return _rows; }
+
+private:
+    ValueRows _rows;
+};
+
+}
+
+class LimitSkipTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    void expectRows(std::string_view query, const ValueRows& expected) {
+        CollectingValueSink sink;
+        runQuery(query, &sink);
+
+        const ValueRows& actual = sink.rows();
+
+        std::string description;
+        describeRows(actual, description);
+
+        EXPECT_EQ(actual, expected)
+            << "query: " << query << "\nactual rows:\n" << description;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(LimitSkipTest, matchLimitZeroEmitsNothing) {
+    expectRows("MATCH (n) RETURN n LIMIT 0", {});
+}
+
+TEST_F(LimitSkipTest, matchSkipOneLimitOneEmitsTheSecondNode) {
+    const ValueRows expected = {{1}};
+    expectRows("MATCH (n) RETURN n SKIP 1 LIMIT 1", expected);
+}
+
+TEST_F(LimitSkipTest, matchSkipOneLimitZeroEmitsNothing) {
+    expectRows("MATCH (n) RETURN n SKIP 1 LIMIT 0", {});
+}
+
+// A projection of constants alone is one row, and LIMIT 0 cuts it.
+TEST_F(LimitSkipTest, constantLimitZeroEmitsNothing) {
+    expectRows("RETURN 42 LIMIT 0", {});
+}
+
+TEST_F(LimitSkipTest, constantLimitOneEmitsTheRow) {
+    const ValueRows expected = {{42}};
+    expectRows("RETURN 42 LIMIT 1", expected);
+}
+
+// The one row is the row SKIP 1 drops, so the LIMIT has nothing left to keep.
+TEST_F(LimitSkipTest, constantSkipOneLimitOneEmitsNothing) {
+    expectRows("RETURN 42 SKIP 1 LIMIT 1", {});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -1009,6 +1009,23 @@ private:
     size_t _totalRows {0};
 };
 
+// A projection of constants alone, capped by a top-level nl.limit. Codegen charges
+// such a cut to the constants themselves, and the truncate is written out rather
+// than folded into the output, so this drives nl.limit_truncate over a chunk that
+// carries no rows of its own.
+std::string nlLimitConstantProgram(uint64_t count) {
+    return std::string("func.func @main() {\n"
+                       "  %h = nl.limit(")
+           + std::to_string(count)
+           + ")\n"
+             "  %c = nl.constant(30 : i64)\n"
+             "  nl.limit_update %h, %c : !nl.chunk<i64>\n"
+             "  %lc = nl.limit_truncate %h, (%c) : !nl.chunk<i64>\n"
+             "  nl.output(%lc) : !nl.chunk<i64>\n"
+             "  func.return\n"
+             "}\n";
+}
+
 // Scan all nodes and output them, capped by a top-level nl.limit. The handle is
 // hoisted, threaded onto the loop, charged by limit_update, and the truncate cuts
 // each chunk to the prefix the budget allows before the plain output.
@@ -1861,6 +1878,33 @@ TEST_F(NLExecutorTest, limitScanEmitsLimitRows) {
     std::vector<std::vector<uint64_t>> rows;
     sink.sortedRows(rows);
     EXPECT_EQ(rows.size(), 3u);
+}
+
+TEST_F(NLExecutorTest, limitTruncateKeepsTheConstantRow) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    const std::string program = nlLimitConstantProgram(1);
+    runProgram(program.c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    const std::vector<std::vector<int64_t>> expected {{30}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The constant stands for the one row the projection has, so a LIMIT 0 leaves the
+// truncated chunk holding no row at all rather than the value it broadcasts.
+TEST_F(NLExecutorTest, limitTruncateZeroDropsTheConstantRow) {
+    auto graph = Graph::create();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CountingSink sink;
+    const std::string program = nlLimitConstantProgram(0);
+    runProgram(program.c_str(), reader.getView(), ChunkConfig::CHUNK_SIZE, sink);
+
+    EXPECT_EQ(sink.getTotalRows(), 0u);
 }
 
 TEST_F(NLExecutorTest, limitZeroScansNothing) {


### PR DESCRIPTION
Fixes for SKIP and LIMIT over a constant.
```cypher
MATCH (n) RETURN n LIMIT 0

MATCH (n) RETURN n SKIP 1 LIMIT 1

MATCH (n) RETURN n SKIP 1 LIMIT 0

RETURN 42 LIMIT 0

RETURN 42 LIMIT 1

RETURN 42 SKIP 1 LIMIT 1