### PR TITLE
MLIR: apply a MATCH's ORDER BY, SKIP and LIMIT and unit test the query suite's read cases

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1376,7 +1376,11 @@ void DBProgramGenerator::generateFiltersAndCalls(const CypherAST* ast) {
 
         if (kind == Stmt::Kind::MATCH) {
             matchSeen = true;
-            generateMatchFilter(static_cast<const MatchStmt*>(stmt));
+
+            const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
+            generateMatchFilter(matchStmt);
+            generateMatchOrderBy(matchStmt);
+            generateMatchWindow(matchStmt);
         } else if (kind == Stmt::Kind::CALL) {
             const bool drivesTheTraversal = _drivenRoot && !matchSeen;
 
@@ -1398,6 +1402,112 @@ void DBProgramGenerator::generateMatchFilter(const MatchStmt* matchStmt) {
     flattenConjuncts(where->getExpr(), conjuncts);
 
     applyPredicateFilters(conjuncts);
+}
+
+void DBProgramGenerator::generateMatchOrderBy(const MatchStmt* matchStmt) {
+    if (!matchStmt->hasOrderBy()) {
+        return;
+    }
+
+    InFlightColumns inFlight;
+    collectInFlightColumns(inFlight);
+
+    if (inFlight._columns.empty()) {
+        return;
+    }
+
+    VariableColumnMap variableColumns;
+    collectVariableColumns(variableColumns);
+
+    llvm::SmallVector<mlir::Value> sorted(inFlight._columns.begin(), inFlight._columns.end());
+    llvm::SmallVector<int64_t> keyColumns;
+    llvm::SmallVector<bool> keyAscending;
+
+    for (const OrderByItem* item : matchStmt->getOrderBy()->getItems()) {
+        const Expr* keyExpr = item->getExpr();
+
+        // A constant key holds the same value in every row, so it changes no order
+        if (!keyExpr->isDynamic()) {
+            continue;
+        }
+
+        const mlir::Value keyColumn = getOrTranslateExprColumn(variableColumns, keyExpr);
+        if (yieldsConstantColumn(keyColumn)) {
+            continue;
+        }
+
+        // A key the match does not carry - the n.name of MATCH (n) ORDER BY n.name - is
+        // handed to the sort as one more column, so that it moves with the row it belongs
+        // to; its result is then left unread, which is what keeps it out of the rows
+        auto sortedKey = std::find(sorted.begin(), sorted.end(), keyColumn);
+        if (sortedKey == sorted.end()) {
+            sorted.push_back(keyColumn);
+            sortedKey = std::prev(sorted.end());
+        }
+
+        keyColumns.push_back(static_cast<int64_t>(std::distance(sorted.begin(), sortedKey)));
+        keyAscending.push_back(item->getType() == OrderByType::ASC);
+    }
+
+    if (keyColumns.empty()) {
+        return;
+    }
+
+    llvm::SmallVector<mlir::Type> sortResultTypes;
+    for (const mlir::Value column : sorted) {
+        sortResultTypes.push_back(column.getType());
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    auto sortOp = _opBuilder.create<mlir::db::Sort>(loc,
+                                                    sortResultTypes,
+                                                    mlir::ValueRange {sorted},
+                                                    keyColumns,
+                                                    keyAscending);
+
+    rebindInFlightColumns(sortOp.getResults(), /*firstResult=*/0, inFlight);
+}
+
+void DBProgramGenerator::generateMatchWindow(const MatchStmt* matchStmt) {
+    if (matchStmt->hasSkip()) {
+        const int64_t skipValue = evaluateConstantInteger(matchStmt->getSkip()->getExpr());
+
+        if (skipValue < 0) {
+            throw TuringException("SKIP expression must be a non-negative integer");
+        }
+
+        cutAllColumns<mlir::db::Skip>(static_cast<uint64_t>(skipValue));
+    }
+
+    if (matchStmt->hasLimit()) {
+        const int64_t limitValue = evaluateConstantInteger(matchStmt->getLimit()->getExpr());
+
+        if (limitValue < 0) {
+            throw TuringException("LIMIT expression must be a non-negative integer");
+        }
+
+        cutAllColumns<mlir::db::Limit>(static_cast<uint64_t>(limitValue));
+    }
+}
+
+template <typename CutOp>
+void DBProgramGenerator::cutAllColumns(uint64_t count) {
+    InFlightColumns inFlight;
+    collectInFlightColumns(inFlight);
+
+    if (inFlight._columns.empty()) {
+        return;
+    }
+
+    llvm::SmallVector<mlir::Type> resultTypes;
+    for (const mlir::Value column : inFlight._columns) {
+        resultTypes.push_back(column.getType());
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    auto cutOp = _opBuilder.create<CutOp>(loc, resultTypes, inFlight._columns, count);
+
+    rebindInFlightColumns(cutOp.getResults(), /*firstResult=*/0, inFlight);
 }
 
 void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
@@ -1935,6 +2045,27 @@ void DBProgramGenerator::generateDelete(const CypherAST* ast) {
     }
 }
 
+void DBProgramGenerator::collectVariableColumns(VariableColumnMap& variableColumns) const {
+    for (const auto& [cypherVar, columns] : _varMap) {
+        const std::string_view varName = cypherVar->getName();
+
+        bioassert(not columns.empty(), "No definitions for {}", varName);
+        variableColumns[varName] = columns.back();
+    }
+
+    // A CALL's yielded columns are variables of the query too, named by the YIELD.
+    for (const YieldedColumn& yieldedColumn : _yieldedColumns) {
+        variableColumns[yieldedColumn.first] = yieldedColumn.second;
+    }
+
+    for (const auto& [name, vars] : _vdg.edgeIdentities()) {
+        bioassert(!vars.empty(), "Empty edge identity for '{}'", name);
+        const VariableDependency* representative = vars.front();
+        bioassert(_varMap.contains(representative), "Edge identity representative not in varMap");
+        variableColumns[name] = _varMap.at(representative).back();
+    }
+}
+
 void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     const CypherAST::QueryCommands& queries = ast->queries();
     if (queries.size() != 1) {
@@ -1971,26 +2102,7 @@ void DBProgramGenerator::generateOutput(const CypherAST* ast) {
     const Projection::Items& returned = proj->items();
 
     VariableColumnMap variableColumns;
-    for (auto& [cypherVar, mlirCol] : _varMap) {
-        const std::string_view varName = cypherVar->getName();
-
-        bioassert(not mlirCol.empty(), "No definitions for {}", varName);
-        const mlir::Value finalValue = mlirCol.back();
-
-        variableColumns[varName] = finalValue;
-    }
-
-    // A CALL's yielded columns are variables of the query too, named by the YIELD.
-    for (const YieldedColumn& yieldedColumn : _yieldedColumns) {
-        variableColumns[yieldedColumn.first] = yieldedColumn.second;
-    }
-
-    for (const auto& [name, vars] : _vdg.edgeIdentities()) {
-        bioassert(!vars.empty(), "Empty edge identity for '{}'", name);
-        const VariableDependency* representative = vars.front();
-        bioassert(_varMap.contains(representative), "Edge identity representative not in varMap");
-        variableColumns[name] = _varMap.at(representative).back();
-    }
+    collectVariableColumns(variableColumns);
 
     const auto getVarForItem = [&](auto&& item) -> mlir::Value {
         using Type = std::remove_cvref_t<decltype(item)>;

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -160,6 +160,14 @@ private:
     // predicate reading what a call yielded is generated once the call has bound it.
     void generateFiltersAndCalls(const CypherAST* ast);
     void generateMatchFilter(const MatchStmt* matchStmt);
+
+    // Emits the Sort a MATCH's ORDER BY asks for, over everything in flight: the rows the
+    // rest of the query reads are then the ordered ones.
+    void generateMatchOrderBy(const MatchStmt* matchStmt);
+
+    // Emits the cuts a MATCH's SKIP and LIMIT ask for, the SKIP first: what the rest of the
+    // query reads is then the window rather than every row matched.
+    void generateMatchWindow(const MatchStmt* matchStmt);
     void generateCall(const CallStmt* callStmt);
 
     // Generate the filter a CALL's YIELD ... WHERE asks for, over everything in flight once
@@ -179,6 +187,10 @@ private:
     // Collect those columns. One bound in another block is skipped: an op here can only
     // take what this block binds.
     void collectInFlightColumns(InFlightColumns& inFlight);
+
+    // Cut the rows in flight with a db.skip or a db.limit, given as @tparam CutOp
+    template <typename CutOp>
+    void cutAllColumns(uint64_t count);
 
     // Rebind them to an op's results, so later ops read what it produced. firstResult is
     // where its pass-through results start - zero for an op that only takes them (a
@@ -210,6 +222,10 @@ private:
     void translateOrderBy(const Projection* projection,
                           const VariableColumnMap& variableColumns,
                           llvm::SmallVectorImpl<mlir::Value>& projected);
+
+    // The column each variable of the query is bound to, under the name it carries: the
+    // traversal variables, what a CALL yielded, and each edge identity under its own name
+    void collectVariableColumns(VariableColumnMap& variableColumns) const;
 
     // The column holding the values of an expression: the column already published for
     // the traversal variable it names, when the expression is nothing but that variable,

--- a/test/query/ir/AggregateWithReturnItemsTest.cpp
+++ b/test/query/ir/AggregateWithReturnItemsTest.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+constexpr size_t nodeCount = 18;
+
+}
+
+// The query test suite's avg-mixed-return-error, count-m-return-n, count-n-return-m and
+// return-count-n-count-m cases on the v3 engine. Each returns an aggregate beside another
+// item, which the v1 planner turned away as one unsupported shape; here the plain item is
+// the grouping key, as SQL groups by what it selects beside an aggregate.
+class AggregateWithReturnItemsTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRows(std::string_view query, std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        std::sort(expected.begin(), expected.end());
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// avg-mixed-return-error: one group per node, so each average reads that node's age alone.
+// Remy and Adam are the only nodes carrying one, both 32; every other group averages a
+// single null.
+TEST_F(AggregateWithReturnItemsTest, averagesWithinTheGroupOfEachReturnedNode) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t node = 0; node < nodeCount; node++) {
+        const std::string age = node <= 1 ? "32" : "null";
+        expected.push_back({age, std::to_string(node)});
+    }
+
+    expectRows("MATCH (n) RETURN avg(n.age), n", expected);
+}
+
+// count-m-return-n: the two patterns cross into a row per pair of nodes, so each of the
+// eighteen groups counts the eighteen m it was paired with
+TEST_F(AggregateWithReturnItemsTest, countsThePairsOfEachReturnedNode) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t node = 0; node < nodeCount; node++) {
+        expected.push_back({std::to_string(node), std::to_string(nodeCount)});
+    }
+
+    expectRows("MATCH (n), (m) RETURN n, count(m)", expected);
+}
+
+// count-n-return-m: the same grouping when the aggregate is written first
+TEST_F(AggregateWithReturnItemsTest, countsThePairsWhenTheAggregateComesFirst) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t node = 0; node < nodeCount; node++) {
+        expected.push_back({std::to_string(nodeCount), std::to_string(node)});
+    }
+
+    expectRows("MATCH (n), (m) RETURN count(n), m", expected);
+}
+
+// return-count-n-count-m: two aggregates and nothing else leave no grouping key, so the
+// whole cross product of eighteen by eighteen is counted into one row
+TEST_F(AggregateWithReturnItemsTest, countsEveryPairOnceWhenBothItemsAggregate) {
+    std::vector<StringRowSink::Row> expected {{"324", "324"}};
+
+    expectRows("MATCH (n), (m) RETURN COUNT(n), COUNT(m)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1027,3 +1027,25 @@ target_link_libraries(test_query_ir_multi_pattern_join PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_multi_pattern_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_match_order_by MatchOrderByTest.cpp)
+target_sources(test_query_ir_match_order_by PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_match_order_by PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_match_order_by PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_match_skip_limit MatchSkipLimitTest.cpp)
+target_sources(test_query_ir_match_skip_limit PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_match_skip_limit PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_match_skip_limit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -974,3 +974,56 @@ target_link_libraries(test_query_ir_comma_pattern_join_keys PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_comma_pattern_join_keys PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_variable_type_conflict VariableTypeConflictTest.cpp)
+target_link_libraries(test_query_ir_variable_type_conflict PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_variable_type_conflict PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_unknown_variable UnknownVariableTest.cpp)
+target_link_libraries(test_query_ir_unknown_variable PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_unknown_variable PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_aggregate_with_return_items AggregateWithReturnItemsTest.cpp)
+target_sources(test_query_ir_aggregate_with_return_items PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_aggregate_with_return_items PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_aggregate_with_return_items PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_pattern_loop PatternLoopTest.cpp)
+target_sources(test_query_ir_pattern_loop PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_pattern_loop PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_pattern_loop PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_multi_pattern_join MultiPatternJoinTest.cpp)
+target_sources(test_query_ir_multi_pattern_join PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_multi_pattern_join PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_multi_pattern_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/ConstantPredicateProjectionTest.cpp
+++ b/test/query/ir/ConstantPredicateProjectionTest.cpp
@@ -163,6 +163,18 @@ TEST_F(ConstantPredicateProjectionTest, dedupsAConstantNegationUnderAWindow) {
     expectRows("RETURN DISTINCT not true SKIP 0 LIMIT 1", expected);
 }
 
+// The query test suite's where-not-true-return-not-false case: the constant predicate keeps
+// no node, so the projection standing for every row stands for none.
+TEST_F(ConstantPredicateProjectionTest, emitsNothingWhenAConstantPredicateExcludesEveryMatchedRow) {
+    expectRows("MATCH (n) WHERE NOT TRUE RETURN NOT FALSE", {});
+}
+
+// The same projection once the predicate keeps every node of simpledb
+TEST_F(ConstantPredicateProjectionTest, emitsTheConstantForEveryMatchedRowWhenTheConstantPredicateKeepsThem) {
+    const BoolRows expected(18, {true});
+    expectRows("MATCH (n) WHERE NOT FALSE RETURN NOT FALSE", expected);
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/MatchOrderByTest.cpp
+++ b/test/query/ir/MatchOrderByTest.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The query test suite's fail-reads-order-by-0 case on the v3 engine. An ORDER BY written on
+// the MATCH orders the rows the match produced, which the RETURN then reads in that order.
+class MatchOrderByTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRowsInOrder(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// fail-reads-order-by-0: the eighteen nodes of simpledb by name, Adam (1) first and Travel
+// (14) last, where the match alone would answer them by id
+TEST_F(MatchOrderByTest, ordersTheMatchedRowsByTheKeyTheMatchNames) {
+    const std::vector<StringRowSink::Row> expected {{"1"},
+                                                    {"10"},
+                                                    {"4"},
+                                                    {"2"},
+                                                    {"5"},
+                                                    {"15"},
+                                                    {"17"},
+                                                    {"3"},
+                                                    {"6"},
+                                                    {"13"},
+                                                    {"16"},
+                                                    {"9"},
+                                                    {"11"},
+                                                    {"8"},
+                                                    {"7"},
+                                                    {"0"},
+                                                    {"12"},
+                                                    {"14"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name RETURN n", expected);
+}
+
+TEST_F(MatchOrderByTest, ordersTheMatchedRowsDownwards) {
+    const std::vector<StringRowSink::Row> expected {{"14"},
+                                                    {"12"},
+                                                    {"0"},
+                                                    {"7"},
+                                                    {"8"},
+                                                    {"11"},
+                                                    {"9"},
+                                                    {"16"},
+                                                    {"13"},
+                                                    {"6"},
+                                                    {"3"},
+                                                    {"17"},
+                                                    {"15"},
+                                                    {"5"},
+                                                    {"2"},
+                                                    {"4"},
+                                                    {"10"},
+                                                    {"1"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name DESC RETURN n", expected);
+}
+
+// The order is over the rows the match kept, so the label constraint cuts the eighteen down
+// to the eight Person nodes before they are ordered
+TEST_F(MatchOrderByTest, ordersOnlyTheRowsTheMatchKept) {
+    const std::vector<StringRowSink::Row> expected {{"1"}, {"15"}, {"17"}, {"9"}, {"11"}, {"8"}, {"0"}, {"12"}};
+
+    expectRowsInOrder("MATCH (n:Person) ORDER BY n.name RETURN n", expected);
+}
+
+// A property the RETURN reads is read from the ordered rows, not from the ones the match
+// produced before the sort
+TEST_F(MatchOrderByTest, readsAProjectedPropertyFromTheOrderedRows) {
+    const std::vector<StringRowSink::Row> expected {{"Adam"}, {"Cyrus"}, {"Doruk"}, {"Luc"}, {"Martina"}, {"Maxime"}, {"Remy"}, {"Suhas"}};
+
+    expectRowsInOrder("MATCH (n:Person) ORDER BY n.name RETURN n.name", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MatchSkipLimitTest.cpp
+++ b/test/query/ir/MatchSkipLimitTest.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The SKIP and LIMIT siblings of the ORDER BY a MATCH may carry: they cut the rows the match
+// produced, so the rest of the query reads the window rather than everything matched.
+class MatchSkipLimitTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRowsInOrder(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The three nodes the match produced first, which it answers in the order it scanned them
+TEST_F(MatchSkipLimitTest, keepsTheFirstMatchedRows) {
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"1"}, {"2"}};
+
+    expectRowsInOrder("MATCH (n) LIMIT 3 RETURN n", expected);
+}
+
+// Adam, Animals and Bio, the first three of simpledb by name
+TEST_F(MatchSkipLimitTest, keepsTheFirstOfTheOrderedRows) {
+    const std::vector<StringRowSink::Row> expected {{"1"}, {"10"}, {"4"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name LIMIT 3 RETURN n", expected);
+}
+
+// Remy, Suhas and Travel, the three the order leaves once fifteen are passed
+TEST_F(MatchSkipLimitTest, dropsTheOrderedRowsItSkipsPast) {
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"12"}, {"14"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name SKIP 15 RETURN n", expected);
+}
+
+// The SKIP cuts before the LIMIT, so the window is Bio, Computers and Cooking
+TEST_F(MatchSkipLimitTest, keepsTheWindowBothCutsLeave) {
+    const std::vector<StringRowSink::Row> expected {{"4"}, {"2"}, {"5"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name SKIP 2 LIMIT 3 RETURN n", expected);
+}
+
+TEST_F(MatchSkipLimitTest, keepsNothingWhenTheSkipPassesEveryMatchedRow) {
+    expectRowsInOrder("MATCH (n) SKIP 20 RETURN n", {});
+}
+
+// The projection cuts what the match handed it, so the RETURN skips into the five rows the
+// match kept and answers the two that are left, not into the eighteen it matched
+TEST_F(MatchSkipLimitTest, cutsAgainWhenTheProjectionCarriesItsOwnWindow) {
+    const std::vector<StringRowSink::Row> expected {{"2"}, {"5"}};
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name LIMIT 5 RETURN n SKIP 3", expected);
+}
+
+// An aggregate folds over the rows the cut left, not over everything the match produced
+TEST_F(MatchSkipLimitTest, countsOnlyTheRowsTheCutLeft) {
+    const std::vector<StringRowSink::Row> expected {{"3"}};
+
+    expectRowsInOrder("MATCH (n) LIMIT 3 RETURN count(n)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MultiPatternJoinTest.cpp
+++ b/test/query/ir/MultiPatternJoinTest.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The query test suite's success-reads-match-9 and success-reads-joins-on-filters-5 cases on
+// the v3 engine. Both name the same variable in patterns that reach it from either end, the
+// shape the v1 planner turned away as a common successor joined with a common ancestor.
+class MultiPatternJoinTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// success-reads-match-9: the second pattern already spells the first, so the rows are the
+// two-hop walks a -> b -> c of simpledb - out of Remy (0), Adam (1) and Ghosts (6), the only
+// nodes an edge both enters and leaves
+TEST_F(MultiPatternJoinTest, joinsAPatternWithTheWalkThatContainsIt) {
+    const std::vector<StringRowSink::Row> expected {{"0", "1", "0"},
+                                                    {"0", "1", "4"},
+                                                    {"0", "1", "5"},
+                                                    {"0", "6", "0"},
+                                                    {"1", "0", "1"},
+                                                    {"1", "0", "2"},
+                                                    {"1", "0", "3"},
+                                                    {"1", "0", "6"},
+                                                    {"6", "0", "1"},
+                                                    {"6", "0", "2"},
+                                                    {"6", "0", "3"},
+                                                    {"6", "0", "6"}};
+
+    expectRows("MATCH (b)-->(c), (a)-->(b)-->(c) RETURN a, b, c;", expected);
+}
+
+// success-reads-joins-on-filters-5: nothing forces a and b apart, nor c and d, so every pair
+// of edges into x is crossed with every pair of two-hop ways out of x onto one e. Remy (0),
+// Adam (1) and Ghosts (6) are the only such x, and a is whoever enters them.
+TEST_F(MultiPatternJoinTest, joinsTwoWaysIntoANodeWithTwoWaysOutOfIt) {
+    std::vector<StringRowSink::Row> expected;
+    expected.insert(expected.end(), 8, {"0"});
+    expected.insert(expected.end(), 12, {"1"});
+    expected.insert(expected.end(), 12, {"6"});
+
+    expectRows("MATCH (a)-->(x), (b)-->(x), (x)-->(c)-->(e), (x)-->(d)-->(e) RETURN a", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/PatternLoopTest.cpp
+++ b/test/query/ir/PatternLoopTest.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The query test suite's fail-reads-loop-0 case on the v3 engine. A pattern whose last node
+// is its first walks back to where it started, which the v1 planner turned away as a loop;
+// here it is a hop joined to the node it left.
+class PatternLoopTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// fail-reads-loop-0: simpledb closes a two-hop loop through the two pairs answering each
+// other, Remy (0) with Adam (1) and Remy with Ghosts (6), read from either end
+TEST_F(PatternLoopTest, walksBackToTheNodeThePatternStartedFrom) {
+    const std::vector<StringRowSink::Row> expected {{"0", "1"}, {"0", "6"}, {"1", "0"}, {"6", "0"}};
+
+    expectRows("MATCH (a)-->(b)-->(a) RETURN a, b;", expected);
+}
+
+// The same shape one hop longer, which no simpledb edge closes
+TEST_F(PatternLoopTest, matchesNothingWhenNoLoopIsThatLong) {
+    expectRows("MATCH (a)-->(b)-->(c)-->(a) RETURN a, b, c;", {});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/UnknownVariableTest.cpp
+++ b/test/query/ir/UnknownVariableTest.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+class RowCountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+}
+
+// The query test suite's fail-reads-match-1 case on the v3 engine. A name no pattern binds
+// stands for nothing the query can read, so it is turned away wherever it is read from -
+// through a property, on its own, or as the subject of a label test.
+class UnknownVariableTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectUnknownVariableRejection(std::string_view query, std::string_view reason) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR) << "query: " << query;
+
+        const std::string error = status.getError();
+        EXPECT_NE(error.find(reason), std::string::npos) << "query: " << query << "\nerror: " << error;
+    }
+
+    void expectRowCount(std::string_view query, size_t expected) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getRowCount(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+
+private:
+    void runQuery(std::string_view query, QueryStatus& status, NLOutputSink& sink) {
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+    }
+};
+
+// fail-reads-match-1: 'a' is read for a property in a WHERE comparing the two patterns
+TEST_F(UnknownVariableTest, rejectsAnUnknownVariableReadForAProperty) {
+    expectUnknownVariableRejection("MATCH (n) MATCH (m) WHERE n.duration = a.duration RETURN n, m;",
+                                   "Variable 'a' not found");
+}
+
+// The same name read on its own, where the projection asks for the entity rather than one
+// of its properties
+TEST_F(UnknownVariableTest, rejectsAnUnknownVariableReturnedOnItsOwn) {
+    expectUnknownVariableRejection("MATCH (n) RETURN n, a;", "Variable 'a' not found");
+}
+
+// The same name as the subject of a label test
+TEST_F(UnknownVariableTest, rejectsAnUnknownVariableTestedForALabel) {
+    expectUnknownVariableRejection("MATCH (n) WHERE a:Person RETURN n;", "Variable 'a' not found");
+}
+
+// The valid neighbour of those: the WHERE reads a property of the second pattern instead of
+// an unbound name. Remy and Adam are the only nodes carrying an age, and both are 32, so
+// every ordered pair of them matches.
+TEST_F(UnknownVariableTest, joinsTwoPatternsOnAPropertyOfADeclaredVariable) {
+    expectRowCount("MATCH (n) MATCH (m) WHERE n.age = m.age RETURN n, m;", 4);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/VariableTypeConflictTest.cpp
+++ b/test/query/ir/VariableTypeConflictTest.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+class RowCountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+}
+
+// The query test suite's fail-reads-match-0 case on the v3 engine. A name bound to an edge
+// in one pattern and to a node in another names two things that cannot be the same value,
+// so the query is turned away - while the same name kept to one kind across patterns is a
+// join on that entity, and runs.
+class VariableTypeConflictTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectTypeConflictRejection(std::string_view query, std::string_view reason) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        EXPECT_EQ(status.getStatus(), QueryStatus::Status::ANALYZE_ERROR) << "query: " << query;
+
+        const std::string error = status.getError();
+        EXPECT_NE(error.find(reason), std::string::npos) << "query: " << query << "\nerror: " << error;
+    }
+
+    void expectRowCount(std::string_view query, size_t expected) {
+        RowCountingSink sink;
+        QueryStatus status;
+        runQuery(query, status, sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.getRowCount(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+
+private:
+    void runQuery(std::string_view query, QueryStatus& status, NLOutputSink& sink) {
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+    }
+};
+
+// fail-reads-match-0: 'e' is the edge of the first pattern, then the end node of the second
+TEST_F(VariableTypeConflictTest, rejectsAnEdgeVariableReusedAsANode) {
+    expectTypeConflictRejection("MATCH (n: Person { name: \"Luc\" })-[e:KNOWS_WELL { name: \"Whatever\" }]->(m)-[e2]->(c:Person)\n"
+                                "MATCH (a)-->(b)-->(e)\n"
+                                "RETURN n, e, m;",
+                                "Variable 'e' is already declared with type 'EdgePattern'");
+}
+
+// The same conflict the other way round, where the node comes first
+TEST_F(VariableTypeConflictTest, rejectsANodeVariableReusedAsAnEdge) {
+    expectTypeConflictRejection("MATCH (n)-->(m)\nMATCH (a)-[n]->(b)\nRETURN m;",
+                                "Variable 'n' is already declared with type 'NodePattern'");
+}
+
+// The valid neighbour of those two: 'm' stays a node in both patterns and joins them on it.
+// Luc reaches Animals and Computers; Animals is entered by Luc alone, Computers by Remy and
+// Luc.
+TEST_F(VariableTypeConflictTest, joinsANodeVariableSharedByTwoPatterns) {
+    expectRowCount("MATCH (n:Person { name: \"Luc\" })-[e]->(m)\nMATCH (a)-->(m)\nRETURN n, a;", 3);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Implement MATCH-level ORDER BY, SKIP and LIMIT.

```
MATCH (n) ORDER BY n.name RETURN n
MATCH (n) ORDER BY n.name DESC RETURN n
MATCH (n:Person) ORDER BY n.name RETURN n.name

MATCH (n) LIMIT 3 RETURN n
MATCH (n) SKIP 20 RETURN n
MATCH (n) LIMIT 3 RETURN count(n)

MATCH (n) ORDER BY n.name LIMIT 3 RETURN n
MATCH (n) ORDER BY n.name SKIP 15 RETURN n
MATCH (n) ORDER BY n.name SKIP 2 LIMIT 3 RETURN n
MATCH (n) ORDER BY n.name LIMIT 5 RETURN n SKIP 3
```
