### PR TITLE
MLIR: Fix generation for `MATCH ... CREATE`

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -922,6 +922,11 @@ void DBProgramGenerator::generateCreate(const CypherAST* ast) {
         }
     }
 
+    mlir::Value matchCardinality;
+    if (!knownVars.empty()) {
+        matchCardinality = knownVars.begin()->second;
+    }
+
     const mlir::db::ColumnType nodeIDType = allocColumnType(mlir::storage::NodeIDType::get(_mlirCtxt));
     const mlir::db::ColumnType edgeIDType = allocColumnType(mlir::storage::EdgeIDType::get(_mlirCtxt));
     const mlir::Location loc = _opBuilder.getUnknownLoc();
@@ -957,12 +962,15 @@ void DBProgramGenerator::generateCreate(const CypherAST* ast) {
             }
         }
 
+        const mlir::Value cardinality = matchCardinality;
+
         mlir::db::CreateNode createNode = _opBuilder.create<mlir::db::CreateNode>(
             loc,
             nodeIDType,
             _opBuilder.getStrArrayAttr(labelNames),
             _opBuilder.getStrArrayAttr(propNames),
-            mlir::ValueRange{propValues});
+            mlir::ValueRange{propValues},
+            cardinality);
         const mlir::Value nodeValue = createNode.getResult();
 
         if (!name.empty()) {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -975,7 +975,7 @@ def FilterOp : TuringOp<"filter", [Pure]> {
   }];
 }
 
-def CreateNode : TuringOp<"create_node"> {
+def CreateNode : TuringOp<"create_node", [AttrSizedOperandSegments]> {
   let summary = "Create one node per input row, with given labels and property values";
 
   let description = [{
@@ -993,13 +993,14 @@ def CreateNode : TuringOp<"create_node"> {
 
   let arguments = (ins StrArrayAttr:$labels,
                        StrArrayAttr:$prop_names,
-                       Variadic<Column>:$prop_values);
+                       Variadic<Column>:$prop_values,
+                       Optional<Column>:$cardinality);
   let results   = (outs ColumnNodeIDs:$result);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $labels `,` $prop_names `,` `{` $prop_values `}` `)` attr-dict `:`
-    functional-type(operands, results)
+    `(` $labels `,` $prop_names `,` `{` $prop_values `}` `)` ( `foreach` $cardinality^ )?
+    attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1598,7 +1598,7 @@ def Collect : NLOp<"collect", [Pure]> {
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }
 
-def CreateNode : NLOp<"create_node"> {
+def CreateNode : NLOp<"create_node", [AttrSizedOperandSegments]> {
   let summary = "Write one node per input row into the open transaction's write buffer";
   let description = [{
     Adds one pending node per row to the transaction's CommitWriteBuffer.
@@ -1612,12 +1612,14 @@ def CreateNode : NLOp<"create_node"> {
 
   let arguments = (ins StrArrayAttr:$labels,
                        StrArrayAttr:$prop_names,
-                       Variadic<NLChunk>:$prop_values);
+                       Variadic<NLChunk>:$prop_values,
+                       Optional<NLChunk>:$cardinality);
   let results   = (outs NLNodeIDChunk:$result);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $labels `,` $prop_names `,` `{` $prop_values `}` attr-dict
+    $labels `,` $prop_names `,` `{` $prop_values `}`
+    ( `foreach` $cardinality^ `:` qualified(type($cardinality)) )? attr-dict
     ( `:` qualified(type($prop_values))^ )?
   }];
 }

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1730,17 +1730,20 @@ public:
     ColumnNodeIDs* getResult() const { return _result; }
     const std::vector<Property>& properties() const { return _properties; }
 
-    size_t getRowCount() const {
-        return _properties.empty() ? 1 : _properties.front()._values->size();
-    }
+    size_t getRowCount() const { return _cardinality ? _cardinality->size() : 1; }
 
     void addProperty(const Property& property) {
         _properties.push_back(property);
     }
 
+    void setCardinality(const Column* cardinality) {
+        _cardinality = cardinality;
+    }
+
 private:
     std::vector<Property> _properties;
     ColumnNodeIDs* _result {nullptr};
+    const Column* _cardinality {nullptr};
     LabelSetHandle _labelsetHandle;
 };
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -871,6 +871,10 @@ void NLTranslator::translateCreateNode(nl::CreateNode createNode, NLStmtContaine
         data->addProperty({._propertyTypeID=propType._id, ._values=propColumn});
     }
 
+    if (const mlir::Value cardinality = createNode.getCardinality()) {
+        data->setCardinality(getColumn(cardinality));
+    }
+
     body->emplaceStmt(&NLExecutor::runCreateNode, data);
 }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1743,9 +1743,14 @@ void DBLowering::lowerCreateNode(mlir::db::CreateNode createNode) {
         propChunks.push_back(mapValue(propValue));
     }
 
-    if (propChunks.empty()) {
-        // Try find a block where the result of this create_node is used to create an edge
-        // Otherwise: entry block
+    mlir::Value cardinalityChunk;
+    if (createNode.getCardinality()) {
+        cardinalityChunk = mapValue(createNode.getCardinality());
+    }
+
+    if (cardinalityChunk) {
+        setInsertionInto(ownerBlock(cardinalityChunk));
+    } else {
         mlir::Block* targetBlock = _entryBlock;
         for (const mlir::OpOperand& use : createNode.getResult().getUses()) {
             auto createEdge = mlir::dyn_cast<mlir::db::CreateEdge>(use.getOwner());
@@ -1772,22 +1777,14 @@ void DBLowering::lowerCreateNode(mlir::db::CreateNode createNode) {
         }
 
         setInsertionInto(targetBlock);
-    } else {
-        mlir::Value reference = propChunks[0];
-        for (size_t i = 1; i < propChunks.size(); i++) {
-            mlir::Block* const block = deeperBlock(reference, propChunks[i]);
-            if (ownerBlock(propChunks[i]) == block) {
-                reference = propChunks[i];
-            }
-        }
-        setInsertionInto(ownerBlock(reference));
     }
 
     nl::CreateNode create = _builder.create<nl::CreateNode>(
         loc,
         createNode.getLabelsAttr(),
         createNode.getPropNamesAttr(),
-        propChunks);
+        propChunks,
+        cardinalityChunk);
     _valueMap[createNode.getResult()] = create.getResult();
 }
 

--- a/samples/mlir/match_create_edge_src.mlir
+++ b/samples/mlir/match_create_edge_src.mlir
@@ -2,7 +2,7 @@
 
 func.func @main() {
   %0 = db.scan_nodes() : !db.column<!storage.node_id>
-  %1 = db.create_node(["New"], [], {}) : () -> !db.column<!storage.node_id>
+  %1 = db.create_node(["New"], [], {}) foreach %0 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
   %2 = db.create_edge(%0, %1, "COMES_BEFORE", [], {}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.edge_id>
   return
 }

--- a/samples/mlir/match_create_edge_src.nl.mlir
+++ b/samples/mlir/match_create_edge_src.nl.mlir
@@ -3,7 +3,7 @@
 func.func @main() {
   %0 = nl.scan_nodes()
   nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
-    %1 = nl.create_node ["New"], [], {}
+    %1 = nl.create_node ["New"], [], {} foreach %arg0 : !nl.chunk<!storage.node_id>
     %2 = nl.create_edge %arg0, %1, "COMES_BEFORE", [], {}
   }
   return

--- a/test/query/ir/CreateEquivalenceTest.cpp
+++ b/test/query/ir/CreateEquivalenceTest.cpp
@@ -333,6 +333,16 @@ TEST_F(CreateEquivalenceTest, matchThreeComponentCrossProductCreateNode) {
         "MATCH (m:Gadget) RETURN count(m)");
 }
 
+// A node-id-filtered MATCH feeding a CREATE that hangs a new node off the single
+// matched node: the binding is one row, so exactly one LIKES edge and one Interest
+// are created, from node 0 only - not from every node.
+TEST_F(CreateEquivalenceTest, matchFilteredCreateEdgeToNewNode) {
+    expectSeededCreateEquivalent(
+        R"(CREATE (:Person {name: "Remy"}), (:Person {name: "Adam"}))",
+        R"(MATCH (n) WHERE n = 0 CREATE (n)-[:LIKES]->(c:Interest {name: "Cake"}))",
+        R"(MATCH (n)-[:LIKES]->(c:Interest) RETURN n.name, c.name)");
+}
+
 TEST_F(CreateEquivalenceTest, multipleSequentialCreates) {
     applyV2(_v2GraphName, R"(CREATE (n:Person {name: "Alice"}))");
     applyV2(_v2GraphName, R"(CREATE (n:Person {name: "Bob"}))");

--- a/test/query/ir/CreateEquivalenceTest.cpp
+++ b/test/query/ir/CreateEquivalenceTest.cpp
@@ -209,6 +209,31 @@ protected:
         }
     }
 
+    void expectSeededCreateEquivalent(std::string_view seedQuery,
+                                      std::string_view createQuery,
+                                      std::string_view matchQuery) {
+        applyV2(_v2GraphName, seedQuery);
+        applyV2(_v3GraphName, seedQuery);
+
+        applyV2(_v2GraphName, createQuery);
+        applyV3(_v3GraphName, createQuery);
+
+        Rows v2Rows;
+        matchV2(_v2GraphName, matchQuery, v2Rows);
+        Rows v3Rows;
+        matchV2(_v3GraphName, matchQuery, v3Rows);
+
+        std::ranges::sort(v2Rows);
+        std::ranges::sort(v3Rows);
+
+        ASSERT_EQ(v2Rows.size(), v3Rows.size())
+            << "Row count mismatch for CREATE: " << createQuery;
+
+        for (auto [v2Row, v3Row] : rv::zip(v2Rows, v3Rows)) {
+            EXPECT_EQ(v2Row, v3Row) << "Row mismatch for CREATE: " << createQuery;
+        }
+    }
+
     const std::string _v2GraphName = "v2Graph";
     const std::string _v3GraphName = "v3Graph";
     std::unique_ptr<TuringTestEnv> _env;
@@ -257,6 +282,55 @@ TEST_F(CreateEquivalenceTest, nodeWithMultipleLabels) {
     expectCreateEquivalent(
         R"(CREATE (n:Person:Employee {name: "Alice"}))",
         "MATCH (n:Employee) RETURN n.name");
+}
+
+TEST_F(CreateEquivalenceTest, matchCreatePropertyCarriesCardinality) {
+    expectSeededCreateEquivalent(
+        R"(CREATE (:Widget {tag: "a"}), (:Widget {tag: "b"}), (:Widget {tag: "c"}))",
+        R"(MATCH (n:Widget) CREATE (m:Gadget {origin: n.tag}))",
+        "MATCH (m:Gadget) RETURN m.origin");
+}
+
+TEST_F(CreateEquivalenceTest, matchCreateNodeOncePerMatchedRow) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget), (:Widget)",
+        "MATCH (n:Widget) CREATE (m:Gadget)",
+        "MATCH (m:Gadget) RETURN count(m)");
+}
+
+TEST_F(CreateEquivalenceTest, matchCreateNodeReadBackAllRows) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget)",
+        R"(MATCH (n:Widget) CREATE (m:Gadget {origin: "seed"}))",
+        "MATCH (m:Gadget) RETURN m.origin");
+}
+
+TEST_F(CreateEquivalenceTest, matchCreateEdgeOncePerMatchedRow) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget), (:Widget)",
+        "MATCH (n:Widget) CREATE (n)-[e:LINKED]->(m:Gadget)",
+        "MATCH (:Widget)-[e:LINKED]->(:Gadget) RETURN count(e)");
+}
+
+TEST_F(CreateEquivalenceTest, matchCrossProductCreateNodePerBindingRow) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget), (:Gizmo), (:Gizmo), (:Gizmo)",
+        "MATCH (a:Widget), (b:Gizmo) CREATE (m:Gadget)",
+        "MATCH (m:Gadget) RETURN count(m)");
+}
+
+TEST_F(CreateEquivalenceTest, matchCrossProductCreateNodeReadBackAllRows) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget), (:Gizmo), (:Gizmo), (:Gizmo)",
+        R"(MATCH (a:Widget), (b:Gizmo) CREATE (m:Gadget {origin: "x"}))",
+        "MATCH (m:Gadget) RETURN m.origin");
+}
+
+TEST_F(CreateEquivalenceTest, matchThreeComponentCrossProductCreateNode) {
+    expectSeededCreateEquivalent(
+        "CREATE (:Widget), (:Widget), (:Gizmo), (:Gizmo), (:Gizmo), (:Doohickey)",
+        "MATCH (a:Widget), (b:Gizmo), (c:Doohickey) CREATE (m:Gadget)",
+        "MATCH (m:Gadget) RETURN count(m)");
 }
 
 TEST_F(CreateEquivalenceTest, multipleSequentialCreates) {

--- a/test/query/ir/SetEquivalenceTest.cpp
+++ b/test/query/ir/SetEquivalenceTest.cpp
@@ -286,3 +286,10 @@ TEST_F(SetEquivalenceTest, setEdgeProperty) {
         R"(MATCH (a:Person)-[e:KNOWS]->(b:Person) SET e.since = 1999)",
         "MATCH (a:Person)-[e:KNOWS]->(b:Person) RETURN e.since");
 }
+
+TEST_F(SetEquivalenceTest, setAcrossCrossProduct) {
+    expectSetEquivalent(
+        R"(CREATE (:Person {name: "a"}), (:Person {name: "b"}), (:Robot), (:Robot), (:Robot))",
+        "MATCH (p:Person), (r:Robot) SET p.rank = 7",
+        "MATCH (p:Person) RETURN p.name, p.rank");
+}


### PR DESCRIPTION
`MATCH ... CREATE` queries resulted in a single `CREATE` rather than 1-per `MATCH` row in cases where there are no properties.

This PR adds a "cardinality" argument to the `CREATE` MLIR ops which informs how many nodes/edges are to be created.