### PR TITLE
Order a grouped projection by expressions over its grouping keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,35 @@ These are structural properties of the graph model, not validation rules layered
 - `memory/` - Memory management
 - `vector/` - Vector search with Faiss
 
+## Cypher language support
+
+**If a query is valid openCypher, implement it. Do not reject it in the analyzer.** An
+analyzer error is for queries that are genuinely ill-formed; it is never a shortcut around
+a gap in codegen. When a valid query fails somewhere downstream — a lowering assert, an
+invalid-IR error, wrong rows — the fix is to make the engine execute it. Adding a rule that
+turns it away is a regression dressed as validation: it closes the door on the feature and
+hides the gap behind a message that blames the user's query.
+
+Before writing any new analyzer rejection, establish which side of the line the query is on:
+- **Valid Cypher** → implement it. Judge by the language's semantics, not by how far the
+  current implementation happens to reach. Reference points: openCypher, Neo4j's behaviour,
+  and SQL where the construct is shared (`GROUP BY` / `ORDER BY` / `DISTINCT` scoping).
+- **Invalid Cypher** → reject it, with a message naming what is wrong with the query.
+
+Worked example — `ORDER BY` over an aggregating projection:
+- `RETURN n.age, count(n.name) ORDER BY n.age + 1` is **valid**: `n.age + 1` is functionally
+  determined by the grouping key `n.age`, exactly as SQL allows `GROUP BY age ... ORDER BY
+  age + 1`. So grouping keys are substituted into the key expression at any depth
+  (`DBProgramGenerator::bindOrderByKeyColumns`), and the key is computed over the grouped
+  column.
+- `RETURN n, count(b) ORDER BY b.name` is **invalid**: `b` is neither a grouping key nor
+  determined by one, so `b.name` has no single value per group to order on. That one is
+  rejected (`CypherAnalyzer::analyzeAggregateOrderBy`).
+
+Corollary: a rejection rule must reject *exactly* the invalid set. Probe the engine with
+the shapes on both sides of the line before writing the check, so a rule aimed at the
+invalid ones does not also turn away queries that already work.
+
 ## C++ Coding Style
 
 Please read `CODING_STYLE.md` for guidelines before any new work.

--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ast_sources
     expr/UnaryExpr.cpp
     expr/FunctionInvocationExpr.cpp
     expr/IndexExpr.cpp
+    expr/ExprChildren.cpp
     expr/StructuralExpressionComparator.cpp
 
     stmt/Stmt.cpp

--- a/query/AST/Projection.cpp
+++ b/query/AST/Projection.cpp
@@ -112,3 +112,29 @@ const Expr* Projection::findItemExpr(const Expr* key) const {
 bool Projection::hasItem(const Expr* key) const {
     return locateItem(key) != _items.end();
 }
+
+bool Projection::hasVariableItem(const VarDecl* decl) const {
+    if (!decl) {
+        return false;
+    }
+
+    for (const ReturnItem& item : _items) {
+        if (const Expr* const* itemExpr = std::get_if<Expr*>(&item)) {
+            const Expr* projectedExpr = *itemExpr;
+
+            // Only a bare variable returns the variable itself; every other item returns
+            // a value computed from it, which leaves the variable behind
+            const bool isBareVariable = projectedExpr->getKind() == Expr::Kind::SYMBOL;
+
+            if (isBareVariable && projectedExpr->getExprVarDecl() == decl) {
+                return true;
+            }
+        } else if (const VarDecl* const* itemDecl = std::get_if<VarDecl*>(&item)) {
+            if (*itemDecl == decl) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/query/AST/Projection.h
+++ b/query/AST/Projection.h
@@ -79,6 +79,7 @@ public:
     size_t findItemIndex(const Expr* key) const;
     const Expr* findItemExpr(const Expr* key) const;
     bool hasItem(const Expr* key) const;
+    bool hasVariableItem(const VarDecl* decl) const;
 
 private:
     Limit* _limit {nullptr};

--- a/query/AST/expr/ExprChildren.cpp
+++ b/query/AST/expr/ExprChildren.cpp
@@ -1,0 +1,103 @@
+#include "ExprChildren.h"
+
+#include "FunctionInvocation.h"
+
+#include "BinaryExpr.h"
+#include "Expr.h"
+#include "ExprChain.h"
+#include "FunctionInvocationExpr.h"
+#include "IndexExpr.h"
+#include "ListExpr.h"
+#include "StringExpr.h"
+#include "UnaryExpr.h"
+
+using namespace db;
+
+bool ExprChildren::collect(const Expr* expr, std::vector<const Expr*>& children) {
+    children.clear();
+
+    if (!expr) {
+        return true;
+    }
+
+    switch (expr->getKind()) {
+        case Expr::Kind::BINARY: {
+            const BinaryExpr* binary = static_cast<const BinaryExpr*>(expr);
+
+            children.push_back(binary->getLHS());
+            children.push_back(binary->getRHS());
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::UNARY: {
+            const UnaryExpr* unary = static_cast<const UnaryExpr*>(expr);
+
+            children.push_back(unary->getSubExpr());
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::STRING: {
+            const StringExpr* string = static_cast<const StringExpr*>(expr);
+
+            children.push_back(string->getLHS());
+            children.push_back(string->getRHS());
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::INDEX: {
+            const IndexExpr* index = static_cast<const IndexExpr*>(expr);
+
+            children.push_back(index->getBase());
+            children.push_back(index->getIndexExpr());
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::LIST: {
+            const ListExpr* list = static_cast<const ListExpr*>(expr);
+
+            for (const Expr* element : list->getElements()) {
+                children.push_back(element);
+            }
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::FUNCTION_INVOCATION: {
+            const FunctionInvocationExpr* call = static_cast<const FunctionInvocationExpr*>(expr);
+            const ExprChain* arguments = call->getFunctionInvocation()->getArguments();
+            if (!arguments) {
+                return true;
+            }
+
+            for (const Expr* argument : arguments->getExprs()) {
+                children.push_back(argument);
+            }
+
+            return true;
+        }
+        break;
+
+        case Expr::Kind::SYMBOL:
+        case Expr::Kind::PROPERTY:
+        case Expr::Kind::ENTITY_TYPES:
+            // A leaf as far as expressions go: what it reads is a variable, not another
+            // expression
+            return true;
+        break;
+
+        default:
+            // A path holds a pattern and a literal may hold a map, neither of which is a
+            // list of sub-expressions this can hand back
+            return false;
+        break;
+    }
+}

--- a/query/AST/expr/ExprChildren.h
+++ b/query/AST/expr/ExprChildren.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+
+namespace db {
+
+class Expr;
+
+class ExprChildren {
+public:
+    ExprChildren() = delete;
+    ~ExprChildren() = delete;
+
+    static bool collect(const Expr* expr, std::vector<const Expr*>& children);
+};
+
+}

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -34,7 +34,9 @@
 #include "Projection.h"
 #include "decl/DeclContext.h"
 #include "decl/EvaluatedType.h"
+#include "expr/EntityTypeExpr.h"
 #include "expr/Expr.h"
+#include "expr/ExprChildren.h"
 #include "expr/PropertyExpr.h"
 #include "metadata/PropertyType.h"
 #include "reader/GraphReader.h"
@@ -310,6 +312,8 @@ void CypherAnalyzer::analyze(const ReturnStmt* returnSt) {
     if (isAggregate) {
         projection->setAggregate();
         projection->setHasGroupingKeys(hasGroupingKeys);
+
+        analyzeAggregateOrderBy(projection);
     }
 }
 
@@ -360,6 +364,74 @@ void CypherAnalyzer::analyzeDistinct(const ReturnStmt* returnSt, const Projectio
             throwError("ORDER BY with DISTINCT may only order by returned columns.", keyExpr);
         }
     }
+}
+
+void CypherAnalyzer::analyzeAggregateOrderBy(const Projection* projection) const {
+    if (!projection->hasOrderBy()) {
+        return;
+    }
+
+    const OrderBy* orderBy = projection->getOrderBy();
+
+    for (const OrderByItem* item : orderBy->getItems()) {
+        const Expr* keyExpr = item->getExpr();
+
+        if (!isGroupWise(keyExpr, projection)) {
+            throwError("ORDER BY with an aggregate may only order by expressions over the "
+                       "returned columns.",
+                       keyExpr);
+        }
+    }
+}
+
+bool CypherAnalyzer::isGroupWise(const Expr* expr, const Projection* projection) const {
+    if (!expr) {
+        return true;
+    }
+
+    // A constant holds the same value in every matched row, so it holds one per group too
+    if (!expr->isDynamic()) {
+        return true;
+    }
+
+    // A grouping key holds one value per group by construction, and so does the alias of
+    // one: the projection carries that column, at whatever depth of the key it is read
+    if (projection->hasItem(expr)) {
+        return true;
+    }
+
+    const Expr::Kind kind = expr->getKind();
+
+    if (kind == Expr::Kind::PROPERTY) {
+        const PropertyExpr* property = static_cast<const PropertyExpr*>(expr);
+
+        return projection->hasVariableItem(property->getEntityVarDecl());
+    } else if (kind == Expr::Kind::ENTITY_TYPES) {
+        const EntityTypeExpr* entityType = static_cast<const EntityTypeExpr*>(expr);
+
+        return projection->hasVariableItem(entityType->getEntityVarDecl());
+    } else if (kind == Expr::Kind::SYMBOL) {
+        // A returned variable, and the alias of a returned item, are both matched above:
+        // a symbol reaching here names a variable the grouping consumed
+        return false;
+    }
+
+    std::vector<const Expr*> children;
+    if (!ExprChildren::collect(expr, children)) {
+        return false;
+    }
+
+    return isGroupWise(children, projection);
+}
+
+bool CypherAnalyzer::isGroupWise(std::span<const Expr* const> exprs, const Projection* projection) const {
+    for (const Expr* expr : exprs) {
+        if (!isGroupWise(expr, projection)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void CypherAnalyzer::analyze(OrderBy* orderBySt, const Projection* projection) {

--- a/query/analyzer/CypherAnalyzer.h
+++ b/query/analyzer/CypherAnalyzer.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <span>
 #include <string_view>
+#include <vector>
 
 #include "views/GraphView.h"
 
@@ -88,6 +90,9 @@ private:
 
     void declareItemAlias(Expr* item, std::string_view alias);
     void analyzeDistinct(const ReturnStmt* returnSt, const Projection* projection) const;
+    void analyzeAggregateOrderBy(const Projection* projection) const;
+    bool isGroupWise(const Expr* expr, const Projection* projection) const;
+    bool isGroupWise(std::span<const Expr* const> exprs, const Projection* projection) const;
 
     [[noreturn]] void throwError(std::string_view msg, const void* obj = 0) const;
 };

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -51,9 +51,11 @@
 #include "expr/BinaryExpr.h"
 #include "expr/Expr.h"
 #include "expr/ExprChain.h"
+#include "expr/ExprChildren.h"
 #include "expr/FunctionInvocationExpr.h"
 #include "expr/LiteralExpr.h"
 #include "expr/PropertyExpr.h"
+#include "expr/StructuralExpressionComparator.h"
 #include "expr/SymbolExpr.h"
 #include "expr/UnaryExpr.h"
 #include "stmt/CreateStmt.h"
@@ -2168,11 +2170,14 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
 
     const mlir::ResultRange results = groupAgg.getResults();
 
+    GroupedKeyColumns groupedKeys;
+
     for (size_t i = 0; i < keyCount; i++) {
         if (keyVarAtPos[i]) {
             registerValue(keyVarAtPos[i], results[i]);
         } else {
             _exprMap[keyExprAtPos[i]] = results[i];
+            groupedKeys.emplace_back(keyExprAtPos[i], results[i]);
 
             const bool isSymbol = keyExprAtPos[i]->getKind() == Expr::Kind::SYMBOL;
             if (not isSymbol) {
@@ -2193,5 +2198,44 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
 
     for (size_t i = 0; i < aggCount; i++) {
         _exprMap[aggFuncExprs[i]] = results[keyCount + i];
+    }
+
+    bindOrderByKeyColumns(proj, groupedKeys);
+}
+
+void DBProgramGenerator::bindOrderByKeyColumns(const Projection* projection,
+                                               const GroupedKeyColumns& groupedKeys) {
+    if (!projection->hasOrderBy() || groupedKeys.empty()) {
+        return;
+    }
+
+    const OrderBy* orderBy = projection->getOrderBy();
+
+    for (const OrderByItem* item : orderBy->getItems()) {
+        bindGroupedKeyColumn(item->getExpr(), groupedKeys);
+    }
+}
+
+void DBProgramGenerator::bindGroupedKeyColumn(const Expr* expr, const GroupedKeyColumns& groupedKeys) {
+    if (!expr || _exprMap.contains(expr)) {
+        return;
+    }
+
+    for (const auto& [keyExpr, keyColumn] : groupedKeys) {
+        // The key reads this grouping key whole, so the grouped column is what it reads:
+        // nothing below it has to be looked at, let alone translated again
+        if (StructuralExpressionComparator::equal(keyExpr, expr)) {
+            _exprMap[expr] = keyColumn;
+            return;
+        }
+    }
+
+    std::vector<const Expr*> children;
+    if (!ExprChildren::collect(expr, children)) {
+        return;
+    }
+
+    for (const Expr* child : children) {
+        bindGroupedKeyColumn(child, groupedKeys);
     }
 }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -50,6 +50,10 @@ public:
     // projection and its ORDER BY read
     using VariableColumnMap = std::unordered_map<std::string_view, mlir::Value>;
 
+    // Each grouping key expression of an aggregating projection beside the column the
+    // group aggregate reduced it to, one value per group
+    using GroupedKeyColumns = llvm::SmallVector<std::pair<const Expr*, mlir::Value>>;
+
     explicit DBProgramGenerator(mlir::ModuleOp* mainModule);
     ~DBProgramGenerator();
 
@@ -135,6 +139,12 @@ private:
     void applyPredicateFilters(std::span<const Expr* const> predicates);
 
     void generateGroupAggregate(const CypherAST* ast);
+
+    // Publishes the grouped column of every grouping key an ORDER BY key reads, so that
+    // translating the key computes over one value per group instead of re-reading the
+    // ungrouped column the group aggregate consumed
+    void bindOrderByKeyColumns(const Projection* projection, const GroupedKeyColumns& groupedKeys);
+    void bindGroupedKeyColumn(const Expr* expr, const GroupedKeyColumns& groupedKeys);
 
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -458,3 +458,24 @@ target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_aggregate_over_constant_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_order_by_aggregate_unprojected_key OrderByAggregateUnprojectedKeyTest.cpp)
+target_link_libraries(test_query_ir_order_by_aggregate_unprojected_key PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_order_by_aggregate_unprojected_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/OrderByAggregateUnprojectedKeyTest.cpp
+++ b/test/query/ir/OrderByAggregateUnprojectedKeyTest.cpp
@@ -1,0 +1,435 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "AnalyzeException.h"
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+const std::string_view droppedKeyReason =
+    "ORDER BY with an aggregate may only order by expressions over the returned columns";
+
+// A group of MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name): the source node,
+// the age it is grouped by, and how many targets it has.
+using GroupRow = std::tuple<uint64_t, std::optional<int64_t>, uint64_t>;
+using GroupRows = std::vector<GroupRow>;
+
+// The eight simpledb Persons with an out-edge, by name ascending - Adam, Cyrus, Doruk,
+// Luc, Martina, Maxime, Remy, Suhas - each with its out-degree. Only Remy and Adam carry
+// an age. Ghosts has an out-edge too but is no Person, so it is not among the groups.
+const GroupRows groupsByName = {
+    {1, 32, 3},
+    {15, std::nullopt, 2},
+    {17, std::nullopt, 1},
+    {9, std::nullopt, 2},
+    {11, std::nullopt, 1},
+    {8, std::nullopt, 2},
+    {0, 32, 4},
+    {12, std::nullopt, 2},
+};
+
+// The same groups by age then by name, the order the compound key asks for: the two aged
+// groups first, and the six the age leaves tied ordered by the second key. A null sorts
+// after every value, so the ageless groups close the order.
+const GroupRows groupsByAgeThenName = {
+    {1, 32, 3},
+    {0, 32, 4},
+    {15, std::nullopt, 2},
+    {17, std::nullopt, 1},
+    {9, std::nullopt, 2},
+    {11, std::nullopt, 1},
+    {8, std::nullopt, 2},
+    {12, std::nullopt, 2},
+};
+
+// A group of MATCH (a)-[e]->(b) RETURN e.duration, count(b.name): the duration grouped on
+// and how many edges carry it.
+using DurationRow = std::pair<std::optional<int64_t>, uint64_t>;
+using DurationRows = std::vector<DurationRow>;
+
+// The five groups the eighteen simpledb edges reduce to, by duration ascending. Ten edges
+// carry no duration, and a null sorts after every value, so they close the order.
+const DurationRows durationGroupsAscending = {
+    {10, 1},
+    {15, 1},
+    {20, 5},
+    {200, 1},
+    {std::nullopt, 10},
+};
+
+// The same groups by 0 - duration ascending. Negating reverses the four durations while
+// leaving the null group last, so this is the order no raw grouping key produces: it is
+// only reached by evaluating the key over the grouped column.
+const DurationRows durationGroupsByNegation = {
+    {200, 1},
+    {20, 5},
+    {15, 1},
+    {10, 1},
+    {std::nullopt, 10},
+};
+
+// Collects the group rows in the order the sink sees them. An ORDER BY is only correct if
+// that order survives to the output, so nothing here sorts what it collected.
+class OrderedGroupSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 3u);
+
+        const auto* sources = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        ASSERT_NE(sources, nullptr);
+
+        const auto* ages = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[1]);
+        ASSERT_NE(ages, nullptr);
+
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[2]);
+        ASSERT_NE(counts, nullptr);
+
+        const auto& ageRaw = ages->getRaw();
+        const auto& countRaw = counts->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.emplace_back((*sources)[rowIndex].getValue(), ageRaw[rowIndex], countRaw[rowIndex]);
+        }
+    }
+
+    const GroupRows& rows() const { return _rows; }
+
+private:
+    GroupRows _rows;
+};
+
+// Collects the (grouping key value, count) rows in the order the sink sees them.
+class OrderedDurationSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* durations = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        ASSERT_NE(durations, nullptr);
+
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[1]);
+        ASSERT_NE(counts, nullptr);
+
+        const auto& durationRaw = durations->getRaw();
+        const auto& countRaw = counts->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _rows.emplace_back(durationRaw[rowIndex], countRaw[rowIndex]);
+        }
+    }
+
+    const DurationRows& rows() const { return _rows; }
+
+private:
+    DurationRows _rows;
+};
+
+// Reads whatever shape it is handed, for the queries a test only has to see accepted or
+// turned away rather than check the rows of.
+class AnyShapeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+}
+
+// An ORDER BY over an aggregating projection sorts the groups, not the matched rows, so a
+// key the projection does not carry is only a key at all if it holds one value per group.
+// A key reading a returned variable holds one - a.name is fixed by the a every group is
+// keyed on - and is read off the grouped column beside the groups it orders. A key reading
+// a variable the grouping dropped holds one value per matched row instead, so it lines up
+// with nothing the projection emits and the analyzer turns the query away.
+class OrderByAggregateUnprojectedKeyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp moduleOp = module.get();
+
+        DBProgramGenerator generator(&moduleOp);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(moduleOp, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    void expectRows(std::string_view query, const GroupRows& expected) {
+        OrderedGroupSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query;
+    }
+
+    void expectDurationRows(std::string_view query, const DurationRows& expected) {
+        OrderedDurationSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query;
+    }
+
+    void expectAccepted(std::string_view query) {
+        AnyShapeSink sink;
+        EXPECT_NO_THROW(runQuery(query, &sink)) << "query: " << query;
+    }
+
+    // The query is turned away, and on the dropped key rather than on anything else the
+    // analyzer may have to say about it
+    void expectRejected(std::string_view query) {
+        AnyShapeSink sink;
+
+        try {
+            runQuery(query, &sink);
+        } catch (const AnalyzeException& error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(droppedKeyReason), std::string::npos)
+                << "query: " << query << "\nerror: " << message;
+            return;
+        }
+
+        ADD_FAILURE() << "query was accepted: " << query;
+    }
+
+    // The rows of @param expected from @param first, as many as @param count - the window
+    // a SKIP and a LIMIT cut out of an order
+    void windowOf(const GroupRows& expected, size_t first, size_t count, GroupRows& rows) {
+        rows.assign(expected.begin() + first, expected.begin() + first + count);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+// The key is neither a returned item nor one of the two grouping keys, and it reads the
+// returned variable a: one name per group, so the groups have an order to be put in.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyOverAReturnedVariable) {
+    expectRows("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name", groupsByName);
+}
+
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyOverAReturnedVariableDescending) {
+    const GroupRows expected {groupsByName.rbegin(), groupsByName.rend()};
+
+    expectRows("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name DESC", expected);
+}
+
+// A bounded sort keeps only the best k groups, so the key is carried by the trim that
+// drops the rest as well as by the emit.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyOverAReturnedVariableThenLimits) {
+    GroupRows expected;
+    windowOf(groupsByName, 0, 3, expected);
+
+    expectRows("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name LIMIT 3", expected);
+}
+
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyOverAReturnedVariableThenSkipsAndLimits) {
+    GroupRows expected;
+    windowOf(groupsByName, 2, 3, expected);
+
+    expectRows("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name SKIP 2 LIMIT 3",
+               expected);
+}
+
+// The returned grouping key first and the unreturned key second: one key is read off the
+// column the projection already carries and the other off a column of its own, and both
+// have to hold the same row per group for the second to break the first's ties.
+TEST_F(OrderByAggregateUnprojectedKeyTest, breaksTiesOnAReturnedKeyWithAnUnreturnedOne) {
+    expectRows("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.age, a.name",
+               groupsByAgeThenName);
+}
+
+// A key computing over a returned variable is one value per group just as a property of it
+// is, so what the key does with the variable is not what the rule turns on.
+TEST_F(OrderByAggregateUnprojectedKeyTest, acceptsAKeyComputedOverAReturnedVariable) {
+    expectAccepted("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.age * 2");
+}
+
+// The key is the grouping key itself, which the sort keys on where it already stands: it
+// needs no variable of its own, so e is not required to be returned beside it.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration",
+                       durationGroupsAscending);
+}
+
+// A key computing over a grouping key. The group aggregate reduced e.duration to one value
+// per group, and the key has to be computed from that column rather than from the ungrouped
+// one it was reduced from - which holds one value per edge, and lines up with no group.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyComputedOverAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration + 1",
+                       durationGroupsAscending);
+}
+
+// Adding one to every key changes no order, so the case above would also pass on a sort
+// that ignored the key and used the grouping key column beside it. Negating does reorder
+// the groups, so this is the case that pins the key as the thing being evaluated.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyThatReordersAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY 0 - e.duration",
+                       durationGroupsByNegation);
+}
+
+// The grouping key nested deeper than one operator down
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByADeeperKeyOverAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration * 2 + 1",
+                       durationGroupsAscending);
+}
+
+// An alias is another spelling of the item it names, so a key computing over one computes
+// over that item's grouped column just as spelling the item out does.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyComputedOverTheAliasOfAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration AS d, count(b.name) ORDER BY 0 - d",
+                       durationGroupsByNegation);
+}
+
+// A bounded sort keeps only the best k groups, so the computed key is carried by the trim
+// that drops the rest as well as by the emit.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAComputedKeyThenLimits) {
+    const DurationRows expected {durationGroupsByNegation.begin(), durationGroupsByNegation.begin() + 3};
+
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY 0 - e.duration LIMIT 3",
+                       expected);
+}
+
+// A constant key holds the same value in every group, so it reads no variable and orders
+// nothing.
+TEST_F(OrderByAggregateUnprojectedKeyTest, acceptsAConstantKey) {
+    expectAccepted("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY 1 + 1");
+}
+
+// Returning b groups by it too, which keeps it: the same b.name that is no key beside a
+// alone is one here, over the finer groups the second key makes.
+TEST_F(OrderByAggregateUnprojectedKeyTest, acceptsAKeyOverASecondReturnedVariable) {
+    expectAccepted("MATCH (a:Person)-[e]->(b) RETURN a, b, count(e.name) ORDER BY b.name");
+}
+
+// The key reads b, which the grouping dropped: b.name is one name per edge - seventeen of
+// them - and the projection emits eight groups, so there is no row of the output the key
+// belongs to.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAKeyOverADroppedTargetVariable) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY b.name");
+}
+
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAKeyOverADroppedEdgeVariable) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY e.duration");
+}
+
+// A bare dropped variable, rather than a property of one: the column it names is the one
+// the grouping consumed, so there is none left for the sort to key on.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsABareDroppedVariableKey) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY b");
+}
+
+// One usable key does not excuse the other: the query is rejected on the key reading the
+// dropped variable, wherever it sits among the keys.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsADroppedKeyAmongUsableOnes) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name, b.name");
+}
+
+// One key reading both a returned variable and a dropped one. The returned half is no
+// help: the key is a single column, and it cannot be computed per group.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAKeyMixingAReturnedVariableWithADroppedOne) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY a.age + b.age");
+}
+
+// The line the case above draws: a key computing over the grouping key a.age is one value
+// per group, but a.name is a second property of a variable the grouping consumed - two
+// Persons of one age have two names, so no value of the group is being asked for.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAKeyOverAVariableOnlyAPropertyOfWhichIsReturned) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a.age, count(b.name) ORDER BY a.name");
+}
+
+// Computing over a dropped variable is not saved by the arithmetic around it: b.age is one
+// value per edge whether or not one is added to it.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAComputedKeyOverADroppedVariable) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY b.age + 1");
+}
+
+// A projection with no grouping key at all emits one row for the whole match, and it keeps
+// no variable: there is nothing a dynamic key could hold one value per row of.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAKeyUnderAScalarAggregate) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN count(b.name) ORDER BY a.name");
+}
+
+// The rule is the aggregate's: without one every matched row is returned, so an unreturned
+// key is read into a column of its own and sorted with the row it belongs to.
+TEST_F(OrderByAggregateUnprojectedKeyTest, acceptsADroppedKeyWithoutAnAggregate) {
+    expectAccepted("MATCH (a:Person)-[e]->(b) RETURN a ORDER BY b.name");
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Makes ORDER BY compute over the grouped column when a key reads a grouping key at any depth, so valid Cypher like RETURN n.age, count(n.name) ORDER BY n.age + 1 executes instead of failing in lowering, and rejects only keys reading a variable the grouping dropped.

Both lists agree with Neo4j 5.26.29 community: all 15 accepted queries are accepted there and all 8 rejected ones are rejected, each with `it is not possible to access variables declared before the WITH/RETURN`. Row order matches too, nulls last in both directions.

Accepted:

```cypher
// over a grouping key expression, the shape this adds
MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration
MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration + 1
MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY 0 - e.duration
MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY e.duration * 2 + 1
MATCH (a)-[e]->(b) RETURN e.duration AS d, count(b.name) ORDER BY 0 - d
MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY 0 - e.duration LIMIT 3

// over a returned variable
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name DESC
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name LIMIT 3
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name SKIP 2 LIMIT 3
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.age, a.name
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.age * 2
MATCH (a:Person)-[e]->(b) RETURN a, b, count(e.name) ORDER BY b.name

// no variable to read, and no aggregate to group by
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY 1 + 1
MATCH (a:Person)-[e]->(b) RETURN a ORDER BY b.name
```

Rejected, each on a variable the grouping dropped:

```cypher
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY b.name
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY e.duration
MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY b
MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY a.name, b.name
MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY a.age + b.age
MATCH (a:Person)-[e]->(b) RETURN a, count(b.name) ORDER BY b.age + 1
MATCH (a:Person)-[e]->(b) RETURN count(b.name) ORDER BY a.name

// a.age groups, but a.name is a second property of a consumed variable
MATCH (a:Person)-[e]->(b) RETURN a.age, count(b.name) ORDER BY a.name
```
