### PR TITLE
MLIR: reject an edge variable repeated in one pattern

### DIFF
--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -30,6 +30,7 @@
 
 #include "BioAssert.h"
 #include "FatalException.h"
+#include "TuringException.h"
 
 using namespace db;
 
@@ -130,8 +131,23 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
 
     const auto& chain = ptn->getElementChain();
 
+    // Two patterns sharing an edge variable are joined on identity; one element naming it
+    // twice is rejected instead, as no edge is two hops of one element.
+    std::vector<const VarDecl*> edgesInElement;
+
     VariableDependency* prev = originVar;
     for (const auto& [edge, tgtPtn] : chain) {
+        const VarDecl* edgeDecl = edge->getDecl();
+        bioassert(edgeDecl, "Edge pattern without declaration.");
+
+        const bool alreadyInElement =
+            std::ranges::find(edgesInElement, edgeDecl) != edgesInElement.end();
+        if (alreadyInElement) {
+            throw TuringException("Re-using the same edge variable in a single pattern is not supported");
+        }
+
+        edgesInElement.push_back(edgeDecl);
+
         VariableDependency* tgtVar = getOrCreateVariable(tgtPtn);
 
         const EdgePattern::Direction direction = edge->getDirection();
@@ -144,8 +160,7 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
         src = prev;
         tgt = tgtVar;
 
-        bioassert(edge->getDecl(), "Edge pattern without declaration.");
-        const std::string_view cypherEdgeName = edge->getDecl()->getName();
+        const std::string_view cypherEdgeName = edgeDecl->getName();
         std::vector<VariableDependency*>& edgeOccurrences = _edgeIdentities[std::string(cypherEdgeName)];
         std::string anonymousName;
         anonymousName += cypherEdgeName;

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -951,3 +951,13 @@ target_link_libraries(test_query_ir_count_wildcard_empty_input PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_count_wildcard_empty_input PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_repeated_edge_variable RepeatedEdgeVariableTest.cpp)
+target_link_libraries(test_query_ir_repeated_edge_variable PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_repeated_edge_variable PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/RepeatedEdgeVariableTest.cpp
+++ b/test/query/ir/RepeatedEdgeVariableTest.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+class RowCountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+}
+
+// The query test suite's fail-reads-match-2 case on the v3 engine. An edge variable named
+// twice in one pattern asks the same edge to be two hops of that pattern, which no edge
+// can be, so the query is turned away - while the same variable shared by two patterns is
+// a join on one edge, and runs.
+class RepeatedEdgeVariableTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRepeatedEdgeRejection(std::string_view query) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR) << "query: " << query;
+
+        const std::string error = status.getError();
+        const std::string_view reason = "Re-using the same edge variable in a single pattern is not supported";
+        EXPECT_NE(error.find(reason), std::string::npos) << "query: " << query << "\nerror: " << error;
+    }
+
+    void expectRowCount(std::string_view query, size_t expected) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getRowCount(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+
+private:
+    void runQuery(std::string_view query, QueryStatus& status, NLOutputSink& sink) {
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+    }
+};
+
+// fail-reads-match-2: the second hop repeats both the edge variable and the node the first
+// hop landed on
+TEST_F(RepeatedEdgeVariableTest, rejectsARepeatedEdgeVariableClosingOnItsTarget) {
+    expectRepeatedEdgeRejection("MATCH (n:Person)-[e]->(m:Person)-[e]->(m)\nRETURN n;");
+}
+
+// The same repetition with a fresh node at each end, where the pattern reads as a two-hop
+// walk and only the edge variable is repeated
+TEST_F(RepeatedEdgeVariableTest, rejectsARepeatedEdgeVariableBetweenDistinctNodes) {
+    expectRepeatedEdgeRejection("MATCH (n:Person)-[e]->(m:Person)-[e]->(o:Person)\nRETURN n;");
+}
+
+// The valid neighbour of those two: one edge variable across two patterns joins them on
+// that edge, one row per edge leaving a Person
+TEST_F(RepeatedEdgeVariableTest, joinsAnEdgeVariableSharedByTwoPatterns) {
+    expectRowCount("MATCH (n:Person)-[e]->(m)\nMATCH (a)-[e]->(b)\nRETURN n, a;", 17);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Reject an edge variable repeated in one pattern.

```
MATCH (n:Person)-[e]->(m:Person)-[e]->(m)
RETURN n;

before, v3: PLAN_ERROR: Unexpected exception: Internal Error: The assertion
            '_varMap.contains(var)' failed at
            query/ir/codegen/DBProgramGenerator.cpp:776
            Component var e'0 not registered

after, v3:  PLAN_ERROR: Re-using the same edge variable in a single pattern is
            not supported
```
