### PR TITLE
MLIR: Nested/Expression aggregate logic

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -637,6 +637,19 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
         expr->setAggregate();
     }
 
+    // Nested aggregates not allowed by OpenCypher: reject here
+    bool functionIsAggregate = false;
+    for (const FunctionSignature* candidate : signatures) {
+        if (candidate->isAggregate()) {
+            functionIsAggregate = true;
+            break;
+        }
+    }
+
+    if (functionIsAggregate && isAggregate) {
+        throwError("Aggregate functions cannot be nested inside other aggregate functions", expr);
+    }
+
     // For each overload, check if the argument types match
     for (FunctionSignature* signature : signatures) {
         const auto& expectedArgs = signature->argumentTypes();

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2226,7 +2226,7 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
     llvm::SmallVector<const Expr*> keyExprAtPos;
 
     llvm::SmallVector<mlir::Value> aggInputColumns;
-    llvm::SmallVector<int64_t> aggKinds;
+    llvm::SmallVector<mlir::storage::GroupAggregateKind> aggKinds;
     llvm::SmallVector<const FunctionInvocationExpr*> aggFuncExprs;
 
     const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
@@ -2278,40 +2278,43 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
             continue;
         }
 
-        // An aggregate nested into a map makes the item an expr which is not a function
-        // invocation
-        const bool isInvocation = item->getKind() == Expr::Kind::FUNCTION_INVOCATION;
-        if (!isInvocation) {
+        // An item may carry an aggregate without being one: 2 * count(n) + 20 is an
+        // arithmetic expression the group reduces a count for, not an aggregate function
+        // it reduces whole. Its aggregates become the reduced columns, and the arithmetic
+        // around them is left for the projection to compute over the results.
+        llvm::SmallVector<const FunctionInvocationExpr*> itemAggregates;
+        if (!collectAggregateInvocations(item, itemAggregates)) {
             const std::string_view itemName = item->getName();
             throw TuringException(fmt::format("Nested aggregates are not supported: {}", itemName));
         }
 
-        const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(item);
-        const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
-        const std::string_view funcName = invocation->getSignature()->getFullName();
+        for (const FunctionInvocationExpr* funcExpr : itemAggregates) {
+            const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
+            const std::string_view funcName = invocation->getSignature()->getFullName();
 
-        const std::optional<mlir::storage::GroupAggregateKind> kind = mlir::storage::symbolizeGroupAggregateKind(funcName);
-        if (!kind) {
-            throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
+            const std::optional<mlir::storage::GroupAggregateKind> kind = mlir::storage::symbolizeGroupAggregateKind(funcName);
+            if (!kind) {
+                throw TuringException(fmt::format("Unsupported aggregate function: {}", funcName));
+            }
+
+            const ExprChain* args = invocation->getArguments();
+            bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
+
+            const Expr* argExpr = args->front();
+            mlir::Value inputColumn;
+
+            if (argExpr->getType() == EvaluatedType::Wildcard) {
+                inputColumn = resolveWildcardColumn();
+                bioassert(inputColumn, "count(*) over no column holding the rows it counts.");
+            } else {
+                translateExpr(argExpr);
+                inputColumn = _exprMap.at(argExpr);
+            }
+
+            aggInputColumns.push_back(inputColumn);
+            aggKinds.push_back(*kind);
+            aggFuncExprs.push_back(funcExpr);
         }
-
-        const ExprChain* args = invocation->getArguments();
-        bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
-
-        const Expr* argExpr = args->front();
-        mlir::Value inputColumn;
-
-        if (argExpr->getType() == EvaluatedType::Wildcard) {
-            inputColumn = resolveWildcardColumn();
-            bioassert(inputColumn, "count(*) over no column holding the rows it counts.");
-        } else {
-            translateExpr(argExpr);
-            inputColumn = _exprMap.at(argExpr);
-        }
-
-        aggInputColumns.push_back(inputColumn);
-        aggKinds.push_back(static_cast<int64_t>(*kind));
-        aggFuncExprs.push_back(funcExpr);
     }
 
     const size_t keyCount = keyColumns.size();
@@ -2341,12 +2344,17 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
         resultTypes.push_back(noneType);
     }
 
+    llvm::SmallVector<int64_t> aggKindValues;
+    for (const mlir::storage::GroupAggregateKind kind : aggKinds) {
+        aggKindValues.push_back(static_cast<int64_t>(kind));
+    }
+
     auto groupAgg = _opBuilder.create<mlir::db::GroupAggregate>(
         loc,
         mlir::TypeRange{resultTypes},
         mlir::ValueRange{allColumns},
         static_cast<uint64_t>(keyCount),
-        llvm::ArrayRef<int64_t>{aggKinds});
+        llvm::ArrayRef<int64_t>{aggKindValues});
 
     const mlir::ResultRange results = groupAgg.getResults();
 
@@ -2418,4 +2426,36 @@ void DBProgramGenerator::bindGroupedKeyColumn(const Expr* expr, const GroupedKey
     for (const Expr* child : children) {
         bindGroupedKeyColumn(child, groupedKeys);
     }
+}
+
+bool DBProgramGenerator::collectAggregateInvocations(const Expr* expr,
+                                                     llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found) {
+    if (!expr->isAggregate()) {
+        return true;
+    }
+
+    if (expr->getKind() == Expr::Kind::FUNCTION_INVOCATION) {
+        const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(expr);
+        const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
+
+        // An aggregate over an aggregate is invalid Cypher the analyzer turns away, so a
+        // reduced call is a leaf: its argument is the group's input, not another aggregate
+        if (invocation->getSignature()->isAggregate()) {
+            found.push_back(funcExpr);
+            return true;
+        }
+    }
+
+    std::vector<const Expr*> children;
+    if (!ExprChildren::collect(expr, children)) {
+        return false;
+    }
+
+    for (const Expr* child : children) {
+        if (!collectAggregateInvocations(child, found)) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -154,6 +154,9 @@ private:
     void bindOrderByKeyColumns(const Projection* projection, const GroupedKeyColumns& groupedKeys);
     void bindGroupedKeyColumn(const Expr* expr, const GroupedKeyColumns& groupedKeys);
 
+    bool collectAggregateInvocations(const Expr* expr,
+                                     llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found);
+
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);
     void translateBinaryExpr(const Expr* expr, const BinaryExpr* binExpr);

--- a/test/query-test-suite/tests/nested-counts.json
+++ b/test/query-test-suite/tests/nested-counts.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "MATCH (n) RETURN COUNT(COUNT(n))",
   "expect": {
-    "plan": "flowchart TD\n    0[\"`\n        __SCAN_NODES__\n    `\"]\n    1[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    2[\"`\n        __FILTER_NODE__\n    `\"]\n    3[\"`\n        __AGGREGATE_EVAL__\n        __aggregate_func__: count\n    `\"]\n    4[\"`\n        __AGGREGATE_EVAL__\n        __aggregate_func__: count\n    `\"]\n    5[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->4\n    2-->1\n    3-->5\n    4-->3",
-    "result": "COUNT(COUNT(n))\n1",
-    "resultJson": "{\"header\":{\"column_names\":[\"COUNT(COUNT(n))\"],\"column_types\":[\"UInt64\"]},\"data\":[[[1]]]}"
+    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) RETURN COUNT(COUNT(n))\n       |                  ^^^^^^^^^^^^^^^\n-------* Aggregate functions cannot be nested inside other aggregate functions",
+    "result": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) RETURN COUNT(COUNT(n))\n       |                  ^^^^^^^^^^^^^^^\n-------* Aggregate functions cannot be nested inside other aggregate functions",
+    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n) RETURN COUNT(COUNT(n))\\n       |                  ^^^^^^^^^^^^^^^\\n-------* Aggregate functions cannot be nested inside other aggregate functions\"}"
   },
   "tags": [],
   "write-required": false

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -294,6 +294,48 @@ target_link_libraries(test_query_ir_arithmetic_ext PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_arithmetic_ext PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_group_aggregate_arithmetic GroupAggregateArithmeticTest.cpp)
+target_link_libraries(test_query_ir_group_aggregate_arithmetic PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_group_aggregate_arithmetic PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_group_aggregate_expression GroupAggregateExpressionTest.cpp)
+target_link_libraries(test_query_ir_group_aggregate_expression PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_group_aggregate_expression PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_distinct DistinctTest.cpp)
 target_link_libraries(test_query_ir_distinct PRIVATE
         turing_db_s

--- a/test/query/ir/GroupAggregateArithmeticTest.cpp
+++ b/test/query/ir/GroupAggregateArithmeticTest.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Collects the (nullable int64 grouping key, uint64 value) rows a grouped aggregate whose
+// value is arithmetic over a count emits: a nullable i64 key chunk and a non-null ui64
+// value chunk. 2 * count(n) + 20 and count(n) + 1 both promote to a non-null ui64 because
+// count is a ui64 and every other operand is a non-null integer literal.
+class GroupIntValueSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<int64_t>, uint64_t>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* keys = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[0]);
+        const auto* values = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[1]);
+        ASSERT_NE(keys, nullptr);
+        ASSERT_NE(values, nullptr);
+        ASSERT_EQ(keys->size(), values->size());
+
+        const auto& keyRaw = keys->getRaw();
+        const auto& valueRaw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            std::optional<int64_t> key;
+            if (keyRaw[rowIndex]) {
+                key = *keyRaw[rowIndex];
+            }
+
+            _rows.push_back({key, valueRaw[rowIndex]});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+}
+
+// A grouped aggregate whose projection item wraps the aggregate in arithmetic: the group
+// reduces the count and the surrounding 2 * ... + 20 is computed over the per-group result,
+// the grouped analogue of the scalar RETURN 2 * count(n) + 20 that already works.
+class GroupAggregateArithmeticTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp moduleOp = module.get();
+
+        DBProgramGenerator generator(&moduleOp);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(moduleOp, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+// simpledb has eight Person nodes; only Remy and Adam carry an age (32), so grouping on
+// n.age forms two groups: age 32 with count 2, and the null-age group with count 6.
+// 2 * count + 20 is therefore 24 for the 32 group and 32 for the null-age group.
+TEST_F(GroupAggregateArithmeticTest, scalesAndOffsetsACountPerGroup) {
+    GroupIntValueSink sink;
+    runQuery("MATCH (n:Person) RETURN n.age, 2 * count(n) + 20", &sink);
+
+    std::vector<GroupIntValueSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<GroupIntValueSink::Row> expected {{std::nullopt, 32}, {32, 24}};
+    EXPECT_EQ(rows, expected);
+}
+
+// The same grouping through a lighter expression: count + 1 is 3 for the age-32 group
+// (count 2) and 7 for the null-age group (count 6).
+TEST_F(GroupAggregateArithmeticTest, incrementsACountPerGroup) {
+    GroupIntValueSink sink;
+    runQuery("MATCH (n:Person) RETURN n.age, count(n) + 1", &sink);
+
+    std::vector<GroupIntValueSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<GroupIntValueSink::Row> expected {{std::nullopt, 7}, {32, 3}};
+    EXPECT_EQ(rows, expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/GroupAggregateExpressionTest.cpp
+++ b/test/query/ir/GroupAggregateExpressionTest.cpp
@@ -1,0 +1,335 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnConst.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "metadata/PropertyType.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/GraphWriter.h"
+
+#include "TuringException.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Reads one cell of a numeric output column as a double, whatever integer/float width and
+// nullability the arithmetic resolved to (count is ui64, a sum is a nullable i64, avg is a
+// f64, and mixing them promotes), so a test can assert values without predicting the exact
+// column type of every expression. Returns nullopt for a null cell.
+std::optional<double> readNumeric(const Column* column, size_t row) {
+    if (const auto* c = dynamic_cast<const ColumnVector<int64_t>*>(column)) {
+        return static_cast<double>(c->getRaw()[row]);
+    } else if (const auto* c = dynamic_cast<const ColumnVector<uint64_t>*>(column)) {
+        return static_cast<double>(c->getRaw()[row]);
+    } else if (const auto* c = dynamic_cast<const ColumnVector<double>*>(column)) {
+        return c->getRaw()[row];
+    } else if (const auto* c = dynamic_cast<const ColumnOptVector<int64_t>*>(column)) {
+        const auto& value = c->getRaw()[row];
+        return value ? std::optional<double>(static_cast<double>(*value)) : std::nullopt;
+    } else if (const auto* c = dynamic_cast<const ColumnOptVector<uint64_t>*>(column)) {
+        const auto& value = c->getRaw()[row];
+        return value ? std::optional<double>(static_cast<double>(*value)) : std::nullopt;
+    } else if (const auto* c = dynamic_cast<const ColumnOptVector<double>*>(column)) {
+        const auto& value = c->getRaw()[row];
+        return value ? std::optional<double>(*value) : std::nullopt;
+    } else if (const auto* c = dynamic_cast<const ColumnConst<int64_t>*>(column)) {
+        return static_cast<double>((*c)[row]);
+    } else if (const auto* c = dynamic_cast<const ColumnConst<uint64_t>*>(column)) {
+        return static_cast<double>((*c)[row]);
+    } else if (const auto* c = dynamic_cast<const ColumnConst<double>*>(column)) {
+        return (*c)[row];
+    }
+
+    ADD_FAILURE() << "unrecognized numeric column type";
+    return std::nullopt;
+}
+
+std::optional<std::string> readStringKey(const Column* column, size_t row) {
+    if (const auto* c = dynamic_cast<const ColumnOptVector<std::string_view>*>(column)) {
+        const auto& value = c->getRaw()[row];
+        return value ? std::optional<std::string>(std::string(*value)) : std::nullopt;
+    } else if (const auto* c = dynamic_cast<const ColumnVector<std::string_view>*>(column)) {
+        return std::string(c->getRaw()[row]);
+    }
+
+    ADD_FAILURE() << "unrecognized key column type";
+    return std::nullopt;
+}
+
+// Collects the rows a grouped projection emits as (string key, one double-or-null per value
+// column), so any RETURN n.team, <exprs...> can be asserted order-independently regardless
+// of how many value columns it carries or what numeric type each resolved to.
+class GroupExprSink : public NLOutputSink {
+public:
+    using Row = std::pair<std::optional<std::string>, std::vector<std::optional<double>>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_GE(chunks.size(), 2u);
+
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            std::optional<std::string> key = readStringKey(chunks[0], row);
+
+            std::vector<std::optional<double>> values;
+            for (size_t column = 1; column < chunks.size(); column++) {
+                values.push_back(readNumeric(chunks[column], row));
+            }
+
+            _rows.push_back({key, values});
+        }
+    }
+
+    void sortedRows(std::vector<Row>& rows) const {
+        rows = _rows;
+        std::sort(rows.begin(), rows.end());
+    }
+
+private:
+    std::vector<Row> _rows;
+};
+
+}
+
+// A matrix of grouped aggregations whose projection items combine aggregates and arithmetic
+// every way round: several aggregates in one item, several items each with one, arithmetic
+// inside an aggregate's argument, and nestings of both. Two teams with hand-derivable
+// reductions (a null score inside "red" so per-group null handling is exercised) let each
+// permutation assert exact per-group values, and the aggregate-in-aggregate cases assert the
+// rejection of that invalid openCypher.
+class GroupAggregateExpressionTest : public TuringTest {
+protected:
+    using Row = GroupExprSink::Row;
+
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        buildTeamGraph(_graph);
+    }
+
+    // Five nodes over two teams. "red" holds scores 10, 20 and a third node with no score
+    // (a null inside the group), with bonuses 1, 2, 3; "blue" holds scores 100, 50 with
+    // bonuses 10, 20. So per team: count(n) is 3 / 2, count(n.score) is 2 / 2, sum(score)
+    // is 30 / 150, min 10 / 50, max 20 / 100, avg 15.0 / 75.0, sum(bonus) 6 / 30.
+    void buildTeamGraph(Graph* graph) {
+        JobSystem jobSystem;
+        jobSystem.init();
+
+        GraphWriter writer(graph, &jobSystem);
+
+        const NodeID red1 = writer.addNode({"N"});
+        writer.addNodeProperty<types::String>(red1, "team", "red");
+        writer.addNodeProperty<types::Int64>(red1, "score", 10);
+        writer.addNodeProperty<types::Int64>(red1, "bonus", 1);
+
+        const NodeID red2 = writer.addNode({"N"});
+        writer.addNodeProperty<types::String>(red2, "team", "red");
+        writer.addNodeProperty<types::Int64>(red2, "score", 20);
+        writer.addNodeProperty<types::Int64>(red2, "bonus", 2);
+
+        const NodeID red3 = writer.addNode({"N"});
+        writer.addNodeProperty<types::String>(red3, "team", "red");
+        writer.addNodeProperty<types::Int64>(red3, "bonus", 3);
+
+        const NodeID blue1 = writer.addNode({"N"});
+        writer.addNodeProperty<types::String>(blue1, "team", "blue");
+        writer.addNodeProperty<types::Int64>(blue1, "score", 100);
+        writer.addNodeProperty<types::Int64>(blue1, "bonus", 10);
+
+        const NodeID blue2 = writer.addNode({"N"});
+        writer.addNodeProperty<types::String>(blue2, "team", "blue");
+        writer.addNodeProperty<types::Int64>(blue2, "score", 50);
+        writer.addNodeProperty<types::Int64>(blue2, "bonus", 20);
+
+        writer.submit();
+
+        jobSystem.terminate();
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp moduleOp = module.get();
+
+        DBProgramGenerator generator(&moduleOp);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(moduleOp, &view, sink, &memory);
+        interpreter.run();
+    }
+
+    void expectRows(std::string_view query, const std::vector<Row>& expected) {
+        GroupExprSink sink;
+        runQuery(query, &sink);
+
+        std::vector<Row> rows;
+        sink.sortedRows(rows);
+
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    void expectRejected(std::string_view query) {
+        GroupExprSink sink;
+        EXPECT_THROW(runQuery(query, &sink), TuringException) << "query: " << query;
+    }
+
+    static Row row(std::string key, std::vector<std::optional<double>> values) {
+        return Row {std::optional<std::string>(std::move(key)), std::move(values)};
+    }
+
+    const std::string _graphName = "teams";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+// Baseline: the grouped count these permutations build on, with no arithmetic around it.
+TEST_F(GroupAggregateExpressionTest, groupedCountBaseline) {
+    expectRows("MATCH (n) RETURN n.team, count(n)", {row("blue", {2}), row("red", {3})});
+}
+
+// One aggregate wrapped in arithmetic across several separate items.
+TEST_F(GroupAggregateExpressionTest, oneAggregatePerItemAcrossItems) {
+    expectRows("MATCH (n) RETURN n.team, count(n) + 1, sum(n.score) * 2",
+               {row("blue", {3, 300}), row("red", {4, 60})});
+}
+
+// Several aggregates combined inside a single item.
+TEST_F(GroupAggregateExpressionTest, multipleAggregatesInOneItem) {
+    expectRows("MATCH (n) RETURN n.team, count(n) + sum(n.score)",
+               {row("blue", {152}), row("red", {33})});
+
+    expectRows("MATCH (n) RETURN n.team, sum(n.score) + min(n.score) + max(n.score)",
+               {row("blue", {300}), row("red", {60})});
+}
+
+// Several items, each mixing aggregates and arithmetic differently.
+TEST_F(GroupAggregateExpressionTest, multipleAggregatesAcrossMultipleItems) {
+    expectRows("MATCH (n) RETURN n.team, sum(n.score) * 2, max(n.score) - min(n.score), count(n)",
+               {row("blue", {300, 50, 2}), row("red", {60, 10, 3})});
+}
+
+// The aggregate's argument is itself an expression, reduced per group.
+TEST_F(GroupAggregateExpressionTest, expressionInsideAnAggregate) {
+    expectRows("MATCH (n) RETURN n.team, sum(n.score * 2)",
+               {row("blue", {300}), row("red", {60})});
+
+    expectRows("MATCH (n) RETURN n.team, sum(n.score + n.bonus)",
+               {row("blue", {180}), row("red", {33})});
+
+    expectRows("MATCH (n) RETURN n.team, max(n.score + 5), min(n.score + 5)",
+               {row("blue", {105, 55}), row("red", {25, 15})});
+}
+
+// count over an expression counts only its non-null values: red's null score drops out.
+TEST_F(GroupAggregateExpressionTest, countOverAnExpressionIgnoresNulls) {
+    expectRows("MATCH (n) RETURN n.team, count(n.score + n.bonus)",
+               {row("blue", {2}), row("red", {2})});
+}
+
+// Expression-in-aggregate and multiple aggregates combined in the same projection.
+TEST_F(GroupAggregateExpressionTest, expressionInsideAggregateBesideOtherAggregates) {
+    expectRows("MATCH (n) RETURN n.team, sum(n.score * 2) + count(n.score), max(n.score) - min(n.score)",
+               {row("blue", {302, 50}), row("red", {62, 10})});
+}
+
+// Aggregates buried inside a compound arithmetic expression.
+TEST_F(GroupAggregateExpressionTest, aggregatesInsideCompoundArithmetic) {
+    expectRows("MATCH (n) RETURN n.team, (count(n) + sum(n.score)) * 2",
+               {row("blue", {304}), row("red", {66})});
+
+    expectRows("MATCH (n) RETURN n.team, sum(n.score) + sum(n.bonus) * 2",
+               {row("blue", {210}), row("red", {42})});
+}
+
+// The same aggregate appearing twice in one expression.
+TEST_F(GroupAggregateExpressionTest, sameAggregateTwiceInOneExpression) {
+    expectRows("MATCH (n) RETURN n.team, count(n) * count(n)",
+               {row("blue", {4}), row("red", {9})});
+}
+
+// A floating-point aggregate (avg) carried through arithmetic.
+TEST_F(GroupAggregateExpressionTest, floatingPointAggregateInArithmetic) {
+    expectRows("MATCH (n) RETURN n.team, avg(n.score) + 0.5",
+               {row("blue", {75.5}), row("red", {15.5})});
+}
+
+// Every permutation at once in one item: three distinct aggregates, two of them over an
+// expression, folded into an outer arithmetic expression. red is 60 + 25 * 1 = 85; blue is
+// 300 + 105 * 10 = 1350.
+TEST_F(GroupAggregateExpressionTest, deepPermutationInOneItem) {
+    expectRows("MATCH (n) RETURN n.team, sum(n.score * 2) + max(n.score + 5) * min(n.bonus)",
+               {row("blue", {1350}), row("red", {85})});
+}
+
+// Aggregate-in-aggregate is invalid openCypher and must be turned away, grouped or scalar.
+TEST_F(GroupAggregateExpressionTest, rejectsAggregateInsideAggregate) {
+    expectRejected("MATCH (n) RETURN n.team, count(sum(n.score))");
+    expectRejected("MATCH (n) RETURN n.team, sum(count(n))");
+    expectRejected("MATCH (n) RETURN n.team, sum(n.score + count(n))");
+    expectRejected("MATCH (n) RETURN count(sum(n.score))");
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/NestedAggregateProjectionTest.cpp
+++ b/test/query/ir/NestedAggregateProjectionTest.cpp
@@ -133,8 +133,12 @@ TEST_F(NestedAggregateProjectionTest, rejectsAMapHoldingAnAggregateBesideAGroupi
     expectRejected("MATCH (n:Person) RETURN n.name, {total: count(n)}", nestedAggregateReason);
 }
 
-TEST_F(NestedAggregateProjectionTest, rejectsAnAggregateInsideAnExpression) {
-    expectRejected("MATCH (n:Person) RETURN n.name, count(n) + 1", nestedAggregateReason);
+// An aggregate wrapped in arithmetic is valid openCypher - count(n) + 1 is the group's
+// count read through one more computation, the grouped analogue of the scalar count(n) + 1.
+// The grouped aggregate registers the count and leaves the arithmetic to the projection.
+TEST_F(NestedAggregateProjectionTest, generatesAnAggregateInsideAnExpression) {
+    EXPECT_NO_THROW(generateProgram("MATCH (n:Person) RETURN n.name, count(n) + 1"));
+    EXPECT_NO_THROW(generateProgram("MATCH (n:Person) RETURN n.name, 2 * count(n) + 20"));
 }
 
 TEST_F(NestedAggregateProjectionTest, rejectsAListHoldingAnAggregateBesideAGroupingKey) {


### PR DESCRIPTION
Prior to this PR, expressions that contained aggregates were not treated as aggregates.

This PR adds logic to ensure that aggregates and grouping keys that are nested in an arbitrary expression are generated correctly.