### PR TITLE
MLIR: size a constant projection by the filtered relation

### DIFF
--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1927,6 +1927,18 @@ void DBLowering::lowerFilter(mlir::db::FilterOp filter) {
         const mlir::Value outputChunk = nlFilter.getResult(columnIndex);
         _valueMap[filteredCol] = outputChunk;
     }
+
+    // The cardinality driver stands for the relation a projection of constants alone is a
+    // projection of, and this filter is what narrows that relation: leaving the driver on
+    // the unfiltered chunk would size the emission by the rows the filter dropped.
+    for (size_t columnIndex = 0; columnIndex < columnChunks.size(); columnIndex++) {
+        if (columnChunks[columnIndex] != _innermostCardinality) {
+            continue;
+        }
+
+        _innermostCardinality = nlFilter.getResult(columnIndex);
+        break;
+    }
 }
 
 mlir::Block* DBLowering::deeperBlock(mlir::Value first, mlir::Value second) {

--- a/test/query/ir/AggregateOverConstantAliasTest.cpp
+++ b/test/query/ir/AggregateOverConstantAliasTest.cpp
@@ -196,6 +196,17 @@ TEST_F(AggregateOverConstantAliasTest, countsASpelledOutConstantWithoutAMatch) {
     expectCounts("RETURN count(42)", {1});
 }
 
+// The rows the constant stands for are the rows the match left standing, so a filter is
+// what the aggregate folds over: one node of simpledb is named Remy.
+TEST_F(AggregateOverConstantAliasTest, countsASpelledOutConstantUnderAFilter) {
+    expectCounts("MATCH (n) WHERE n.name = 'Remy' RETURN count(42)", {1});
+}
+
+// The value reduction of that same one row
+TEST_F(AggregateOverConstantAliasTest, sumsOverAConstantAliasUnderAFilter) {
+    expectSums("MATCH (n) WHERE n.name = 'Remy' RETURN 1 AS x, sum(x)", {1});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -397,6 +397,16 @@ target_link_libraries(test_query_ir_unwind_constant_projection PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_unwind_constant_projection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_constant_only_projection ConstantOnlyProjectionTest.cpp)
+target_link_libraries(test_query_ir_constant_only_projection PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_constant_only_projection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_aggregate_over_constant_alias AggregateOverConstantAliasTest.cpp)
 target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
         turing_db_s

--- a/test/query/ir/ConstantOnlyProjectionTest.cpp
+++ b/test/query/ir/ConstantOnlyProjectionTest.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnConst.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Constants = std::vector<int64_t>;
+
+// Collects the one constant column of a projection that names nothing else. The column
+// answers the same value at every subscript, so the rows it yields are only the rows the
+// sink is handed - which is what these tests are about.
+class ConstantSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const ColumnConst<int64_t>* constants = dynamic_cast<const ColumnConst<int64_t>*>(chunks.front());
+        ASSERT_NE(constants, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _constants.push_back((*constants)[rowIndex]);
+        }
+    }
+
+    const Constants& getConstants() const { return _constants; }
+
+private:
+    Constants _constants;
+};
+
+}
+
+// A projection of nothing but a constant has no per-row column to take its row count
+// from, so the count has to come from the relation the match left standing: the constant
+// stands for each of its rows, one value repeated as many times as the filter kept.
+class ConstantOnlyProjectionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void expectConstants(std::string_view query, const Constants& expected) {
+        ConstantSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getConstants(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// One node of simpledb is named Remy, so the filter keeps one row and the constant is
+// emitted once for it.
+TEST_F(ConstantOnlyProjectionTest, emitsTheConstantOncePerMatchedRow) {
+    expectConstants("MATCH (n) WHERE n.name = 'Remy' RETURN 5", {5});
+}
+
+// No node carries that name, so the filter keeps nothing and the constant is emitted for
+// no row at all - a query that matched nothing must not answer with a row of 5.
+TEST_F(ConstantOnlyProjectionTest, emitsNothingWhenTheMatchIsEmpty) {
+    expectConstants("MATCH (n) WHERE n.name = 'nobody' RETURN 5", {});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Fixing wrong row count post filtering when returning a constant projection.

A projection of constants alone was sized by the raw loop chunk rather than the relation the filter left standing, so MATCH (n) WHERE n.name = 'Remy' RETURN 5 emitted one row per node in the graph, as did count/sum over a constant under a WHERE.

```
MATCH (n) WHERE n.name = 'Remy' RETURN 5                     18 rows -> 1 row
MATCH (n) WHERE n.name = 'nobody' RETURN 5                   18 rows -> 0 rows
MATCH (n) WHERE n.name = 'Remy' RETURN count(42)             18      -> 1
MATCH (n) WHERE n.name = 'Remy' RETURN 1 AS x, sum(x)        18      -> 1
```
