### PR TITLE
Unify output logic with ColumnSingleDispatcher

### DIFF
--- a/net/encoders/TuringProtoEncoder.cpp
+++ b/net/encoders/TuringProtoEncoder.cpp
@@ -14,7 +14,7 @@ TuringProtoEncoder::TuringProtoEncoder(net::proto::TuringProtoOutBuf* outBuf)
 }
 
 void TuringProtoEncoder::writeDataframeHeader(const db::Dataframe* df) {
-    using Encoder = db::ColumnSingleDispatcher<ProtoEncoderSupportedTypes, ColumnHeaderWriter, db::OutputtedTypes::Excluded>;
+    using Encoder = db::ColumnSingleDispatcher<db::OutputtedTypes::Allowed, ColumnHeaderWriter, db::OutputtedTypes::Excluded>;
 
     size_t chunkHeaderLen = sizeof(WireSize);
     for (const db::NamedColumn* namedCol : df->cols()) {
@@ -48,7 +48,7 @@ void TuringProtoEncoder::writeDataframe(const db::Dataframe* df) {
         return;
     }
 
-    using Encoder = db::ColumnSingleDispatcher<ProtoEncoderSupportedTypes, DataWriter, db::OutputtedTypes::Excluded>;
+    using Encoder = db::ColumnSingleDispatcher<db::OutputtedTypes::Allowed, DataWriter, db::OutputtedTypes::Excluded>;
 
     DataWriter writer(_outBuf, _stack);
 

--- a/net/encoders/TuringProtoEncoder.h
+++ b/net/encoders/TuringProtoEncoder.h
@@ -54,37 +54,6 @@ inline WireSize computeListByteSize(std::span<const db::ListElementView> element
     return static_cast<WireSize>(totalSize);
 }
 
-using ProtoEncoderSupportedTypes = std::tuple<
-    db::types::Int64::Primitive,
-    db::types::UInt64::Primitive,
-    db::types::Double::Primitive,
-    db::types::String::Primitive,
-    db::types::Bool::Primitive,
-    db::types::Embedding::Primitive,
-    std::optional<db::types::Int64::Primitive>,
-    std::optional<db::types::UInt64::Primitive>,
-    std::optional<db::types::Double::Primitive>,
-    std::optional<db::types::String::Primitive>,
-    std::optional<db::types::Bool::Primitive>,
-    std::optional<db::types::Embedding::Primitive>,
-    db::NodeID,
-    db::EdgeID,
-    db::LabelID,
-    db::LabelSetID,
-    db::EdgeTypeID,
-    db::PropertyTypeID,
-    db::ChangeID,
-    db::TemplateCommitHash<0>,
-    db::TemplateCommitHash<1>,
-    size_t,
-    std::string,
-    db::Path,
-    db::EntityList,
-    db::ListView,
-    db::ListElementView,
-    db::PropertyNull,
-    db::ValueType>;
-
 struct ColInternalKindToProtoEnum {
     template <typename T>
     static constexpr auto map() {

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -31,6 +31,8 @@
 #include "columns/ColumnVector.h"
 #include "columns/ColumnConst.h"
 #include "columns/ColumnOptVector.h"
+#include "columns/AllowedKinds.h"
+#include "columns/ColumnOperatorDispatcher.h"
 #include "dataframe/Dataframe.h"
 #include "dataframe/NamedColumn.h"
 #include "GraphPath.h"
@@ -505,16 +507,9 @@ void asString(std::string& out, db::ValueType v) {
     out += ValueTypeName::value(v);
 }
 
-void asString(std::string& out, ChangeID changeID) {
-    out += fmt::format("{:x}", changeID.get());
-}
-
-void asString(std::string& out, const CommitBuilder* commit) {
-    out += fmt::format("{:x}", commit->hash().get());
-}
-
-void asString(std::string& out, const Change* change) {
-    out += fmt::format("{:x}", change->id().get());
+template <int I>
+void asString(std::string& out, const TemplateCommitHash<I>& hash) {
+    out += fmt::format("{:x}", hash.get());
 }
 
 void asString(std::string& out, const PropertyNull) {
@@ -603,67 +598,29 @@ void tabulateWrite(tabulate::RowStream& rs, const T& value) {
     rs << out;
 }
 
-#define TABULATE_COL_CASE(Type, i)                           \
-    case Type::staticKind(): {                               \
-        const Type& src = *static_cast<const Type*>(column); \
-        tabulateWrite(rs, src[i]);                           \
-    } break;
+struct TabulateCell {
+    tabulate::RowStream& _rowStream;
+    size_t _row {0};
 
-// Writes one column's cell at this row into the table row. Every printable column kind
-// is listed here once, so the dataframe renderer and the nl sink cannot drift apart, and
-// a kind neither can print fails loudly in both rather than showing a placeholder.
-void tabulateCell(tabulate::RowStream& rs, const Column* column, size_t row) {
-    switch (column->getKind()) {
-        TABULATE_COL_CASE(ColumnVector<EntityID>, row)
-        TABULATE_COL_CASE(ColumnVector<NodeID>, row)
-        TABULATE_COL_CASE(ColumnVector<EdgeID>, row)
-        TABULATE_COL_CASE(ColumnVector<Path>, row)
-        TABULATE_COL_CASE(ColumnVector<EntityList>, row)
-        TABULATE_COL_CASE(ColumnVector<PropertyTypeID>, row)
-        TABULATE_COL_CASE(ColumnVector<LabelID>, row)
-        TABULATE_COL_CASE(ColumnVector<EdgeTypeID>, row)
-        TABULATE_COL_CASE(ColumnVector<LabelSetID>, row)
-        TABULATE_COL_CASE(ColumnVector<types::UInt64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<types::Int64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<types::Double::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<types::String::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<types::Bool::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<ValueType>, row)
-        TABULATE_COL_CASE(ColumnVector<ChangeID>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::UInt64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::Int64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::Double::Primitive>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::String::Primitive>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::Bool::Primitive>, row)
-        TABULATE_COL_CASE(ColumnOptVector<types::Embedding::Primitive>, row)
-        TABULATE_COL_CASE(ColumnVector<std::string>, row)
-        TABULATE_COL_CASE(ColumnOptVector<std::string>, row)
-        TABULATE_COL_CASE(ColumnVector<const CommitBuilder*>, row)
-        TABULATE_COL_CASE(ColumnVector<const Change*>, row)
-        TABULATE_COL_CASE(ColumnConst<EntityID>, row)
-        TABULATE_COL_CASE(ColumnConst<NodeID>, row)
-        TABULATE_COL_CASE(ColumnConst<EdgeID>, row)
-        TABULATE_COL_CASE(ColumnConst<types::UInt64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<types::Int64::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<types::Double::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<types::String::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<types::Bool::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<types::Embedding::Primitive>, row)
-        TABULATE_COL_CASE(ColumnConst<PropertyNull>, row)
-
-        TABULATE_COL_CASE(ColumnConst<ListView>, row)
-        TABULATE_COL_CASE(ColumnVector<ListView>, row)
-        TABULATE_COL_CASE(ColumnVector<ListElementView>, row)
-
-        // toX functions on a constant string produce opt const
-        TABULATE_COL_CASE(ColumnConst<std::optional<types::Int64::Primitive>>, row)
-        TABULATE_COL_CASE(ColumnConst<std::optional<types::Double::Primitive>>, row)
-        TABULATE_COL_CASE(ColumnConst<std::optional<types::Bool::Primitive>>, row)
-
-        default: {
-            panic("can not print columns of kind {}", column->getKind());
-        }
+    template <typename T>
+    void operator()(const ColumnVector<T>* column) {
+        tabulateWrite(_rowStream, column->at(_row));
     }
+
+    template <typename T>
+    void operator()(const ColumnConst<T>* column) {
+        tabulateWrite(_rowStream, column->at(_row));
+    }
+};
+
+void tabulateCell(tabulate::RowStream& rs, const Column* column, size_t row) {
+    TabulateCell cell(rs, row);
+
+    using Dispatcher = ColumnSingleDispatcher<OutputtedTypes::Allowed,
+                                              TabulateCell,
+                                              OutputtedTypes::Excluded>;
+
+    Dispatcher::dispatch(column, cell);
 }
 
 void queryCallback(size_t execCount, const Dataframe* df, tabulate::Table& table) {

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -655,6 +655,11 @@ void tabulateCell(tabulate::RowStream& rs, const Column* column, size_t row) {
         TABULATE_COL_CASE(ColumnVector<ListView>, row)
         TABULATE_COL_CASE(ColumnVector<ListElementView>, row)
 
+        // toX functions on a constant string produce opt const
+        TABULATE_COL_CASE(ColumnConst<std::optional<types::Int64::Primitive>>, row)
+        TABULATE_COL_CASE(ColumnConst<std::optional<types::Double::Primitive>>, row)
+        TABULATE_COL_CASE(ColumnConst<std::optional<types::Bool::Primitive>>, row)
+
         default: {
             panic("can not print columns of kind {}", column->getKind());
         }


### PR DESCRIPTION
Removes fragile `switch` cases over column types when outputting e.g. to Tabulate in TuringShell, in favour of using the column dispatcher