### PR TITLE
MLIR: fix SKIP and LIMIT over a cross product dropping rows

### DIFF
--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -386,6 +386,15 @@ bool reducesToOneRow(mlir::Operation* operation) {
                      mlir::db::Avg>(operation);
 }
 
+// Passes some of its rows on and keeps the rest back, so the rows reaching a cut below it
+// are fewer than the rows a producer above it made
+bool dropsRows(mlir::Operation* operation) {
+    return mlir::isa<mlir::db::FilterOp,
+                     mlir::db::Skip,
+                     mlir::db::Limit,
+                     mlir::db::RemoveDuplicates>(operation);
+}
+
 }
 
 DBLowering::DBLowering(mlir::MLIRContext* context, const GraphView* view)
@@ -471,7 +480,7 @@ mlir::func::FuncOp DBLowering::lower(mlir::func::FuncOp dbFunction, mlir::Module
 
         bool producedByALoop = false;
         for (const mlir::Value column : limit.getColumns()) {
-            producedByALoop |= assignProducerLoops(column, handle);
+            producedByALoop |= assignProducerLoops(column, handle, /*rowsDroppedBeforeTheCut=*/false);
         }
 
         // A cut over constants alone walks back to no loop at all - the constants are
@@ -1607,7 +1616,9 @@ void DBLowering::lowerUnwindCollect(mlir::db::UnwindCollect unwindCollect) {
     buildLoopForSource(unwindCollectOp.getResult(), unwindCollect.getOperation());
 }
 
-bool DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
+bool DBLowering::assignProducerLoops(mlir::Value column,
+                                     mlir::Value handle,
+                                     bool rowsDroppedBeforeTheCut) {
     mlir::Operation* const definingOp = column.getDefiningOp();
     if (!definingOp) {
         // A cross-product factor's loop variable is a block argument with no
@@ -1626,15 +1637,28 @@ bool DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
 
     bool reachedALoop = opensLoop || isCrossProduct || emitsThroughLoop;
 
+    // A loop's budget only stops it from taking another step, so bounding one never trims
+    // the step it is in. A cross product's budget cuts the product itself, which stands
+    // only while every row it makes reaches the output: an op below the cut that drops rows
+    // - a filter, a skip, a dedup - would leave it discarding rows that would have
+    // survived, and the cut short of its count. So the product keeps the handle only on a
+    // path that drops nothing; its factor loops take it either way.
+    // Declining the handle is not the same as reaching no loop: a cross product is still a
+    // producer the walk found, so reachedALoop stands and the cut keeps its nest.
+    const bool boundsCrossProduct = isCrossProduct && !rowsDroppedBeforeTheCut;
+    const bool takesTheHandle = opensLoop || boundsCrossProduct || emitsThroughLoop;
+
     // The first limit, in program order, to claim a producer wins, so a loop
     // shared by two limits' nests carries the outer one and never two handles.
-    if (reachedALoop && !_loopLimitHandle.count(definingOp)) {
+    if (takesTheHandle && !_loopLimitHandle.count(definingOp)) {
         _loopLimitHandle[definingOp] = handle;
     }
 
     if (breaksPipeline) {
         return reachedALoop;
     }
+
+    const bool rowsDropped = rowsDroppedBeforeTheCut || dropsRows(definingOp);
 
     if (isCrossProduct) {
         // A cross product takes no column operands - its factors are regions - so
@@ -1645,14 +1669,14 @@ bool DBLowering::assignProducerLoops(mlir::Value column, mlir::Value handle) {
         for (mlir::Region* const factor : factors) {
             mlir::Operation* const yield = factor->front().getTerminator();
             for (const mlir::Value yielded : yield->getOperands()) {
-                reachedALoop |= assignProducerLoops(yielded, handle);
+                reachedALoop |= assignProducerLoops(yielded, handle, rowsDropped);
             }
         }
     } else {
         // A non-loop producer (a property fetch) is traversed but not assigned -
         // it opens no loop - so its input chunk's loop is still reached.
         for (const mlir::Value operand : definingOp->getOperands()) {
-            reachedALoop |= assignProducerLoops(operand, handle);
+            reachedALoop |= assignProducerLoops(operand, handle, rowsDropped);
         }
     }
 
@@ -1666,7 +1690,10 @@ void DBLowering::assignCardinalityDriverLoop(mlir::db::Limit limit, mlir::Value 
     // are the ones nl.output emits the constants over, so they are the rows this budget
     // cuts. A reduction in between leaves no such loop - it emits its one row at function
     // scope, and the relation behind it had to be read in full to reduce it.
+    // A row-dropping op only matters once the driver is behind it: what it drops are the
+    // driver's rows, which is what bars a cross-product driver from the budget.
     mlir::Operation* driver = nullptr;
+    bool rowsDropped = false;
     for (mlir::Operation& operation : *limitOp->getBlock()) {
         if (&operation == limitOp) {
             break;
@@ -1674,8 +1701,11 @@ void DBLowering::assignCardinalityDriverLoop(mlir::db::Limit limit, mlir::Value 
 
         if (opensRowLoop(&operation)) {
             driver = &operation;
+            rowsDropped = false;
         } else if (reducesToOneRow(&operation)) {
             driver = nullptr;
+        } else if (dropsRows(&operation)) {
+            rowsDropped = true;
         }
     }
 
@@ -1683,7 +1713,7 @@ void DBLowering::assignCardinalityDriverLoop(mlir::db::Limit limit, mlir::Value 
         return;
     }
 
-    assignProducerLoops(driver->getResult(0), handle);
+    assignProducerLoops(driver->getResult(0), handle, rowsDropped);
 }
 
 void DBLowering::foldTruncatesIntoOutputs(mlir::func::FuncOp nlFunction) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -308,7 +308,9 @@ private:
     // its input chunk's loop. The first limit to claim a producer keeps it.
     // Returns whether the walk reached a loop at all: a column computed from constants
     // alone is produced by none, which is what sends the handle to the driving relation.
-    bool assignProducerLoops(mlir::Value column, mlir::Value handle);
+    // @param rowsDroppedBeforeTheCut is set once the walk has passed an op that
+    // drops rows, which bars the handle from a cross product below it.
+    bool assignProducerLoops(mlir::Value column, mlir::Value handle, bool rowsDroppedBeforeTheCut);
 
     // Records that the loops producing the relation which drives @param limit's projection
     // carry its handle, so a cut charged to constants alone stops its nest as any other

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -147,6 +147,27 @@ target_link_libraries(test_query_ir_order_by PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_order_by PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_cross_product_cut CrossProductCutTest.cpp)
+target_link_libraries(test_query_ir_cross_product_cut PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_cross_product_cut PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_order_by_alias_key OrderByAliasKeyTest.cpp)
 target_link_libraries(test_query_ir_order_by_alias_key PRIVATE
         turing_db_s

--- a/test/query/ir/CrossProductCutTest.cpp
+++ b/test/query/ir/CrossProductCutTest.cpp
@@ -1,0 +1,345 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = std::vector<std::string>;
+using Rows = std::vector<Row>;
+
+// SimpleGraph's nodes are scanned in ID order, so a cross product of two node scans emits
+// outer-major over this sequence: every b for a = Remy, then every b for a = Adam, and so
+// on. The first five are enough for every expectation below.
+const char* const remy = "Remy";
+const char* const adam = "Adam";
+const char* const computers = "Computers";
+const char* const eighties = "Eighties";
+
+// Remy (0) and Adam (1) are the only nodes carrying an age, and both are 32, so a filter on
+// age = 32 keeps exactly those two on whichever side it is written.
+const Rows agedPairs = {
+    {remy, remy}, {remy, adam}, {adam, remy}, {adam, adam},
+};
+
+class NameRowSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* const column : chunks) {
+                const auto* names = dynamic_cast<const ColumnOptVector<std::string_view>*>(column);
+                if (!names) {
+                    throw TuringException("CrossProductCutTest: expected a string property column");
+                }
+
+                const std::optional<std::string_view>& name = (*names)[rowIndex];
+                row.push_back(name ? std::string(*name) : "null");
+            }
+        }
+    }
+
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
+};
+
+}
+
+// SKIP and LIMIT over a cross product, through the MLIR frontend: each query is parsed,
+// analyzed, generated into the db dialect, then lowered and interpreted, so the assertions
+// are the rows a query returns.
+//
+// A cross product is bounded by the limit budget so the nest can stop early, and that
+// bound truncates the product itself. It is only sound while every produced row reaches
+// the output: a filter, a skip or a dedup between the two drops rows, and a product cut to
+// the budget has then thrown away rows that would have survived. These tests pin the row
+// counts on both sides of that line.
+class CrossProductCutTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, Rows& rows, size_t chunkSize) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        NameRowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+
+        rows = sink.rows();
+    }
+
+    void expectRows(std::string_view query,
+                    const Rows& expected,
+                    size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        Rows actual;
+        runQuery(query, actual, chunkSize);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    // The row count alone, for windows over the unfiltered product's 324 rows, where
+    // spelling every pair out would say nothing the count does not.
+    void expectRowCount(std::string_view query,
+                        size_t expected,
+                        size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        Rows actual;
+        runQuery(query, actual, chunkSize);
+
+        EXPECT_EQ(actual.size(), expected) << "query: " << query;
+    }
+
+    // The first `count` pairs of `rows`
+    static Rows prefix(const Rows& rows, size_t count) {
+        return Rows(rows.begin(), rows.begin() + count);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(CrossProductCutTest, emitsEveryFilteredPair) {
+    // The baseline the windows below cut into: two aged nodes on each side, four pairs.
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name", agedPairs);
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsToOne) {
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 1",
+               prefix(agedPairs, 1));
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsToTwo) {
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 2",
+               prefix(agedPairs, 2));
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsPastTheFirstOuterRow) {
+    // Three rows reach past the first outer node's pairs, so the nest may not stop once the
+    // product has made three rows - the filter dropped some of those.
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 3",
+               prefix(agedPairs, 3));
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsToTheirWholeCount) {
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 4",
+               agedPairs);
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsPastTheirWholeCount) {
+    // A budget wider than the relation keeps every row rather than padding or stopping short.
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 9",
+               agedPairs);
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsToNone) {
+    const Rows expected = {};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 0",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, skipsTheFirstFilteredPair) {
+    const Rows expected = {{remy, adam}, {adam, remy}, {adam, adam}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 1",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, skipsPastTheFirstOuterRowOfFilteredPairs) {
+    const Rows expected = {{adam, remy}, {adam, adam}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 2",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, skipsEveryFilteredPair) {
+    const Rows expected = {};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 4",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfTheFilteredPairs) {
+    // The window straddles the first outer node's pairs and the second's, so neither cut may
+    // be charged the rows the filter dropped.
+    const Rows expected = {{remy, adam}, {adam, remy}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 1 LIMIT 2",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowPastTheFirstOuterRowOfFilteredPairs) {
+    const Rows expected = {{adam, remy}, {adam, adam}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 2 LIMIT 2",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowRunningOffTheEndOfTheFilteredPairs) {
+    const Rows expected = {{adam, adam}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 3 LIMIT 2",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, limitsThePairsOfAFilteredInnerFactor) {
+    // The filter is on the inner factor alone: every one of the eighteen outer nodes pairs
+    // with the two aged ones, so the product makes far more rows than survive.
+    const Rows expected = {{remy, remy}, {remy, adam}, {adam, remy}};
+    expectRows("MATCH (a), (b) WHERE b.age = 32 RETURN a.name, b.name LIMIT 3", expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfAFilteredInnerFactor) {
+    const Rows expected = {{adam, remy}, {adam, adam}};
+    expectRows("MATCH (a), (b) WHERE b.age = 32 RETURN a.name, b.name SKIP 2 LIMIT 2", expected);
+}
+
+TEST_F(CrossProductCutTest, limitsThePairsOfAFilteredOuterFactor) {
+    // The mirror image: filtering the outer factor drops nothing after the product, since
+    // the inner loop only ever runs for a surviving outer row.
+    const Rows expected = {{remy, remy}, {remy, adam}, {remy, computers}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 RETURN a.name, b.name LIMIT 3", expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfAFilteredOuterFactor) {
+    const Rows expected = {{remy, adam}, {remy, computers}, {remy, eighties}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 RETURN a.name, b.name SKIP 1 LIMIT 3", expected);
+}
+
+TEST_F(CrossProductCutTest, limitsTheUnfilteredPairs) {
+    // Nothing drops rows here, so the product may be cut to the budget: the case the bound
+    // exists for.
+    const Rows expected = {{remy, remy}, {remy, adam}, {remy, computers}};
+    expectRows("MATCH (a), (b) RETURN a.name, b.name LIMIT 3", expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfTheUnfilteredPairs) {
+    // A skip drops rows just as a filter does, so the product may not be cut to the LIMIT
+    // alone - the SKIP has to be paid for out of a wider product.
+    const Rows expected = {{remy, adam}, {remy, computers}, {remy, eighties}};
+    expectRows("MATCH (a), (b) RETURN a.name, b.name SKIP 1 LIMIT 3", expected);
+}
+
+TEST_F(CrossProductCutTest, cutsAWideWindowOutOfTheUnfilteredPairs) {
+    // 324 pairs in all - eighteen nodes squared - so a window well inside them keeps its
+    // full width.
+    expectRowCount("MATCH (a), (b) RETURN a.name, b.name SKIP 20 LIMIT 40", 40);
+}
+
+TEST_F(CrossProductCutTest, skipsIntoTheSecondOuterRowOfTheUnfilteredPairs) {
+    // The skip crosses an outer step (eighteen pairs per outer node), so the budget spans
+    // two inner loops.
+    expectRowCount("MATCH (a), (b) RETURN a.name, b.name SKIP 17 LIMIT 3", 3);
+}
+
+TEST_F(CrossProductCutTest, limitsTheFilteredPairsAcrossEmitChunks) {
+    // One row per chunk, so every pair is emitted on its own step and the budget is charged
+    // eighteen times over rather than once.
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 3",
+               prefix(agedPairs, 3),
+               /*chunkSize=*/1);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfTheFilteredPairsAcrossEmitChunks) {
+    const Rows expected = {{remy, adam}, {adam, remy}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name SKIP 1 LIMIT 2",
+               expected,
+               /*chunkSize=*/1);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfAFilteredInnerFactorAcrossEmitChunks) {
+    const Rows expected = {{adam, remy}, {adam, adam}};
+    expectRows("MATCH (a), (b) WHERE b.age = 32 RETURN a.name, b.name SKIP 2 LIMIT 2",
+               expected,
+               /*chunkSize=*/1);
+}
+
+TEST_F(CrossProductCutTest, limitsTheDedupedPairs) {
+    // A dedup drops rows the same way a filter does: the two aged outer nodes give two
+    // distinct names, and a budget of two must reach both.
+    const Rows expected = {{remy}, {adam}};
+    expectRows("MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN DISTINCT a.name LIMIT 2",
+               expected);
+}
+
+TEST_F(CrossProductCutTest, limitsTheThreeWayFilteredPairs) {
+    // Three factors, so eight rows: a budget of five reaches into the second outer node's
+    // pairs, past two nested products.
+    expectRowCount("MATCH (a), (b), (c) WHERE a.age = 32 AND b.age = 32 AND c.age = 32 "
+                   "RETURN a.name, b.name, c.name LIMIT 5",
+                   5);
+}
+
+TEST_F(CrossProductCutTest, cutsAWindowOutOfTheThreeWayFilteredPairs) {
+    expectRowCount("MATCH (a), (b), (c) WHERE a.age = 32 AND b.age = 32 AND c.age = 32 "
+                   "RETURN a.name, b.name, c.name SKIP 3 LIMIT 4",
+                   4);
+}


### PR DESCRIPTION
`MATCH (a), (b) WHERE a.age = 32 AND b.age = 32 RETURN a.name, b.name LIMIT 4` returned 2 rows instead of 4. On simpledb only Remy and Adam carry an age, both 32, so exactly 4 of the 324 pairs survive the filter.

The cross product is handed the limit budget so the nest can stop early, but the filter runs after it: with a budget of 4 the product built the first 4 pairs (Remy,Remy), (Remy,Adam), (Remy,Computers), (Remy,Eighties),  and the filter then dropped the last two, which carry no age. The budget was spent on product rows rather than result rows.

The budget now reaches the product only when nothing between it and the cut drops rows. The factor loops keep it either way, since a loop's budget only decides whether to take another step and never trims the step it is in.
