### PR TITLE
Cypher: stop anonymous pattern variables colliding with user variables

### DIFF
--- a/query/AST/Projection.h
+++ b/query/AST/Projection.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <list>
+#include <vector>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -25,6 +26,7 @@ public:
 
     using ReturnItem = std::variant<Expr*, VarDecl*>;
     using Items = std::list<ReturnItem>;
+    using PublishedDecls = std::vector<VarDecl*>;
 
     static Projection* create(CypherAST* ast);
 
@@ -76,6 +78,12 @@ public:
     std::optional<std::string_view> getName(const VarDecl* item) const;
     bool hasName(const std::string_view& name) const;
 
+    // The variable each item declares in the scope a WITH opens, in item order. What
+    // follows the barrier reads the published columns through these declarations rather
+    // than through the ones the items carry, which belong to the scope above it.
+    const PublishedDecls& publishedDecls() const { return _publishedDecls; }
+    void addPublishedDecl(VarDecl* decl) { _publishedDecls.push_back(decl); }
+
     size_t findItemIndex(const Expr* key) const;
     const Expr* findItemExpr(const Expr* key) const;
     bool hasItem(const Expr* key) const;
@@ -91,6 +99,8 @@ private:
     bool _returningAll {false};
 
     Items _items;
+
+    PublishedDecls _publishedDecls;
 
     // Maps a VarDecl*/Expr* to its column name
     std::unordered_map<uintptr_t, std::string_view> _names;

--- a/query/AST/decl/DeclContext.cpp
+++ b/query/AST/decl/DeclContext.cpp
@@ -41,6 +41,7 @@ VarDecl* DeclContext::getOrCreateNamedVariable(CypherAST* ast, EvaluatedType typ
     if (!decl) {
         decl = VarDecl::create(ast, this, name, type);
         decl->setIsUnnamed(false);
+        _declMap[decl->getName()] = decl;
     }
 
     if (decl->getType() != type) {
@@ -63,6 +64,7 @@ VarDecl* DeclContext::declareProjectedVariable(CypherAST* ast, EvaluatedType typ
 
     VarDecl* decl = VarDecl::create(ast, this, name, type);
     decl->setIsUnnamed(false);
+    _declMap[decl->getName()] = decl;
 
     return decl;
 }
@@ -90,7 +92,6 @@ void DeclContext::declareAlias(std::string_view name, VarDecl* decl) {
 }
 
 void DeclContext::addDecl(VarDecl* decl) {
-    _declMap[decl->getName()] = decl;
     _decls.push_back(decl);
 }
 

--- a/query/AST/stmt/UnwindStmt.h
+++ b/query/AST/stmt/UnwindStmt.h
@@ -7,6 +7,7 @@ namespace db {
 class CypherAST;
 class Expr;
 class Symbol;
+class VarDecl;
 
 class UnwindStmt final : public Stmt {
 public:
@@ -16,10 +17,14 @@ public:
 
     const Expr* arg() const { return _arg; }
     const Symbol* symbol() const { return _symbol; }
+    const VarDecl* getDecl() const { return _decl; }
+
+    void setDecl(const VarDecl* decl) { _decl = decl; }
 
 private:
     Expr* _arg {nullptr};
     Symbol* _symbol {nullptr};
+    const VarDecl* _decl {nullptr};
 
     explicit UnwindStmt(Expr* arg, Symbol* sym)
         : _arg(arg),

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -308,13 +308,13 @@ void CypherAnalyzer::throwOnUnpublishedKeyVariable(const Expr* keyExpr,
 
 // The names a WITH gives its columns are the whole scope of what follows, so a statement
 // after the barrier resolves its items and nothing the projection dropped
-void CypherAnalyzer::openWithScope(const Projection* projection) {
+void CypherAnalyzer::openWithScope(Projection* projection) {
     DeclContext* scope = DeclContext::create(_ast, _ctxt);
 
     for (const Projection::ReturnItem& returnItem : projection->items()) {
         if (const auto* declPtr = std::get_if<VarDecl*>(&returnItem)) {
             const VarDecl* decl = *declPtr;
-            scope->getOrCreateNamedVariable(_ast, decl->getType(), decl->getName());
+            projection->addPublishedDecl(scope->getOrCreateNamedVariable(_ast, decl->getType(), decl->getName()));
             continue;
         }
 
@@ -322,7 +322,7 @@ void CypherAnalyzer::openWithScope(const Projection* projection) {
         const std::optional<std::string_view> name = projection->getName(item);
         bioassert(name.has_value(), "Projected item of a WITH without a name.");
 
-        scope->getOrCreateNamedVariable(_ast, item->getType(), *name);
+        projection->addPublishedDecl(scope->getOrCreateNamedVariable(_ast, item->getType(), *name));
     }
 
     _ctxt = scope;

--- a/query/analyzer/CypherAnalyzer.h
+++ b/query/analyzer/CypherAnalyzer.h
@@ -92,7 +92,7 @@ private:
     bool _isV3 {false};
 
     void analyzeProjection(Projection* projection, const Stmt* clause);
-    void openWithScope(const Projection* projection);
+    void openWithScope(Projection* projection);
     void analyzeWithAliases(const Projection* projection) const;
     void analyzeWithOrderBy(const Projection* projection) const;
     void throwOnUnpublishedKeyVariable(const Expr* keyExpr, const Projection* projection) const;

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -86,7 +86,7 @@ void ReadStmtAnalyzer::analyze(Stmt* stmt) {
         break;
 
         case Stmt::Kind::UNWIND:
-            analyze(static_cast<const UnwindStmt*>(stmt));
+            analyze(static_cast<UnwindStmt*>(stmt));
         break;
 
         case Stmt::Kind::CREATE:
@@ -591,7 +591,7 @@ void ReadStmtAnalyzer::analyze(const ShortestPathStmt* spSt) {
     _ctxt->getOrCreateNamedVariable(_ast, EvaluatedType::GraphPath, pathName);
 }
 
-void ReadStmtAnalyzer::analyze(const UnwindStmt* unwind) {
+void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
     const Expr* arg = unwind->arg();
     bioassert(arg, "Invalid argument");
 
@@ -661,7 +661,8 @@ void ReadStmtAnalyzer::analyze(const UnwindStmt* unwind) {
         throwError(fmt::format("Variable '{}' is already declared", symName), unwind);
     }
 
-    _ctxt->getOrCreateNamedVariable(_ast, itemType, symName);
+    const VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, itemType, symName);
+    unwind->setDecl(decl);
 }
 
 void ReadStmtAnalyzer::throwError(std::string_view msg, const void* obj) const {

--- a/query/analyzer/ReadStmtAnalyzer.h
+++ b/query/analyzer/ReadStmtAnalyzer.h
@@ -53,7 +53,7 @@ public:
     void analyze(Skip* skipSt);
     void analyze(Limit* limitSt);
     void analyze(const ShortestPathStmt* spSt);
-    void analyze(const UnwindStmt* unwind);
+    void analyze(UnwindStmt* unwind);
 
     // Pattern
     void analyze(const Pattern* pattern);

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -177,15 +177,15 @@ bool readsAnyColumn(mlir::ValueRange values, llvm::ArrayRef<mlir::Value> columns
     return false;
 }
 
-// The variables a YIELD binds, named as the query knows them.
-void collectYieldVariables(const YieldClause* yield, llvm::SmallVectorImpl<std::string_view>& variables) {
+// The variables a YIELD binds.
+void collectYieldVariables(const YieldClause* yield, llvm::SmallVectorImpl<const VarDecl*>& variables) {
     const YieldItems* yieldItems = yield ? yield->getItems() : nullptr;
     if (!yieldItems) {
         return;
     }
 
     for (const SymbolExpr* item : *yieldItems) {
-        variables.push_back(item->getSymbol()->getName());
+        variables.push_back(item->getDecl());
     }
 }
 
@@ -481,10 +481,10 @@ void DBProgramGenerator::registerValue(const VariableDependency* var, mlir::Type
     _part._varMap[var].emplace_back(val);
 }
 
-void DBProgramGenerator::rebindYieldedColumn(std::string_view name, mlir::TypedValue<mlir::Type> val) {
+void DBProgramGenerator::rebindYieldedColumn(const VarDecl* decl, mlir::TypedValue<mlir::Type> val) {
     for (YieldedColumn& yielded : _part._yieldedColumns) {
-        if (yielded.first == name) {
-            yielded.second = val;
+        if (yielded._decl == decl) {
+            yielded._column = val;
         }
     }
 }
@@ -505,11 +505,11 @@ void DBProgramGenerator::addYieldedColumn(const VariableDependency* var, mlir::V
 
     // The variable owns those rows now. Leaving them among the yields as well would give one
     // column two names, and only the variable's is rebound as the expansion replicates it.
-    const auto namesVar = [&](const YieldedColumn& yielded) {
-        return yielded.first == var->getName();
+    const auto declaresVar = [&](const YieldedColumn& yielded) {
+        return yielded._decl == var->getDecl();
     };
 
-    std::erase_if(_part._yieldedColumns, namesVar);
+    std::erase_if(_part._yieldedColumns, declaresVar);
 }
 
 void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind) {
@@ -670,7 +670,7 @@ void DBProgramGenerator::walkEdge(const VariableDependency* src,
     // the calls do not drive.
     llvm::SmallVector<size_t> carriedYields;
     for (size_t yieldedIndex = 0; yieldedIndex < _part._yieldedColumns.size(); yieldedIndex++) {
-        const mlir::Value column = _part._yieldedColumns[yieldedIndex].second;
+        const mlir::Value column = _part._yieldedColumns[yieldedIndex]._column;
         if (!isRowAlignedHere(column)) {
             continue;
         }
@@ -719,7 +719,7 @@ void DBProgramGenerator::walkEdge(const VariableDependency* src,
 
     const size_t yieldOffset = edgeTypeOffset + carriedEdgeTypes.size();
     for (size_t i = 0; i < carriedYields.size(); i++) {
-        _part._yieldedColumns[carriedYields[i]].second = op.getResult(yieldOffset + i);
+        _part._yieldedColumns[carriedYields[i]]._column = op.getResult(yieldOffset + i);
     }
 }
 
@@ -1053,7 +1053,7 @@ void DBProgramGenerator::collectInFlightColumns(InFlightColumns& inFlight) {
     // A column an earlier CALL yielded is in flight too: a later op taking the whole row
     // set must take it along, or the rows it holds would stop matching the ones beside it.
     for (size_t yieldedIndex = 0; yieldedIndex < _part._yieldedColumns.size(); yieldedIndex++) {
-        const mlir::Value column = _part._yieldedColumns[yieldedIndex].second;
+        const mlir::Value column = _part._yieldedColumns[yieldedIndex]._column;
         if (!isRowAlignedHere(column)) {
             continue;
         }
@@ -1079,15 +1079,19 @@ void DBProgramGenerator::rebindInFlightColumns(mlir::Operation::result_range res
     }
 
     for (const size_t yieldedIndex : inFlight._yieldedIndices) {
-        _part._yieldedColumns[yieldedIndex].second = results[resultIndex];
+        _part._yieldedColumns[yieldedIndex]._column = results[resultIndex];
         resultIndex++;
     }
 }
 
-mlir::Value DBProgramGenerator::findYieldedColumn(std::string_view name) const {
+mlir::Value DBProgramGenerator::findYieldedColumn(const VarDecl* decl) const {
+    if (!decl) {
+        return mlir::Value {};
+    }
+
     for (const YieldedColumn& yielded : _part._yieldedColumns) {
-        if (yielded.first == name) {
-            return yielded.second;
+        if (yielded._decl == decl) {
+            return yielded._column;
         }
     }
 
@@ -1223,7 +1227,7 @@ void DBProgramGenerator::throwOnRematchedBoundEdge() const {
     const VariableDependencyGraph::EdgeIdentityMap& identities = _vdg.edgeIdentities();
 
     for (const VariableDependency* var : _vdg.boundVars()) {
-        if (identities.contains(std::string(var->getName()))) {
+        if (identities.contains(var->getDecl())) {
             throw TuringException(fmt::format("Matching the edge variable '{}' again after a "
                                               "WITH is not yet supported.",
                                               var->getName()));
@@ -1306,17 +1310,20 @@ void DBProgramGenerator::resolveYieldedIdentities() {
 
     llvm::SmallVector<YieldedIdentity> identities;
     for (size_t yieldedIndex = 0; yieldedIndex < _part._yieldedColumns.size(); yieldedIndex++) {
-        const std::string_view yieldedName = _part._yieldedColumns[yieldedIndex].first;
+        const VarDecl* yieldedDecl = _part._yieldedColumns[yieldedIndex]._decl;
+        if (!yieldedDecl) {
+            continue;
+        }
 
         for (const auto& [var, values] : _part._varMap) {
-            if (var->getName() != yieldedName) {
+            if (var->getDecl() != yieldedDecl) {
                 continue;
             }
 
             identities.push_back({var, yieldedIndex});
         }
 
-        const auto edgeIt = edgeIdentities.find(yieldedName);
+        const auto edgeIt = edgeIdentities.find(yieldedDecl);
         const bool yieldsAPatternEdge = edgeIt != edgeIdentities.end() && !edgeIt->second.empty();
         if (yieldsAPatternEdge) {
             identities.push_back({edgeIt->second.front(), yieldedIndex});
@@ -1332,7 +1339,7 @@ void DBProgramGenerator::resolveYieldedIdentities() {
 
     for (const YieldedIdentity& identity : identities) {
         const mlir::Value patternColumn = _part._varMap.at(identity._variable).back();
-        const mlir::Value yieldedColumn = _part._yieldedColumns[identity._yieldedIndex].second;
+        const mlir::Value yieldedColumn = _part._yieldedColumns[identity._yieldedIndex]._column;
 
         const bool patternAligned = isRowAlignedHere(patternColumn);
         const bool yieldedAligned = isRowAlignedHere(yieldedColumn);
@@ -1435,7 +1442,7 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
     // bound yet - a scan of the graph's nodes.
     const VariableDependencyGraph::UnwindSourceMap& unwindSources = _vdg.unwindSources();
     const auto unwindIt = unwindSources.find(root);
-    const mlir::Value yieldedColumn = findYieldedColumn(root->getName());
+    const mlir::Value yieldedColumn = findYieldedColumn(root->getDecl());
 
     if (yieldedColumn) {
         addYieldedColumn(root, yieldedColumn);
@@ -1744,7 +1751,7 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
         return;
     }
 
-    llvm::SmallVector<std::string_view> yieldedVariables;
+    llvm::SmallVector<const VarDecl*> yieldedVariables;
     for (const Stmt* stmt : leading) {
         collectYieldVariables(yieldClauseOf(stmt), yieldedVariables);
     }
@@ -1754,7 +1761,7 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
     // backwards from it, which is the traversal a reversed edge already emits.
     const VariableDependency* drivenRoot = nullptr;
     for (const VariableDependency& var : _vdg.vars()) {
-        const bool bound = llvm::is_contained(yieldedVariables, var.getName());
+        const bool bound = llvm::is_contained(yieldedVariables, var.getDecl());
         const bool canDrive = bound && isValidRoot(var);
 
         if (canDrive) {
@@ -1944,7 +1951,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
     const YieldItems* yieldItems = yield ? yield->getItems() : nullptr;
 
     llvm::SmallVector<mlir::Attribute> yieldedNames;
-    llvm::SmallVector<std::string_view> yieldedVariables;
+    llvm::SmallVector<YieldedColumn> yielded;
     if (yieldItems && !yieldItems->getItems().empty()) {
         for (const SymbolExpr* item : *yieldItems) {
             const Symbol* symbol = item->getSymbol();
@@ -1953,7 +1960,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
             // is what the call op names; the symbol's name is what the query calls it,
             // which is the alias when the YIELD renamed it.
             yieldedNames.push_back(_opBuilder.getStringAttr(symbol->getOriginalName()));
-            yieldedVariables.push_back(symbol->getName());
+            yielded.push_back({item->getDecl(), symbol->getName(), mlir::Value {}});
         }
     } else {
         // A call naming no return value produces every one the procedure declares, under
@@ -1962,7 +1969,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
         // gets here: the analyzer requires a YIELD of any call inside a query.
         for (const FunctionReturnType& returnType : signature->returnTypes()) {
             yieldedNames.push_back(_opBuilder.getStringAttr(returnType.getName()));
-            yieldedVariables.push_back(returnType.getName());
+            yielded.push_back({nullptr, returnType.getName(), mlir::Value {}});
         }
     }
 
@@ -1987,7 +1994,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
     // is their cartesian product rather than anything a carry set can express. Taking no
     // argument is one way to read none of them; taking only constant ones is another.
     if (!inFlight._columns.empty() && !readsAnyColumn(inputs, inFlight._columns)) {
-        generateCrossedCall(procedureName, yieldedNames, yieldedVariables, inputs, inFlight);
+        generateCrossedCall(procedureName, yieldedNames, yielded, inputs, inFlight);
         generateYieldFilter(yieldItems);
         return;
     }
@@ -2013,15 +2020,15 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
                                                             mlir::ValueRange {inFlight._columns},
                                                             _opBuilder.getArrayAttr(yieldedNames));
 
-    // The yielded columns are new variables of the query, known by the name the YIELD
-    // gave them; the carried ones are the rows already in flight, now aligned with what
-    // the procedure emitted.
+    // The yielded columns are new variables of the query; the carried ones are the rows
+    // already in flight, now aligned with what the procedure emitted.
     const mlir::Operation::result_range results = callOp.getResults();
-    for (size_t yieldIndex = 0; yieldIndex < yieldedVariables.size(); yieldIndex++) {
-        _part._yieldedColumns.emplace_back(yieldedVariables[yieldIndex], results[yieldIndex]);
+    for (size_t yieldIndex = 0; yieldIndex < yielded.size(); yieldIndex++) {
+        yielded[yieldIndex]._column = results[yieldIndex];
+        _part._yieldedColumns.push_back(yielded[yieldIndex]);
     }
 
-    rebindInFlightColumns(results, yieldedVariables.size(), inFlight);
+    rebindInFlightColumns(results, yielded.size(), inFlight);
 
     generateYieldFilter(yieldItems);
 }
@@ -2122,7 +2129,7 @@ void DBProgramGenerator::publishVectorSearchYields(const YieldItems* yieldItems,
         // the column, and the analyzer has already rejected every name but these two.
         const bool isScore = symbol->getOriginalName() == vectorSearchScoreYield;
 
-        _part._yieldedColumns.emplace_back(symbol->getName(), isScore ? scores : ids);
+        _part._yieldedColumns.push_back({item->getDecl(), symbol->getName(), isScore ? scores : ids});
     }
 }
 
@@ -2180,7 +2187,7 @@ void DBProgramGenerator::hoistConstantsOutOfLeftFactor(mlir::db::CrossProduct cr
 
 void DBProgramGenerator::generateCrossedCall(std::string_view procedureName,
                                              llvm::ArrayRef<mlir::Attribute> yieldedNames,
-                                             llvm::ArrayRef<std::string_view> yieldedVariables,
+                                             llvm::SmallVectorImpl<YieldedColumn>& yielded,
                                              mlir::ValueRange inputs,
                                              const InFlightColumns& inFlight) {
     // The call reads none of the rows already in flight, so it produces the same rows for
@@ -2254,19 +2261,19 @@ void DBProgramGenerator::generateCrossedCall(std::string_view procedureName,
     const mlir::Operation::result_range results = crossProduct.getResults();
     rebindInFlightColumns(results, /*firstResult=*/0, inFlight);
 
-    for (size_t yieldIndex = 0; yieldIndex < yieldedVariables.size(); yieldIndex++) {
-        _part._yieldedColumns.emplace_back(yieldedVariables[yieldIndex],
-                                     results[inFlight._columns.size() + yieldIndex]);
+    for (size_t yieldIndex = 0; yieldIndex < yielded.size(); yieldIndex++) {
+        yielded[yieldIndex]._column = results[inFlight._columns.size() + yieldIndex];
+        _part._yieldedColumns.push_back(yielded[yieldIndex]);
     }
 }
 
-void DBProgramGenerator::publishCreatedEntity(std::string_view name,
+void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
                                               mlir::Value column,
                                               llvm::ArrayRef<llvm::StringRef> propNames,
                                               llvm::ArrayRef<mlir::Value> propValues) {
     bioassert(propNames.size() == propValues.size(), "One value per created property expected");
 
-    PartScope::CreatedEntity& created = _part._createdEntities[name];
+    PartScope::CreatedEntity& created = _part._createdEntities[decl];
     created._column = column;
 
     for (size_t index = 0; index < propNames.size(); index++) {
@@ -2281,18 +2288,19 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
         return;
     }
 
-    // Collect the columns a MATCH bound or a CALL yielded, by variable name, so CREATE
+    // Collect the columns a MATCH bound or a CALL yielded, by variable, so CREATE
     // patterns can reference them.
-    std::unordered_map<std::string_view, mlir::Value> knownVars;
+    std::unordered_map<const VarDecl*, mlir::Value> knownVars;
     for (const auto& [var, identities] : _part._varMap) {
-        if (!identities.empty()) {
-            knownVars[var->getName()] = identities.back();
+        const VarDecl* decl = var->getDecl();
+        if (decl && !identities.empty()) {
+            knownVars[decl] = identities.back();
         }
     }
 
     for (const YieldedColumn& yieldedColumn : _part._yieldedColumns) {
-        if (isRowAlignedHere(yieldedColumn.second)) {
-            knownVars[yieldedColumn.first] = yieldedColumn.second;
+        if (yieldedColumn._decl && isRowAlignedHere(yieldedColumn._column)) {
+            knownVars[yieldedColumn._decl] = yieldedColumn._column;
         }
     }
 
@@ -2310,13 +2318,12 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
     const mlir::Location loc = _opBuilder.getUnknownLoc();
 
     // Emit db.create_node for a node that is not already in knownVars, then register
-    // the result under the node's variable name so later patterns can reference it.
+    // the result under the node's variable so later patterns can reference it.
     const auto resolveOrCreateNode = [&](const NodePattern* node) -> mlir::Value {
         const VarDecl* decl = node->getDecl();
-        const std::string_view name = decl ? decl->getName() : "";
 
-        if (!name.empty() && knownVars.contains(name)) {
-            return knownVars.at(name);
+        if (decl && knownVars.contains(decl)) {
+            return knownVars.at(decl);
         }
 
         llvm::SmallVector<llvm::StringRef> labelNames;
@@ -2351,9 +2358,9 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
             cardinality);
         const mlir::Value nodeValue = createNode.getResult();
 
-        if (!name.empty()) {
-            knownVars[name] = nodeValue;
-            publishCreatedEntity(name, nodeValue, propNames, propValues);
+        if (decl) {
+            knownVars[decl] = nodeValue;
+            publishCreatedEntity(decl, nodeValue, propNames, propValues);
         }
 
         return nodeValue;
@@ -2411,7 +2418,7 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
 
                 const VarDecl* edgeDecl = edge->getDecl();
                 if (edgeDecl && !edgeDecl->isUnnamed()) {
-                    publishCreatedEntity(edgeDecl->getName(), createEdge.getResult(), propNames, propValues);
+                    publishCreatedEntity(edgeDecl, createEdge.getResult(), propNames, propValues);
                 }
 
                 lhsValue = rhsValue;
@@ -2420,27 +2427,27 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
     }
 }
 
-mlir::Value DBProgramGenerator::resolveEntityColumn(std::string_view varName) {
+mlir::Value DBProgramGenerator::resolveEntityColumn(const VarDecl* decl) {
     for (const auto& [var, values] : _part._varMap) {
-        if (var->getName() == varName && !values.empty()) {
+        if (var->getDecl() == decl && !values.empty()) {
             return values.back();
         }
     }
 
     const VariableDependencyGraph::EdgeIdentityMap& edgeIdentities = _vdg.edgeIdentities();
-    const auto findIt = edgeIdentities.find(varName);
+    const auto findIt = edgeIdentities.find(decl);
     const bool foundEdgeIdentity = findIt != edgeIdentities.end() && !findIt->second.empty();
     if (foundEdgeIdentity) {
         const VariableDependency* representative = findIt->second.front();
         return _part._varMap.at(representative).back();
     }
 
-    const auto createdIt = _part._createdEntities.find(varName);
+    const auto createdIt = _part._createdEntities.find(decl);
     if (createdIt != end(_part._createdEntities)) {
         return createdIt->second._column;
     }
 
-    return findYieldedColumn(varName);
+    return findYieldedColumn(decl);
 }
 
 mlir::Value DBProgramGenerator::resolveColumnInScope(ColumnPredicate accept) const {
@@ -2459,8 +2466,8 @@ mlir::Value DBProgramGenerator::resolveColumnInScope(ColumnPredicate accept) con
     }
 
     for (const YieldedColumn& yielded : _part._yieldedColumns) {
-        if (isRowAlignedHere(yielded.second)) {
-            return yielded.second;
+        if (isRowAlignedHere(yielded._column)) {
+            return yielded._column;
         }
     }
 
@@ -2537,7 +2544,7 @@ void DBProgramGenerator::generateSet(const SinglePartQuery* query) {
             const std::string_view varName = entityDecl->getName();
             const std::string_view propName = propertyExpr->getPropName();
 
-            const mlir::Value entityColumn = resolveEntityColumn(varName);
+            const mlir::Value entityColumn = resolveEntityColumn(entityDecl);
             bioassert(entityColumn, "SET on unknown variable: {}", varName);
 
             translateExpr(assign->_propValueExpr);
@@ -2584,7 +2591,7 @@ void DBProgramGenerator::generateDelete(const SinglePartQuery* query) {
             bioassert(decl, "DELETE target symbol has no declaration");
             const std::string_view varName = decl->getName();
 
-            const mlir::Value entityColumn = resolveEntityColumn(varName);
+            const mlir::Value entityColumn = resolveEntityColumn(decl);
             if (!entityColumn) {
                 throw TuringException("Cannot delete unbound variable: " + std::string(varName));
             }
@@ -2625,8 +2632,8 @@ void DBProgramGenerator::generateYieldedOutput() {
     llvm::SmallVector<mlir::Value> yielded;
     llvm::SmallVector<llvm::StringRef> yieldedNames;
     for (const YieldedColumn& yieldedColumn : _part._yieldedColumns) {
-        yielded.push_back(yieldedColumn.second);
-        yieldedNames.push_back(llvm::StringRef(yieldedColumn.first.data(), yieldedColumn.first.size()));
+        yielded.push_back(yieldedColumn._column);
+        yieldedNames.push_back(llvm::StringRef(yieldedColumn._name.data(), yieldedColumn._name.size()));
     }
 
     if (yielded.empty()) {
@@ -2654,7 +2661,7 @@ void DBProgramGenerator::generateWith(const WithStmt* with) {
 
     translateProjectionTail(projection, variableColumns, projected);
 
-    publishBoundColumns(names, projected);
+    publishBoundColumns(projection, names, projected);
 
     const WhereClause* where = with->getWhere();
     if (!where) {
@@ -2689,10 +2696,16 @@ void DBProgramGenerator::broadcastConstantProjection(llvm::SmallVectorImpl<mlir:
     }
 }
 
-void DBProgramGenerator::publishBoundColumns(llvm::ArrayRef<llvm::StringRef> names,
+void DBProgramGenerator::publishBoundColumns(const Projection* projection,
+                                             llvm::ArrayRef<llvm::StringRef> names,
                                              llvm::ArrayRef<mlir::Value> columns) {
     bioassert(names.size() == columns.size(), "One name per column a WITH publishes expected");
     bioassert(!names.empty(), "A WITH publishes at least one column");
+
+    // The barrier opens a scope of its own, so what follows it reads these columns through
+    // the declarations that scope holds and not through the ones the projected items carry
+    const Projection::PublishedDecls& publishedDecls = projection->publishedDecls();
+    bioassert(publishedDecls.size() == names.size(), "One declaration per column a WITH publishes expected");
 
     _part = PartScope {};
     _vdg.clear();
@@ -2702,33 +2715,42 @@ void DBProgramGenerator::publishBoundColumns(llvm::ArrayRef<llvm::StringRef> nam
         bioassert(!name.empty(), "Column a WITH publishes without a name");
 
         const std::string_view boundName {name.data(), name.size()};
-        registerValue(_vdg.registerBoundVariable(boundName), columns[index]);
+        registerValue(_vdg.registerBoundVariable(boundName, publishedDecls[index]), columns[index]);
     }
 }
 
 void DBProgramGenerator::publishInFlightColumns() {
-    VariableColumnMap variableColumns;
-    collectVariableColumns(variableColumns);
+    // A cut opens no scope of its own, so the part below reads these columns through the
+    // very declarations the part above bound them to. Each name is copied out: the
+    // variables holding them are the ones this clears, and the part below is opened with
+    // them
+    llvm::SmallVector<PublishedColumn> published;
 
-    // Each name is copied out: the variables holding them are the ones this clears, and the
-    // part below is opened with them
-    llvm::SmallVector<std::pair<std::string, mlir::Value>> published;
-    published.reserve(variableColumns.size());
+    forEachVariableColumn([&published](const VarDecl* decl, std::string_view name, mlir::Value column) {
+        const auto sameName = [name](const PublishedColumn& candidate) {
+            return candidate._name == name;
+        };
 
-    for (const auto& [name, column] : variableColumns) {
-        published.emplace_back(name, column);
-    }
+        const auto foundIt = std::ranges::find_if(published, sameName);
+        if (foundIt != published.end()) {
+            foundIt->_decl = decl;
+            foundIt->_column = column;
+            return;
+        }
+
+        published.push_back({decl, std::string(name), column});
+    });
 
     // Under a name order rather than the map's, so the same query generates the same IR
-    std::ranges::sort(published, [](const auto& left, const auto& right) {
-        return left.first < right.first;
+    std::ranges::sort(published, [](const PublishedColumn& left, const PublishedColumn& right) {
+        return left._name < right._name;
     });
 
     _part = PartScope {};
     _vdg.clear();
 
-    for (const auto& [name, column] : published) {
-        registerValue(_vdg.registerBoundVariable(name), column);
+    for (const PublishedColumn& column : published) {
+        registerValue(_vdg.registerBoundVariable(column._name, column._decl), column._column);
     }
 }
 
@@ -2738,37 +2760,43 @@ void DBProgramGenerator::forEachVariableColumn(const VariableColumnBinding& bind
 
         bioassert(not mlirCol.empty(), "No definitions for {}", varName);
 
-        bind(varName, mlirCol.back());
+        bind(cypherVar->getDecl(), varName, mlirCol.back());
     }
 
-    // A CALL's yielded columns are variables of the query too, named by the YIELD.
+    // A CALL's yielded columns are variables of the query too, declared by the YIELD.
     for (const YieldedColumn& yieldedColumn : _part._yieldedColumns) {
-        bind(yieldedColumn.first, yieldedColumn.second);
+        bind(yieldedColumn._decl, yieldedColumn._name, yieldedColumn._column);
     }
 
-    // So are the entities a CREATE wrote, named by its pattern
-    for (const auto& [createdName, created] : _part._createdEntities) {
-        bind(createdName, created._column);
+    // So are the entities a CREATE wrote, declared by its pattern
+    for (const auto& [createdDecl, created] : _part._createdEntities) {
+        bind(createdDecl, createdDecl->getName(), created._column);
     }
 
-    for (const auto& [name, vars] : _vdg.edgeIdentities()) {
-        bioassert(!vars.empty(), "Empty edge identity for '{}'", name);
+    for (const auto& [decl, vars] : _vdg.edgeIdentities()) {
+        bioassert(!vars.empty(), "Empty edge identity for '{}'", decl->getName());
         const VariableDependency* representative = vars.front();
         bioassert(_part._varMap.contains(representative), "Edge identity representative not in varMap");
-        bind(name, _part._varMap.at(representative).back());
+        bind(decl, decl->getName(), _part._varMap.at(representative).back());
     }
 }
 
 void DBProgramGenerator::collectVariableColumns(VariableColumnMap& variableColumns) const {
-    forEachVariableColumn([&variableColumns](std::string_view name, mlir::Value column) {
-        variableColumns[name] = column;
+    forEachVariableColumn([&variableColumns](const VarDecl* decl, std::string_view name, mlir::Value column) {
+        if (decl) {
+            variableColumns[decl] = column;
+        }
     });
 }
 
-mlir::Value DBProgramGenerator::findVariableColumn(std::string_view name) const {
+mlir::Value DBProgramGenerator::findVariableColumn(const VarDecl* decl) const {
+    if (!decl) {
+        return mlir::Value {};
+    }
+
     mlir::Value found;
-    forEachVariableColumn([&found, name](std::string_view boundName, mlir::Value column) {
-        if (boundName == name) {
+    forEachVariableColumn([&found, decl](const VarDecl* boundDecl, std::string_view name, mlir::Value column) {
+        if (boundDecl == decl) {
             found = column;
         }
     });
@@ -2784,9 +2812,8 @@ void DBProgramGenerator::translateProjection(const Projection* projection,
         using Type = std::remove_cvref_t<decltype(item)>;
 
         if constexpr (std::is_same_v<Type, VarDecl*>) {
-            const std::string_view name = item->getName();
-            const auto findIt = variableColumns.find(name);
-            bioassert(findIt != end(variableColumns), "Return variable '{}' not found", name);
+            const auto findIt = variableColumns.find(item);
+            bioassert(findIt != end(variableColumns), "Return variable '{}' not found", item->getName());
             return findIt->second;
         } else {
             return getOrTranslateExprColumn(variableColumns, item);
@@ -3032,16 +3059,16 @@ void DBProgramGenerator::translateOrderBy(const Projection* projection,
 
 mlir::Value DBProgramGenerator::getOrTranslateExprColumn(const VariableColumnMap& variableColumns,
                                                          const Expr* expr) {
-    // One column is held per variable, under the name of that variable, so an expression
-    // only has a column to be found there when it is a variable and nothing else.
-    // Anything more is a computation over columns, and has to be translated - as is a
-    // symbol naming no variable but the alias of a projected item, which the translation
-    // resolves through the item that published that column
+    // One column is held per variable, so an expression only has a column to be found
+    // there when it is a variable and nothing else. Anything more is a computation over
+    // columns, and has to be translated - as is a symbol naming no variable but the alias
+    // of a projected item, which the translation resolves through the item that published
+    // that column
     if (expr->getKind() == Expr::Kind::SYMBOL) {
         const VarDecl* var = expr->getExprVarDecl();
         bioassert(var, "Symbol expression without a declaration.");
 
-        const auto findIt = variableColumns.find(var->getName());
+        const auto findIt = variableColumns.find(var);
         if (findIt != end(variableColumns)) {
             return findIt->second;
         }
@@ -3058,7 +3085,7 @@ mlir::Value DBProgramGenerator::getOrTranslateExprColumn(const Expr* expr) {
         const VarDecl* var = expr->getExprVarDecl();
         bioassert(var, "Symbol expression without a declaration.");
 
-        if (const mlir::Value column = findVariableColumn(var->getName())) {
+        if (const mlir::Value column = findVariableColumn(var)) {
             return column;
         }
     }
@@ -3228,7 +3255,7 @@ void DBProgramGenerator::translateExpr(const Expr* expr) {
             if (projectedIt != end(_part._projectedColumns)) {
                 _part._exprMap[expr] = projectedIt->second;
             } else {
-                const mlir::Value entityColumn = resolveEntityColumn(varName);
+                const mlir::Value entityColumn = resolveEntityColumn(decl);
                 if (entityColumn) {
                     _part._exprMap[expr] = entityColumn;
                 }
@@ -3237,7 +3264,7 @@ void DBProgramGenerator::translateExpr(const Expr* expr) {
             // A variable a CALL yielded appears in no pattern, so it is no VDG variable;
             // its column is the one the call produced for that return value.
             if (!_part._exprMap.contains(expr)) {
-                if (const mlir::Value yielded = findYieldedColumn(varName)) {
+                if (const mlir::Value yielded = findYieldedColumn(decl)) {
                     _part._exprMap[expr] = yielded;
                 }
             }
@@ -3527,7 +3554,7 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
     // A created entity holds a provisional ID, which the graph a fetch reads knows nothing
     // about: the value of one of its properties is the one the CREATE wrote there, and
     // every property it did not write is null
-    const auto createdIt = _part._createdEntities.find(varName);
+    const auto createdIt = _part._createdEntities.find(entityDecl);
     if (createdIt != end(_part._createdEntities)) {
         const auto& properties = createdIt->second._properties;
         const auto propertyIt = properties.find(propName);
@@ -3539,7 +3566,7 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
         return nullConstantColumn();
     }
 
-    const mlir::Value entityColumn = resolveEntityColumn(varName);
+    const mlir::Value entityColumn = resolveEntityColumn(entityDecl);
 
     bioassert(entityColumn, "WHERE clause property access on unknown variable: {}", varName);
 
@@ -3755,22 +3782,22 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     collectVariableColumns(variableColumns);
 
     // An edge identity is carried by the traversal variable that produced it, under a
-    // name of its own: the representative is where its column - and its grouped
+    // declaration of its own: the representative is where its column - and its grouped
     // replacement - is published, since the identity has no variable of its own
-    llvm::StringMap<const VariableDependency*> edgeIdentityVars;
-    for (const auto& [name, vars] : _vdg.edgeIdentities()) {
+    std::unordered_map<const VarDecl*, const VariableDependency*> edgeIdentityVars;
+    for (const auto& [decl, vars] : _vdg.edgeIdentities()) {
         if (!vars.empty() && _part._varMap.contains(vars.front())) {
-            edgeIdentityVars[name] = vars.front();
+            edgeIdentityVars[decl] = vars.front();
         }
     }
 
-    // Parallel: a key position is either a variable, named by keyVarNameAtPos and carried
-    // by keyVarAtPos, or an expression, held by keyExprAtPos. A column a CALL yielded is
-    // a variable with no keyVarAtPos: it appears in no pattern, so the VDG has nothing
-    // for it and its name is the only handle on it.
+    // Parallel: a key position is either a variable, declared by keyVarDeclAtPos and
+    // carried by keyVarAtPos, or an expression, held by keyExprAtPos. A column a CALL
+    // yielded is a variable with no keyVarAtPos: it appears in no pattern, so the VDG has
+    // nothing for it and its declaration is the only handle on it.
     llvm::SmallVector<mlir::Value> keyColumns;
     llvm::SmallVector<const VariableDependency*> keyVarAtPos;
-    llvm::SmallVector<std::string_view> keyVarNameAtPos;
+    llvm::SmallVector<const VarDecl*> keyVarDeclAtPos;
     llvm::SmallVector<const Expr*> keyExprAtPos;
 
     llvm::SmallVector<mlir::Value> aggInputColumns;
@@ -3786,9 +3813,9 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
 
     for (const Projection::ReturnItem& returnItem : projection->items()) {
         if (const VarDecl* const* varDeclPtr = std::get_if<VarDecl*>(&returnItem)) {
-            const std::string_view name = (*varDeclPtr)->getName();
-            const auto findIt = variableColumns.find(name);
-            bioassert(findIt != variableColumns.end(), "Grouping key variable {} not found.", name);
+            const VarDecl* decl = *varDeclPtr;
+            const auto findIt = variableColumns.find(decl);
+            bioassert(findIt != variableColumns.end(), "Grouping key variable {} not found.", decl->getName());
             const mlir::Value keyColumn = findIt->second;
 
             // A constant tells no two rows apart, so it groups nothing - whether the
@@ -3801,15 +3828,15 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
 
             // An edge identity's column is published under its representative, and that
             // is the one the projection reads back, so the grouped column has to replace
-            // it there rather than under a traversal variable of the same name
+            // it there
             const VariableDependency* keyVar = nullptr;
-            const auto identityIt = edgeIdentityVars.find(name);
+            const auto identityIt = edgeIdentityVars.find(decl);
 
             if (identityIt != edgeIdentityVars.end()) {
                 keyVar = identityIt->second;
             } else {
                 for (auto& [var, values] : _part._varMap) {
-                    if (var->getName() == name) {
+                    if (var->getDecl() == decl) {
                         keyVar = var;
                         break;
                     }
@@ -3817,7 +3844,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
             }
 
             keyVarAtPos.push_back(keyVar);
-            keyVarNameAtPos.push_back(name);
+            keyVarDeclAtPos.push_back(decl);
             keyExprAtPos.push_back(nullptr);
             continue;
         }
@@ -3845,7 +3872,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
 
             keyColumns.push_back(keyColumn);
             keyVarAtPos.push_back(nullptr);
-            keyVarNameAtPos.push_back({});
+            keyVarDeclAtPos.push_back(nullptr);
             keyExprAtPos.push_back(item);
             continue;
         }
@@ -3997,14 +4024,14 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
     GroupedColumns groupedColumns;
 
     for (size_t i = 0; i < keyCount; i++) {
-        if (!keyVarNameAtPos[i].empty()) {
+        if (keyVarDeclAtPos[i]) {
             if (keyVarAtPos[i]) {
                 registerValue(keyVarAtPos[i], results[i]);
             }
 
             // A YIELD can bind onto a variable a pattern already carries, which leaves the
-            // one name on both a variable and a yielded column, so both are rebound.
-            rebindYieldedColumn(keyVarNameAtPos[i], results[i]);
+            // one declaration on both a variable and a yielded column, so both are rebound.
+            rebindYieldedColumn(keyVarDeclAtPos[i], results[i]);
             continue;
         }
 
@@ -4021,11 +4048,11 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         // own, and the projection reads it back through the identity's
         // representative, so that is where the grouped column has to land
         const SymbolExpr* sym = static_cast<const SymbolExpr*>(keyExprAtPos[i]);
-        const std::string_view symName = sym->getDecl()->getName();
+        const VarDecl* symDecl = sym->getDecl();
 
-        rebindYieldedColumn(symName, results[i]);
+        rebindYieldedColumn(symDecl, results[i]);
 
-        const auto identityIt = edgeIdentityVars.find(symName);
+        const auto identityIt = edgeIdentityVars.find(symDecl);
 
         if (identityIt != edgeIdentityVars.end()) {
             registerValue(identityIt->second, results[i]);
@@ -4033,7 +4060,7 @@ void DBProgramGenerator::generateGroupAggregate(const Projection* projection) {
         }
 
         for (auto& [var, values] : _part._varMap) {
-            if (var->getName() == symName) {
+            if (var->getDecl() == symDecl) {
                 registerValue(var, results[i]);
                 break;
             }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <span>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -61,11 +62,29 @@ public:
     using ExprValueMap = std::unordered_map<const Expr*, mlir::Value>;
     using ProjectedColumnMap = std::unordered_map<const VarDecl*, mlir::Value>;
     using ColumnPredicate = llvm::function_ref<bool(mlir::Value)>;
-    using VariableColumnBinding = llvm::function_ref<void(std::string_view, mlir::Value)>;
+    using VariableColumnBinding = llvm::function_ref<void(const VarDecl*, std::string_view, mlir::Value)>;
 
-    // Maps a Cypher variable name to the last column defined for it, the one the
-    // projection and its ORDER BY read
-    using VariableColumnMap = std::unordered_map<std::string_view, mlir::Value>;
+    // Maps a Cypher variable to the last column defined for it, the one the projection
+    // and its ORDER BY read
+    using VariableColumnMap = std::unordered_map<const VarDecl*, mlir::Value>;
+
+    // A column a CALL produced for one of its yielded return values, under the declaration
+    // the query knows it by and the name it is output under. A standalone call naming no
+    // YIELD declares nothing, so its columns carry a null declaration.
+    struct YieldedColumn {
+        const VarDecl* _decl {nullptr};
+        std::string_view _name;
+        mlir::Value _column;
+    };
+
+    // A column a part cut hands to the part below it, under the declaration and the name
+    // it was bound to above. The name is owned, since publishing clears the variables the
+    // one in flight points into.
+    struct PublishedColumn {
+        const VarDecl* _decl {nullptr};
+        std::string _name;
+        mlir::Value _column;
+    };
 
     // The columns a grouped aggregation produces, each under the expression it computes:
     // the grouping keys and the aggregate results
@@ -83,13 +102,6 @@ private:
 
     // A WITH drops this whole object rather than naming its members one at a time, so a
     // map added here is one the next part cannot read a stale binding out of
-    // The column a CALL produced for each of its yielded return values, named as the
-    // query knows it - its alias when the YIELD renamed it. A yielded variable appears in
-    // no pattern, so it is not a VDG variable and cannot live in _varMap; the projection
-    // and symbol translation consult both. Kept in yield order, because a standalone CALL
-    // has no projection of its own and emits its columns in that order.
-    using YieldedColumn = std::pair<std::string_view, mlir::Value>;
-
     struct PartScope {
         VariableIdentityMap _varMap;
 
@@ -101,6 +113,11 @@ private:
         // alias of that item shares with it
         ProjectedColumnMap _projectedColumns;
 
+        // The column a CALL produced for each of its yielded return values. A yielded
+        // variable appears in no pattern, so it is not a VDG variable and cannot live in
+        // _varMap; the projection and symbol translation consult both. Kept in yield
+        // order, because a standalone CALL has no projection of its own and emits its
+        // columns in that order.
         std::vector<YieldedColumn> _yieldedColumns;
 
         // What a CREATE wrote for one of its named pattern entities: the column of
@@ -112,7 +129,7 @@ private:
             std::unordered_map<std::string_view, mlir::Value> _properties;
         };
 
-        std::unordered_map<std::string_view, CreatedEntity> _createdEntities;
+        std::unordered_map<const VarDecl*, CreatedEntity> _createdEntities;
 
         // The traversal root a CALL ahead of the MATCH bound, when the query lets the
         // traversal expand that column instead of scanning the graph and joining. Null
@@ -240,7 +257,7 @@ private:
 
     // Records what a CREATE wrote for one named entity of its pattern, so the projection
     // reads that back rather than fetching an ID the graph does not hold yet
-    void publishCreatedEntity(std::string_view name,
+    void publishCreatedEntity(const VarDecl* decl,
                               mlir::Value column,
                               llvm::ArrayRef<llvm::StringRef> propNames,
                               llvm::ArrayRef<mlir::Value> propValues);
@@ -278,9 +295,10 @@ private:
     // the call has run - so the predicate reads the rows the procedure emitted.
     void generateYieldFilter(const YieldItems* yieldItems);
 
+    // Fills the column of each entry of @param yielded and appends them to _yieldedColumns
     void generateCrossedCall(std::string_view procedureName,
                              llvm::ArrayRef<mlir::Attribute> yieldedNames,
-                             llvm::ArrayRef<std::string_view> yieldedVariables,
+                             llvm::SmallVectorImpl<YieldedColumn>& yielded,
                              mlir::ValueRange inputs,
                              const InFlightColumns& inFlight);
 
@@ -313,9 +331,8 @@ private:
                                size_t firstResult,
                                const InFlightColumns& inFlight);
 
-    // The column a yielded variable of this name holds, or a null Value when no CALL
-    // yielded it.
-    mlir::Value findYieldedColumn(std::string_view name) const;
+    // The column a yielded variable holds, or a null Value when no CALL yielded it.
+    mlir::Value findYieldedColumn(const VarDecl* decl) const;
 
     void generateWith(const WithStmt* with);
 
@@ -323,23 +340,26 @@ private:
     // this binds a projection of constants alone to the rows of the match under it
     void broadcastConstantProjection(llvm::SmallVectorImpl<mlir::Value>& projected);
 
-    void publishBoundColumns(llvm::ArrayRef<llvm::StringRef> names,
+    void publishBoundColumns(const Projection* projection,
+                             llvm::ArrayRef<llvm::StringRef> names,
                              llvm::ArrayRef<mlir::Value> columns);
 
     // Publishes every column in scope under the name it already carries, so the part that
     // follows a cut reads them the way it reads what a WITH published
     void publishInFlightColumns();
 
-    // The column each variable in scope is bound to, under the name it carries: the
-    // traversal variables, what a CALL yielded, what a CREATE wrote, and each edge
-    // identity under its own name. A name a later source rebinds is visited twice, with
-    // the binding that wins last, so a map filled from it holds what the query reads.
+    // The column each variable in scope is bound to, under the declaration and the name
+    // it carries: the traversal variables, what a CALL yielded, what a CREATE wrote, and
+    // each edge identity under its own declaration. A variable a later source rebinds is
+    // visited twice, with the binding that wins last, so a map filled from it holds what
+    // the query reads. A standalone CALL declares nothing, so its columns are bound under
+    // a null declaration.
     void forEachVariableColumn(const VariableColumnBinding& bind) const;
     void collectVariableColumns(VariableColumnMap& variableColumns) const;
 
-    // The column one name is bound to, over the same bindings, for a caller that reads a
-    // single variable rather than every one in scope
-    mlir::Value findVariableColumn(std::string_view name) const;
+    // The column one variable is bound to, over the same bindings, for a caller that reads
+    // a single variable rather than every one in scope
+    mlir::Value findVariableColumn(const VarDecl* decl) const;
 
     void translateProjection(const Projection* projection,
                              const VariableColumnMap& variableColumns,
@@ -376,7 +396,7 @@ private:
     mlir::Value getOrTranslateExprColumn(const VariableColumnMap& variableColumns, const Expr* expr);
     mlir::Value getOrTranslateExprColumn(const Expr* expr);
 
-    mlir::Value resolveEntityColumn(std::string_view varName);
+    mlir::Value resolveEntityColumn(const VarDecl* decl);
 
     mlir::Value nullConstantColumn();
 
@@ -524,7 +544,7 @@ private:
 
     mlir::db::ColumnType allocColumnType(mlir::Type type);
     void registerValue(const VariableDependency* var, mlir::TypedValue<mlir::Type> val);
-    void rebindYieldedColumn(std::string_view name, mlir::TypedValue<mlir::Type> val);
+    void rebindYieldedColumn(const VarDecl* decl, mlir::TypedValue<mlir::Type> val);
 };
 
 }

--- a/query/ir/frontend/cypher/VariableDependency.h
+++ b/query/ir/frontend/cypher/VariableDependency.h
@@ -16,6 +16,7 @@ namespace db {
 namespace rg = ranges;
 namespace rv = rg::views;
 
+class VarDecl;
 class VariableDependencyGraph;
 
 /**
@@ -35,11 +36,18 @@ public:
     {
     }
 
+    VariableDependency(std::string_view name, const VarDecl* decl)
+        : _name(name),
+        _decl(decl)
+    {
+    }
+
     auto edges() const { return rv::concat(_incoming, _outgoing); }
     const Edges& outgoing() const { return _outgoing; }
     const Edges& incoming() const { return _incoming; }
 
     std::string_view getName() const { return _name; }
+    const VarDecl* getDecl() const { return _decl; }
 
     const std::optional<Constraint>& constraints() const { return _constraints; }
 
@@ -65,6 +73,7 @@ private:
     std::optional<Constraint> _constraints;
 
     std::string _name;
+    const VarDecl* _decl {nullptr};
 };
 
 }

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -15,7 +15,6 @@
 #include "VariableDependencyGraphDumper.h"
 #include "Pattern.h"
 #include "PatternElement.h"
-#include "Symbol.h"
 #include "stmt/MatchStmt.h"
 #include "stmt/UnwindStmt.h"
 #include "decl/PatternData.h"
@@ -81,8 +80,8 @@ void VariableDependencyGraph::build(std::span<Stmt* const> stmts) {
     eliminateCycles();
 }
 
-VariableDependency* VariableDependencyGraph::registerBoundVariable(std::string_view name) {
-    VariableDependency* boundVar = newVariable(name);
+VariableDependency* VariableDependencyGraph::registerBoundVariable(std::string_view name, const VarDecl* decl) {
+    VariableDependency* boundVar = &_vars.emplace_back(name, decl);
     _boundVars.push_back(boundVar);
 
     return boundVar;
@@ -163,13 +162,13 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
         const std::string_view cypherEdgeName = edgeDecl->getName();
 
         // An edge the pattern leaves anonymous is one occurrence of one variable, so it
-        // joins nothing: only a name the query wrote gets an identity, whose occurrences
-        // the code generator equates
+        // joins nothing: only a variable the query named gets an identity, whose
+        // occurrences the code generator equates
         VariableDependency* edgeVar = nullptr;
         if (edgeDecl->isUnnamed()) {
-            edgeVar = newAnonymousVariable(cypherEdgeName);
+            edgeVar = newAnonymousVariable(edgeDecl);
         } else {
-            std::vector<VariableDependency*>& edgeOccurrences = _edgeIdentities[std::string(cypherEdgeName)];
+            std::vector<VariableDependency*>& edgeOccurrences = _edgeIdentities[edgeDecl];
             std::string occurrenceName;
             occurrenceName += cypherEdgeName;
             occurrenceName += '\'';
@@ -197,42 +196,41 @@ void VariableDependencyGraph::registerPatternElement(const PatternElement* ptn) 
 }
 
 void VariableDependencyGraph::registerUnwindStmt(const UnwindStmt* stmt) {
-    const Symbol* symbol = stmt->symbol();
-    bioassert(symbol, "UNWIND without a variable.");
+    const VarDecl* decl = stmt->getDecl();
+    bioassert(decl, "UNWIND without a declaration.");
 
     // An UNWIND variable is bound to a list rather than to a pattern, so it depends on
     // no other variable and enters the graph isolated - a root of its own connected
-    // component, whose dataflow the code generator opens from the list. The lookup by
-    // name is what registerPatternElement does: two variables of one name would leave
-    // every name-keyed resolver picking one of them by container order.
-    VariableDependency* unwindVar = findVariable(symbol->getName());
+    // component, whose dataflow the code generator opens from the list. The lookup is what
+    // registerPatternElement does: two variables of one declaration would leave every
+    // resolver picking one of them by container order.
+    VariableDependency* unwindVar = findVariable(decl);
     if (!unwindVar) {
-        unwindVar = newVariable(symbol->getName());
+        unwindVar = newVariable(decl);
     }
 
     _unwindSources[unwindVar] = stmt;
 }
 
-VariableDependency* VariableDependencyGraph::newVariable(const EntityPattern* entity) {
-    bioassert(entity->getDecl(), "Variable without declaration.");
-    return &_vars.emplace_back(std::string(entity->getDecl()->getName()));
+VariableDependency* VariableDependencyGraph::newVariable(const VarDecl* decl) {
+    return &_vars.emplace_back(decl->getName(), decl);
 }
 
 VariableDependency* VariableDependencyGraph::newVariable(std::string_view name) {
     return &_vars.emplace_back(name);
 }
 
-VariableDependency* VariableDependencyGraph::newAnonymousVariable(std::string_view declName) {
+VariableDependency* VariableDependencyGraph::newAnonymousVariable(const VarDecl* decl) {
     std::string name;
-    name += declName;
+    name += decl->getName();
     name += '\'';
 
-    return newVariable(name);
+    return &_vars.emplace_back(name, decl);
 }
 
-VariableDependency* VariableDependencyGraph::findVariable(std::string_view name) {
-    const auto match = [name](const VariableDependency& dep) {
-        return name == dep.getName();
+VariableDependency* VariableDependencyGraph::findVariable(const VarDecl* decl) {
+    const auto match = [decl](const VariableDependency& dep) {
+        return dep.getDecl() == decl;
     };
     const auto foundIt = std::ranges::find_if(_vars, match);
 
@@ -244,17 +242,11 @@ VariableDependency* VariableDependencyGraph::getOrCreateVariable(const EntityPat
     bioassert(decl, "Variable with null declaration.");
 
     // The name of an entity the pattern leaves anonymous is generated, and a Cypher alias
-    // can carry that spelling too - `WITH p AS v0` beside a `MATCH (v0)-->()` - so
-    // matching it by name would join the pattern onto whatever that alias holds. It gets
-    // a name of the graph's own instead, which no Cypher identifier can be
-    VariableDependency* var = nullptr;
-    if (decl->isUnnamed()) {
-        var = newAnonymousVariable(decl->getName());
-    } else {
-        var = findVariable(decl->getName());
-        if (!var) {
-            var = newVariable(entity);
-        }
+    // can carry that spelling too - `WITH p AS v0` beside a `MATCH (v0)-->()` - so it is
+    // given a name of the graph's own, which no Cypher identifier can be
+    VariableDependency* var = findVariable(decl);
+    if (!var) {
+        var = decl->isUnnamed() ? newAnonymousVariable(decl) : newVariable(decl);
     }
 
     const NodePattern* node = dynamic_cast<const NodePattern*>(entity);

--- a/query/ir/frontend/cypher/VariableDependencyGraph.h
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <deque>
-#include <functional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -18,6 +17,7 @@ class EntityPattern;
 class PatternElement;
 class Stmt;
 class UnwindStmt;
+class VarDecl;
 
 /**
  * @brief Graph representation of the dependencies among variables, generated from
@@ -37,17 +37,8 @@ class UnwindStmt;
  */
 class VariableDependencyGraph {
 public:
-    struct EdgeIdentityHash {
-        using is_transparent = void;
-
-        size_t operator()(std::string_view name) const { return std::hash<std::string_view> {}(name); }
-    };
-
     using Cycle = std::vector<VariableDependency*>;
-    using EdgeIdentityMap = std::unordered_map<std::string,
-                                               std::vector<VariableDependency*>,
-                                               EdgeIdentityHash,
-                                               std::equal_to<>>;
+    using EdgeIdentityMap = std::unordered_map<const VarDecl*, std::vector<VariableDependency*>>;
     using UnwindSourceMap = std::unordered_map<const VariableDependency*, const UnwindStmt*>;
     using BoundVars = std::vector<VariableDependency*>;
 
@@ -60,7 +51,7 @@ public:
 
     /// Declares a variable a preceding WITH bound, whose column the code generator holds:
     /// a pattern naming it is a join onto that column, not a scan, so it enters isolated
-    VariableDependency* registerBoundVariable(std::string_view name);
+    VariableDependency* registerBoundVariable(std::string_view name, const VarDecl* decl);
 
     /// Drops every variable and edge, so the graph can be rebuilt for the next query part
     void clear();
@@ -95,7 +86,7 @@ private:
     // Tracks how many times a variable has been anonimised
     std::unordered_map<VariableDependency*, int> _anonymised;
 
-    // Maps each Cypher edge variable name to all anonymous VDG variables created for it
+    // Maps each Cypher edge variable to all anonymous VDG variables created for it
     EdgeIdentityMap _edgeIdentities;
 
     // Maps each UNWIND variable to the statement whose list it is bound to
@@ -105,13 +96,13 @@ private:
     BoundVars _boundVars;
 
     VariableDependency* getOrCreateVariable(const EntityPattern* entity);
-    VariableDependency* newVariable(const EntityPattern* entity);
+    VariableDependency* newVariable(const VarDecl* decl);
     VariableDependency* newVariable(std::string_view name);
 
     /// Under a name no Cypher identifier can be, so a user alias never resolves to it
-    VariableDependency* newAnonymousVariable(std::string_view declName);
+    VariableDependency* newAnonymousVariable(const VarDecl* decl);
 
-    VariableDependency* findVariable(std::string_view name);
+    VariableDependency* findVariable(const VarDecl* decl);
 
     void getNextAnonymisation(VariableDependency* v, std::string& buf);
 

--- a/test/query/ir/AnonymousMatchTest.cpp
+++ b/test/query/ir/AnonymousMatchTest.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+constexpr size_t simpleGraphNodeCount = 18;
+constexpr size_t simpleGraphEdgeCount = 18;
+
+}
+
+// A MATCH whose pattern binds no variable, followed by the clause that introduces the one
+// the query returns: the anonymous edges still drive what follows, one row per edge.
+class AnonymousMatchTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        ASSERT_TRUE(status.isOk()) << query << ": " << status.getError();
+
+        std::vector<StringRowSink::Row> actual;
+        sink.sortedRows(actual);
+
+        std::vector<StringRowSink::Row> sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(AnonymousMatchTest, unwindsAfterAnAnonymousEdgeMatch) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t edge = 0; edge < simpleGraphEdgeCount; edge++) {
+        expected.push_back({"1"});
+        expected.push_back({"2"});
+    }
+
+    expectRows("MATCH ()-->() UNWIND [1,2] AS v0 RETURN v0", expected);
+}
+
+TEST_F(AnonymousMatchTest, matchesNodesAfterAnAnonymousEdgeMatch) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t edge = 0; edge < simpleGraphEdgeCount; edge++) {
+        for (size_t nodeID = 0; nodeID < simpleGraphNodeCount; nodeID++) {
+            expected.push_back({std::to_string(nodeID)});
+        }
+    }
+
+    expectRows("MATCH ()-->() MATCH (v0) RETURN v0", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/AnonymousMatchTest.cpp
+++ b/test/query/ir/AnonymousMatchTest.cpp
@@ -43,10 +43,14 @@ protected:
         SimpleGraph::createSimpleGraph(graph);
     }
 
+    void runQuery(std::string_view query, StringRowSink& sink, QueryStatus& status) {
+        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+    }
+
     void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
         StringRowSink sink;
         QueryStatus status;
-        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+        runQuery(query, sink, status);
         ASSERT_TRUE(status.isOk()) << query << ": " << status.getError();
 
         std::vector<StringRowSink::Row> actual;
@@ -56,6 +60,16 @@ protected:
         std::sort(sortedExpected.begin(), sortedExpected.end());
 
         EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    void expectError(std::string_view query, std::string_view reason) {
+        StringRowSink sink;
+        QueryStatus status;
+        runQuery(query, sink, status);
+        ASSERT_FALSE(status.isOk()) << "accepted: " << query;
+
+        const std::string error = status.getError();
+        EXPECT_NE(error.find(reason), std::string::npos) << query << ": " << error;
     }
 
     const std::string _graphName = "simpledb";
@@ -82,6 +96,10 @@ TEST_F(AnonymousMatchTest, matchesNodesAfterAnAnonymousEdgeMatch) {
     }
 
     expectRows("MATCH ()-->() MATCH (v0) RETURN v0", expected);
+}
+
+TEST_F(AnonymousMatchTest, doesNotResolveAnAnonymousNodeByName) {
+    expectError("MATCH ()-->() RETURN v0", "Variable 'v0' not found");
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/AnonymousMatchTest.cpp
+++ b/test/query/ir/AnonymousMatchTest.cpp
@@ -102,6 +102,10 @@ TEST_F(AnonymousMatchTest, doesNotResolveAnAnonymousNodeByName) {
     expectError("MATCH ()-->() RETURN v0", "Variable 'v0' not found");
 }
 
+TEST_F(AnonymousMatchTest, doesNotResolveTheAnonymousNodesOfAChainByName) {
+    expectError("match ()--()--() where v0=42 and v1=17 return count(*)", "Variable 'v0' not found");
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1470,3 +1470,14 @@ target_link_libraries(test_query_ir_multi_match PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_multi_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_anonymous_match AnonymousMatchTest.cpp)
+target_sources(test_query_ir_anonymous_match PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_anonymous_match PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_anonymous_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Keep anonymous pattern variables out of the user namespace.

```
MATCH ()-->() UNWIND [1,2] AS v0 RETURN v0
MATCH ()-->() MATCH (v0) RETURN v0

MATCH ()-->() RETURN v0
match ()--()--() where v0=42 and v1=17 return count(*)
```