### PR TITLE
MLIR: accept any chunk as an output's cardinality driver

### DIFF
--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -580,13 +580,19 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
     nl.output(%targets) skip %h : !nl.chunk<!storage.node_id>
 
     An optional `cardinality` operand carries a representative chunk of the driving
-    relation (a node-ID loop variable). A projection of only constants - RETURN 5 -
-    has no per-row column to size the emission, yet its cardinality is the driving
-    relation's (projection preserves cardinality), so the output nests in the driving
-    loop and reads its row count from this chunk; the constants broadcast against it.
-    Absent for a per-row projection (its own columns size it) or a single-row emit.
+    relation. A projection of only constants - RETURN 5 - has no per-row column to
+    size the emission, yet its cardinality is the driving relation's (projection
+    preserves cardinality), so the output nests in the driving loop and reads its row
+    count from this chunk; the constants broadcast against it. Absent for a per-row
+    projection (its own columns size it) or a single-row emit.
 
-    nl.output(%c) cardinality %n : !nl.chunk<i64>
+    nl.output(%c) cardinality(%n : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
+
+    Only that row count is read, never a value, so the driver is a chunk of any
+    element type - the node IDs a scan binds, the values an UNWIND unwinds - as
+    nl.broadcast_constant's own cardinality operand is:
+
+    nl.output(%c) cardinality(%x : !nl.chunk<!storage.nullable<i64>>) : !nl.chunk<i64>
 
     An optional `names` array carries the result column names db.output was given,
     one per column, which the interpreter hands to the sink so it can label the
@@ -601,11 +607,10 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   // operand-segment sizes to tell them apart, the same as nl.cross_product's column
   // groups. A folded output carries at most one of limit/skip (the truncate adjacent
   // to it); the two are not produced together (see foldSkipTruncatesIntoOutputs).
-  // cardinality's type is buildable (always a node-ID chunk) and so omitted.
   let arguments = (ins Variadic<NLChunk>:$columns,
                        Optional<NLLimitStateHandle>:$limit,
                        Optional<NLSkipStateHandle>:$skip,
-                       Optional<NLNodeIDChunk>:$cardinality,
+                       Optional<NLChunk>:$cardinality,
                        OptionalAttr<StrArrayAttr>:$column_names);
 
   // The chunk element types vary from call to call and - unlike the source
@@ -616,9 +621,11 @@ def Output : NLOp<"output", [AttrSizedOperandSegments]> {
   // annotation. qualified(...) forces the leading !nl. on every printed type.
   // The optional limit and skip handles, when present, print after a `limit` or
   // `skip` keyword; both types are buildable and so omitted. Each optional group
-  // has its own literal anchor, so the declarative parser tells them apart.
+  // has its own literal anchor, so the declarative parser tells them apart. The
+  // cardinality driver is a chunk of any element type, which no recipe can build, so
+  // it is parenthesized with its own type - keeping the trailing colon the columns'.
   let assemblyFormat = [{
-    `(` $columns `)` (`names` $column_names^)? (`limit` $limit^)? (`skip` $skip^)? (`cardinality` $cardinality^)? attr-dict `:` qualified(type($columns))
+    `(` $columns `)` (`names` $column_names^)? (`limit` $limit^)? (`skip` $skip^)? (`cardinality` `(` $cardinality^ `:` qualified(type($cardinality)) `)`)? attr-dict `:` qualified(type($columns))
   }];
 
   // Emitting an unnamed result is the common case - every hand-written program and

--- a/samples/mlir/scan_return_constant.nl.mlir
+++ b/samples/mlir/scan_return_constant.nl.mlir
@@ -2,7 +2,7 @@ func.func @main() {
   %c = nl.constant(5 : i64)
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
-    nl.output(%c) cardinality %a : !nl.chunk<i64>
+    nl.output(%c) cardinality(%a : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
   }
   func.return
 }

--- a/samples/mlir/unwind_return_constant.mlir
+++ b/samples/mlir/unwind_return_constant.mlir
@@ -1,0 +1,8 @@
+// UNWIND [1, 2, 3] AS x RETURN 5
+
+func.func @main() {
+  %0 = db.unwind_const([1, 2, 3]) : !db.column<i64>
+  %1 = db.constant(5 : i64)
+  db.output(%1) names ["5"] : !db.column<i64>
+  return
+}

--- a/samples/mlir/unwind_return_constant.nl.mlir
+++ b/samples/mlir/unwind_return_constant.nl.mlir
@@ -1,0 +1,15 @@
+// UNWIND [1, 2, 3] AS x RETURN 5
+//
+// The scan-driven scan_return_constant.nl.mlir with a list for a driving relation: the
+// projection is a constant alone either way, and the cardinality operand is whatever
+// chunk carries the rows it stands for - here the unwound values, a nullable i64 chunk
+// rather than the node IDs a scan binds. Only its row count is read.
+
+func.func @main() {
+  %0 = nl.constant(5 : i64)
+  %1 = nl.unwind_const([1, 2, 3]) : !nl.iter<!nl.chunk<!storage.nullable<i64>>>
+  nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.nullable<i64>>> {
+    nl.output(%0) names ["5"] cardinality(%arg0 : !nl.chunk<!storage.nullable<i64>>) : !nl.chunk<i64>
+  }
+  return
+}

--- a/samples/mlir/xprod_return_constant.nl.mlir
+++ b/samples/mlir/xprod_return_constant.nl.mlir
@@ -5,7 +5,7 @@ func.func @main() {
     %2 = nl.scan_nodes()
     nl.for %arg1 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %3:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-      nl.output(%0) cardinality %3#0 : !nl.chunk<i64>
+      nl.output(%0) cardinality(%3#0 : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
     }
   }
   return

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -387,6 +387,16 @@ target_link_libraries(test_query_ir_wildcard_return PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_wildcard_return PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_unwind_constant_projection UnwindConstantProjectionTest.cpp)
+target_link_libraries(test_query_ir_unwind_constant_projection PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_unwind_constant_projection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_aggregate_over_constant_alias AggregateOverConstantAliasTest.cpp)
 target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
         turing_db_s

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -379,7 +379,7 @@ func.func @main() {
   %c = nl.constant(5 : i64)
   %nodes = nl.scan_nodes()
   nl.for %a in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
-    nl.output(%c) cardinality %a : !nl.chunk<i64>
+    nl.output(%c) cardinality(%a : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
   }
   func.return
 }

--- a/test/query/ir/UnwindConstantProjectionTest.cpp
+++ b/test/query/ir/UnwindConstantProjectionTest.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnConst.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Constants = std::vector<int64_t>;
+
+// The eighteen nodes of simpledb, which MATCH (n) matches
+constexpr size_t nodeCount = 18;
+
+class ConstantSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const ColumnConst<int64_t>* constants = dynamic_cast<const ColumnConst<int64_t>*>(chunks.front());
+        ASSERT_NE(constants, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _constants.push_back((*constants)[rowIndex]);
+        }
+    }
+
+    const Constants& getConstants() const { return _constants; }
+
+private:
+    Constants _constants;
+};
+
+}
+
+// A projection of constants alone sized by an UNWIND. The driving relation is then a
+// column of values rather than of node IDs, and only its row count is read - the same
+// count nl.broadcast_constant lays a constant out over.
+class UnwindConstantProjectionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void expectConstants(std::string_view query, const Constants& expected) {
+        ConstantSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getConstants(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The list opens one row per element, and the constant stands for each of them.
+TEST_F(UnwindConstantProjectionTest, emitsTheConstantOncePerUnwoundElement) {
+    expectConstants("UNWIND [1, 2, 3] AS x RETURN 5", Constants(3, 5));
+}
+
+// A list whose elements disagree on type unwinds into a type-erased column of tagged
+// scalars, which drives the projection the same way: what is read of it is its rows.
+TEST_F(UnwindConstantProjectionTest, emitsTheConstantOverAHeterogeneousList) {
+    expectConstants("UNWIND [true, 'mixed', 10] AS x RETURN 5", Constants(3, 5));
+}
+
+// An UNWIND with incoming rows is crossed with them, so the driver is the product: one
+// row of the constant per node per element.
+TEST_F(UnwindConstantProjectionTest, emitsTheConstantOverAMatchCrossedWithAnUnwind) {
+    expectConstants("MATCH (n) UNWIND [1, 2] AS x RETURN 5", Constants(2 * nodeCount, 5));
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
nl.output's cardinality operand only accepted a node-ID chunk, so an UNWIND-driven projection of constants alone had no chunk it could name as its driver and failed MLIR verification. It now accepts any chunk, as nl.broadcast_constant's own cardinality operand already did, and the driver is printed with its type.

```
UNWIND [1, 2, 3] AS x RETURN 5                  verification error -> 3 rows
UNWIND [true, 'mixed', 10] AS x RETURN 5        verification error -> 3 rows
MATCH (n) UNWIND [1, 2] AS x RETURN 5           2 rows per node, unchanged (the driver is the cross product's node chunk)
MATCH (n) RETURN 5                              one row per node, unchanged
UNWIND [true, 'mixed', 10] AS x RETURN count(42) 3, unchanged (broadcast_constant already took any chunk)
```
