### PR TITLE
MLIR: Predicate pushdown

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -686,6 +686,7 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
 void DBProgramGenerator::runPasses() {
     mlir::PassManager passManager(_mlirCtxt);
     passManager.addPass(mlir::db::createFuseScanByLabel());
+    passManager.addPass(mlir::db::createPushDownFilters());
 
     if (mlir::failed(passManager.run(*_module))) {
         throw FatalException("DB pass pipeline failed");

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -105,6 +105,14 @@ bool isEdgeHop(Operation* op) {
     return isa<GetOutEdges, GetInEdges, GetEdges, GetOutEdgesByType, GetInEdgesByType>(op);
 }
 
+// The columns a cross_product factor yields, in result order.
+Operation::operand_range factorYieldColumns(mlir::Region& factor) {
+    mlir::Block& factorBlock = factor.front();
+    Yield yield = cast<Yield>(factorBlock.getTerminator());
+
+    return yield.getColumns();
+}
+
 // Walk op chain until we reach a node/edge source or something we can't push down to
 Value climbToLineageAnchor(Value column) {
     while (true) {
@@ -123,6 +131,25 @@ Value climbToLineageAnchor(Value column) {
             }
 
             return column;
+        }
+
+        if (CrossProduct product = dyn_cast<CrossProduct>(def)) {
+            // Descend into the xprod factor which holds def
+            const unsigned resultIndex = cast<OpResult>(column).getResultNumber();
+
+            mlir::Region& leftFactor = product.getLeftFactor();
+            const Operation::operand_range leftColumns = factorYieldColumns(leftFactor);
+            const unsigned leftCount = leftColumns.size();
+
+            if (resultIndex < leftCount) {
+                column = leftColumns[resultIndex];
+            } else {
+                mlir::Region& rightFactor = product.getRightFactor();
+                const Operation::operand_range rightColumns = factorYieldColumns(rightFactor);
+                column = rightColumns[resultIndex - leftCount];
+            }
+
+            continue;
         }
 
         if (isEdgeHop(def)) {
@@ -209,7 +236,7 @@ std::optional<PushablePredicate> matchPushablePredicate(FilterOp filter) {
     }
 
     Value anchor;
-    bool hasHopToCross = false;
+    bool reachedAnchor = true;
     for (const Value input : cone._inputs) {
         const Value inputAnchor = climbToLineageAnchor(input);
         if (!inputAnchor) {
@@ -224,12 +251,12 @@ std::optional<PushablePredicate> matchPushablePredicate(FilterOp filter) {
         }
 
         if (input != inputAnchor) {
-            hasHopToCross = true;
+            reachedAnchor = false;
         }
     }
 
-    // The mask already reads the anchor itself, so the filter is at its earliest point.
-    if (!hasHopToCross) {
+    // Filter already maximally pushed down
+    if (reachedAnchor) {
         return std::nullopt;
     }
 
@@ -239,6 +266,7 @@ std::optional<PushablePredicate> matchPushablePredicate(FilterOp filter) {
 void pushDownPredicate(FilterOp filter, const PushablePredicate& pushable, mlir::OpBuilder& builder) {
     Value anchor = pushable._anchor;
     const MaskCone& cone = pushable._cone;
+    const mlir::Location loc = filter.getLoc();
 
     // Rebuild the mask over the anchor version of the column, right after it is bound.
     mlir::IRMapping mapping;
@@ -258,7 +286,7 @@ void pushDownPredicate(FilterOp filter, const PushablePredicate& pushable, mlir:
     const Value clonedMask = mapping.lookup(filter.getMask());
 
     const llvm::SmallVector<mlir::Type, 1> resultTypes {anchor.getType()};
-    auto pushed = builder.create<FilterOp>(filter.getLoc(), resultTypes, clonedMask, mlir::ValueRange {anchor});
+    FilterOp pushed = builder.create<FilterOp>(loc, resultTypes, clonedMask, mlir::ValueRange {anchor});
     const Value pushedColumn = pushed.getResult(0);
     anchorReaders.insert(pushed.getOperation());
 

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -105,6 +105,10 @@ bool isEdgeHop(Operation* op) {
     return isa<GetOutEdges, GetInEdges, GetEdges, GetOutEdgesByType, GetInEdgesByType>(op);
 }
 
+bool isReverseHop(Operation* op) {
+    return isa<GetInEdges, GetInEdgesByType>(op);
+}
+
 // The columns a cross_product factor yields, in result order.
 Operation::operand_range factorYieldColumns(mlir::Region& factor) {
     mlir::Block& factorBlock = factor.front();
@@ -155,9 +159,12 @@ Value climbToLineageAnchor(Value column) {
         if (isEdgeHop(def)) {
             const unsigned resultIndex = cast<OpResult>(column).getResultNumber();
             const unsigned srcResultIndex = 0;
+            const unsigned tgtResultIndex = 3;
             const unsigned fixedResultCount = 4;
 
-            if (resultIndex == srcResultIndex) {
+            const unsigned inputResultIndex = isReverseHop(def) ? tgtResultIndex : srcResultIndex;
+
+            if (resultIndex == inputResultIndex) {
                 column = def->getOperand(0);
             } else if (resultIndex >= fixedResultCount) {
                 // Carried columns follow input_nodes (operand 0) in operand order.

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,5 +1,7 @@
 #include "DBPasses.h"
 
+#include <optional>
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Operation.h"
@@ -10,9 +12,6 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
-#include <optional>
-
-#include "DBDialect.h"
 #include "DBOps.h"
 
 namespace mlir::db {
@@ -119,7 +118,7 @@ Operation::operand_range factorYieldColumns(mlir::Region& factor) {
 
 // Walk op chain until we reach a node/edge source or something we can't push down to
 Value climbToLineageAnchor(Value column) {
-    while (true) {
+    for (;;) {
         Operation* const def = column.getDefiningOp();
         if (!def) {
             return {};
@@ -129,11 +128,9 @@ Value climbToLineageAnchor(Value column) {
             return column;
         }
 
-        if (FilterOp filter = dyn_cast<FilterOp>(def)) {
-            if (filter.getColumnsToFilter().size() != 1) {
-                return {};
-            }
-
+        if (isa<FilterOp>(def)) {
+            // A filter passes each column through unchanged, so its result is the same
+            // variable one step on - a valid boundary to sit a further filter right after.
             return column;
         }
 
@@ -157,12 +154,16 @@ Value climbToLineageAnchor(Value column) {
         }
 
         if (isEdgeHop(def)) {
-            const unsigned resultIndex = cast<OpResult>(column).getResultNumber();
-            const unsigned srcResultIndex = 0;
-            const unsigned tgtResultIndex = 3;
-            const unsigned fixedResultCount = 4;
+            const size_t resultIndex = cast<OpResult>(column).getResultNumber();
+            constexpr size_t srcResultIndex = 0;
+            constexpr size_t tgtResultIndex = 3;
+            constexpr size_t fixedResultCount = 4;
 
-            const unsigned inputResultIndex = isReverseHop(def) ? tgtResultIndex : srcResultIndex;
+            // The input node re-surfaces as srcids (forward) or tgtids (reverse) and each
+            // carried column passes through: those continue a variable that existed before
+            // the hop, so keep climbing. The opposite node end and the eids/etypes are
+            // bound here, so the variable is born at this hop - its earliest filter point.
+            const size_t inputResultIndex = isReverseHop(def) ? tgtResultIndex : srcResultIndex;
 
             if (resultIndex == inputResultIndex) {
                 column = def->getOperand(0);
@@ -170,7 +171,7 @@ Value climbToLineageAnchor(Value column) {
                 // Carried columns follow input_nodes (operand 0) in operand order.
                 column = def->getOperand(1 + (resultIndex - fixedResultCount));
             } else {
-                return {};
+                return column;
             }
         } else {
             return {};
@@ -275,34 +276,46 @@ void pushDownPredicate(FilterOp filter, const PushablePredicate& pushable, mlir:
     const MaskCone& cone = pushable._cone;
     const mlir::Location loc = filter.getLoc();
 
+    Operation* const anchorProducer = anchor.getDefiningOp();
+
+    llvm::SmallVector<mlir::Value> liveColumns;
+    for (const mlir::Value result : anchorProducer->getResults()) {
+        if (!result.use_empty()) {
+            liveColumns.push_back(result);
+        }
+    }
+
     // Rebuild the mask over the anchor version of the column, right after it is bound.
     mlir::IRMapping mapping;
     for (const Value input : cone._inputs) {
         mapping.map(input, anchor);
     }
 
-    builder.setInsertionPointAfter(anchor.getDefiningOp());
+    builder.setInsertionPointAfter(anchorProducer);
 
-    llvm::SmallPtrSet<Operation*, 8> anchorReaders;
+    llvm::SmallPtrSet<Operation*, 8> boundaryReaders;
     for (Operation* const coneOp : cone._ops) {
         Operation* const cloned = builder.clone(*coneOp, mapping);
-        anchorReaders.insert(cloned);
+        boundaryReaders.insert(cloned);
         builder.setInsertionPointAfter(cloned);
     }
 
     const Value clonedMask = mapping.lookup(filter.getMask());
 
-    const llvm::SmallVector<mlir::Type, 1> resultTypes {anchor.getType()};
-    FilterOp pushed = builder.create<FilterOp>(loc, resultTypes, clonedMask, mlir::ValueRange {anchor});
-    const Value pushedColumn = pushed.getResult(0);
-    anchorReaders.insert(pushed.getOperation());
+    llvm::SmallVector<mlir::Type, 8> resultTypes;
+    for (const mlir::Value column : liveColumns) {
+        resultTypes.push_back(column.getType());
+    }
 
-    // Every downstream consumer of the anchor now reads the filtered column; the clones
-    // and the pushed filter keep reading the anchor itself.
-    anchor.replaceAllUsesExcept(pushedColumn, anchorReaders);
+    FilterOp pushed = builder.create<FilterOp>(loc, resultTypes, clonedMask, liveColumns);
+    boundaryReaders.insert(pushed.getOperation());
 
-    // The original filter is now redundant - its rows were already dropped upstream - so
-    // its outputs fold back onto its inputs and it, then its dead mask cone, are erased.
+    // Replace live columns with filtered versions
+    for (size_t i {0}; mlir::Value liveCol : liveColumns) {
+        liveCol.replaceAllUsesExcept(pushed.getResult(i++), boundaryReaders);
+    }
+
+    // Remove original filter
     const mlir::ResultRange filtered = filter.getFilteredColumns();
     const Operation::operand_range carried = filter.getColumnsToFilter();
     for (size_t index = 0; index < filtered.size(); index++) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,9 +1,13 @@
 #include "DBPasses.h"
 
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <optional>
@@ -14,6 +18,7 @@
 namespace mlir::db {
 
 #define GEN_PASS_DEF_FUSESCANBYLABEL
+#define GEN_PASS_DEF_PUSHDOWNFILTERS
 #include "DBPasses.h.inc"
 
 namespace {
@@ -88,6 +93,210 @@ struct FuseScanByLabel : public impl::FuseScanByLabelBase<FuseScanByLabel> {
             eraseIfUnused(chain->check);
             eraseIfUnused(chain->labelSet);
             eraseIfUnused(chain->scan);
+        }
+    }
+};
+
+bool isNodeSource(Operation* op) {
+    return isa<ScanNodes, ScanNodesByLabel, ConstScanNodes>(op);
+}
+
+bool isEdgeHop(Operation* op) {
+    return isa<GetOutEdges, GetInEdges, GetEdges, GetOutEdgesByType, GetInEdgesByType>(op);
+}
+
+// Walk op chain until we reach a node/edge source or something we can't push down to
+Value climbToLineageAnchor(Value column) {
+    while (true) {
+        Operation* const def = column.getDefiningOp();
+        if (!def) {
+            return {};
+        }
+
+        if (isNodeSource(def)) {
+            return column;
+        }
+
+        if (FilterOp filter = dyn_cast<FilterOp>(def)) {
+            if (filter.getColumnsToFilter().size() != 1) {
+                return {};
+            }
+
+            return column;
+        }
+
+        if (isEdgeHop(def)) {
+            const unsigned resultIndex = cast<OpResult>(column).getResultNumber();
+            const unsigned srcResultIndex = 0;
+            const unsigned fixedResultCount = 4;
+
+            if (resultIndex == srcResultIndex) {
+                column = def->getOperand(0);
+            } else if (resultIndex >= fixedResultCount) {
+                // Carried columns follow input_nodes (operand 0) in operand order.
+                column = def->getOperand(1 + (resultIndex - fixedResultCount));
+            } else {
+                return {};
+            }
+        } else {
+            return {};
+        }
+    }
+}
+
+bool isMaskComputeOp(Operation* op) {
+    return isa<EqOp, NeqOp, GtOp, LtOp, GteOp, LteOp,
+               AndOp, OrOp, XorOp, NotOp,
+               AddOp, SubOp, MulOp, DivOp, ModOp, PowOp,
+               ConstantOp,
+               GetNodeProperties, GetEdgeProperties>(op);
+}
+
+struct MaskCone {
+    llvm::SmallVector<Operation*> _ops;
+    llvm::SmallSetVector<Value, 4> _inputs;
+};
+
+// Gathers the mask's compute cone and the external columns feeding it. The cone ops
+// come back in topological (block) order, ready to clone.
+MaskCone collectMaskCone(Value mask) {
+    MaskCone cone;
+
+    llvm::SmallPtrSet<Operation*, 8> inCone;
+    llvm::SmallVector<Value, 8> worklist {mask};
+    while (!worklist.empty()) {
+        const Value value = worklist.pop_back_val();
+        Operation* const def = value.getDefiningOp();
+
+        if (!def || !isMaskComputeOp(def)) {
+            cone._inputs.insert(value);
+            continue;
+        }
+
+        if (!inCone.insert(def).second) {
+            continue;
+        }
+
+        cone._ops.push_back(def);
+        for (const Value operand : def->getOperands()) {
+            worklist.push_back(operand);
+        }
+    }
+
+    llvm::sort(cone._ops, [](Operation* lhs, Operation* rhs) {
+        return lhs->isBeforeInBlock(rhs);
+    });
+
+    return cone;
+}
+
+// A single-variable property-predicate filter and where its mask should be rebuilt:
+// the lineage anchor of the one column its mask reads.
+struct PushablePredicate {
+    Value _anchor;
+    MaskCone _cone;
+};
+
+std::optional<PushablePredicate> matchPushablePredicate(FilterOp filter) {
+    Operation* const maskDef = filter.getMask().getDefiningOp();
+    if (!maskDef || !isMaskComputeOp(maskDef)) {
+        return std::nullopt;
+    }
+
+    MaskCone cone = collectMaskCone(filter.getMask());
+    if (cone._inputs.empty()) {
+        return std::nullopt;
+    }
+
+    Value anchor;
+    bool hasHopToCross = false;
+    for (const Value input : cone._inputs) {
+        const Value inputAnchor = climbToLineageAnchor(input);
+        if (!inputAnchor) {
+            return std::nullopt;
+        }
+
+        if (!anchor) {
+            anchor = inputAnchor;
+        } else if (anchor != inputAnchor) {
+            // More than one lineage feeds the mask: not a single-variable predicate.
+            return std::nullopt;
+        }
+
+        if (input != inputAnchor) {
+            hasHopToCross = true;
+        }
+    }
+
+    // The mask already reads the anchor itself, so the filter is at its earliest point.
+    if (!hasHopToCross) {
+        return std::nullopt;
+    }
+
+    return PushablePredicate {._anchor = anchor, ._cone = std::move(cone)};
+}
+
+void pushDownPredicate(FilterOp filter, const PushablePredicate& pushable, mlir::OpBuilder& builder) {
+    Value anchor = pushable._anchor;
+    const MaskCone& cone = pushable._cone;
+
+    // Rebuild the mask over the anchor version of the column, right after it is bound.
+    mlir::IRMapping mapping;
+    for (const Value input : cone._inputs) {
+        mapping.map(input, anchor);
+    }
+
+    builder.setInsertionPointAfter(anchor.getDefiningOp());
+
+    llvm::SmallPtrSet<Operation*, 8> anchorReaders;
+    for (Operation* const coneOp : cone._ops) {
+        Operation* const cloned = builder.clone(*coneOp, mapping);
+        anchorReaders.insert(cloned);
+        builder.setInsertionPointAfter(cloned);
+    }
+
+    const Value clonedMask = mapping.lookup(filter.getMask());
+
+    const llvm::SmallVector<mlir::Type, 1> resultTypes {anchor.getType()};
+    auto pushed = builder.create<FilterOp>(filter.getLoc(), resultTypes, clonedMask, mlir::ValueRange {anchor});
+    const Value pushedColumn = pushed.getResult(0);
+    anchorReaders.insert(pushed.getOperation());
+
+    // Every downstream consumer of the anchor now reads the filtered column; the clones
+    // and the pushed filter keep reading the anchor itself.
+    anchor.replaceAllUsesExcept(pushedColumn, anchorReaders);
+
+    // The original filter is now redundant - its rows were already dropped upstream - so
+    // its outputs fold back onto its inputs and it, then its dead mask cone, are erased.
+    const mlir::ResultRange filtered = filter.getFilteredColumns();
+    const Operation::operand_range carried = filter.getColumnsToFilter();
+    for (size_t index = 0; index < filtered.size(); index++) {
+        filtered[index].replaceAllUsesWith(carried[index]);
+    }
+    filter.erase();
+
+    for (Operation* const coneOp : llvm::reverse(cone._ops)) {
+        eraseIfUnused(coneOp);
+    }
+}
+
+struct PushDownFilters : public impl::PushDownFiltersBase<PushDownFilters> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        llvm::SmallVector<FilterOp> filters;
+        root->walk([&](FilterOp filter) {
+            filters.push_back(filter);
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (FilterOp filter : filters) {
+            std::optional<PushablePredicate> pushable = matchPushablePredicate(filter);
+            if (!pushable) {
+                continue;
+            }
+
+            pushDownPredicate(filter, *pushable, builder);
         }
     }
 };

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -8,4 +8,9 @@ def FuseScanByLabel : Pass<"fuse_scan_by_label"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def PushDownFilters : Pass<"push_down_filters"> {
+    let summary = "Sink a single-variable property-predicate filter to its variable's scan";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 #endif // TURINGDB_PASSES

--- a/samples/mlir/3hop_filter_pushdown.mlir
+++ b/samples/mlir/3hop_filter_pushdown.mlir
@@ -1,0 +1,13 @@
+// MATCH (n)-->()-->() WHERE n.age = 32 RETURN *
+
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.get_node_properties(%0, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.constant(32 : i64)
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %4 = db.filter(%3, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %5, %6, %7, %8 = db.get_out_edges(%4, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %9, %10, %11, %12, %13, %14, %15 = db.get_out_edges(%8, {%5, %6, %7}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>)
+  db.output(%13) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/3hop_filter_pushdown.nl.mlir
+++ b/samples/mlir/3hop_filter_pushdown.nl.mlir
@@ -1,0 +1,20 @@
+// MATCH (n)-->()-->() WHERE n.age = 32 RETURN *
+
+func.func @main() {
+  %0 = nl.constant(32 : i64)
+  %1 = nl.get_property_type("age")
+  %2 = nl.scan_nodes()
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %3 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<i64>>
+    %4 = nl.eq %3, %0 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %5 = nl.filter %4, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %6 = nl.get_out_edges(%5, {})
+    nl.for %arg1, %arg2, %arg3, %arg4 in %6 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+      %7 = nl.get_out_edges(%arg4, {%arg1, %arg2, %arg3}) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>
+      nl.for %arg5, %arg6, %arg7, %arg8, %arg9, %arg10, %arg11 in %7 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>> {
+        nl.output(%arg9) names ["n"] : !nl.chunk<!storage.node_id>
+      }
+    }
+  }
+  return
+}

--- a/samples/mlir/xprod_filter_pushdown.mlir
+++ b/samples/mlir/xprod_filter_pushdown.mlir
@@ -1,0 +1,17 @@
+// MATCH (n), (m) WHERE n.age = 32 RETURN *
+
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+    %3 = db.constant(32 : i64)
+    %4 = db.eq %2, %3 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+    %5 = db.filter(%4, {%1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %5 : !db.column<!storage.node_id>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %1 : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/xprod_filter_pushdown.nl.mlir
+++ b/samples/mlir/xprod_filter_pushdown.nl.mlir
@@ -1,0 +1,18 @@
+// MATCH (n), (m) WHERE n.age = 32 RETURN *
+
+func.func @main() {
+  %0 = nl.constant(32 : i64)
+  %1 = nl.get_property_type("age")
+  %2 = nl.scan_nodes()
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %3 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<i64>>
+    %4 = nl.eq %3, %0 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %5 = nl.filter %4, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %6 = nl.scan_nodes()
+    nl.for %arg1 in %6 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %7:2 = nl.cross_product{%5} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.output(%7#0, %7#1) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    }
+  }
+  return
+}

--- a/samples/mlir/xprod_multifilter_pushdown.mlir
+++ b/samples/mlir/xprod_multifilter_pushdown.mlir
@@ -1,0 +1,25 @@
+// MATCH (n), (m) WHERE n.age = 32 and n.name = 'Remy' AND m.age IS NULL RETURN *
+
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+    %3 = db.constant(32 : i64)
+    %4 = db.eq %2, %3 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+    %5 = db.filter(%4, {%1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    %6 = db.get_node_properties(%5, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    %7 = db.constant("Remy" : !storage.string)
+    %8 = db.eq %6, %7 : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+    %9 = db.filter(%8, {%5}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %9 : !db.column<!storage.node_id>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+    %3 = db.constant("" : !storage.nullable<none>)
+    %4 = db.eq %2, %3 : (!db.column<none>, !db.column<!storage.nullable<none>>) -> !db.column<!storage.bool>
+    %5 = db.filter(%4, {%1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %5 : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/xprod_multifilter_pushdown.nl.mlir
+++ b/samples/mlir/xprod_multifilter_pushdown.nl.mlir
@@ -1,0 +1,27 @@
+// MATCH (n), (m) WHERE n.age = 32 and n.name = 'Remy' AND m.age IS NULL RETURN *
+
+func.func @main() {
+  %0 = nl.constant("" : !storage.nullable<none>)
+  %1 = nl.constant("Remy" : !storage.string)
+  %2 = nl.get_property_type("name")
+  %3 = nl.constant(32 : i64)
+  %4 = nl.get_property_type("age")
+  %5 = nl.scan_nodes()
+  nl.for %arg0 in %5 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %6 = nl.get_node_properties(%arg0, %4) : !nl.chunk<!storage.nullable<i64>>
+    %7 = nl.eq %6, %3 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+    %8 = nl.filter %7, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %9 = nl.get_node_properties(%8, %2) : !nl.chunk<!storage.nullable<!storage.string>>
+    %10 = nl.eq %9, %1 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+    %11 = nl.filter %10, (%8) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    %12 = nl.scan_nodes()
+    nl.for %arg1 in %12 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      %13 = nl.get_node_properties(%arg1, %4) : !nl.chunk<!storage.nullable<i64>>
+      %14 = nl.eq %13, %0 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<none>>) -> !nl.chunk<!storage.nullable<i1>>
+      %15 = nl.filter %14, (%arg1) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+      %16:2 = nl.cross_product{%11} {%15} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.output(%16#0, %16#1) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    }
+  }
+  return
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -174,6 +174,7 @@ target_link_libraries(test_query_ir_db_procedures PRIVATE
         turing_db_ir_codegen_s)
 
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
+add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 
 # The branch two-hop test runs against the shared SimpleGraph fixture.

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -453,6 +453,7 @@ TEST_F(EquivalenceTest, crossProd) {
 
 TEST_F(EquivalenceTest, eqFilters) {
     expectEquivalent("MATCH (a) WHERE a.age = 32 RETURN a");
+    expectEquivalent("MATCH (a), (b) WHERE a.age = 32 RETURN a, b");
     expectEquivalent("MATCH (a), (b) WHERE a.age = b.age RETURN a, b");
     expectEquivalent("MATCH (a), (b) WHERE a.name = a.name RETURN b");
 

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -556,6 +556,8 @@ TEST_F(EquivalenceTest, arbitraryFilters) {
 
     expectEquivalent("MATCH (a {isFrench: true})-->(b), (c {hasPhD: false}) WHERE a.hasPhD RETURN a, b, c");
     expectEquivalent("MATCH (a {age: 32})-->(b), (c {isFrench: false}) WHERE a.isFrench RETURN a, c");
+
+    expectEquivalent("MATCH (a)<--(n)-->(m) WHERE n.age = 32 RETURN *");
 }
 
 TEST_F(EquivalenceTest, labelConstraints) {

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -256,22 +256,30 @@ func.func @main() {
 }
 )mlir";
 
-TEST_F(PushDownFilterTest, leavesInEdgeNeighbourPredicateAlone) {
+TEST_F(PushDownFilterTest, sinksNeighbourPredicateToBindingHop) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(inEdgeNeighbourPredicate);
     ASSERT_TRUE(module);
     ASSERT_TRUE(runPushDown(*module));
     ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
 
-    // The predicate is not pushed: the in-hop binds n, so there is nowhere earlier to go.
     llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
     ASSERT_EQ(filters.size(), 1u);
     mlir::db::FilterOp filter = filters.front();
 
-    // Still the original many-column filter, still below the hop that binds n - not a
-    // single-column filter hoisted above the scan.
-    EXPECT_EQ(filter.getColumnsToFilter().size(), 3u);
-
     llvm::SmallVector<mlir::db::GetInEdges> inHops = collect<mlir::db::GetInEdges>(*module);
     ASSERT_EQ(inHops.size(), 1u);
-    EXPECT_TRUE(inHops.front().getOperation()->isBeforeInBlock(filter.getOperation()));
+    llvm::SmallVector<mlir::db::GetOutEdges> outHops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(outHops.size(), 1u);
+    mlir::db::GetInEdges inHop = inHops.front();
+    mlir::db::GetOutEdges outHop = outHops.front();
+
+    EXPECT_TRUE(inHop.getOperation()->isBeforeInBlock(filter.getOperation()));
+    EXPECT_TRUE(filter.getOperation()->isBeforeInBlock(outHop.getOperation()));
+
+    EXPECT_EQ(filter.getColumnsToFilter().size(), 2u);
+    EXPECT_EQ(outHop.getInputNodes().getDefiningOp(), filter.getOperation());
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_EQ(reads.front().getInputNodes().getDefiningOp(), inHop.getOperation());
 }

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -1,0 +1,194 @@
+#include <gtest/gtest.h>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "StorageDialect.h"
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+}
+
+class PushDownFilterTest : public ::testing::Test {
+protected:
+    PushDownFilterTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    // Runs the pushdown pass over the module and reports whether it succeeded.
+    bool runPushDown(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createPushDownFilters());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// MATCH (a)-->(b)-->(c) WHERE a.age > 30 RETURN a, b, c
+const char* const twoHopRootPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %ac = db.get_out_edges(%t1, {%s1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%ac, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %lim = db.constant(30 : i64)
+  %mask = db.gt %age, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %af, %bf, %cf = db.filter(%mask, {%ac, %s2, %t2}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%af, %bf, %cf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, sinksRootPredicatePastHops) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoHopRootPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 2u);
+    mlir::db::GetOutEdges firstHop = hops.front();
+
+    // The filter now precedes both hops.
+    EXPECT_TRUE(filter.getOperation()->isBeforeInBlock(firstHop.getOperation()));
+
+    // The filter carries the single scanned column, and the first hop consumes the
+    // filtered result rather than the raw scan.
+    ASSERT_EQ(filter.getColumnsToFilter().size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(filter.getColumnsToFilter().front().getDefiningOp()));
+    EXPECT_EQ(firstHop.getInputNodes().getDefiningOp(), filter.getOperation());
+
+    // The mask reads the property off the scanned column, not a hop output.
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    mlir::db::GetNodeProperties read = reads.front();
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(read.getInputNodes().getDefiningOp()));
+}
+
+// MATCH (a) WHERE a.age > 30 RETURN a
+const char* const rootOnlyPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %lim = db.constant(30 : i64)
+  %mask = db.gt %age, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %af = db.filter(%mask, {%a}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%af) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, leavesRootAdjacentPredicateAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(rootOnlyPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    // Still exactly one filter - the pass did not clone it.
+    const llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    EXPECT_EQ(filters.size(), 1u);
+
+    const llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    EXPECT_EQ(reads.size(), 1u);
+}
+
+// MATCH (a {age: 32, score: 5})-->(b) RETURN a, b
+const char* const twoRootPredicatesStack = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%s1, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %c32 = db.constant(32 : i64)
+  %m1 = db.eq %age, %c32 : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %a1, %b1 = db.filter(%m1, {%s1, %t1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %score = db.get_node_properties(%a1, "score") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %c5 = db.constant(5 : i64)
+  %m2 = db.eq %score, %c5 : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %a2, %b2 = db.filter(%m2, {%a1, %b1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%a2, %b2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, stacksTwoRootPredicatesBeforeHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoRootPredicatesStack);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdges hop = hops.front();
+
+    // Both filters precede the hop, and each carries a single column.
+    for (mlir::db::FilterOp filter : filters) {
+        EXPECT_TRUE(filter.getOperation()->isBeforeInBlock(hop.getOperation()));
+        EXPECT_EQ(filter.getColumnsToFilter().size(), 1u);
+    }
+
+    // The hop consumes a filter's output: the two are stacked scan -> filter -> filter -> hop.
+    EXPECT_TRUE(mlir::isa<mlir::db::FilterOp>(hop.getInputNodes().getDefiningOp()));
+}
+
+// MATCH (a)-[e]->(b) WHERE e.duration > 10 RETURN a
+const char* const edgePredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %dur = db.get_edge_properties(%e1, "duration") : (!db.column<!storage.edge_id>) -> !db.column<i64>
+  %lim = db.constant(10 : i64)
+  %mask = db.gt %dur, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %sf, %tf = db.filter(%mask, {%s1, %t1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, leavesEdgePredicateAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(edgePredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+
+    // The filter still sits after the hop.
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_TRUE(hops.front().getOperation()->isBeforeInBlock(filters.front().getOperation()));
+}

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -192,3 +192,51 @@ TEST_F(PushDownFilterTest, leavesEdgePredicateAlone) {
     ASSERT_EQ(hops.size(), 1u);
     EXPECT_TRUE(hops.front().getOperation()->isBeforeInBlock(filters.front().getOperation()));
 }
+
+// MATCH (n), (m) WHERE n.age = 32 RETURN n, m
+const char* const crossProductFactorPredicate = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %n = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %n : !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  %age = db.get_node_properties(%0#0, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %c32 = db.constant(32 : i64)
+  %mask = db.eq %age, %c32 : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf, %mf = db.filter(%mask, {%0#0, %0#1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%nf, %mf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, sinksPredicateIntoCrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(crossProductFactorPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+
+    // The filter now lives inside a cross_product factor, not at the top level.
+    mlir::db::CrossProduct product = filter.getOperation()->getParentOfType<mlir::db::CrossProduct>();
+    ASSERT_TRUE(product);
+
+    // It carries the single scanned column of that factor.
+    ASSERT_EQ(filter.getColumnsToFilter().size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(filter.getColumnsToFilter().front().getDefiningOp()));
+
+    // The factor now yields the filtered column, so the product crosses filtered n.
+    mlir::db::Yield leftYield = mlir::cast<mlir::db::Yield>(product.getLeftFactor().front().getTerminator());
+    ASSERT_EQ(leftYield.getColumns().size(), 1u);
+    EXPECT_EQ(leftYield.getColumns().front().getDefiningOp(), filter.getOperation());
+
+    // The mask reads the property off the scanned column, not the product result.
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
+}

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -240,3 +240,38 @@ TEST_F(PushDownFilterTest, sinksPredicateIntoCrossProductFactor) {
     ASSERT_EQ(reads.size(), 1u);
     EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
 }
+
+// MATCH (a)<--(n)-->(m) WHERE n.age = 32 RETURN a, n, m
+const char* const inEdgeNeighbourPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %ac = db.get_out_edges(%s1, {%t1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%s2, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %k = db.constant(32 : i64)
+  %mask = db.eq %age, %k : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf, %mf, %af = db.filter(%mask, {%s2, %t2, %ac}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%af, %nf, %mf) names ["a", "n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, leavesInEdgeNeighbourPredicateAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(inEdgeNeighbourPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    // The predicate is not pushed: the in-hop binds n, so there is nowhere earlier to go.
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+
+    // Still the original many-column filter, still below the hop that binds n - not a
+    // single-column filter hoisted above the scan.
+    EXPECT_EQ(filter.getColumnsToFilter().size(), 3u);
+
+    llvm::SmallVector<mlir::db::GetInEdges> inHops = collect<mlir::db::GetInEdges>(*module);
+    ASSERT_EQ(inHops.size(), 1u);
+    EXPECT_TRUE(inHops.front().getOperation()->isBeforeInBlock(filter.getOperation()));
+}

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -283,3 +283,54 @@ TEST_F(PushDownFilterTest, sinksNeighbourPredicateToBindingHop) {
     ASSERT_EQ(reads.size(), 1u);
     EXPECT_EQ(reads.front().getInputNodes().getDefiningOp(), inHop.getOperation());
 }
+
+// MATCH (a)-->(b)-->(c) WHERE a.age = pow(2, 5) RETURN a, b, c
+const char* const powConstantPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %ac = db.get_out_edges(%t1, {%s1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%ac, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %base = db.constant(2 : i64)
+  %exp = db.constant(5 : i64)
+  %pow = db.pow %base, %exp : (!db.column<i64>, !db.column<i64>) -> !db.column<f64>
+  %mask = db.eq %age, %pow : (!db.column<i64>, !db.column<f64>) -> !db.column<!storage.bool>
+  %af, %bf, %cf = db.filter(%mask, {%ac, %s2, %t2}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%af, %bf, %cf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, sinksRootPredicateWithConstantPowExpression) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(powConstantPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 2u);
+    mlir::db::GetOutEdges firstHop = hops.front();
+
+    // The whole mask cone - the pow of two constants included - sinks ahead of both hops.
+    EXPECT_TRUE(filter.getOperation()->isBeforeInBlock(firstHop.getOperation()));
+    EXPECT_EQ(firstHop.getInputNodes().getDefiningOp(), filter.getOperation());
+
+    llvm::SmallVector<mlir::db::PowOp> pows = collect<mlir::db::PowOp>(*module);
+    ASSERT_EQ(pows.size(), 1u);
+    EXPECT_TRUE(pows.front().getOperation()->isBeforeInBlock(firstHop.getOperation()));
+
+    llvm::SmallVector<mlir::db::ConstantOp> constants = collect<mlir::db::ConstantOp>(*module);
+    ASSERT_EQ(constants.size(), 2u);
+    for (mlir::db::ConstantOp constant : constants) {
+        EXPECT_TRUE(constant.getOperation()->isBeforeInBlock(firstHop.getOperation()));
+    }
+
+    // The mask still reads age off the scanned column, with pow feeding the equality.
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
+}


### PR DESCRIPTION
Implements a basic MLIR passes for pushing a predicate up into a cross product factor or an edge chain