### PR TITLE
MLIR: DISTINCT, SKIP/LIMIT and cardinality over a projection of constants

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1326,9 +1326,11 @@ void DBProgramGenerator::translateDistinct(const Projection* projection,
     collectRowColumns(projection, projected, dedupedItems, dedupedColumns);
 
     // Every column is constant, so the projection is one row repeated as many times as
-    // the query matched: the single row to keep is a row count, not a dedup
+    // the query matched: no column tells two of those rows apart, and the one the dedup
+    // keeps is the first of them - the projection capped at a single row
     if (dedupedColumns.empty()) {
-        throw TuringException("DISTINCT over a projection of constants is not yet supported.");
+        translateDistinctOverConstants(projection, projected);
+        return;
     }
 
     llvm::SmallVector<mlir::Type> dedupedTypes;
@@ -1344,6 +1346,28 @@ void DBProgramGenerator::translateDistinct(const Projection* projection,
     const mlir::ResultRange results = distinctOp.getResults();
     for (size_t resultIndex = 0; resultIndex < dedupedItems.size(); resultIndex++) {
         projected[dedupedItems[resultIndex]] = results[resultIndex];
+    }
+}
+
+void DBProgramGenerator::translateDistinctOverConstants(const Projection* projection,
+                                                        llvm::SmallVectorImpl<mlir::Value>& projected) {
+    llvm::SmallVector<size_t> cappedItems;
+    llvm::SmallVector<mlir::Value> capped;
+    collectCutColumns(projection, projected, cappedItems, capped);
+
+    llvm::SmallVector<mlir::Type> cappedTypes;
+    for (const mlir::Value column : capped) {
+        cappedTypes.push_back(column.getType());
+    }
+
+    const uint64_t keptRowCount = 1;
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    auto limitOp = _opBuilder.create<mlir::db::Limit>(loc, cappedTypes, mlir::ValueRange{capped}, keptRowCount);
+
+    const mlir::ResultRange results = limitOp.getResults();
+    for (size_t resultIndex = 0; resultIndex < cappedItems.size(); resultIndex++) {
+        projected[cappedItems[resultIndex]] = results[resultIndex];
     }
 }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -109,6 +109,11 @@ private:
     void translateDistinct(const Projection* projection,
                            llvm::SmallVectorImpl<mlir::Value>& projected);
 
+    // Dedups a projection of constants alone, whose rows are one row repeated, by
+    // capping @param projected at the single row the dedup would keep
+    void translateDistinctOverConstants(const Projection* projection,
+                                        llvm::SmallVectorImpl<mlir::Value>& projected);
+
     void runPasses();
 
     // Reorders the projection with a Sort over @param projected, replacing each

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -266,6 +266,36 @@ nl::Output soleOutputConsumer(mlir::ResultRange results) {
     return sharedByAllResults ? output : nl::Output();
 }
 
+bool opensSourceLoop(mlir::Operation* operation) {
+    return mlir::isa<mlir::db::ScanNodes,
+                     mlir::db::ConstScanNodes,
+                     mlir::db::UnwindConst,
+                     mlir::db::ScanNodesByLabel,
+                     mlir::db::ScanEdges,
+                     mlir::db::GetOutEdges,
+                     mlir::db::GetInEdges,
+                     mlir::db::GetEdges,
+                     mlir::db::GetOutEdgesByType,
+                     mlir::db::GetInEdgesByType>(operation);
+}
+
+// The db ops whose rows a projection is emitted over: a source, the nest a cross product
+// builds, and the emit loop a pipeline breaker opens over what it accumulated
+bool opensRowLoop(mlir::Operation* operation) {
+    return opensSourceLoop(operation)
+        || mlir::isa<mlir::db::CrossProduct, mlir::db::Sort, mlir::db::GroupAggregate>(operation);
+}
+
+// A reduction emits its one row at function scope, so what follows it walks no rows of the
+// relation it read - and that relation had to be read in full to reduce it
+bool reducesToOneRow(mlir::Operation* operation) {
+    return mlir::isa<mlir::db::Count,
+                     mlir::db::Sum,
+                     mlir::db::Min,
+                     mlir::db::Max,
+                     mlir::db::Avg>(operation);
+}
+
 // Whether a chunk holds one value standing for every row rather than one per row.
 // The arithmetic ops listed are bound wherever their operands are, so a chunk
 // computed from constants alone through them is hoisted out of the producing loop
@@ -369,8 +399,18 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
     // shared producer wins, so a loop never needs to carry two handles.
     for (mlir::db::Limit limit : limits) {
         const mlir::Value handle = _limitHandles[limit.getOperation()];
+
+        bool producedByALoop = false;
         for (const mlir::Value column : limit.getColumns()) {
-            assignProducerLoops(column, handle);
+            producedByALoop |= assignProducerLoops(column, handle);
+        }
+
+        // A cut over constants alone walks back to no loop at all - the constants are
+        // bound above the nest - so the handle goes to the relation driving the
+        // projection instead. Without it the nest runs to its end and the budget only
+        // stops the output, producing every row to throw all but k away.
+        if (!producedByALoop) {
+            assignCardinalityDriverLoop(limit, handle);
         }
     }
 
@@ -1494,41 +1534,33 @@ void DBLowering::lowerUnwindCollect(mlir::db::UnwindCollect unwindCollect) {
     buildLoopForSource(unwindCollectOp.getResult(), unwindCollect.getOperation());
 }
 
-void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
+bool DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
     mlir::Operation* const definingOp = column.getDefiningOp();
     if (!definingOp) {
         // A cross-product factor's loop variable is a block argument with no
         // defining op; its producing loop is reached through the factor's yield
         // in the cross-product branch below, not from here.
-        return;
+        return false;
     }
 
-    const bool opensLoop = mlir::isa<mlir::db::ScanNodes,
-                                     mlir::db::ConstScanNodes,
-                                     mlir::db::UnwindConst,
-                                     mlir::db::ScanNodesByLabel,
-                                     mlir::db::ScanEdges,
-                                     mlir::db::GetOutEdges,
-                                     mlir::db::GetInEdges,
-                                     mlir::db::GetEdges,
-                                     mlir::db::GetOutEdgesByType,
-                                     mlir::db::GetInEdgesByType>(definingOp);
+    const bool opensLoop = opensSourceLoop(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
     // A pipeline breaker accumulates every row before emitting any, so the walk stops
     // here; the limit budgets its emit loop instead, when it opens one.
     const bool emitsThroughLoop = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
-    const bool breaksPipeline = emitsThroughLoop
-        || mlir::isa<mlir::db::Count, mlir::db::Sum, mlir::db::Min, mlir::db::Max, mlir::db::Avg>(definingOp);
+    const bool breaksPipeline = emitsThroughLoop || reducesToOneRow(definingOp);
+
+    bool reachedALoop = opensLoop || isCrossProduct || emitsThroughLoop;
 
     // The first limit, in program order, to claim a producer wins, so a loop
     // shared by two limits' nests carries the outer one and never two handles.
-    if ((opensLoop || isCrossProduct || emitsThroughLoop) && !_loopLimitHandle.count(definingOp)) {
+    if (reachedALoop && !_loopLimitHandle.count(definingOp)) {
         _loopLimitHandle[definingOp] = handle;
     }
 
     if (breaksPipeline) {
-        return;
+        return reachedALoop;
     }
 
     if (isCrossProduct) {
@@ -1540,16 +1572,45 @@ void DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
         for (mlir::Region* const factor : factors) {
             mlir::Operation* const yield = factor->front().getTerminator();
             for (const mlir::Value yielded : yield->getOperands()) {
-                assignProducerLoops(yielded, handle);
+                reachedALoop |= assignProducerLoops(yielded, handle);
             }
         }
     } else {
         // A non-loop producer (a property fetch) is traversed but not assigned -
         // it opens no loop - so its input chunk's loop is still reached.
         for (const mlir::Value operand : definingOp->getOperands()) {
-            assignProducerLoops(operand, handle);
+            reachedALoop |= assignProducerLoops(operand, handle);
         }
     }
+
+    return reachedALoop;
+}
+
+void DBLowering::assignCardinalityDriverLoop(mlir::db::Limit limit, mlir::Value handle) {
+    mlir::Operation* const limitOp = limit.getOperation();
+
+    // The relation driving the projection is the loop opened last before the cut: its rows
+    // are the ones nl.output emits the constants over, so they are the rows this budget
+    // cuts. A reduction in between leaves no such loop - it emits its one row at function
+    // scope, and the relation behind it had to be read in full to reduce it.
+    mlir::Operation* driver = nullptr;
+    for (mlir::Operation& operation : *limitOp->getBlock()) {
+        if (&operation == limitOp) {
+            break;
+        }
+
+        if (opensRowLoop(&operation)) {
+            driver = &operation;
+        } else if (reducesToOneRow(&operation)) {
+            driver = nullptr;
+        }
+    }
+
+    if (!driver) {
+        return;
+    }
+
+    assignProducerLoops(driver->getResult(0), handle);
 }
 
 void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -310,7 +310,7 @@ bool isConstantChunk(mlir::Value chunk) {
         return true;
     }
 
-    if (!mlir::isa<nl::Add, nl::Sub, nl::Mul, nl::Div>(definingOp)) {
+    if (!mlir::isa<nl::Add, nl::Sub, nl::Mul, nl::Div, nl::Mod, nl::Pow>(definingOp)) {
         return false;
     }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -2014,12 +2014,9 @@ void DBLowering::lowerOutput(mlir::db::Output output) {
     const bool returningNonLooped = anchorBlock == _entryBlock;
     if (returningNonLooped && _innermostLoopBody) {
         // but if we have all constants, then it need be moved to the inner most loop to
-        // match cardinality
-        const bool allConstants =
-            std::ranges::all_of(columns, [](const mlir::Value column) {
-                mlir::Operation* const definingOp = column.getDefiningOp();
-                return llvm::isa_and_nonnull<nl::Constant>(definingOp);
-            });
+        // match cardinality. An expression over constants alone is one of them: it is
+        // bound where its operands are, above the loop whose rows it is projected over
+        const bool allConstants = llvm::all_of(columns, isConstantChunk);
 
         if (allConstants) {
             anchorBlock = _innermostLoopBody;

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -981,6 +981,8 @@ void DBLowering::lowerLimit(mlir::db::Limit limit) {
         throw IRException("db.limit requires at least one column");
     }
 
+    rowAlignCutChunks(chunks);
+
     const mlir::Location loc = _builder.getUnknownLoc();
     const mlir::Value handle = _limitHandles.lookup(limit.getOperation());
 
@@ -1018,6 +1020,8 @@ void DBLowering::lowerSkip(mlir::db::Skip skip) {
     if (chunks.empty()) {
         throw IRException("db.skip requires at least one column");
     }
+
+    rowAlignCutChunks(chunks);
 
     const mlir::Location loc = _builder.getUnknownLoc();
 
@@ -2110,6 +2114,18 @@ mlir::Value DBLowering::mapValue(mlir::Value dbValue) const {
     }
 
     return slotIt->second;
+}
+
+void DBLowering::rowAlignCutChunks(llvm::SmallVectorImpl<mlir::Value>& chunks) {
+    // With no relation driving the projection a constant is the single row that
+    // projection is, and the cut charges it as it stands.
+    if (!_innermostCardinality) {
+        return;
+    }
+
+    for (mlir::Value& chunk : chunks) {
+        chunk = rowAlignedChunk(chunk, _innermostCardinality);
+    }
 }
 
 mlir::Value DBLowering::rowAlignedChunk(mlir::Value chunk, mlir::Value cardinality) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -330,6 +330,13 @@ private:
     // Point the builder at the right place for an op consuming lhs and rhs.
     void setInsertionForBinaryOp(mlir::Value lhs, mlir::Value rhs);
 
+    // Lays the constants among the chunks a cut is charged to over the rows of the
+    // driving relation. A cut walks rows and a constant carries none of its own - it
+    // holds one value standing for every row of the step - so the loop's rows are the
+    // count a cut over constants alone charges, and the count every cut chained after it
+    // reads in turn.
+    void rowAlignCutChunks(llvm::SmallVectorImpl<mlir::Value>& chunks);
+
     // The chunk a step that walks rows is handed for @param chunk: itself when it
     // carries rows, and its value laid out over the rows of @param cardinality - the
     // driving relation's chunk, null when no relation drives the projection - when it

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -300,7 +300,14 @@ private:
     // A cross product's factors are regions, so it recurses through their
     // db.yield operands; a property fetch opens no loop but is traversed to reach
     // its input chunk's loop. The first limit to claim a producer keeps it.
-    void assignProducerLoops(mlir::Value column, mlir::Value handle);
+    // Returns whether the walk reached a loop at all: a column computed from constants
+    // alone is produced by none, which is what sends the handle to the driving relation.
+    bool assignProducerLoops(mlir::Value column, mlir::Value handle);
+
+    // Records that the loops producing the relation which drives @param limit's projection
+    // carry its handle, so a cut charged to constants alone stops its nest as any other
+    // cut does rather than letting it run to the end.
+    void assignCardinalityDriverLoop(mlir::db::Limit limit, mlir::Value handle);
 
     // Peephole over the lowered nl function: where an nl.limit_truncate's results
     // are consumed exactly by one adjacent nl.output (the terminal-LIMIT shape),

--- a/test/query/ir/ConstantOnlyProjectionTest.cpp
+++ b/test/query/ir/ConstantOnlyProjectionTest.cpp
@@ -29,6 +29,7 @@ using namespace turing::test;
 namespace {
 
 using Constants = std::vector<int64_t>;
+using DoubleConstants = std::vector<double>;
 
 // The eighteen nodes of simpledb, which MATCH (n) matches
 constexpr size_t nodeCount = 18;
@@ -53,6 +54,27 @@ public:
 
 private:
     Constants _constants;
+};
+
+// The double sibling of ConstantSink: a power promotes what it computes to f64, so the
+// column standing for every row is one of doubles.
+class DoubleConstantSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const ColumnConst<double>* constants = dynamic_cast<const ColumnConst<double>*>(chunks.front());
+        ASSERT_NE(constants, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _constants.push_back((*constants)[rowIndex]);
+        }
+    }
+
+    const DoubleConstants& getConstants() const { return _constants; }
+
+private:
+    DoubleConstants _constants;
 };
 
 }
@@ -88,6 +110,28 @@ protected:
         EXPECT_EQ(sink.getConstants(), expected) << "query: " << query;
     }
 
+    void expectDoubleConstants(std::string_view query, const DoubleConstants& expected) {
+        DoubleConstantSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        const DoubleConstants& actual = sink.getConstants();
+        ASSERT_EQ(actual.size(), expected.size()) << "query: " << query;
+
+        for (size_t rowIndex = 0; rowIndex < expected.size(); rowIndex++) {
+            EXPECT_DOUBLE_EQ(actual[rowIndex], expected[rowIndex]) << "query: " << query;
+        }
+    }
+
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
     std::unique_ptr<QueryInterpreterV3> _interpreter;
@@ -109,6 +153,18 @@ TEST_F(ConstantOnlyProjectionTest, emitsNothingWhenTheMatchIsEmpty) {
 // way: one row of 42 per matched node.
 TEST_F(ConstantOnlyProjectionTest, emitsTheComputedConstantOncePerMatchedRow) {
     expectConstants("MATCH (n) RETURN 40 + 2", Constants(nodeCount, 42));
+}
+
+// Every arithmetic operator computes a constant from constants, the ones spelled with a
+// symbol of their own included.
+TEST_F(ConstantOnlyProjectionTest, emitsAComputedModuloOncePerMatchedRow) {
+    expectConstants("MATCH (n) RETURN 40 % 3", Constants(nodeCount, 1));
+}
+
+// A power is a constant of the same kind, promoted to a double by the operator rather than
+// by what it reads.
+TEST_F(ConstantOnlyProjectionTest, emitsAComputedPowerOncePerMatchedRow) {
+    expectDoubleConstants("MATCH (n) RETURN 2 ^ 3", DoubleConstants(nodeCount, 8.0));
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/ConstantOnlyProjectionTest.cpp
+++ b/test/query/ir/ConstantOnlyProjectionTest.cpp
@@ -30,6 +30,9 @@ namespace {
 
 using Constants = std::vector<int64_t>;
 
+// The eighteen nodes of simpledb, which MATCH (n) matches
+constexpr size_t nodeCount = 18;
+
 // Collects the one constant column of a projection that names nothing else. The column
 // answers the same value at every subscript, so the rows it yields are only the rows the
 // sink is handed - which is what these tests are about.
@@ -100,6 +103,12 @@ TEST_F(ConstantOnlyProjectionTest, emitsTheConstantOncePerMatchedRow) {
 // no row at all - a query that matched nothing must not answer with a row of 5.
 TEST_F(ConstantOnlyProjectionTest, emitsNothingWhenTheMatchIsEmpty) {
     expectConstants("MATCH (n) WHERE n.name = 'nobody' RETURN 5", {});
+}
+
+// An expression over constants alone is a constant column too, so it is sized the same
+// way: one row of 42 per matched node.
+TEST_F(ConstantOnlyProjectionTest, emitsTheComputedConstantOncePerMatchedRow) {
+    expectConstants("MATCH (n) RETURN 40 + 2", Constants(nodeCount, 42));
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -674,6 +674,29 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n) RETURN 5 LIMIT 3
+constexpr const char* constantLimitOverMatchProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %c = db.constant(5 : i64)
+  %lc = db.limit(%c) count 3 : (!db.column<i64>) -> !db.column<i64>
+  db.output(%lc) : !db.column<i64>
+  return
+}
+)mlir";
+
+// The same cut with a reduction over the scan before it, which has to see every node.
+constexpr const char* constantLimitPastACountProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k = db.count(%n) : (!db.column<!storage.node_id>) -> !db.column<ui64>
+  %c = db.constant(5 : i64)
+  %lc = db.limit(%c) count 3 : (!db.column<i64>) -> !db.column<i64>
+  db.output(%lc) : !db.column<i64>
+  return
+}
+)mlir";
+
 // MATCH (a), (b) RETURN 5
 constexpr const char* constantOverCrossProductProgram = R"mlir(
 func.func @main() {
@@ -3916,6 +3939,102 @@ TEST_F(DBLoweringTest, lowersLimitToHandleUpdateAndLoopOperands) {
     // The update sits in the innermost loop body, the same block as the output.
     EXPECT_EQ(updateOp->getBlock(), outputOp->getBlock());
     EXPECT_TRUE(mlir::isa<mlir::nl::For>(updateOp->getParentOp()));
+}
+
+// A cut over constants alone: the constants are bound above the nest, so no column of
+// the cut walks back to the scan. The handle still has to reach it - the rows the budget
+// cuts are the ones the scan makes - or the scan runs to its end and the budget only
+// stops the output, producing every node to emit three of them.
+TEST_F(DBLoweringTest, boundsTheDrivingLoopOfACutOverConstants) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule =
+        mlir::parseSourceString<mlir::ModuleOp>(constantLimitOverMatchProgram, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    mlir::nl::Limit limitOp;
+    mlir::nl::LimitUpdate updateOp;
+    size_t forCount = 0;
+    size_t forsWithLimit = 0;
+
+    nlModule->walk([&](mlir::Operation* operation) {
+        if (mlir::nl::Limit found = mlir::dyn_cast<mlir::nl::Limit>(operation)) {
+            limitOp = found;
+        } else if (mlir::nl::For forOp = mlir::dyn_cast<mlir::nl::For>(operation)) {
+            forCount++;
+            if (forOp.getLimit()) {
+                forsWithLimit++;
+            }
+        } else if (mlir::nl::LimitUpdate found = mlir::dyn_cast<mlir::nl::LimitUpdate>(operation)) {
+            updateOp = found;
+        }
+    });
+
+    ASSERT_TRUE(limitOp);
+    ASSERT_TRUE(updateOp);
+    EXPECT_EQ(forCount, 1u);
+    EXPECT_EQ(forsWithLimit, 1u);
+
+    // The scan's loop and the update charging it name the one hoisted handle, and the
+    // update sits inside that loop - the constants are laid out over its rows there.
+    const mlir::Value handle = limitOp.getState();
+    nlModule->walk([&](mlir::nl::For forOp) {
+        EXPECT_EQ(forOp.getLimit(), handle);
+    });
+    EXPECT_EQ(updateOp.getState(), handle);
+    EXPECT_TRUE(mlir::isa<mlir::nl::For>(updateOp->getParentOp()));
+}
+
+// The same cut with a reduction between the scan and the cut: the count has to see every
+// node, so the scan is not the loop this budget may stop - a cut over constants finds no
+// driving loop past a reduction.
+TEST_F(DBLoweringTest, leavesTheDrivingLoopUnboundedPastAReduction) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    const mlir::ParserConfig parserConfig(&context);
+    mlir::OwningOpRef<mlir::ModuleOp> dbModule =
+        mlir::parseSourceString<mlir::ModuleOp>(constantLimitPastACountProgram, parserConfig);
+    ASSERT_TRUE(dbModule);
+
+    const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+    ASSERT_TRUE(dbFunction);
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    DBLowering lowering(&context, &reader.getView());
+    lowering.lower(dbFunction, *nlModule);
+
+    size_t forsWithLimit = 0;
+    nlModule->walk([&](mlir::nl::For forOp) {
+        if (forOp.getLimit()) {
+            forsWithLimit++;
+        }
+    });
+
+    EXPECT_EQ(forsWithLimit, 0u);
 }
 
 TEST_F(DBLoweringTest, limitsChainedMidQueryFansOutBeyondBudget) {

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -662,6 +662,18 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n) RETURN 40 + 2
+constexpr const char* constantExpressionOverMatchProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %x = db.constant(40 : i64)
+  %y = db.constant(2 : i64)
+  %s = db.add %x, %y : (!db.column<i64>, !db.column<i64>) -> !db.column<i64>
+  db.output(%s) : !db.column<i64>
+  return
+}
+)mlir";
+
 // MATCH (a), (b) RETURN 5
 constexpr const char* constantOverCrossProductProgram = R"mlir(
 func.func @main() {
@@ -2750,6 +2762,21 @@ TEST_F(DBLoweringTest, constantProjectionOverMatchHasRelationCardinality) {
     // four rows of 5 - not one. (Before the fix the output floated to function scope
     // and emitted a single row.)
     const std::vector<std::vector<int64_t>> expected {{5}, {5}, {5}, {5}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+TEST_F(DBLoweringTest, constantExpressionProjectionOverMatchHasRelationCardinality) {
+    auto graph = buildDiamondGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    CollectingConstSink<int64_t> sink;
+    runLoweredProgram(constantExpressionOverMatchProgram, reader.getView(), sink);
+
+    // An expression over constants alone is a constant column too, so it is projected
+    // over the relation's rows as a literal is: four rows of 42, not the single row the
+    // expression is bound as above the loop.
+    const std::vector<std::vector<int64_t>> expected {{42}, {42}, {42}, {42}};
     EXPECT_EQ(sink.rows(), expected);
 }
 

--- a/test/query/ir/DistinctTest.cpp
+++ b/test/query/ir/DistinctTest.cpp
@@ -56,6 +56,9 @@ using Rows = std::vector<Row>;
 using Names = std::vector<std::string>;
 using ConstantNameRow = std::pair<int64_t, std::string>;
 using ConstantNameRows = std::vector<ConstantNameRow>;
+using Int64Values = std::vector<int64_t>;
+using ConstantPair = std::pair<int64_t, int64_t>;
+using ConstantPairs = std::vector<ConstantPair>;
 using OptInt64Values = std::vector<std::optional<int64_t>>;
 using NodeValueRow = std::pair<uint64_t, std::optional<int64_t>>;
 using NodeValueRows = std::vector<NodeValueRow>;
@@ -303,6 +306,53 @@ public:
 
 private:
     Counts _counts;
+};
+
+// Collects a projection of one constant column, which holds a single value for however
+// many rows the chunk carries rather than one per row. A constant a cut is charged to is
+// laid out over the rows of the driving relation, so the matched cases read their column
+// through DistinctOptInt64Sink instead.
+class DistinctConstantSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* constants = dynamic_cast<const ColumnConst<int64_t>*>(chunks[0]);
+        ASSERT_NE(constants, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back((*constants)[rowIndex]);
+        }
+    }
+
+    const Int64Values& values() const { return _values; }
+
+private:
+    Int64Values _values;
+};
+
+// The two-column sibling of DistinctConstantSink: a projection of two constants, whose
+// rows are told apart by their count alone.
+class DistinctConstantPairSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* firsts = dynamic_cast<const ColumnConst<int64_t>*>(chunks[0]);
+        ASSERT_NE(firsts, nullptr);
+
+        const auto* seconds = dynamic_cast<const ColumnConst<int64_t>*>(chunks[1]);
+        ASSERT_NE(seconds, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.emplace_back((*firsts)[rowIndex], (*seconds)[rowIndex]);
+        }
+    }
+
+    const ConstantPairs& rows() const { return _rows; }
+
+private:
+    ConstantPairs _rows;
 };
 
 }
@@ -560,13 +610,75 @@ TEST_F(DistinctTest, dedupsPastATrailingConstant) {
     EXPECT_EQ(actual, expected);
 }
 
-// Every column of the projection is constant, so all its rows are one row repeated and
-// the dedup is left with no column to tell them apart: the one row it should keep is a
-// row count, which is not something the dedup expresses. Rejected rather than answered
-// with the repeats.
-TEST_F(DistinctTest, rejectsADistinctOverConstantsAlone) {
-    DistinctNodeSink sink;
-    EXPECT_THROW(runQuery("MATCH (n) RETURN DISTINCT 5", &sink), TuringException);
+// Every column of the projection is constant, so its 18 rows are one row repeated and
+// no column tells two of them apart: what the dedup keeps is the first row alone, which
+// codegen charges to the constants as a cap of one row rather than to a dedup keyed on a
+// column that never varies.
+TEST_F(DistinctTest, keepsOneRowOfAMatchedConstantProjection) {
+    DistinctOptInt64Sink sink;
+    runQuery("MATCH (n) RETURN DISTINCT 5", &sink);
+
+    const OptInt64Values expected = {5};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// The same projection with nothing matched, which is one row to begin with: the cap has
+// no repeat to cut and the row comes back as it is.
+TEST_F(DistinctTest, keepsTheOneRowOfAConstantProjection) {
+    DistinctConstantSink sink;
+    runQuery("RETURN DISTINCT 42", &sink);
+
+    const Int64Values expected = {42};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// An expression over constants alone is constant too, so it is capped the same way
+// rather than deduped.
+TEST_F(DistinctTest, keepsTheOneRowOfAConstantExpression) {
+    DistinctConstantSink sink;
+    runQuery("RETURN DISTINCT 40 + 2", &sink);
+
+    const Int64Values expected = {42};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// Every column of the projection is capped, not just the first: two constants are one row
+// of two columns, and the row that survives carries both.
+TEST_F(DistinctTest, keepsOneRowOfEveryConstantColumn) {
+    DistinctConstantPairSink sink;
+    runQuery("RETURN DISTINCT 5, 7", &sink);
+
+    const ConstantPairs expected = {{5, 7}};
+    EXPECT_EQ(sink.rows(), expected);
+}
+
+// The cross product emits its 44 rows over several steps of a nest, where the cap is
+// charged step by step: the row survives the first of them and every later step is left
+// with none, so the repeats do not come back one per step.
+TEST_F(DistinctTest, keepsOneRowOfAConstantProjectionAcrossANest) {
+    DistinctOptInt64Sink sink;
+    runQuery("MATCH (a)-->(b), (a)-->(c) RETURN DISTINCT 5", &sink);
+
+    const OptInt64Values expected = {5};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// A LIMIT after the dedup is charged to the row the dedup left, not to the 18 the match
+// made, so a limit of more than one row keeps that single row.
+TEST_F(DistinctTest, limitsTheOneRowOfAConstantProjection) {
+    DistinctOptInt64Sink sink;
+    runQuery("MATCH (n) RETURN DISTINCT 5 LIMIT 3", &sink);
+
+    const OptInt64Values expected = {5};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// The SKIP sibling: the deduped projection is one row, so skipping a row leaves nothing.
+TEST_F(DistinctTest, skipsTheOneRowOfAConstantProjection) {
+    DistinctOptInt64Sink sink;
+    runQuery("MATCH (n) RETURN DISTINCT 5 SKIP 1", &sink);
+
+    EXPECT_TRUE(sink.values().empty());
 }
 
 // The projection is a grouped aggregate first, so the dedup runs on its results, where a
@@ -784,6 +896,32 @@ TEST_F(DistinctTest, dedupsBeforeSorting) {
     ASSERT_EQ(distinctOp.getResults().size(), 1u);
     ASSERT_EQ(sortOp.getColumns().size(), 1u);
     EXPECT_EQ(sortOp.getColumns().front().getDefiningOp(), distinctOp.getOperation());
+}
+
+// The generated program holds no dedup at all for a projection of constants: the rows
+// are one row repeated, so a db.remove_duplicates would be keyed on columns that never
+// vary. It is a db.limit of one row instead, which is what keeps the first row.
+TEST_F(DistinctTest, capsAConstantProjectionInsteadOfDedupingIt) {
+    mlir::MLIRContext context;
+    mlir::OwningOpRef<mlir::ModuleOp> module;
+    generateProgram("MATCH (n) RETURN DISTINCT 5", context, module);
+
+    mlir::db::Limit limitOp;
+    size_t distinctCount = 0;
+    size_t limitCount = 0;
+
+    module->walk([&](mlir::Operation* operation) {
+        if (mlir::isa<mlir::db::RemoveDuplicates>(operation)) {
+            distinctCount++;
+        } else if (mlir::db::Limit found = mlir::dyn_cast<mlir::db::Limit>(operation)) {
+            limitOp = found;
+            limitCount++;
+        }
+    });
+
+    EXPECT_EQ(distinctCount, 0u);
+    ASSERT_EQ(limitCount, 1u);
+    EXPECT_EQ(limitOp.getCount(), 1u);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/LimitSkipTest.cpp
+++ b/test/query/ir/LimitSkipTest.cpp
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -33,6 +34,7 @@
 #include "SystemManager.h"
 #include "columns/ColumnConst.h"
 #include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
 #include "versioning/Transaction.h"
 #include "views/GraphView.h"
 
@@ -47,11 +49,21 @@ namespace {
 using ValueRow = std::vector<int64_t>;
 using ValueRows = std::vector<ValueRow>;
 
+// A constant a cut is charged to is laid out over the rows of the relation driving the
+// projection, so a constant column reaches the sink as a value column wherever a MATCH
+// makes its rows, and as a ColumnConst only when the projection is the one row it is.
 int64_t readValue(const Column* column, size_t row) {
     if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
         return static_cast<int64_t>((*nodeIDs)[row].getValue());
     } else if (const auto* constants = dynamic_cast<const ColumnConst<int64_t>*>(column)) {
         return (*constants)[row];
+    } else if (const auto* values = dynamic_cast<const ColumnOptVector<int64_t>*>(column)) {
+        const std::optional<int64_t>& value = values->getRaw()[row];
+        if (!value) {
+            throw std::runtime_error("LimitSkipTest: null row in a value output column");
+        }
+
+        return *value;
     }
 
     throw std::runtime_error("LimitSkipTest: unsupported output column type");
@@ -182,6 +194,56 @@ TEST_F(LimitSkipTest, constantLimitOneEmitsTheRow) {
 // The one row is the row SKIP 1 drops, so the LIMIT has nothing left to keep.
 TEST_F(LimitSkipTest, constantSkipOneLimitOneEmitsNothing) {
     expectRows("RETURN 42 SKIP 1 LIMIT 1", {});
+}
+
+// A constant beside a MATCH is one row per matched row, so the 18 nodes make 18 rows of
+// it: the cut is charged to the rows the match makes and not to the single value the
+// constant column holds.
+TEST_F(LimitSkipTest, matchedConstantLimitKeepsTheLimitedRows) {
+    const ValueRows expected = {{5}, {5}, {5}};
+    expectRows("MATCH (n) RETURN 5 LIMIT 3", expected);
+}
+
+// The SKIP sibling: 18 rows minus the first 16 leaves two of them.
+TEST_F(LimitSkipTest, matchedConstantSkipKeepsTheSurvivingRows) {
+    const ValueRows expected = {{5}, {5}};
+    expectRows("MATCH (n) RETURN 5 SKIP 16", expected);
+}
+
+TEST_F(LimitSkipTest, matchedConstantSkipLimitCutsAWindow) {
+    const ValueRows expected = {{5}, {5}};
+    expectRows("MATCH (n) RETURN 5 SKIP 1 LIMIT 2", expected);
+}
+
+// An expression over constants alone is a constant column too, and is cut the same way.
+TEST_F(LimitSkipTest, matchedConstantExpressionLimitKeepsTheLimitedRows) {
+    const ValueRows expected = {{42}, {42}, {42}};
+    expectRows("MATCH (n) RETURN 40 + 2 LIMIT 3", expected);
+}
+
+// Every constant column is cut, not just the first one the cut is charged to.
+TEST_F(LimitSkipTest, matchedConstantsLimitKeepsEveryColumn) {
+    const ValueRows expected = {{5, 7}, {5, 7}, {5, 7}};
+    expectRows("MATCH (n) RETURN 5, 7 LIMIT 3", expected);
+}
+
+// The cross product emits its 44 rows over several steps of a nest, so the budget is
+// charged step by step rather than once for the whole projection.
+TEST_F(LimitSkipTest, matchedConstantLimitAcrossANest) {
+    const ValueRows expected = {{5}, {5}, {5}, {5}, {5}};
+    expectRows("MATCH (a)-->(b), (a)-->(c) RETURN 5 LIMIT 5", expected);
+}
+
+// A limit of more rows than the match makes keeps all 18 of them.
+TEST_F(LimitSkipTest, matchedConstantLimitPastTheMatchedRowsKeepsThemAll) {
+    const ValueRows expected(18, ValueRow {5});
+    expectRows("MATCH (n) RETURN 5 LIMIT 20", expected);
+}
+
+// A skip past every matched row leaves nothing, where charging the cut to the constant
+// column would leave its one value behind.
+TEST_F(LimitSkipTest, matchedConstantSkipPastTheMatchedRowsEmitsNothing) {
+    expectRows("MATCH (n) RETURN 5 SKIP 20", {});
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Makes a projection whose columns are all constant behave like any other projection under DISTINCT, SKIP/LIMIT and plain output, including when a MATCH drives its rows.

```cypher
// on simpledb (18 nodes), rows before -> rows after
RETURN DISTINCT 42                           // error -> 1
MATCH (n) RETURN DISTINCT 5                  // error -> 1
MATCH (n) RETURN 40 + 2                      //     1 -> 18
MATCH (n) RETURN 40 % 3                      //     1 -> 18
MATCH (n) RETURN 2 ^ 3                       //     1 -> 18
MATCH (n) RETURN 5 LIMIT 3                   //     1 -> 3
MATCH (n) RETURN 5, 7 LIMIT 3                //     1 -> 3
MATCH (n) RETURN 40 + 2 LIMIT 3              //     1 -> 3
MATCH (a)-->(b), (a)-->(c) RETURN 5 LIMIT 5  //     1 -> 5
MATCH (n) RETURN 5 SKIP 16                   //     0 -> 2
MATCH (n) RETURN 5 SKIP 1 LIMIT 2            //     0 -> 2
```

A LIMIT over such a projection now also bounds the loops driving it, instead of walking the whole relation to emit k rows.
