### PR TITLE
MLIR: aggregate over a constant column

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2024,7 +2024,25 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
         const Expr* item = std::get<Expr*>(returnItem);
 
         if (!item->isAggregate()) {
-            keyColumns.push_back(getOrTranslateExprColumn(variableColumns, item));
+            const mlir::Value keyColumn = getOrTranslateExprColumn(variableColumns, item);
+
+            // An aggregate may be taken over the alias of an item declared before it -
+            // count(x) of RETURN 1 AS x, count(x) - and the column that alias names is
+            // this one, so it is published under the item's declaration for the symbol
+            // to be resolved through, as the projection publishes it for an ORDER BY key
+            const VarDecl* itemDecl = item->getExprVarDecl();
+            if (itemDecl) {
+                _projectedColumns[itemDecl] = keyColumn;
+            }
+
+            // A constant column holds the same value in every row, so it tells no two
+            // rows apart: it groups nothing and rides along beside the groups, as it
+            // rides past a dedup or a sort
+            if (isConstantColumn(keyColumn)) {
+                continue;
+            }
+
+            keyColumns.push_back(keyColumn);
             keyVarAtPos.push_back(nullptr);
             keyExprAtPos.push_back(item);
             continue;
@@ -2078,8 +2096,14 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
 
     const size_t keyCount = keyColumns.size();
     const size_t aggCount = aggInputColumns.size();
-    bioassert(keyCount > 0, "grouped aggregate with no key columns.");
     bioassert(aggCount > 0, "grouped aggregate with no aggregate columns.");
+
+    // Every non-aggregate item was constant, so nothing tells the matched rows apart:
+    // the projection is one group, which is the scalar aggregate the projection
+    // translates on its own - RETURN 1 AS x, count(n) counts the whole match
+    if (keyCount == 0) {
+        return;
+    }
 
     llvm::SmallVector<mlir::Value> allColumns;
     for (const mlir::Value col : keyColumns) {

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1140,6 +1140,34 @@ def Constant : NLOp<"constant", [Pure, InferTypeOpAdaptor]> {
   let assemblyFormat = "`(` $value `)` attr-dict";
 }
 
+def BroadcastConstant : NLOp<"broadcast_constant", [Pure]> {
+  let summary = "Repeat a constant chunk's single value over the rows of a step";
+  let description = [{
+      A constant chunk holds one value standing for every row rather than one per
+      row, so a step that walks rows - an aggregate's fold, a grouped fold - cannot
+      read it: it would see the single row the constant is, not the rows the step
+      has. This lays that value out over the rows of the driving relation, whose
+      chunk the cardinality operand is, giving a row-aligned nullable value chunk
+      the folds read like any column. The projection's sibling is nl.output's own
+      cardinality operand, against which its constants broadcast as it emits.
+
+      %r = nl.broadcast_constant %c, %n : (!nl.chunk<i64>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.nullable<i64>>
+
+      The cardinality operand is absent when no relation drives the projection -
+      RETURN 1 AS x, count(x) with no MATCH - which is one row of its own, so the
+      value is laid out over that single row:
+
+      %r = nl.broadcast_constant %c : (!nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i64>>
+  }];
+
+  // The cardinality is the only variable-length operand, so MLIR can tell it apart
+  // from the value without operand-segment sizes (as nl.for's limit handle is).
+  let arguments = (ins NLChunk:$value, Optional<NLChunk>:$cardinality);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "$value (`,` $cardinality^)? attr-dict `:` functional-type(operands, results)";
+}
+
 /**
 * Add
 */

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -369,6 +369,21 @@ void tileColumn(const Column* input, size_t factor, size_t outputRowCount, Colum
     }
 }
 
+// Constant broadcast: the one value a ColumnConst holds is laid out over every row
+// of the step, as a present value. The two broadcasts above repeat the several
+// values of a chunk; a constant column has no rows of its own to repeat, so its row
+// count comes from the driving relation and its value from the column itself.
+template <typename Primitive>
+void broadcastConstantColumn(const Column* value, size_t rowCount, Column* output) {
+    const ColumnConst<Primitive>* typedValue = static_cast<const ColumnConst<Primitive>*>(value);
+    ColumnOptVector<Primitive>* typedOutput = static_cast<ColumnOptVector<Primitive>*>(output);
+
+    auto& outputRaw = typedOutput->getRaw();
+    outputRaw.resize(rowCount);
+
+    std::fill_n(outputRaw.begin(), rowCount, std::optional<Primitive>(typedValue->getRaw()));
+}
+
 // Range copy: rows [inputOffset, inputOffset + rowCount) of the input land at
 // output indices [0, rowCount). This lifts a skip's surviving suffix to the front
 // of a fresh chunk - nl.skip_truncate passes inputOffset = skipThisStep and
@@ -1879,6 +1894,18 @@ void NLExecutor::runOutput(NLExecutionContext* context, NLFunctionData* data) {
     context->getSink()->appendChunks(cols, offset, rowCount);
 }
 
+void NLExecutor::runBroadcastConstant(NLExecutionContext*, NLFunctionData* data) {
+    const NLBroadcastConstantData* broadcast = static_cast<NLBroadcastConstantData*>(data);
+    const Column* cardinality = broadcast->getCardinality();
+
+    // The driving relation's chunk sizes this step, exactly as it sizes an output of
+    // constants alone; a projection no relation drives is the single row the constant
+    // is. The fill writes that many rows of the constant's value.
+    const size_t rowCount = cardinality ? cardinality->size() : 1;
+
+    broadcast->getFill()(broadcast->getValue(), rowCount, broadcast->getOutput());
+}
+
 void NLExecutor::runBinary(NLExecutionContext*, NLFunctionData* data) {
     const NLBinaryData* binary = static_cast<NLBinaryData*>(data);
     binary->getFn()(binary->getResult(), binary->getLhs(), binary->getRhs());
@@ -2589,6 +2616,16 @@ NLBroadcastFunction NLExecutor::selectOptTileFunction(ValueType valueType) {
     ValueTypeDispatcher(valueType).execute(select);
 
     return broadcast;
+}
+
+NLBroadcastConstantFunction NLExecutor::selectConstantBroadcast(ValueType valueType) {
+    NLBroadcastConstantFunction fill = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        fill = &broadcastConstantColumn<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return fill;
 }
 
 // A list_element chunk is a ColumnVector<ListElementView> of fixed-width tagged

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -216,6 +216,11 @@ public:
 
     static NLUnaryFn selectNot(const Column* operand, LocalMemory* memory, Column*& result);
 
+    // Lay a constant chunk's single value out over the driving relation's rows
+    // (nl.broadcast_constant), so a fold that walks rows is handed the step's rows
+    // rather than the one row a constant column is.
+    static void runBroadcastConstant(NLExecutionContext* context, NLFunctionData* data);
+
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
     // Gather for a nullable value chunk of this value type (sort emit re-chunk).
@@ -254,6 +259,10 @@ public:
 
     // Tile for a nullable value chunk of this value type (inner column).
     static NLBroadcastFunction selectOptTileFunction(ValueType valueType);
+
+    // The fill that lays a constant column's single value out over a step's rows,
+    // for a nullable value chunk of this value type (nl.broadcast_constant).
+    static NLBroadcastConstantFunction selectConstantBroadcast(ValueType valueType);
 
     // Block-repeat (outer column) and tile (inner column) for a list_element chunk: a
     // tagged scalar carries its own type, so there is no value type to dispatch on.

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -572,6 +572,44 @@ private:
     NLLimitState* _limit {nullptr};
 };
 
+// Lay a constant column's single value out over rowCount rows of a fresh output
+// chunk, as one present value per row. The cross product's broadcast repeats a
+// chunk's several values; this one repeats the single value a ColumnConst holds,
+// so a fold that walks rows sees the step's rows rather than the one row the
+// constant is. One per value type, selected during translation.
+using NLBroadcastConstantFunction = void (*)(const Column* value,
+                                             size_t rowCount,
+                                             Column* output);
+
+// nl.broadcast_constant data: the constant column to repeat, the driving
+// relation's chunk whose row count says how many times - null when no relation
+// drives the projection, which is a single row - the output chunk to fill and the
+// fill that writes it.
+class NLBroadcastConstantData : public NLFunctionData {
+public:
+    NLBroadcastConstantData(const Column* value,
+                            const Column* cardinality,
+                            Column* output,
+                            NLBroadcastConstantFunction fill)
+        : _value(value),
+        _cardinality(cardinality),
+        _output(output),
+        _fill(fill)
+    {
+    }
+
+    const Column* getValue() const { return _value; }
+    const Column* getCardinality() const { return _cardinality; }
+    Column* getOutput() const { return _output; }
+    NLBroadcastConstantFunction getFill() const { return _fill; }
+
+private:
+    const Column* _value {nullptr};
+    const Column* _cardinality {nullptr};
+    Column* _output {nullptr};
+    NLBroadcastConstantFunction _fill {nullptr};
+};
+
 // nl.limit data: resets a counter to its budget each time the block it lives in
 // runs - once at function scope for a top-level LIMIT, or per enclosing step for
 // a nested one.

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -348,6 +348,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             // The handle carries only a name; a fetch/hop resolves it on consumption
         } else if (nl::Constant constant = mlir::dyn_cast<nl::Constant>(operation)) {
             translateConstant(constant);
+        } else if (nl::BroadcastConstant broadcast = mlir::dyn_cast<nl::BroadcastConstant>(operation)) {
+            translateBroadcastConstant(broadcast, body);
         } else if (nl::Add add = mlir::dyn_cast<nl::Add>(operation)) {
             translateAdd(add, body);
         } else if (nl::Sub sub = mlir::dyn_cast<nl::Sub>(operation)) {
@@ -1003,6 +1005,26 @@ void NLTranslator::translateConstant(nl::Constant constant) {
     bioassert(column, "Failed to allocate column.");
 
     _valueSlots[res] = column;
+}
+
+void NLTranslator::translateBroadcastConstant(nl::BroadcastConstant broadcast, NLStmtContainer* body) {
+    const Column* value = getColumn(broadcast.getValue());
+
+    // Absent when no relation drives the projection, which is then the single row the
+    // constant is, so there is no chunk to read a row count from
+    const mlir::Value cardinalityChunk = broadcast.getCardinality();
+    const Column* cardinality = cardinalityChunk ? getColumn(cardinalityChunk) : nullptr;
+
+    const mlir::Value result = broadcast.getResult();
+    const mlir::Type resultType = result.getType();
+
+    Column* output = allocColumnForChunkType(resultType);
+    _valueSlots[result] = output;
+
+    const NLBroadcastConstantFunction fill = NLExecutor::selectConstantBroadcast(nullableChunkValueType(resultType));
+
+    NLBroadcastConstantData* data = _program->allocFunctionData<NLBroadcastConstantData>(value, cardinality, output, fill);
+    body->emplaceStmt(&NLExecutor::runBroadcastConstant, data);
 }
 
 void NLTranslator::translateAdd(nl::Add add, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -424,6 +424,10 @@ private:
     // Allocates singleton column for the constant and assigns MLIR value
     void translateConstant(mlir::nl::Constant constant);
 
+    // Allocates the row-aligned column a constant is laid out into, and binds the
+    // fill that writes the driving relation's row count of its value each step
+    void translateBroadcastConstant(mlir::nl::BroadcastConstant broadcast, NLStmtContainer* body);
+
     /// Expression operations: alloc result column and resolve function pointer to execute
     void translateAdd(mlir::nl::Add add, NLStmtContainer* body);
     void translateSub(mlir::nl::Sub sub, NLStmtContainer* body);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -266,6 +266,27 @@ nl::Output soleOutputConsumer(mlir::ResultRange results) {
     return sharedByAllResults ? output : nl::Output();
 }
 
+// Whether a chunk holds one value standing for every row rather than one per row.
+// The arithmetic ops listed are bound wherever their operands are, so a chunk
+// computed from constants alone through them is hoisted out of the producing loop
+// with the constants themselves and carries no more rows than they do.
+bool isConstantChunk(mlir::Value chunk) {
+    mlir::Operation* const definingOp = chunk.getDefiningOp();
+    if (!definingOp) {
+        return false;
+    }
+
+    if (mlir::isa<nl::Constant>(definingOp)) {
+        return true;
+    }
+
+    if (!mlir::isa<nl::Add, nl::Sub, nl::Mul, nl::Div>(definingOp)) {
+        return false;
+    }
+
+    return llvm::all_of(definingOp->getOperands(), isConstantChunk);
+}
+
 }
 
 DBLowering::DBLowering(mlir::MLIRContext* context, const GraphView* view)
@@ -1180,8 +1201,9 @@ void DBLowering::lowerRemoveDuplicates(mlir::db::RemoveDuplicates distinct) {
 
 void DBLowering::lowerCount(mlir::db::Count count) {
     // The nl chunk the counted column lowered to; the update reads its per-step
-    // non-null row count.
-    const mlir::Value inputChunk = mapValue(count.getInput());
+    // non-null row count. A constant column counts the rows it stands for, not the
+    // one row it is, so it is laid out over the driving relation first.
+    const mlir::Value inputChunk = rowAlignedChunk(mapValue(count.getInput()), _innermostCardinality);
 
     const mlir::Location loc = _builder.getUnknownLoc();
 
@@ -1221,8 +1243,9 @@ void DBLowering::lowerCount(mlir::db::Count count) {
 
 void DBLowering::lowerAggregate(mlir::Value input, mlir::Value result, storage::AggregateKind kind) {
     // The nl chunk the aggregated column lowered to; the update folds its per-step
-    // non-null values into the accumulator.
-    const mlir::Value inputChunk = mapValue(input);
+    // non-null values into the accumulator. A constant column is reduced over the
+    // rows it stands for, so it is laid out over the driving relation first.
+    const mlir::Value inputChunk = rowAlignedChunk(mapValue(input), _innermostCardinality);
 
     mlir::MLIRContext* const context = _builder.getContext();
     const mlir::Location loc = _builder.getUnknownLoc();
@@ -1289,6 +1312,13 @@ void DBLowering::lowerGroupAggregate(mlir::db::GroupAggregate groupAggregate) {
     // here means unverified IR - a defensive backstop, as in lowerSort.
     if (chunks.empty()) {
         throw IRException("db.group_aggregate requires at least one column");
+    }
+
+    // A constant aggregate input is reduced over the rows of the group it falls in,
+    // not over the single row it is, so it is laid out over the chunk the grouping
+    // keys are read from - the same rows the group assignment is computed for.
+    for (size_t inputIndex = keyCount; inputIndex < chunks.size(); inputIndex++) {
+        chunks[inputIndex] = rowAlignedChunk(chunks[inputIndex], chunks.front());
     }
 
     mlir::MLIRContext* const context = _builder.getContext();
@@ -2055,6 +2085,33 @@ mlir::Value DBLowering::mapValue(mlir::Value dbValue) const {
     }
 
     return slotIt->second;
+}
+
+mlir::Value DBLowering::rowAlignedChunk(mlir::Value chunk, mlir::Value cardinality) {
+    // A chunk that carries rows is its own alignment
+    if (!isConstantChunk(chunk)) {
+        return chunk;
+    }
+
+    const auto chunkType = mlir::cast<nl::ChunkType>(chunk.getType());
+    mlir::Type valueElement = chunkType.getElementType();
+    if (const auto nullable = mlir::dyn_cast<storage::NullableType>(valueElement)) {
+        valueElement = nullable.getValueType();
+    }
+
+    // The rows are laid out as a nullable value chunk - present in every row - which is
+    // what every fold, key serialization and reduction reads a value column as.
+    mlir::MLIRContext* const context = _builder.getContext();
+    const nl::ChunkType resultType = nl::ChunkType::get(context, storage::NullableType::get(context, valueElement));
+
+    // With no relation driving the projection the value is laid out where the constant
+    // itself is bound, over the single row that projection is
+    mlir::Block* const homeBlock = cardinality ? ownerBlock(cardinality) : ownerBlock(chunk);
+
+    setInsertionInto(homeBlock);
+    nl::BroadcastConstant broadcast = _builder.create<nl::BroadcastConstant>(_builder.getUnknownLoc(), resultType, chunk, cardinality);
+
+    return broadcast.getResult();
 }
 
 mlir::Block* DBLowering::ownerBlock(mlir::Value chunkValue) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -329,6 +329,13 @@ private:
     // Point the builder at the right place for an op consuming lhs and rhs.
     void setInsertionForBinaryOp(mlir::Value lhs, mlir::Value rhs);
 
+    // The chunk a step that walks rows is handed for @param chunk: itself when it
+    // carries rows, and its value laid out over the rows of @param cardinality - the
+    // driving relation's chunk, null when no relation drives the projection - when it
+    // is a constant, which holds one value standing for every row and so has no rows
+    // of its own to walk.
+    mlir::Value rowAlignedChunk(mlir::Value chunk, mlir::Value cardinality);
+
     // The nl chunk a db value lowered to, and the block that holds a chunk
     mlir::Value mapValue(mlir::Value dbValue) const;
     static mlir::Block* ownerBlock(mlir::Value chunkValue);

--- a/test/query/ir/AggregateOverConstantAliasTest.cpp
+++ b/test/query/ir/AggregateOverConstantAliasTest.cpp
@@ -37,6 +37,9 @@ using Sums = std::vector<std::optional<int64_t>>;
 // The eight Person nodes of simpledb are what every count below is taken over
 constexpr uint64_t personCount = 8;
 
+// Its eighteen nodes of every label, which MATCH (n) matches
+constexpr uint64_t nodeCount = 18;
+
 // Collects the ui64 column a grouped count emits. The aggregates come behind the
 // grouping keys, so the count is the last chunk whichever key is grouped on.
 class CountSink : public NLOutputSink {
@@ -179,6 +182,18 @@ TEST_F(AggregateOverConstantAliasTest, countsATraversalVariableUnderAConstantKey
 // the count is that one row rather than the graph's.
 TEST_F(AggregateOverConstantAliasTest, countsOverAConstantAliasWithoutAMatch) {
     expectCounts("RETURN 1 AS x, count(x)", {1});
+}
+
+// The alias is only a name for the constant behind it, so the aggregate spelled over the
+// constant itself is the same aggregate: 42 is a value in every matched row, and every
+// node of simpledb is matched.
+TEST_F(AggregateOverConstantAliasTest, countsASpelledOutConstant) {
+    expectCounts("MATCH (n) RETURN count(42)", {nodeCount});
+}
+
+// Both spellings answer the same way with nothing driving them, too
+TEST_F(AggregateOverConstantAliasTest, countsASpelledOutConstantWithoutAMatch) {
+    expectCounts("RETURN count(42)", {1});
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/AggregateOverConstantAliasTest.cpp
+++ b/test/query/ir/AggregateOverConstantAliasTest.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Counts = std::vector<uint64_t>;
+using Sums = std::vector<std::optional<int64_t>>;
+
+// The eight Person nodes of simpledb are what every count below is taken over
+constexpr uint64_t personCount = 8;
+
+// Collects the ui64 column a grouped count emits. The aggregates come behind the
+// grouping keys, so the count is the last chunk whichever key is grouped on.
+class CountSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_FALSE(chunks.empty());
+
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks.back());
+        ASSERT_NE(counts, nullptr);
+
+        const auto& countRaw = counts->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _counts.push_back(countRaw[rowIndex]);
+        }
+    }
+
+    void sortedCounts(Counts& counts) const {
+        counts = _counts;
+        std::sort(counts.begin(), counts.end());
+    }
+
+private:
+    Counts _counts;
+};
+
+// The same for a sum, whose value column is a nullable i64 rather than a ui64 count
+class SumSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_FALSE(chunks.empty());
+
+        const auto* sums = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks.back());
+        ASSERT_NE(sums, nullptr);
+
+        const auto& sumRaw = sums->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _sums.push_back(sumRaw[rowIndex]);
+        }
+    }
+
+    void sortedSums(Sums& sums) const {
+        sums = _sums;
+        std::sort(sums.begin(), sums.end());
+    }
+
+private:
+    Sums _sums;
+};
+
+}
+
+// An aggregate taken over the alias of a constant item - the count(x) of
+// RETURN 1 AS x, count(x). The alias is a second name for a column holding one value
+// standing for every row, so the aggregate folds as many values as the match produced:
+// what the argument names is a constant, but how many times it is folded is not.
+class AggregateOverConstantAliasTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    // The counts the query emits, one per group, compared order-independently
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    void expectSums(std::string_view query, const Sums& expected) {
+        SumSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Sums actual;
+        sink.sortedSums(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The constant is the only grouping key, so every match falls in one group and the count
+// is the whole match: one row holding the number of Person nodes.
+TEST_F(AggregateOverConstantAliasTest, countsOverAConstantAlias) {
+    expectCounts("MATCH (n:Person) RETURN 1 AS x, count(x)", {personCount});
+}
+
+// The sum reads the values the count only tallied: eight rows of the constant 1.
+TEST_F(AggregateOverConstantAliasTest, sumsOverAConstantAlias) {
+    expectSums("MATCH (n:Person) RETURN 1 AS x, sum(x)", {personCount});
+}
+
+// The same aggregate beside a key that does group the rows: the eight distinct names of
+// simpledb's Person nodes split the match into eight groups of one.
+TEST_F(AggregateOverConstantAliasTest, countsOverAConstantAliasBesideARowKey) {
+    expectCounts("MATCH (n:Person) RETURN n.name, 1 AS x, count(x)", Counts(personCount, 1));
+}
+
+// The value reduction of the same shape: each group holds one row of the constant, so
+// each group's sum is the constant itself.
+TEST_F(AggregateOverConstantAliasTest, sumsOverAConstantAliasBesideARowKey) {
+    expectSums("MATCH (n:Person) RETURN n.name, 1 AS x, sum(x)", Sums(personCount, 1));
+}
+
+// The alias is what the aggregate is taken over, not what it is grouped by: counting the
+// traversal variable under the same constant key must reach the same answer as counting
+// the alias of that key.
+TEST_F(AggregateOverConstantAliasTest, countsATraversalVariableUnderAConstantKey) {
+    expectCounts("MATCH (n:Person) RETURN 1 AS x, count(n)", {personCount});
+}
+
+// The same projection with nothing driving it: a constant stands for every row of the
+// relation the query matched, and a query that matched none is one row of its own - so
+// the count is that one row rather than the graph's.
+TEST_F(AggregateOverConstantAliasTest, countsOverAConstantAliasWithoutAMatch) {
+    expectCounts("RETURN 1 AS x, count(x)", {1});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -386,3 +386,13 @@ target_link_libraries(test_query_ir_wildcard_return PRIVATE
         turing_db_storage_s
         MLIRParser)
 target_include_directories(test_query_ir_wildcard_return PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_aggregate_over_constant_alias AggregateOverConstantAliasTest.cpp)
+target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_aggregate_over_constant_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Fix aggregate over a variable which is an alias for a constant
```cypher
MATCH (n:Person) RETURN 1 AS x, count(n)
```
and aggregate of a constant directly:
```cypher
RETURN count(42)
```