### PR TITLE
MLIR: match several patterns on one node pair

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -845,8 +845,13 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
             continue;
         }
 
+        // A merge edge joins two dataflows instead of traversing the graph, so it never
+        // is half of a (source, edge, target) triple: it closes the chain it lands on,
+        // and whatever leaves its target opens a new one.
+        const bool predTraverses = pred && !pred->isMetaEdge();
+
         // Have we found a (source, edge, target) triple yet on this traversal?
-        const bool haveTriple = pred && predPred;
+        const bool haveTriple = predTraverses && predPred;
 
         for (const DependencyEdge* e : var->edges()) {
             const VariableDependency* other = e->src() == var ? e->tgt() : e->src();
@@ -854,9 +859,10 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
                 continue;
             }
 
-            if (haveTriple) {
-                // We have discovered a full (src, edge, tgt) triple, set the next
-                // elements on the stack to only have (src, edge) and await tgt
+            if (haveTriple || !predTraverses) {
+                // We have discovered a full (src, edge, tgt) triple, or @ref pred is a
+                // merge edge that cannot open one: either way the next elements on the
+                // stack only have (src, edge) and await tgt
                 stack.emplace_back(other, e, nullptr);
             } else {
                 // We have not yet discovered a full (src, edge, tgt) triple, but the

--- a/samples/mlir/cascaded_merge.mlir
+++ b/samples/mlir/cascaded_merge.mlir
@@ -1,0 +1,54 @@
+module {
+  func.func @main() {
+    // MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b) RETURN count(*)
+    //
+    // Three patterns joining the same pair of nodes. Each one is a hop of its own, so `b`
+    // is reached three times over - once per pattern - and the three arrivals have to be
+    // collapsed onto one variable. The dependency graph does that with merge edges: every
+    // pattern past the first closes a cycle, broken by giving that pattern its own copy of
+    // `b` plus a merge edge from the copy to `b`. A node carries at most two of them, so a
+    // third copy is cascaded through an intermediate merge node first.
+    //
+    // A merge lowers to a db.eq over its two sources and a db.filter of every live column,
+    // so the cascade reads as a chain of them: the first pairs two copies, the second pairs
+    // the third copy against the first's survivor. Past both, all three arrivals are the
+    // same node - which is what makes e1 and e2 bind the edge of the pair.
+    //
+    // The hops run in the order the traversal discovered them, the reverse of the query:
+    // e2, then e1, then the anonymous KNOWS_WELL edge.
+    %0 = db.scan_nodes() : !db.column<!storage.node_id>
+
+    // Hop 1, (a)-[e2]->(b): nothing carried yet. %4 is e2's copy of `b`.
+    %1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+
+    // Hop 2, (a)-[e1]->(b): leaves from the same `a` (%1) and carries hop 1's columns.
+    // %8 is e1's copy of `b`, %10 is e2's carried through.
+    %5, %6, %7, %8, %9, %10, %11 = db.get_out_edges(%1, {%2, %4, %3}) : (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>)
+
+    // Hop 3, (a)-[:KNOWS_WELL]->(b): %15 is its copy of `b`, with e2's (%17) and e1's
+    // (%19) carried alongside. All three copies are now live in one row.
+    %12, %13, %14, %15, %16, %17, %18, %19, %20, %21 = db.get_out_edges(%5, {%9, %10, %6, %8, %7, %11}) : (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>)
+
+    // The KNOWS_WELL constraint, on hop 3's edge type.
+    %22 = db.check_edge_type_constraint(%14, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+    %23:10 = db.filter(%22, {%13, %15, %18, %19, %16, %17, %12, %14, %20, %21}) : (!db.column<!storage.bool>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>)
+
+    // First merge: e2's copy of `b` (%23#5) against KNOWS_WELL's (%23#1). Its survivor
+    // also stands for the intermediate merge node, so it is carried twice - once as
+    // itself, once as that node.
+    %24 = db.eq %23#5, %23#1 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+    %25:11 = db.filter(%24, {%23#0, %23#1, %23#2, %23#5, %23#3, %23#4, %23#5, %23#6, %23#7, %23#8, %23#9}) : (!db.column<!storage.bool>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>)
+
+    // Second merge, the root of the cascade: e1's copy (%25#4) against the intermediate
+    // node (%25#3). Its survivor is `b`.
+    %26 = db.eq %25#4, %25#3 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+    %27:12 = db.filter(%26, {%25#4, %25#0, %25#1, %25#2, %25#3, %25#4, %25#5, %25#6, %25#7, %25#8, %25#9, %25#10}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.edge_type_id>)
+
+    // count(*) counts the rows of the query's first variable, `a` (%27#8).
+    %28 = db.count(%27#8) : (!db.column<!storage.node_id>) -> !db.column<none>
+
+    db.output(%28) names ["count(*)"] : !db.column<none>
+
+    return
+  }
+}

--- a/samples/mlir/cascaded_merge.nl.mlir
+++ b/samples/mlir/cascaded_merge.nl.mlir
@@ -1,0 +1,59 @@
+// Generated nl-dialect lowering of cascaded_merge.mlir (db dialect).
+// Reproduce with: mlir -f cascaded_merge.mlir -l -g <graph>
+// This is the DBLowering output; edit cascaded_merge.mlir, not this file.
+//
+// MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b) RETURN count(*). One hop per
+// pattern, so three nested loops - each one leaving from the same `a` (the outer loop's
+// srcids, not the previous hop's target) and carrying every column of the hops above it.
+// The three copies of `b` therefore all reach the innermost body, where the merges can
+// compare them.
+//
+// A merge is a per-chunk filter, nothing more: nl.eq over two copies of `b` and an
+// nl.filter of every live chunk. The cascade is the chain of two - the first pairs e2's
+// copy with KNOWS_WELL's, the second pairs e1's against the first's survivor - and needs
+// no state across chunks, so it lowers entirely inside the innermost loop.
+//
+// Needs -graph: check_edge_type_constraint resolves KNOWS_WELL to an edge type ID, so the
+// constraint prints as [0] here where the db dialect still names it.
+module {
+  func.func @main() {
+    %0 = nl.count
+    %1 = nl.scan_nodes()
+    nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
+      // Hop 1, (a)-[e2]->(b): %arg1 is `a`, %arg4 is e2's copy of `b`.
+      %3 = nl.get_out_edges(%arg0, {})
+      nl.for %arg1, %arg2, %arg3, %arg4 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
+        // Hop 2, (a)-[e1]->(b): input is %arg1, the same `a`. %arg8 is e1's copy of `b`,
+        // %arg10 is e2's carried through.
+        %4 = nl.get_out_edges(%arg1, {%arg2, %arg4, %arg3}) : !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>
+        nl.for %arg5, %arg6, %arg7, %arg8, %arg9, %arg10, %arg11 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>> {
+          // Hop 3, (a)-[:KNOWS_WELL]->(b): %arg15 is its copy of `b`, joining e2's
+          // (%arg17) and e1's (%arg19) in this body.
+          %5 = nl.get_out_edges(%arg5, {%arg9, %arg10, %arg6, %arg8, %arg7, %arg11}) : !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>
+          nl.for %arg12, %arg13, %arg14, %arg15, %arg16, %arg17, %arg18, %arg19, %arg20, %arg21 in %5 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>> {
+            // The KNOWS_WELL constraint, on hop 3's edge type.
+            %6 = nl.check_edge_type_constraint(%arg14, [0]) : !nl.chunk<!storage.bool>
+            %7:10 = nl.filter %6, (%arg13, %arg15, %arg18, %arg19, %arg16, %arg17, %arg12, %arg14, %arg20, %arg21) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>) -> (!nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>)
+
+            // First merge: e2's copy of `b` (%7#5) against KNOWS_WELL's (%7#1). Its
+            // survivor is carried twice, once as itself and once as the intermediate
+            // merge node the cascade compares next.
+            %8 = nl.eq %7#5, %7#1 : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.chunk<i1>
+            %9:11 = nl.filter %8, (%7#0, %7#1, %7#2, %7#5, %7#3, %7#4, %7#5, %7#6, %7#7, %7#8, %7#9) : (!nl.chunk<i1>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>) -> (!nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>)
+
+            // Second merge: e1's copy (%9#4) against that intermediate node (%9#3). Past
+            // it the three copies are one node - `b`.
+            %10 = nl.eq %9#4, %9#3 : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.chunk<i1>
+            %11:12 = nl.filter %10, (%9#4, %9#0, %9#1, %9#2, %9#3, %9#4, %9#5, %9#6, %9#7, %9#8, %9#9, %9#10) : (!nl.chunk<i1>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.edge_type_id>)
+
+            // count(*) tallies the rows of `a` (%11#8) that survived both merges.
+            nl.count_update %0, %11#8 : !nl.chunk<!storage.node_id>
+          }
+        }
+      }
+    }
+    %2 = nl.count_result(%0) : !nl.chunk<ui64>
+    nl.output(%2) names ["count(*)"] : !nl.chunk<ui64>
+    return
+  }
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -739,3 +739,24 @@ target_link_libraries(test_query_ir_count_distinct_value PRIVATE
         turing_db_storage_s
         MLIRParser)
 target_include_directories(test_query_ir_count_distinct_value PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_cascaded_merge_join CascadedMergeJoinTest.cpp)
+target_link_libraries(test_query_ir_cascaded_merge_join PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_cascaded_merge_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CascadedMergeJoinTest.cpp
+++ b/test/query/ir/CascadedMergeJoinTest.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Counts = std::vector<uint64_t>;
+using Row = std::vector<std::string>;
+using Rows = std::vector<Row>;
+
+class ScalarCountSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(chunks[0]);
+        ASSERT_NE(counts, nullptr);
+
+        const auto& raw = counts->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const Counts& values() const { return _values; }
+
+private:
+    Counts _values;
+};
+
+class NameRowSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* const column : chunks) {
+                const auto* names = dynamic_cast<const ColumnOptVector<std::string_view>*>(column);
+                if (!names) {
+                    throw TuringException("CascadedMergeJoinTest: expected a string property column");
+                }
+
+                const std::optional<std::string_view>& name = (*names)[rowIndex];
+                row.push_back(name ? std::string(*name) : "null");
+            }
+        }
+    }
+
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
+};
+
+}
+
+// Several patterns joining the same pair of nodes, through the MLIR frontend: each query
+// is parsed, analyzed, generated into the db dialect, then lowered and interpreted.
+//
+// Every extra pattern between the same two nodes adds a cycle the dependency graph breaks
+// with a merge edge, and once a node collects more than two of them they are cascaded
+// through intermediate merge nodes. A merge edge joins two dataflows rather than
+// traversing the graph, so it is never half of a (source, edge, target) triple: reading
+// one as such made a three-pattern query fail in codegen instead of running.
+class CascadedMergeJoinTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+    }
+
+    void expectScalarCount(std::string_view query, uint64_t expected) {
+        ScalarCountSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.values(), (Counts {expected})) << "query: " << query;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        NameRowSink sink;
+        runQuery(query, &sink);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+// The reported query. SimpleGraph holds three KNOWS_WELL edges - Remy -> Adam,
+// Adam -> Remy and Ghosts -> Remy - and no two nodes carry more than one edge between
+// them, so e1 and e2 each have the single edge of the pair to bind and the three patterns
+// match one row per KNOWS_WELL edge.
+TEST_F(CascadedMergeJoinTest, countsThreePatternsOnOneNodePair) {
+    expectScalarCount("MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b) RETURN count(*)", 3);
+}
+
+// The merges constrain the pair, so both edge variables land on the pair's own edge -
+// the KNOWS_WELL edge the first pattern matched.
+TEST_F(CascadedMergeJoinTest, bindsEveryEdgeVariableToTheEdgeOfThePair) {
+    const Rows knownPairs = {
+        {"Remy", "Adam", "Remy -> Adam", "Remy -> Adam"},
+        {"Adam", "Remy", "Adam -> Remy", "Adam -> Remy"},
+        {"Ghosts", "Remy", "Ghosts -> Remy", "Ghosts -> Remy"},
+    };
+
+    expectRows("MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b) "
+               "RETURN a.name, b.name, e1.name, e2.name",
+               knownPairs);
+}
+
+// A fourth pattern cascades the merges one level deeper without widening the match.
+TEST_F(CascadedMergeJoinTest, countsFourPatternsOnOneNodePair) {
+    expectScalarCount("MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b), (a)-[e3]->(b) "
+                      "RETURN count(*)",
+                      3);
+}
+
+// Unconstrained, the patterns collapse onto one edge each, so the match is every edge of
+// the graph: SimpleGraph has 18.
+TEST_F(CascadedMergeJoinTest, countsThreeUntypedPatternsOnOneNodePair) {
+    expectScalarCount("MATCH (a)-[e1]->(b), (a)-[e2]->(b), (a)-[e3]->(b) RETURN count(*)", 18);
+}
+
+// Traversing on from the merged pair: e3 leaves b once the two patterns have merged onto
+// it, so the match is the two-hop chain, which MATCH (a)-[e1]->(b)-[e3]->(c) also counts.
+TEST_F(CascadedMergeJoinTest, traversesOnFromTheMergedPair) {
+    expectScalarCount("MATCH (a)-[e1]->(b), (a)-[e2]->(b), (b)-[e3]->(c) RETURN count(*)", 12);
+    expectScalarCount("MATCH (a)-[e1]->(b)-[e3]->(c) RETURN count(*)", 12);
+}


### PR DESCRIPTION
MATCH (a)-[:KNOWS_WELL]->(b), (a)-[e1]->(b), (a)-[e2]->(b) RETURN count(*) failed the producesEdgeVar assert in codegen because the traversal read a cascaded merge edge as half of a (source, edge, target) triple.