### PR TITLE
MLIR: count the one row of a bare RETURN

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1799,6 +1799,28 @@ mlir::Value DBProgramGenerator::resolveWildcardColumn() const {
     return mlir::Value {};
 }
 
+mlir::Value DBProgramGenerator::translateAggregateInput(const Expr* argExpr) {
+    if (argExpr->getType() != EvaluatedType::Wildcard) {
+        translateExpr(argExpr);
+        return _exprMap.at(argExpr);
+    }
+
+    const mlir::Value column = resolveWildcardColumn();
+    if (column) {
+        return column;
+    }
+
+    // A query binding no column runs over one row of its own, and count(*) tallies
+    // that row: a constant stands for it, as the 42 of RETURN count(42) does
+    const bool bindsNoColumn = _varMap.empty() && _yieldedColumns.empty();
+    bioassert(bindsNoColumn, "count(*) over no column holding the rows it counts.");
+
+    const mlir::TypedAttr oneAttr = _opBuilder.getI64IntegerAttr(1);
+    const mlir::db::ColumnType oneType = allocColumnType(oneAttr.getType());
+
+    return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), oneType, oneAttr).getResult();
+}
+
 void DBProgramGenerator::generateSet(const CypherAST* ast) {
     const CypherAST::QueryCommands& queries = ast->queries();
     if (queries.size() != 1) {
@@ -2725,15 +2747,7 @@ void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
     bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
 
     const Expr* argExpr = args->front();
-    mlir::Value inputColumn;
-
-    if (argExpr->getType() == EvaluatedType::Wildcard) {
-        inputColumn = resolveWildcardColumn();
-        bioassert(inputColumn, "count(*) over no column holding the rows it counts.");
-    } else {
-        translateExpr(argExpr);
-        inputColumn = _exprMap.at(argExpr);
-    }
+    const mlir::Value inputColumn = translateAggregateInput(argExpr);
 
     const bool isDistinct = invocation->isDistinct();
 
@@ -2990,15 +3004,7 @@ void DBProgramGenerator::generateGroupAggregate(const CypherAST* ast) {
         bioassert(args && !args->empty(), "Aggregate function invocation with no arguments.");
 
         const Expr* argExpr = args->front();
-        mlir::Value inputColumn;
-
-        if (argExpr->getType() == EvaluatedType::Wildcard) {
-            inputColumn = resolveWildcardColumn();
-            bioassert(inputColumn, "count(*) over no column holding the rows it counts.");
-        } else {
-            translateExpr(argExpr);
-            inputColumn = _exprMap.at(argExpr);
-        }
+        const mlir::Value inputColumn = translateAggregateInput(argExpr);
 
         aggInputColumns.push_back(inputColumn);
         aggKinds.push_back(*kind);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -223,6 +223,10 @@ private:
     // declares its variables so the choice is the query's and not the addresses'
     mlir::Value resolveWildcardColumn() const;
 
+    // The column an aggregate folds over: the column count(*) counts, or the one its
+    // argument's translation computes
+    mlir::Value translateAggregateInput(const Expr* argExpr);
+
     void generatePropertyConstraints(const CypherAST* ast);
 
     void applyPredicateFilters(std::span<const Expr* const> predicates);

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -941,3 +941,13 @@ target_link_libraries(test_query_ir_aggregate_over_constant_arithmetic PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_aggregate_over_constant_arithmetic PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_count_wildcard_empty_input CountWildcardEmptyInputTest.cpp)
+target_link_libraries(test_query_ir_count_wildcard_empty_input PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_count_wildcard_empty_input PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CountWildcardEmptyInputTest.cpp
+++ b/test/query/ir/CountWildcardEmptyInputTest.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnVector.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Integers = std::vector<int64_t>;
+using ColumnNames = std::vector<std::string>;
+
+// Collects the column names and the values of the integer column a standalone count, or
+// an expression over one, emits - the last column, behind any grouping key - and whether
+// that column is signed: a count comes out as a ui64 tally, any arithmetic over it as
+// the i64 the language's one integer type is.
+class ScalarIntegerSink : public NLOutputSink {
+public:
+    void setColumnNames(std::span<const std::string_view> names) override {
+        _names.assign(names.begin(), names.end());
+    }
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_FALSE(chunks.empty());
+
+        const auto* signedValues = dynamic_cast<const ColumnVector<int64_t>*>(chunks.back());
+        const auto* unsignedValues = dynamic_cast<const ColumnVector<uint64_t>*>(chunks.back());
+        ASSERT_TRUE(signedValues || unsignedValues);
+
+        _signedColumn = signedValues != nullptr;
+
+        if (signedValues) {
+            const std::vector<int64_t>& raw = signedValues->getRaw();
+            _values.insert(_values.end(), raw.begin() + offset, raw.begin() + offset + rowCount);
+        } else {
+            const std::vector<uint64_t>& raw = unsignedValues->getRaw();
+            std::transform(raw.begin() + offset,
+                           raw.begin() + offset + rowCount,
+                           std::back_inserter(_values),
+                           [](uint64_t value) { return static_cast<int64_t>(value); });
+        }
+    }
+
+    const ColumnNames& names() const { return _names; }
+    const Integers& values() const { return _values; }
+    bool isSignedColumn() const { return _signedColumn; }
+
+private:
+    ColumnNames _names;
+    Integers _values;
+    bool _signedColumn {false};
+};
+
+}
+
+// The query test suite's count-wildcard-*-empty-input cases on the v3 engine. A RETURN
+// with no MATCH in front of it runs over one row of its own, so a count(*) there tallies
+// that row rather than answering for an input it never had.
+class CountWildcardEmptyInputTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void expectScalar(std::string_view query, const ColumnNames& columnNames, int64_t expected, bool signedColumn) {
+        ScalarIntegerSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.names(), columnNames) << "query: " << query;
+        EXPECT_EQ(sink.values(), (Integers {expected})) << "query: " << query;
+        EXPECT_EQ(sink.isSignedColumn(), signedColumn) << "query: " << query;
+    }
+
+    void expectCount(std::string_view query, const ColumnNames& columnNames, int64_t expected) {
+        expectScalar(query, columnNames, expected, false);
+    }
+
+    void expectSignedInteger(std::string_view query, const ColumnNames& columnNames, int64_t expected) {
+        expectScalar(query, columnNames, expected, true);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// count-wildcard-empty-input: the tally of the one row a bare RETURN runs over
+TEST_F(CountWildcardEmptyInputTest, countsTheOneRowOfABareReturn) {
+    expectCount("RETURN COUNT(*)", {"COUNT(*)"}, 1);
+}
+
+// The same row under a grouping key: the constant key puts it in one group, whose count
+// is that row
+TEST_F(CountWildcardEmptyInputTest, countsTheOneRowOfABareReturnUnderAConstantKey) {
+    expectCount("RETURN 1 AS x, count(*)", {"x", "count(*)"}, 1);
+}
+
+// count-wildcard-divide-limit-empty-input: the division is an expression over the tally,
+// so its column is a signed integer, and a LIMIT above the one row leaves it standing
+TEST_F(CountWildcardEmptyInputTest, dividesTheCountUnderALimit) {
+    expectSignedInteger("RETURN COUNT(*) / 999 LIMIT 2", {"COUNT(*) / 999"}, 0);
+}
+
+// count-wildcard-increment-empty-input: every + past the first of each run is a unary
+// plus, so the item reads COUNT(*) + 9 + 99
+TEST_F(CountWildcardEmptyInputTest, addsThroughRunsOfUnaryPluses) {
+    const std::string expression = "++++++++++++++++++++++++++++++++COUNT(*)++++++++9++++++++++++++++++++++++++++++99";
+    expectSignedInteger("RETURN " + expression, {expression}, 109);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Count the one row a RETURN with no MATCH runs over.

| Test | Query | v3 before | v2 | openCypher | v3 after |
|---|---|---|---|---|---|
| count-wildcard-empty-input | `RETURN COUNT(*)` | PLAN ERROR (internal assert) | 0 | 1 | 1 |
| count-wildcard-divide-limit-empty-input | `RETURN COUNT(*) / 999 LIMIT 2` | PLAN ERROR (internal assert) | 0 | 0 | 0 |
| count-wildcard-increment-empty-input | `RETURN ++++++++++++++++++++++++++++++++COUNT(*)++++++++9++++++++++++++++++++++++++++++99` | PLAN ERROR (internal assert) | PLAN ERROR (unary PLUS unsupported) | 109 | 109 |