### PR TITLE
MLIR: add tests for heterogeneous lists and add count overload for embeddings

### DIFF
--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -119,17 +119,20 @@ void FunctionDecls::initDefault() {
     countNulls->setIsAggregate(true);
 
     // count over a whole list: a list is never null, so the tally is every row. Only the
-    // MLIR engine lays a list cell out over the driving relation, which ExprAnalyzer's
-    // v3 gate is what keeps the legacy planner away from.
+    // MLIR engine lays a list cell out over the driving relation - the legacy planner
+    // reduces the single row the cell is, and count([1, 2]) answers 1 where the relation
+    // holds more - so this overload and the embedding one below are v3-only.
     FunctionSignature* countLists = createFunction("count");
     countLists->setArguments({EvaluatedType::List});
     countLists->setReturnTypes({{EvaluatedType::Integer}});
     countLists->setIsAggregate(true);
+    countLists->setIsV3Only(true);
 
     FunctionSignature* countEmbeddings = createFunction("count");
     countEmbeddings->setArguments({EvaluatedType::Embedding});
     countEmbeddings->setReturnTypes({{EvaluatedType::Integer}});
     countEmbeddings->setIsAggregate(true);
+    countEmbeddings->setIsV3Only(true);
 
     // The schema types a CALL can yield are columns like any other, so count tallies their
     // rows too. Without these overloads a YIELD of a label, a property type or a value type
@@ -188,6 +191,16 @@ void FunctionDecls::initDefault() {
     avgDouble->setArguments({EvaluatedType::Double});
     avgDouble->setReturnTypes({{EvaluatedType::Double}});
     avgDouble->setIsAggregate(true);
+
+    // avg over a type-erased column of tagged cells - what a list mixing numeric types,
+    // holding a null or holding nothing unwinds into. Each cell is read through its tag,
+    // and an average is a double whatever those tags were. Only the MLIR engine folds such
+    // a column, so the overload is v3-only like the whole-cell counts above.
+    FunctionSignature* avgListItems = createFunction("avg");
+    avgListItems->setArguments({EvaluatedType::ListItem});
+    avgListItems->setReturnTypes({{EvaluatedType::Double}});
+    avgListItems->setIsAggregate(true);
+    avgListItems->setIsV3Only(true);
 
     // sum() enabled for v3 analyzer 
     FunctionSignature* sumInt = createFunction("sum");

--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -126,6 +126,11 @@ void FunctionDecls::initDefault() {
     countLists->setReturnTypes({{EvaluatedType::Integer}});
     countLists->setIsAggregate(true);
 
+    FunctionSignature* countEmbeddings = createFunction("count");
+    countEmbeddings->setArguments({EvaluatedType::Embedding});
+    countEmbeddings->setReturnTypes({{EvaluatedType::Integer}});
+    countEmbeddings->setIsAggregate(true);
+
     // The schema types a CALL can yield are columns like any other, so count tallies their
     // rows too. Without these overloads a YIELD of a label, a property type or a value type
     // could be returned but never aggregated.

--- a/query/AST/FunctionSignature.h
+++ b/query/AST/FunctionSignature.h
@@ -68,6 +68,8 @@ public:
 
     bool isProcedure() const { return _isProcedure; }
 
+    bool isV3Only() const { return _isV3Only; }
+
     size_t getMinArgCount() const { return _requiredArgCount; }
 
     void setArguments(ArgumentTypes&& args) {
@@ -84,6 +86,8 @@ public:
 
     void setIsProcedure(bool procedure) { _isProcedure = procedure; }
 
+    void setIsV3Only(bool v3Only) { _isV3Only = v3Only; }
+
 private:
     std::string_view _fullName;
     ArgumentTypes _argumentTypes;
@@ -91,6 +95,10 @@ private:
     size_t _requiredArgCount {0};
     bool _isAggregate {false};
     bool _isProcedure {false};
+
+    // An overload only the MLIR engine answers: the legacy planner either cannot lay its
+    // argument out or reduces it over the wrong rows, so it never matches there
+    bool _isV3Only {false};
 };
 
 }

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -676,17 +676,10 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
             continue;
         }
 
-        // Reducing a whole list or a whole embedding means reducing one constant cell
-        // standing for every row, and only the MLIR engine lays that cell out over the
-        // driving relation. The legacy planner reduces the single row the cell is -
-        // count([1, 2]) and count((1,2,3)) answer 1 where the relation holds more - so the
-        // overloads stay out of its reach. Procedures and the distance functions take these
-        // types there too, and are no aggregate, so this leaves them alone.
-        const bool takesAList = std::ranges::find(expectedArgs, EvaluatedType::List, &FunctionArgumentType::getType) != expectedArgs.end();
-        const bool takesAnEmbedding = std::ranges::find(expectedArgs, EvaluatedType::Embedding, &FunctionArgumentType::getType) != expectedArgs.end();
-
-        const bool reducesAWholeCell = signature->isAggregate() && (takesAList || takesAnEmbedding);
-        if (!_isV3 && reducesAWholeCell) {
+        // An overload the legacy planner cannot answer correctly is declared v3-only
+        // (FunctionDecls names which and why), so it never matches there and another
+        // overload - or the argument error - stands instead.
+        if (!_isV3 && signature->isV3Only()) {
             continue;
         }
 

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -676,14 +676,17 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
             continue;
         }
 
-        // Reducing a whole list means reducing one constant cell standing for every row,
-        // and only the MLIR engine lays that cell out over the driving relation. The legacy
-        // planner reduces the single row the cell is - count([1, 2]) answers 1 where the
-        // relation holds more - so the overload stays out of its reach. Procedures take
-        // lists there too, and are no aggregate, so this leaves them alone.
-        const bool reducesAList = signature->isAggregate()
-            && std::ranges::find(expectedArgs, EvaluatedType::List, &FunctionArgumentType::getType) != expectedArgs.end();
-        if (!_isV3 && reducesAList) {
+        // Reducing a whole list or a whole embedding means reducing one constant cell
+        // standing for every row, and only the MLIR engine lays that cell out over the
+        // driving relation. The legacy planner reduces the single row the cell is -
+        // count([1, 2]) and count((1,2,3)) answer 1 where the relation holds more - so the
+        // overloads stay out of its reach. Procedures and the distance functions take these
+        // types there too, and are no aggregate, so this leaves them alone.
+        const bool takesAList = std::ranges::find(expectedArgs, EvaluatedType::List, &FunctionArgumentType::getType) != expectedArgs.end();
+        const bool takesAnEmbedding = std::ranges::find(expectedArgs, EvaluatedType::Embedding, &FunctionArgumentType::getType) != expectedArgs.end();
+
+        const bool reducesAWholeCell = signature->isAggregate() && (takesAList || takesAnEmbedding);
+        if (!_isV3 && reducesAWholeCell) {
             continue;
         }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -551,6 +551,8 @@ mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
 
     if (kind == Literal::Kind::NULL_LITERAL) {
         return _opBuilder.getUnitAttr();
+    } else if (kind == Literal::Kind::EMBEDDING) {
+        return embeddingLiteralAttr(static_cast<const EmbeddingLiteral*>(literal));
     } else if (kind == Literal::Kind::LIST) {
         const ListLiteral* nested = static_cast<const ListLiteral*>(literal);
 
@@ -562,8 +564,8 @@ mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
 
     const mlir::TypedAttr scalarAttr = scalarLiteralAttr(literal);
     if (!scalarAttr) {
-        throw TuringException("Only booleans, integers, floats, strings, nulls and lists are "
-                              "supported as list elements.");
+        throw TuringException("Only booleans, integers, floats, strings, nulls, embeddings and "
+                              "lists are supported as list elements.");
     }
 
     return scalarAttr;
@@ -3187,6 +3189,12 @@ mlir::TypedAttr DBProgramGenerator::scalarLiteralAttr(const Literal* literal) {
     }
 }
 
+mlir::Attribute DBProgramGenerator::embeddingLiteralAttr(const EmbeddingLiteral* literal) {
+    const std::span<const float> floats = literal->getValue();
+
+    return mlir::DenseF32ArrayAttr::get(_mlirCtxt, llvm::ArrayRef<float> {floats.data(), floats.size()});
+}
+
 mlir::Value DBProgramGenerator::translateLiteralExpr(const Literal* literal) {
     const mlir::Location uloc = _opBuilder.getUnknownLoc();
 
@@ -3201,21 +3209,10 @@ mlir::Value DBProgramGenerator::translateLiteralExpr(const Literal* literal) {
         break;
 
         case Literal::Kind::EMBEDDING: {
-            const EmbeddingLiteral* embeddingLiteral = static_cast<const EmbeddingLiteral*>(literal);
-            const std::span<const float> floats = embeddingLiteral->getValue();
-            const mlir::FloatType f32Type = _opBuilder.getF32Type();
-            const size_t size = floats.size();
-
-            const mlir::RankedTensorType tensorType = mlir::RankedTensorType::get(size, f32Type);
-
-            const auto* bytes = reinterpret_cast<const char*>(floats.data());
-            const size_t numBytes = size * sizeof(float);
-
-            const llvm::ArrayRef<char> rawBytes {bytes, numBytes};
-
-            const mlir::TypedAttr embAttr = mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawBytes);
+            const mlir::Attribute embeddingAttr = embeddingLiteralAttr(static_cast<const EmbeddingLiteral*>(literal));
             const mlir::db::ColumnType embResultType = allocColumnType(mlir::storage::EmbeddingType::get(_mlirCtxt));
-            return _opBuilder.create<mlir::db::ConstantOp>(uloc, embResultType, embAttr).getResult();
+
+            return _opBuilder.create<mlir::db::ConstantOp>(uloc, embResultType, embeddingAttr).getResult();
         }
         break;
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -33,6 +33,7 @@ class FunctionInvocation;
 class UnaryExpr;
 class CallStmt;
 class CypherAST;
+class EmbeddingLiteral;
 class Expr;
 class Literal;
 class ListLiteral;
@@ -400,6 +401,11 @@ private:
     // The attribute carrying a scalar literal's value and type, or a null attribute for
     // any other literal kind
     mlir::TypedAttr scalarLiteralAttr(const Literal* literal);
+
+    // The attribute carrying an embedding literal's floats: a dense f32 array, which -
+    // unlike a dense tensor - stores a repeated run element by element rather than
+    // uniquing it down to the one value every element holds
+    mlir::Attribute embeddingLiteralAttr(const EmbeddingLiteral* literal);
 
     // Fills one attribute per element of a literal list, each keeping its literal's type
     void translateListElements(const ListLiteral* list,

--- a/query/ir/common/IRLiteralList.h
+++ b/query/ir/common/IRLiteralList.h
@@ -8,7 +8,8 @@ namespace db {
 
 // The homogeneity verdict over a literal list's elements: the one type they all carry, or
 // null when they disagree - or when any of them carries none at all, which a null (a unit
-// attr) and a nested list (an array attr) do not. An empty list has no type to read either.
+// attr), an embedding (a dense f32 array attr) and a nested list (an array attr) do not. An
+// empty list has no type to read either.
 //
 // A null verdict is the type-erased form, a list of tagged scalars. An array attribute
 // carries no type of its own, so this is what both dialects' constant ops read to infer the

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -469,28 +469,26 @@ LogicalResult ConstantOp::inferReturnTypes(MLIRContext* context,
         return success();
     }
 
+    // A dense f32 array is an embedding: a flat run of floats, which is the one attribute
+    // kind carrying no type of its own that still names its column's element type.
+    if (llvm::isa<mlir::DenseF32ArrayAttr>(adaptor.getValue())) {
+        const mlir::Type embeddingType = storage::EmbeddingType::get(context);
+
+        inferredReturnTypes.emplace_back(mlir::db::ColumnType::get(context, embeddingType));
+        return success();
+    }
+
     // Type inference runs while the op is still being parsed, ahead of the operand
-    // constraint that limits the value to a typed attribute or an array, so an attribute of
-    // any other kind has to be turned away here rather than cast blindly.
+    // constraint that limits the value to those three kinds, so an attribute of any other
+    // kind has to be turned away here rather than cast blindly.
     const mlir::TypedAttr typedValue = llvm::dyn_cast<mlir::TypedAttr>(adaptor.getValue());
     if (!typedValue) {
         return mlir::emitOptionalError(location,
-                                       "db.constant carries a typed value or an array of "
-                                       "literals, not ", adaptor.getValue());
+                                       "db.constant carries a typed value, a dense f32 array "
+                                       "or an array of literals, not ", adaptor.getValue());
     }
 
-    mlir::Type elementType;
-    if (const auto elements = mlir::dyn_cast<mlir::DenseElementsAttr>(typedValue)) {
-        const auto shapedType = mlir::cast<mlir::ShapedType>(elements.getType());
-        const bool isEmbedding = shapedType.getElementType().isF32()
-                                 && shapedType.hasRank()
-                                 && shapedType.getRank() == 1;
-        elementType = isEmbedding ? storage::EmbeddingType::get(context) : typedValue.getType();
-    } else {
-        elementType = typedValue.getType();
-    }
-
-    inferredReturnTypes.emplace_back(mlir::db::ColumnType::get(context, elementType));
+    inferredReturnTypes.emplace_back(mlir::db::ColumnType::get(context, typedValue.getType()));
     return mlir::success();
 }
 

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -959,11 +959,12 @@ def EuclideanDistance : BinaryFunctionOp<"euclidean_distance">;
 def ConstantOp : TuringOp<"constant", [Pure, ConstantLike, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Produces a constant value in a column";
 
-  // A typed attribute for a scalar (or a dense one for an embedding), or an array of
-  // per-element attributes for a list literal. The array carries no type of its own, so
-  // the column's element type is the homogeneity verdict inferReturnTypes reads off the
-  // elements - which is why a list needs no separate op.
-  let arguments = (ins AnyAttrOf<[TypedAttrInterface, ArrayAttr]>: $value);
+  // A typed attribute for a scalar, a dense f32 array for an embedding, or an array of
+  // per-element attributes for a list literal. Neither array carries a type of its own, so
+  // the column's element type is what inferReturnTypes reads off them: an embedding for the
+  // dense array, the homogeneity verdict over the elements for the list - which is why a
+  // list needs no separate op.
+  let arguments = (ins AnyAttrOf<[TypedAttrInterface, DenseF32ArrayAttr, ArrayAttr]>: $value);
   let results = (outs Column : $result);
 
   let assemblyFormat = "`(` $value `)` attr-dict";

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -500,22 +500,35 @@ LogicalResult Aggregate::verify() {
 // rather than folding into a wrongly-typed or wrongly-initialized accumulator.
 LogicalResult AggregateUpdate::verify() {
     const storage::AggregateKind kind = getKind();
+    const bool isAvg = kind == storage::AggregateKind::Avg;
+    const Type accumulatorType = cast<AggregateStateType>(getState().getType()).getElementType();
 
-    // The input is a property value chunk; its value type is what the fold reads.
-    const Type inputValueType = aggregateValueType(getRows().getType());
-    if (!inputValueType) {
-        return emitOpError("input must be a nullable value chunk (a property column)");
+    // A type-erased column of tagged cells has no one value type: every cell is read
+    // through its own tag. Only avg folds one, since its f64 accumulator is the same
+    // whatever the tags were, where sum/min/max hold the reduced value in the input's
+    // own type and so have to know it.
+    const auto rowsChunk = cast<ChunkType>(getRows().getType());
+    const bool taggedCells = isa<storage::ListElementType>(rowsChunk.getElementType());
+    if (taggedCells && !isAvg) {
+        return emitOpError("only avg folds a column of tagged cells");
     }
 
-    // avg folds any numeric input into an f64 accumulator; sum/min/max fold into an
-    // accumulator of the input's own value type.
-    const Type accumulatorType = cast<AggregateStateType>(getState().getType()).getElementType();
-    if (kind == storage::AggregateKind::Avg) {
-        if (!isa<Float64Type>(accumulatorType)) {
-            return emitOpError("avg must fold into an f64 accumulator state");
+    // Every other input is a property value chunk; its value type is what the fold
+    // reads, and sum/min/max fold into an accumulator of that type.
+    if (!taggedCells) {
+        const Type inputValueType = aggregateValueType(getRows().getType());
+        if (!inputValueType) {
+            return emitOpError("input must be a nullable value chunk (a property column)");
         }
-    } else if (inputValueType != accumulatorType) {
-        return emitOpError("sum/min/max must fold into an accumulator of the input's value type");
+
+        if (!isAvg && inputValueType != accumulatorType) {
+            return emitOpError("sum/min/max must fold into an accumulator of the input's value type");
+        }
+    }
+
+    // avg folds any numeric input into an f64 accumulator, tagged cells included.
+    if (isAvg && !isa<Float64Type>(accumulatorType)) {
+        return emitOpError("avg must fold into an f64 accumulator state");
     }
 
     // The accumulator's reset depends on the producer's kind (a present zero for

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -199,27 +199,23 @@ LogicalResult Constant::inferReturnTypes(MLIRContext* context,
         return success();
     }
 
+    // The db-dialect sibling's rule: a dense f32 array is an embedding, a type the attribute
+    // itself does not carry.
+    if (isa<DenseF32ArrayAttr>(adaptor.getValue())) {
+        inferredReturnTypes.push_back(ChunkType::get(context, storage::EmbeddingType::get(context)));
+        return success();
+    }
+
     // Inference runs during parsing, ahead of the operand constraint, so an attribute that
     // is neither typed nor an array is rejected here rather than cast blindly.
     const auto value = dyn_cast<TypedAttr>(adaptor.getValue());
     if (!value) {
         return emitOptionalError(location,
-                                 "nl.constant carries a typed value or an array of "
-                                 "literals, not ", adaptor.getValue());
+                                 "nl.constant carries a typed value, a dense f32 array or "
+                                 "an array of literals, not ", adaptor.getValue());
     }
 
-    Type elementType;
-    if (const auto elements = dyn_cast<DenseElementsAttr>(value)) {
-        const auto shapedType = cast<ShapedType>(elements.getType());
-        const bool isEmbedding = shapedType.getElementType().isF32()
-                                 && shapedType.hasRank()
-                                 && shapedType.getRank() == 1;
-        elementType = isEmbedding ? storage::EmbeddingType::get(context) : value.getType();
-    } else {
-        elementType = value.getType();
-    }
-
-    inferredReturnTypes.push_back(ChunkType::get(context, elementType));
+    inferredReturnTypes.push_back(ChunkType::get(context, value.getType()));
     return success();
 }
 

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1152,7 +1152,7 @@ def Constant : NLOp<"constant", [Pure, ConstantLike, InferTypeOpAdaptor]> {
       %c = nl.constant(30 : i64) : !nl.chunk<i64>
   }];
 
-  let arguments = (ins AnyAttrOf<[TypedAttrInterface, ArrayAttr]>:$value);
+  let arguments = (ins AnyAttrOf<[TypedAttrInterface, DenseF32ArrayAttr, ArrayAttr]>:$value);
   let results   = (outs NLChunk:$result);
 
   let assemblyFormat = "`(` $value `)` attr-dict";

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1053,6 +1053,53 @@ void aggregateResultAvg(const NLAggregateState* state, Column* output) {
     }
 }
 
+// The number one tagged cell holds, widened to the f64 an average accumulates in. A cell
+// of any other type is no number to average, which is an error rather than a cell to skip
+// - only a null cell is skipped, by the folds below, before they read it.
+double listElementAsDouble(const ListElementView element) {
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            return static_cast<double>(element.getAs<types::Int64::Primitive>());
+        break;
+
+        case ListBufferTypeTag::UInt:
+            return static_cast<double>(element.getAs<types::UInt64::Primitive>());
+        break;
+
+        case ListBufferTypeTag::Double:
+            return element.getAs<types::Double::Primitive>();
+        break;
+
+        default:
+            throw IRException("avg requires a numeric column");
+        break;
+    }
+}
+
+// Fold a type-erased chunk's numeric cells into an avg accumulator: the tagged-cell
+// sibling of aggregateUpdateAvg, reading each cell through its own tag so that an integer
+// and a double element both charge the one running f64 sum. A null cell is skipped, as an
+// absent value of a nullable column is.
+void aggregateUpdateAvgElements(NLAggregateState* state, const Column* input) {
+    auto* accumulator = static_cast<ColumnOptVector<double>*>(state->getAccumulator());
+    std::optional<double>& current = accumulator->getRaw().front();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    double running = current.value();
+    size_t seen = 0;
+    for (const ListElementView element : inputRaw) {
+        if (element.getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        running += listElementAsDouble(element);
+        seen++;
+    }
+
+    current = running;
+    state->addCount(seen);
+}
+
 // The fold handler for a sum over a column of this value type. sum adds the
 // values, so only a numeric column is valid - a string or bool sum is rejected
 // (which also keeps aggregateUpdateSum from being instantiated for a type whose
@@ -1333,6 +1380,61 @@ void groupFoldAvgDistinct(Column* accumulator,
 
         std::optional<double>& running = raw[group];
         running = running.value() + static_cast<double>(*value);
+        counts[group]++;
+    }
+}
+
+// Fold a type-erased chunk's numeric cells into per-group avg accumulators: the
+// tagged-cell sibling of groupFoldAvg.
+void groupFoldAvgListElement(Column* accumulator,
+                             std::vector<uint64_t>& counts,
+                             const Column* input,
+                             const std::vector<size_t>& groups,
+                             NLGroupDistinctTally& distinct) {
+    auto& raw = static_cast<ColumnOptVector<double>*>(accumulator)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const ListElementView element = inputRaw[row];
+        if (element.getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        const size_t group = groups[row];
+        std::optional<double>& running = raw[group];
+        running = running.value() + listElementAsDouble(element);
+        counts[group]++;
+    }
+}
+
+// The distinct sibling of groupFoldAvgListElement (avg(DISTINCT x) over tagged cells):
+// cells are keyed by value across tags, as a DISTINCT over the same column keys them, so
+// the 1 and the 1.0 of one group are charged once between them.
+void groupFoldAvgDistinctListElement(Column* accumulator,
+                                     std::vector<uint64_t>& counts,
+                                     const Column* input,
+                                     const std::vector<size_t>& groups,
+                                     NLGroupDistinctTally& distinct) {
+    auto& raw = static_cast<ColumnOptVector<double>*>(accumulator)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const ListElementView element = inputRaw[row];
+        if (element.getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        const size_t group = groups[row];
+
+        distinct.beginKey(group);
+        distinctAppendElementBytes(distinct.getKey(), element);
+
+        if (!distinct.insertIfNew()) {
+            continue;
+        }
+
+        std::optional<double>& running = raw[group];
+        running = running.value() + listElementAsDouble(element);
         counts[group]++;
     }
 }
@@ -3623,6 +3725,24 @@ NLKeyAppendFunction NLExecutor::selectListElementKeyAppendFunction() {
 
 NLCountFunction NLExecutor::selectListElementCountFunction() {
     return &countNonNullElementsColumn;
+}
+
+NLAggregateUpdateFunction NLExecutor::selectListElementAggregateUpdate(AggregateKind kind) {
+    if (kind != AggregateKind::Avg) {
+        throw IRException("only avg reduces a column of tagged cells");
+    }
+
+    return &aggregateUpdateAvgElements;
+}
+
+NLGroupAggregateFoldFunction NLExecutor::selectListElementGroupAggregateFold(GroupAggregateKind kind) {
+    if (kind == GroupAggregateKind::Avg) {
+        return &groupFoldAvgListElement;
+    } else if (kind == GroupAggregateKind::AvgDistinct) {
+        return &groupFoldAvgDistinctListElement;
+    }
+
+    throw IRException("only avg reduces a column of tagged cells");
 }
 
 NLGroupKeyGatherFunction NLExecutor::selectListElementGroupKeyGatherFunction() {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -380,6 +380,11 @@ public:
     // a numeric type, min/max an orderable one. Used by the nl.aggregate ops.
     static NLAggregateResetFunction selectAggregateReset(AggregateKind kind, ValueType accumulatorType);
     static NLAggregateUpdateFunction selectAggregateUpdate(AggregateKind kind, ValueType inputType);
+
+    // The siblings of selectAggregateUpdate / selectGroupAggregateFold for a type-erased
+    // column, whose cells carry their own tags rather than sharing one value type
+    static NLAggregateUpdateFunction selectListElementAggregateUpdate(AggregateKind kind);
+    static NLGroupAggregateFoldFunction selectListElementGroupAggregateFold(GroupAggregateKind kind);
     static NLAggregateResultFunction selectAggregateResult(AggregateKind kind, ValueType resultType);
 
     // The grouped counterparts, selected for one aggregate of a grouped

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1870,14 +1870,13 @@ void NLTranslator::translateAggregateUpdate(nl::AggregateUpdate update, NLStmtCo
     // or throws if it was not produced by an nl.aggregate.
     NLAggregateState* state = aggregateStateFor(update.getState());
 
-    // Fold the chunk's non-null values the way its kind and value type demand. The
+    // Fold the chunk's non-null values the way its kind and chunk type demand. The
     // input value type may differ from the accumulator's (an avg of i64 folds into
-    // an f64 accumulator), so the handler is selected from the input type here.
+    // an f64 accumulator), so the handler is selected from the input here.
     const mlir::Value rows = update.getRows();
     const Column* input = getColumn(rows);
     const AggregateKind kind = toRuntimeAggregateKind(update.getKind());
-    const ValueType inputType = nullableChunkValueType(rows.getType());
-    const NLAggregateUpdateFunction fold = NLExecutor::selectAggregateUpdate(kind, inputType);
+    const NLAggregateUpdateFunction fold = selectAggregateUpdateForChunkType(kind, rows.getType());
 
     NLAggregateUpdateData* data = _program->allocFunctionData<NLAggregateUpdateData>(state, input, fold);
     body->emplaceStmt(&NLExecutor::runAggregateUpdate, data);
@@ -2011,14 +2010,23 @@ void NLTranslator::buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKin
             // own type. nullableChunkValueType rejects an ID chunk here. The distinct
             // kinds keep the shape of the kind they mirror and differ only in the
             // fold, which charges each of a group's values once.
-            const ValueType inputType = nullableChunkValueType(chunkType);
+            //
+            // A type-erased column is the exception: its cells carry their own tags, so
+            // only avg folds one (lowering rejects the others) and it accumulates in the
+            // f64 an average is whatever those tags were.
+            const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+            const bool taggedCells = mlir::isa<storage::ListElementType>(chunk.getElementType());
+
+            const ValueType inputType = taggedCells ? ValueType::Double
+                                                    : nullableChunkValueType(chunkType);
             const bool accumulatesAsDouble = (kind == GroupAggregateKind::Avg)
                                           || (kind == GroupAggregateKind::AvgDistinct);
             const ValueType accumulatorType = accumulatesAsDouble ? ValueType::Double : inputType;
 
             aggregate._accumulator = allocOptColumnForValueType(accumulatorType);
             aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, accumulatorType);
-            aggregate._fold = NLExecutor::selectGroupAggregateFold(kind, inputType);
+            aggregate._fold = taggedCells ? NLExecutor::selectListElementGroupAggregateFold(kind)
+                                          : NLExecutor::selectGroupAggregateFold(kind, inputType);
             aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, accumulatorType);
         }
         break;
@@ -2807,6 +2815,18 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     }
 
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
+}
+
+// The value-reduction sibling of selectCountForChunkType: a type-erased column of tagged
+// cells is folded cell by cell, every other one through the value type it shares.
+NLAggregateUpdateFunction NLTranslator::selectAggregateUpdateForChunkType(AggregateKind kind,
+                                                                         mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    if (mlir::isa<storage::ListElementType>(chunk.getElementType())) {
+        return NLExecutor::selectListElementAggregateUpdate(kind);
+    }
+
+    return NLExecutor::selectAggregateUpdate(kind, nullableChunkValueType(chunkType));
 }
 
 NLCountFunction NLTranslator::selectCountForChunkType(mlir::Type chunkType) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -178,7 +178,7 @@ ValueType valueTypeFromElementType(mlir::Type elementType) {
 }
 
 template <SupportedType T>
-typename T::Primitive constantValueAs(mlir::TypedAttr value) {
+typename T::Primitive constantValueAs(mlir::Attribute value) {
     if constexpr (std::same_as<T, types::Int64>) {
         return mlir::cast<mlir::IntegerAttr>(value).getInt();
     } else if constexpr (std::same_as<T, types::UInt64>) {
@@ -190,12 +190,8 @@ typename T::Primitive constantValueAs(mlir::TypedAttr value) {
     } else if constexpr (std::same_as<T, types::String>) {
         return mlir::cast<mlir::StringAttr>(value).getValue();
     } else if constexpr (std::same_as<T, types::Embedding>) {
-        const mlir::DenseElementsAttr elements =
-            mlir::cast<mlir::DenseElementsAttr>(value);
-        const llvm::ArrayRef<char> rawBytes = elements.getRawData();
-        const float* floats = reinterpret_cast<const float*>(rawBytes.data());
-        const size_t size = rawBytes.size() / sizeof(float);
-        return std::span<const float>{floats, size};
+        const llvm::ArrayRef<float> floats = mlir::cast<mlir::DenseF32ArrayAttr>(value).asArrayRef();
+        return std::span<const float> {floats.data(), floats.size()};
     } else {
         throw IRException("Unsupported constant value type");
     }
@@ -745,6 +741,8 @@ size_t NLTranslator::listValueBytes(mlir::ArrayAttr elements) {
             valueBytes += sizeof(types::Double::Primitive);
         } else if (mlir::isa<mlir::StringAttr>(element)) {
             valueBytes += sizeof(types::String::Primitive);
+        } else if (mlir::isa<mlir::DenseF32ArrayAttr>(element)) {
+            valueBytes += sizeof(types::Embedding::Primitive);
         } else if (mlir::isa<mlir::UnitAttr>(element)) {
             valueBytes += sizeof(PropertyNull);
         } else if (mlir::isa<mlir::ArrayAttr>(element)) {
@@ -781,6 +779,12 @@ ListView NLTranslator::materializeListView(mlir::ArrayAttr elements) {
             const llvm::StringRef value = stringAttr.getValue();
             cursor.writeValue(ListBufferTypeTag::String,
                               types::String::Primitive(value.data(), value.size()));
+        } else if (const auto embeddingAttr = mlir::dyn_cast<mlir::DenseF32ArrayAttr>(element)) {
+            // The floats stay in the attribute, as a string element's bytes do, so the
+            // stored span points at them rather than at a copy
+            const llvm::ArrayRef<float> floats = embeddingAttr.asArrayRef();
+            cursor.writeValue(ListBufferTypeTag::Embedding,
+                              types::Embedding::Primitive(floats.data(), floats.size()));
         } else if (mlir::isa<mlir::UnitAttr>(element)) {
             cursor.writeValue(ListBufferTypeTag::Null, PropertyNull {});
         } else if (const auto nestedAttr = mlir::dyn_cast<mlir::ArrayAttr>(element)) {
@@ -1154,7 +1158,7 @@ void NLTranslator::translateConstant(nl::Constant constant) {
         return;
     }
 
-    const mlir::TypedAttr value = mlir::cast<mlir::TypedAttr>(constant.getValue());
+    const mlir::Attribute value = constant.getValue();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
         if (mlir::isa<mlir::NoneType>(nullableType.getValueType())) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -473,6 +473,11 @@ private:
     // nl.count_update.
     static NLCountFunction selectCountForChunkType(mlir::Type chunkType);
 
+    // The fold handler for a value reduction over a chunk type. Used by
+    // nl.aggregate_update.
+    static NLAggregateUpdateFunction selectAggregateUpdateForChunkType(AggregateKind kind,
+                                                                      mlir::Type chunkType);
+
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the
     // handle) to a PropertyTypeID and value type, allocate the nullable value

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -259,10 +259,13 @@ nl::ChunkType procedureChunkType(mlir::OpBuilder& builder, ProcedureType procedu
 }
 
 // The accumulator (and result) element type of an aggregate over a column whose
-// nullable value chunk wraps inputElement. avg always reduces to an f64; sum,
+// nullable value chunk wraps inputElement - or over a type-erased column, whose
+// inputElement is the tagged cell itself. avg always reduces to an f64; sum,
 // min and max keep the input's own type. Throws for a value type the reduction
 // cannot handle: sum/avg need a numeric column, min/max an orderable one (so a
-// string sum, a bool sum or an embedding min is rejected, matching Cypher).
+// string sum, a bool sum or an embedding min is rejected, matching Cypher). A
+// tagged cell is numeric only once read, so only avg - whose result type does not
+// depend on what the tags were - accepts one.
 mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
                                       storage::AggregateKind kind,
                                       mlir::Type inputElement) {
@@ -272,6 +275,7 @@ mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
     const bool isInteger = integerType && !isBool;
     const bool isNumeric = isFloat || isInteger;
     const bool isString = mlir::isa<storage::StringType>(inputElement);
+    const bool isTaggedCell = mlir::isa<storage::ListElementType>(inputElement);
 
     switch (kind) {
         case storage::AggregateKind::Sum: {
@@ -283,7 +287,7 @@ mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
         break;
 
         case storage::AggregateKind::Avg: {
-            if (!isNumeric) {
+            if (!isNumeric && !isTaggedCell) {
                 throw IRException("db.avg requires a numeric column");
             }
             return builder.getF64Type();
@@ -451,14 +455,16 @@ nl::ChunkType groupAggregateResultChunkType(mlir::OpBuilder& builder,
         case storage::GroupAggregateKind::Avg:
         case storage::GroupAggregateKind::AvgDistinct: {
             const nl::ChunkType inputChunkType = mlir::cast<nl::ChunkType>(inputChunk.getType());
-            const auto inputNullable = mlir::dyn_cast<storage::NullableType>(inputChunkType.getElementType());
-            if (!inputNullable) {
+            const mlir::Type inputElement = inputChunkType.getElementType();
+            const auto inputNullable = mlir::dyn_cast<storage::NullableType>(inputElement);
+            const bool taggedCells = mlir::isa<storage::ListElementType>(inputElement);
+            if (!inputNullable && !taggedCells) {
                 throw IRException("db.group_aggregate sum/min/max/avg requires a property value column");
             }
 
             const mlir::Type resultElement = aggregateResultElementType(builder,
                                                                         groupKindToAggregateKind(kind),
-                                                                        inputNullable.getValueType());
+                                                                        taggedCells ? inputElement : inputNullable.getValueType());
             const storage::NullableType resultNullable = storage::NullableType::get(context, resultElement);
 
             return nl::ChunkType::get(context, resultNullable);
@@ -1582,17 +1588,29 @@ void DBLowering::lowerAggregate(mlir::Value input, mlir::Value result, storage::
     // The nl chunk the aggregated column lowered to; the update folds its per-step
     // non-null values into the accumulator. A constant column is reduced over the
     // rows it stands for, so it is laid out over the driving relation first.
-    const mlir::Value inputChunk = nullableValueChunk(rowAlignedChunk(mapValue(input), _innermostCardinality));
+    const mlir::Value alignedChunk = rowAlignedChunk(mapValue(input), _innermostCardinality);
+
+    // A type-erased column of tagged cells - what a list mixing types, holding a null
+    // or holding nothing unwinds into - is folded as it stands: every cell carries its
+    // own tag, so there is no one value type to read the column as.
+    const mlir::Type alignedElement = mlir::cast<nl::ChunkType>(alignedChunk.getType()).getElementType();
+    const bool taggedCells = mlir::isa<storage::ListElementType>(alignedElement);
+
+    const mlir::Value inputChunk = taggedCells ? alignedChunk : nullableValueChunk(alignedChunk);
 
     mlir::MLIRContext* const context = _builder.getContext();
     const mlir::Location loc = _builder.getUnknownLoc();
 
-    const nl::ChunkType inputChunkType = mlir::cast<nl::ChunkType>(inputChunk.getType());
-    const auto inputNullable = mlir::cast<storage::NullableType>(inputChunkType.getElementType());
+    // A type-erased column is read as the tagged cell it holds; every other input is a
+    // nullable value chunk, and the reduction is resolved from the value type it wraps.
+    const mlir::Type inputChunkElement = mlir::cast<nl::ChunkType>(inputChunk.getType()).getElementType();
+    const mlir::Type inputElement = taggedCells
+        ? inputChunkElement
+        : mlir::cast<storage::NullableType>(inputChunkElement).getValueType();
 
     // The accumulator (and result) element type: avg widens to f64, the rest keep
     // the input type. This also validates the reduction against the value type.
-    const mlir::Type resultElement = aggregateResultElementType(_builder, kind, inputNullable.getValueType());
+    const mlir::Type resultElement = aggregateResultElementType(_builder, kind, inputElement);
 
     // The accumulator is hoisted to the top of the entry block, above every loop,
     // so it is reset once at function scope and dominates the update in the
@@ -1673,8 +1691,15 @@ void DBLowering::lowerGroupAggregate(mlir::db::GroupAggregate groupAggregate) {
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
         const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
 
-        if (reducesValues(kind)) {
-            chunks[keyCount + aggregateIndex] = nullableValueChunk(chunks[keyCount + aggregateIndex]);
+        // A type-erased column of tagged cells is folded as it stands, like a count's
+        // input: every cell carries its own tag, so there is no one value type to read
+        // the column as.
+        const mlir::Value aggregateChunk = chunks[keyCount + aggregateIndex];
+        const mlir::Type aggregateElement = mlir::cast<nl::ChunkType>(aggregateChunk.getType()).getElementType();
+        const bool taggedCells = mlir::isa<storage::ListElementType>(aggregateElement);
+
+        if (reducesValues(kind) && !taggedCells) {
+            chunks[keyCount + aggregateIndex] = nullableValueChunk(aggregateChunk);
         }
     }
 

--- a/test/query/ir/AvgEmptyTest.cpp
+++ b/test/query/ir/AvgEmptyTest.cpp
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+using ColumnNames = std::vector<std::string>;
+
+// No node of SimpleGraph carries this name, so the match keeps no row at all
+const std::string_view emptyMatch = "MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' ";
+
+}
+
+// The query test suite's avg-empty and avg-all-null cases on the v3 engine:
+// MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN avg(n.age)
+// MATCH (n) WHERE n.age IS NULL RETURN avg(n.age)
+//
+// There is no value to divide either way - no row at all in the first, no non-null age in
+// the second - so the average is null, as Cypher's is. Only sum and count answer a number
+// over nothing: a sum starts at its identity and a count tallies rows it never saw, where
+// an average would have to divide by zero. The suite's own expectation of 0 is the legacy
+// engine's, which does not distinguish the two.
+class AvgEmptyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    void expectNamedRows(std::string_view query, const ColumnNames& names, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getNames(), names) << "query: " << query;
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// avg-empty: an aggregate answers one row whether or not the match kept any, and that row
+// holds no average
+TEST_F(AvgEmptyTest, averagesAnEmptyMatchToNull) {
+    const Rows expected = {{"null"}};
+    expectNamedRows(std::string(emptyMatch) + "RETURN avg(n.age)", {"avg(n.age)"}, expected);
+}
+
+// avg-all-null: the match keeps the 16 ageless nodes of SimpleGraph, so there are rows to
+// fold but no value in them
+TEST_F(AvgEmptyTest, averagesAnAllNullPropertyToNull) {
+    const Rows expected = {{"null"}};
+    expectNamedRows("MATCH (n) WHERE n.age IS NULL RETURN avg(n.age)", {"avg(n.age)"}, expected);
+}
+
+// The two aggregates that do answer a number over nothing, against the same empty match.
+TEST_F(AvgEmptyTest, countsAnEmptyMatchAsZero) {
+    const Rows expected = {{"0"}};
+    expectRows(std::string(emptyMatch) + "RETURN count(n.age)", expected);
+}
+
+TEST_F(AvgEmptyTest, sumsAnEmptyMatchToZero) {
+    const Rows expected = {{"0"}};
+    expectRows(std::string(emptyMatch) + "RETURN sum(n.age)", expected);
+}
+
+// min and max have no identity to start from, so they answer as the average does.
+TEST_F(AvgEmptyTest, minimisesAndMaximisesAnEmptyMatchToNull) {
+    const Rows expected = {{"null", "null"}};
+    expectRows(std::string(emptyMatch) + "RETURN min(n.age), max(n.age)", expected);
+}
+
+// The average of nothing carries through the arithmetic over it rather than reading as a
+// zero the addition would move.
+TEST_F(AvgEmptyTest, keepsTheNullAverageThroughAnExpression) {
+    const Rows expected = {{"null"}};
+    expectRows(std::string(emptyMatch) + "RETURN avg(n.age) + 10", expected);
+}
+
+// The same fold over rows that do hold a value: only Remy and Adam carry an age, both 32,
+// and the ageless nodes are skipped rather than counted as zero - which is the same rule
+// that leaves the all-null average null.
+TEST_F(AvgEmptyTest, averagesOnlyTheRowsHoldingAValue) {
+    const Rows expected = {{"32"}};
+    expectRows("MATCH (n) RETURN avg(n.age)", expected);
+}
+
+// Under a grouping key there is no group to answer for, so an empty match collapses to no
+// row where the ungrouped aggregate above still answers one.
+TEST_F(AvgEmptyTest, emitsNoRowForAGroupedAverageOverAnEmptyMatch) {
+    const Rows expected = {};
+    expectRows(std::string(emptyMatch) + "RETURN n.name, avg(n.age)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/AvgEmptyTest.cpp
+++ b/test/query/ir/AvgEmptyTest.cpp
@@ -30,6 +30,20 @@ using ColumnNames = std::vector<std::string>;
 // No node of SimpleGraph carries this name, so the match keeps no row at all
 const std::string_view emptyMatch = "MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' ";
 
+// Only Remy and Adam carry an age, so this match keeps rows - the other 16 nodes - whose
+// age is null in every one of them
+const std::string_view allNullMatch = "MATCH (n) WHERE n.age IS NULL ";
+
+constexpr uint64_t agelessNodeCount = 16;
+
+// The ageless nodes of SimpleGraph by name, in ascending byte order: every node but Remy
+// and Adam, the two the age belongs to.
+const std::vector<std::string> agelessNodeNames = {
+    "Animals", "Bio", "Computers", "Cooking", "Cyrus",
+    "Doruk", "Eighties", "Ghosts", "Gym", "JiuJitsu", "Luc",
+    "Martina", "Maxime", "Padel", "Suhas", "Travel",
+};
+
 }
 
 // The query test suite's avg-empty and avg-all-null cases on the v3 engine:
@@ -97,6 +111,46 @@ TEST_F(AvgEmptyTest, averagesAnEmptyMatchToNull) {
 TEST_F(AvgEmptyTest, averagesAnAllNullPropertyToNull) {
     const Rows expected = {{"null"}};
     expectNamedRows("MATCH (n) WHERE n.age IS NULL RETURN avg(n.age)", {"avg(n.age)"}, expected);
+}
+
+// The rows an all-null match keeps are rows all the same: count(n) tallies them, where
+// count(n.age) reads the values and finds none. This is the whole difference between the
+// two cases - an empty match has neither.
+TEST_F(AvgEmptyTest, countsTheRowsOfAnAllNullMatchButNoneOfItsValues) {
+    const Rows rowTally = {{std::to_string(agelessNodeCount), "0"}};
+    expectRows(std::string(allNullMatch) + "RETURN count(n), count(n.age)", rowTally);
+}
+
+TEST_F(AvgEmptyTest, sumsAnAllNullPropertyToZero) {
+    const Rows expected = {{"0"}};
+    expectRows(std::string(allNullMatch) + "RETURN sum(n.age)", expected);
+}
+
+TEST_F(AvgEmptyTest, minimisesAndMaximisesAnAllNullPropertyToNull) {
+    const Rows expected = {{"null", "null"}};
+    expectRows(std::string(allNullMatch) + "RETURN min(n.age), max(n.age)", expected);
+}
+
+TEST_F(AvgEmptyTest, keepsTheAllNullAverageThroughAnExpression) {
+    const Rows expected = {{"null"}};
+    expectRows(std::string(allNullMatch) + "RETURN avg(n.age) + 10", expected);
+}
+
+// Under a grouping key each kept row is a group of its own, so an all-null match answers
+// one null average per node - where the empty match below answers no row at all.
+TEST_F(AvgEmptyTest, emitsANullAverageForEveryGroupOfAnAllNullMatch) {
+    Rows expected;
+    for (const std::string& name : agelessNodeNames) {
+        expected.push_back({name, "null"});
+    }
+
+    StringRowSink sink;
+    runQuery(std::string(allNullMatch) + "RETURN n.name, avg(n.age)", sink);
+
+    Rows rows;
+    sink.sortedRows(rows);
+
+    EXPECT_EQ(rows, expected);
 }
 
 // The two aggregates that do answer a number over nothing, against the same empty match.

--- a/test/query/ir/AvgLiteralTest.cpp
+++ b/test/query/ir/AvgLiteralTest.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+using ColumnNames = std::vector<std::string>;
+
+constexpr uint64_t simpleGraphNodeCount = 18;
+
+}
+
+// The query test suite's avg-literal case on the v3 engine: RETURN avg(42)
+//
+// The constant is the aggregate's whole input, and a constant column holds one value
+// standing for every row rather than one per row, so what the fold charges is the rows of
+// the driving relation. A bare RETURN runs over one row, so 42 is charged once; a MATCH in
+// front of it lays the same constant over every matched row, which leaves the average 42
+// but not the sum or the tally. With no row at all there is nothing to charge and the
+// average is null - where the legacy engine reduces the single row the constant is, and
+// answers 42 whatever the relation holds.
+class AvgLiteralTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    void expectNamedRows(std::string_view query, const ColumnNames& names, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getNames(), names) << "query: " << query;
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// avg-literal: the one row a bare RETURN runs over holds the constant, so the average is
+// the constant itself - carried in the double an average is, whatever the literal was
+TEST_F(AvgLiteralTest, averagesAnIntegerLiteral) {
+    const Rows expected = {{"42"}};
+    expectNamedRows("RETURN avg(42)", {"avg(42)"}, expected);
+}
+
+TEST_F(AvgLiteralTest, averagesADoubleLiteral) {
+    const Rows expected = {{"42.5"}};
+    expectNamedRows("RETURN avg(42.5)", {"avg(42.5)"}, expected);
+}
+
+TEST_F(AvgLiteralTest, averagesALiteralUnderAnExpression) {
+    const Rows expected = {{"43"}};
+    expectRows("RETURN avg(42) + 1", expected);
+}
+
+// The same constant over a match: it is laid out over the 18 matched rows, and the mean of
+// one value repeated is that value, so the broadcast leaves the answer alone.
+TEST_F(AvgLiteralTest, averagesTheLiteralRepeatedByEveryMatchedRow) {
+    const Rows expected = {{"42"}};
+    expectRows("MATCH (n) RETURN avg(42)", expected);
+}
+
+// The two reductions the broadcast does move: the sum charges the constant once per matched
+// row and the tally counts them, where a bare RETURN would answer 42 and 1.
+TEST_F(AvgLiteralTest, sumsAndCountsTheLiteralOverEveryMatchedRow) {
+    const uint64_t sum = 42 * simpleGraphNodeCount;
+
+    const Rows expected = {{std::to_string(sum), std::to_string(simpleGraphNodeCount)}};
+    expectRows("MATCH (n) RETURN sum(42), count(42)", expected);
+}
+
+TEST_F(AvgLiteralTest, sumsAndCountsTheLiteralOfABareReturn) {
+    const Rows expected = {{"42", "1"}};
+    expectRows("RETURN sum(42), count(42)", expected);
+}
+
+// No row to charge the constant against, so there is no value to divide: the average is
+// null rather than the constant standing on its own.
+TEST_F(AvgLiteralTest, averagesTheLiteralOfAnEmptyMatchToNull) {
+    const Rows expected = {{"null"}};
+    expectRows("MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN avg(42)", expected);
+}
+
+// Under a grouping key the constant is averaged within each group: Remy (0) and Adam (1)
+// are the two nodes carrying an age, so each answers for its own row.
+TEST_F(AvgLiteralTest, averagesTheLiteralWithinEachGroup) {
+    const Rows expected = {{"0", "42"}, {"1", "42"}};
+    expectRows("MATCH (n) WHERE n.age = 32 RETURN n, avg(42)", expected);
+}
+
+// A constant is one value however many rows it stands for, so avg(DISTINCT 42) charges it
+// once and answers the same 42 the ungrouped average does.
+TEST_F(AvgLiteralTest, averagesTheDistinctLiteralOverAMatch) {
+    const Rows expected = {{"42"}};
+    expectRows("MATCH (n) RETURN avg(DISTINCT 42)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/AvgUnwindTest.cpp
+++ b/test/query/ir/AvgUnwindTest.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+using ColumnNames = std::vector<std::string>;
+
+}
+
+// The query test suite's avg-unwind-dbl and avg-unwind-int cases on the v3 engine:
+// unwind [1.2, 2.2, 1.1] as rg return avg(rg)
+// unwind [333, 1000, 200] as rg return avg(rg)
+//
+// UNWIND is the driving relation and the aggregate reduces the rows it yields, so the fold
+// runs over the elements of a list rather than over a scanned column. An average is a
+// double whatever its input was, so an integer list averages to the fraction between two
+// of its elements rather than to a truncated integer.
+class AvgUnwindTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    void expectNamedRows(std::string_view query, const ColumnNames& names, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getNames(), names) << "query: " << query;
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// avg-unwind-dbl: the three doubles sum to 4.5 exactly, so their average is the 1.5 the
+// aliased column is named for
+TEST_F(AvgUnwindTest, averagesTheReportedDoubleList) {
+    const Rows expected = {{"1.5"}};
+    expectNamedRows("unwind [1.2,2.2, 1.1] as rg return avg(rg)", {"avg(rg)"}, expected);
+}
+
+// avg-unwind-int
+TEST_F(AvgUnwindTest, averagesTheReportedIntegerList) {
+    const Rows expected = {{"511"}};
+    expectNamedRows("unwind [333, 1000, 200] as rg return avg(rg)", {"avg(rg)"}, expected);
+}
+
+// An integer list whose average falls between two elements: the result is the double the
+// division gives, not the integer the inputs were.
+TEST_F(AvgUnwindTest, averagesAnIntegerListToAFraction) {
+    const Rows expected = {{"1.5"}};
+    expectRows("UNWIND [1, 2] AS rg RETURN avg(rg)", expected);
+}
+
+TEST_F(AvgUnwindTest, averagesASingleElement) {
+    const Rows expected = {{"2.5"}};
+    expectRows("UNWIND [2.5] AS rg RETURN avg(rg)", expected);
+}
+
+// The same column under sum and count beside the average: an average is what the two of
+// them divide to, and the three folds read the one unwound column together.
+TEST_F(AvgUnwindTest, averagesWhatTheSumAndCountDivideTo) {
+    const Rows expected = {{"4.5", "3", "1.5"}};
+    expectRows("unwind [1.2,2.2, 1.1] as rg return sum(rg), count(rg), avg(rg)", expected);
+}
+
+// Crossed with a match, the elements are laid out over the matched rows, so the fold reads
+// one row per pair. Remy (0) is the only node named so, which leaves the elements'
+// average unchanged - where every node of SimpleGraph would repeat each element 18 times,
+// to the same average again.
+TEST_F(AvgUnwindTest, averagesTheElementsCrossedWithAMatch) {
+    const Rows expected = {{"2"}};
+    expectRows("UNWIND [1.0, 2.0, 3.0] AS rg MATCH (n) WHERE n.name = 'Remy' RETURN avg(rg)", expected);
+}
+
+TEST_F(AvgUnwindTest, averagesTheElementsRepeatedByEveryMatchedNode) {
+    const Rows expected = {{"1.5"}};
+    expectRows("UNWIND [1.0, 2.0] AS rg MATCH (n) RETURN avg(rg)", expected);
+}
+
+// The unwound cell as a grouping key beside the average of its own group: the repeated
+// element groups once and each group averages to the value it holds.
+TEST_F(AvgUnwindTest, averagesEachGroupOfTheUnwoundCell) {
+    const Rows expected = {{"1", "1"}, {"2", "2"}};
+    expectRows("UNWIND [1.0, 1.0, 2.0] AS rg RETURN rg, avg(rg)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/AvgUnwindTest.cpp
+++ b/test/query/ir/AvgUnwindTest.cpp
@@ -37,6 +37,10 @@ using ColumnNames = std::vector<std::string>;
 // runs over the elements of a list rather than over a scanned column. An average is a
 // double whatever its input was, so an integer list averages to the fraction between two
 // of its elements rather than to a truncated integer.
+//
+// A list whose elements share one type unwinds into a column of that type; one that mixes
+// numeric types, holds a null or holds nothing at all unwinds into a type-erased column of
+// tagged cells, which the fold reads a tag at a time. Both average the same way.
 class AvgUnwindTest : public TuringTest {
 protected:
     void initialize() override {
@@ -74,6 +78,26 @@ protected:
 
         EXPECT_EQ(sink.getNames(), names) << "query: " << query;
         EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    // The query is turned away, and on @param reason: an average of something that is not
+    // a number is a different failure from one the engine cannot lay out.
+    void expectError(std::string_view query, std::string_view reason) {
+        StringRowSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_FALSE(status.isOk()) << "query was accepted: " << query;
+
+        const std::string error = status.getError();
+        EXPECT_NE(error.find(reason), std::string::npos) << "query: " << query << "\nerror: " << error;
     }
 
     const std::string _graphName = "simpledb";
@@ -132,6 +156,75 @@ TEST_F(AvgUnwindTest, averagesTheElementsRepeatedByEveryMatchedNode) {
 TEST_F(AvgUnwindTest, averagesEachGroupOfTheUnwoundCell) {
     const Rows expected = {{"1", "1"}, {"2", "2"}};
     expectRows("UNWIND [1.0, 1.0, 2.0] AS rg RETURN rg, avg(rg)", expected);
+}
+
+// A list mixing an integer and a double unwinds type-erased, so the fold reads each cell
+// through its own tag and widens both to the double an average is.
+TEST_F(AvgUnwindTest, averagesAMixedNumericList) {
+    const Rows expected = {{"1.75"}};
+    expectRows("UNWIND [1, 2.5] AS x RETURN avg(x)", expected);
+}
+
+TEST_F(AvgUnwindTest, averagesAcrossThreeMixedElements) {
+    const Rows expected = {{"2.5"}};
+    expectRows("UNWIND [1, 2.5, 4] AS x RETURN avg(x)", expected);
+}
+
+// A null element makes the list type-erased too, and the fold skips it as it skips the
+// null of a property column: the average divides by the two values it did read.
+TEST_F(AvgUnwindTest, averagesPastTheNullElementsOfAList) {
+    const Rows expected = {{"1.5"}};
+    expectRows("UNWIND [1.0, null, 2.0] AS x RETURN avg(x)", expected);
+}
+
+TEST_F(AvgUnwindTest, averagesAnAllNullListToNull) {
+    const Rows expected = {{"null"}};
+    expectRows("UNWIND [null, null] AS x RETURN avg(x)", expected);
+}
+
+// An empty list yields no row to fold, and the aggregate still answers one - holding no
+// average, as it does over a match that kept nothing.
+TEST_F(AvgUnwindTest, averagesAnEmptyListToNull) {
+    const Rows expected = {{"null"}};
+    expectNamedRows("UNWIND [] AS x RETURN avg(x)", {"avg(x)"}, expected);
+}
+
+// A string is no number, so averaging one is an error rather than a cell the fold skips.
+TEST_F(AvgUnwindTest, rejectsAveragingANonNumericElement) {
+    expectError("UNWIND [1, 'two'] AS x RETURN avg(x)", "numeric");
+}
+
+// avg(DISTINCT x) over tagged cells keys them by value: the repeated element is charged
+// once, so the average is taken over the two values the list holds.
+TEST_F(AvgUnwindTest, averagesTheDistinctCellsOfAMixedList) {
+    const Rows expected = {{"1.75"}};
+    expectRows("UNWIND [1, 1, 2.5] AS x RETURN avg(DISTINCT x)", expected);
+}
+
+// Under a grouping key the fold runs per group: Remy (0) is the only node the match
+// keeps, so the two cells average within that one group.
+TEST_F(AvgUnwindTest, averagesAMixedListWithinAMatchedGroup) {
+    const Rows expected = {{"0", "1.75"}};
+    expectRows("UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN n, avg(x)", expected);
+}
+
+// Two groups, each pairing with the same two cells: Remy (0) and Adam (1) are the nodes
+// carrying an age, and neither group reads the other's rows.
+TEST_F(AvgUnwindTest, averagesAMixedListWithinEachMatchedGroup) {
+    const Rows expected = {{"0", "1.75"}, {"1", "1.75"}};
+    expectRows("UNWIND [1, 2.5] AS x MATCH (n) WHERE n.age = 32 RETURN n, avg(x)", expected);
+}
+
+TEST_F(AvgUnwindTest, averagesTheDistinctCellsWithinAMatchedGroup) {
+    const Rows expected = {{"0", "1.75"}};
+    expectRows("UNWIND [1, 1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN n, avg(DISTINCT x)", expected);
+}
+
+// The tagged cell as the grouping key of its own average: 1 and 1.0 are one Cypher value,
+// so they group together and the group averages to the value they share.
+TEST_F(AvgUnwindTest, averagesEachGroupOfAMixedUnwoundCell) {
+    const Rows expected = {{"1", "1"}, {"2.5", "2.5"}};
+    expectRows("UNWIND [1, 1.0, 2.5] AS x RETURN x, avg(x)", expected);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1273,3 +1273,14 @@ target_link_libraries(test_query_ir_avg_unwind PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_avg_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_avg_empty AvgEmptyTest.cpp)
+target_sources(test_query_ir_avg_empty PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_avg_empty PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_avg_empty PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1262,3 +1262,14 @@ target_link_libraries(test_query_ir_unwind_heterogeneous_list PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_unwind_heterogeneous_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_avg_unwind AvgUnwindTest.cpp)
+target_sources(test_query_ir_avg_unwind PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_avg_unwind PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_avg_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1251,3 +1251,14 @@ target_link_libraries(test_query_ir_return_heterogeneous_list PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_return_heterogeneous_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_unwind_heterogeneous_list UnwindHeterogeneousListTest.cpp)
+target_sources(test_query_ir_unwind_heterogeneous_list PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_unwind_heterogeneous_list PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_unwind_heterogeneous_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1241,3 +1241,13 @@ target_link_libraries(test_query_ir_match_skip_limit PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_match_skip_limit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_return_heterogeneous_list ReturnHeterogeneousListTest.cpp)
+target_link_libraries(test_query_ir_return_heterogeneous_list PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_return_heterogeneous_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1284,3 +1284,14 @@ target_link_libraries(test_query_ir_avg_empty PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_avg_empty PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_avg_literal AvgLiteralTest.cpp)
+target_sources(test_query_ir_avg_literal PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_avg_literal PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_avg_literal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CypherListLiteralTest.cpp
+++ b/test/query/ir/CypherListLiteralTest.cpp
@@ -823,7 +823,7 @@ TEST_F(CypherListLiteralTest, rejectsMapListElements) {
     // A map literal is a literal, so it clears the analyzer's element check and is turned
     // away only where the element becomes an attribute - the one rejection of the three
     // that reaches codegen.
-    expectRejected("RETURN [{age: 32}]", "Only booleans, integers, floats, strings, nulls and lists");
+    expectRejected("RETURN [{age: 32}]", "Only booleans, integers, floats, strings, nulls");
 }
 
 TEST_F(CypherListLiteralTest, rejectsAPropertyListElement) {

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -1230,11 +1230,11 @@ func.func @main() {
 }
 )mlir";
 
-// An embedding constant: a rank-1 f32 dense attribute, which is typed and shaped, so it is
-// a different kind of attribute from the array a list literal carries.
+// An embedding constant: a dense f32 array, a flat run of floats, so it is a different kind
+// of attribute from the array of per-element ones a list literal carries.
 const char* const embeddingConstantProgram = R"mlir(
 func.func @main() {
-  %e = db.constant(dense<[1.0, 2.0, 3.0]> : tensor<3xf32>)
+  %e = db.constant(array<f32: 1.0, 2.0, 3.0>)
   db.output(%e) : !db.column<!storage.embedding>
   return
 }
@@ -1599,9 +1599,9 @@ TEST_F(DBDialectTest, rejectsAListSpelledWithADisagreeingType) {
 }
 
 // db.constant carries three kinds of value - a scalar, an embedding and a list - and each
-// is recognised by the kind of attribute it rides. An embedding is a dense, shaped, typed
-// attribute; a list is an untyped array of per-element ones. Nothing has to disambiguate
-// them, which is what lets one op carry all three.
+// is recognised by the kind of attribute it rides. An embedding is a dense f32 array; a
+// list is an array of per-element attributes. Nothing has to disambiguate them, which is
+// what lets one op carry all three.
 TEST_F(DBDialectTest, infersAnEmbeddingFromADenseFloatAttribute) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(embeddingConstantProgram);
     ASSERT_TRUE(module);
@@ -1613,11 +1613,9 @@ TEST_F(DBDialectTest, infersAnEmbeddingFromADenseFloatAttribute) {
     });
     ASSERT_TRUE(embedding);
 
-    // Rank-1 f32 is the embedding shape, so the column is one of embeddings rather than of
-    // the tensor the attribute spells.
-    const auto dense = mlir::dyn_cast<mlir::DenseElementsAttr>(embedding.getValue());
-    ASSERT_TRUE(dense);
-    EXPECT_EQ(dense.getNumElements(), 3);
+    const auto floats = mlir::dyn_cast<mlir::DenseF32ArrayAttr>(embedding.getValue());
+    ASSERT_TRUE(floats);
+    EXPECT_EQ(floats.size(), 3);
 
     const mlir::Type embeddingType = mlir::storage::EmbeddingType::get(&_context);
     EXPECT_EQ(embedding.getResult().getType(), mlir::db::ColumnType::get(&_context, embeddingType));
@@ -1625,7 +1623,7 @@ TEST_F(DBDialectTest, infersAnEmbeddingFromADenseFloatAttribute) {
 
 TEST_F(DBDialectTest, infersAListRatherThanAnEmbeddingFromAnArrayOfFloats) {
     // The same three floats as an array of elements: an array attribute is never a dense
-    // one, so this is a list of doubles and the embedding shape rule never sees it.
+    // one, so this is a list of doubles and the embedding rule never sees it.
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(floatListConstantProgram);
     ASSERT_TRUE(module);
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*module)));

--- a/test/query/ir/ReturnHeterogeneousListTest.cpp
+++ b/test/query/ir/ReturnHeterogeneousListTest.cpp
@@ -1,0 +1,308 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <spdlog/fmt/bundled/format.h>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnConst.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
+#include "columns/ColumnVector.h"
+#include "list/ListBufferTypeTag.h"
+#include "list/ListElementView.h"
+#include "list/ListView.h"
+#include "metadata/PropertyType.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = std::vector<std::string>;
+using Rows = std::vector<Row>;
+using ColumnNames = std::vector<std::string>;
+
+// An embedding reads as the parenthesised run of floats the query spells it with, so an
+// embedding element never reads the same as the nested list of the same numbers.
+std::string renderEmbedding(const types::Embedding::Primitive floats) {
+    std::string rendered = "(";
+    for (size_t index = 0; index < floats.size(); index++) {
+        if (index > 0) {
+            rendered += ", ";
+        }
+
+        rendered += fmt::format("{}", floats[index]);
+    }
+
+    return rendered + ")";
+}
+
+std::string renderList(ListView list);
+
+std::string renderListElement(const ListElementView element) {
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            return fmt::format("{}", element.getAs<int64_t>());
+        break;
+
+        case ListBufferTypeTag::Double:
+            return fmt::format("{}", element.getAs<double>());
+        break;
+
+        case ListBufferTypeTag::Bool:
+            return element.getAs<bool>() ? "true" : "false";
+        break;
+
+        case ListBufferTypeTag::String:
+            return "'" + std::string(element.getAs<std::string_view>()) + "'";
+        break;
+
+        case ListBufferTypeTag::Embedding:
+            return renderEmbedding(element.getAs<types::Embedding::Primitive>());
+        break;
+
+        case ListBufferTypeTag::ListView:
+            return renderList(element.getAs<ListView>());
+        break;
+
+        case ListBufferTypeTag::Null:
+            return "null";
+        break;
+
+        default:
+            throw TuringException("ReturnHeterogeneousListTest: unsupported list element tag");
+        break;
+    }
+}
+
+std::string renderList(const ListView list) {
+    std::string rendered = "[";
+    for (size_t index = 0; const ListElementView& element : list) {
+        if (index > 0) {
+            rendered += ", ";
+        }
+
+        rendered += renderListElement(element);
+        index++;
+    }
+
+    return rendered + "]";
+}
+
+// Render one output cell: the list a literal holds in every row, the embedding a
+// standalone one holds, a node ID or a property value beside them.
+std::string renderCell(const Column* column, size_t row) {
+    if (const auto* lists = dynamic_cast<const ColumnConst<ListView>*>(column)) {
+        return renderList((*lists)[row]);
+    }
+
+    if (const auto* listRows = dynamic_cast<const ColumnVector<ListView>*>(column)) {
+        return renderList((*listRows)[row]);
+    }
+
+    if (const auto* embeddings = dynamic_cast<const ColumnConst<types::Embedding::Primitive>*>(column)) {
+        return renderEmbedding((*embeddings)[row]);
+    }
+
+    if (const auto* counts = dynamic_cast<const ColumnVector<uint64_t>*>(column)) {
+        return std::to_string((*counts)[row]);
+    }
+
+    if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
+        return std::to_string((*nodeIDs)[row].getValue());
+    }
+
+    if (const auto* names = dynamic_cast<const ColumnOptVector<std::string_view>*>(column)) {
+        const std::optional<std::string_view>& name = (*names)[row];
+        return name ? std::string(*name) : "null";
+    }
+
+    throw TuringException("ReturnHeterogeneousListTest: unsupported output column type");
+}
+
+class CollectingListSink : public NLOutputSink {
+public:
+    void setColumnNames(std::span<const std::string_view> names) override {
+        _names.assign(names.begin(), names.end());
+    }
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* column : chunks) {
+                row.push_back(renderCell(column, rowIndex));
+            }
+        }
+    }
+
+    const Rows& getRows() const { return _rows; }
+    const ColumnNames& getNames() const { return _names; }
+
+private:
+    Rows _rows;
+    ColumnNames _names;
+};
+
+}
+
+// The query test suite's return-hetero-list case on the v3 engine:
+// RETURN [true, "i love turingdb", 20.3, (1,2,3,4)] AS list
+//
+// Its fourth element is an embedding literal, a value no other list element is: the
+// elements of the list are written into the list buffer, and this one carries a whole run
+// of floats rather than a single scalar. The list shares no element type, so it is
+// type-erased and every element keeps its own tag - the embedding's among them.
+//
+// The embedding literal is read as a column of its own here too, so that the run it holds
+// is pinned wherever the query puts it.
+class ReturnHeterogeneousListTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, CollectingListSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        CollectingListSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    void expectNamedRows(std::string_view query, const ColumnNames& names, const Rows& expected) {
+        CollectingListSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getNames(), names) << "query: " << query;
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// return-hetero-list: the reported query, aliased column name and all
+TEST_F(ReturnHeterogeneousListTest, returnsTheReportedList) {
+    const Rows expected = {{"[true, 'i love turingdb', 20.3, (1, 2, 3, 4)]"}};
+    expectNamedRows("RETURN [true, \"i love turingdb\", 20.3, (1,2,3,4)] AS list", {"list"}, expected);
+}
+
+TEST_F(ReturnHeterogeneousListTest, returnsAnEmbeddingAsTheOnlyElement) {
+    const Rows expected = {{"[(1, 2, 3, 4)]"}};
+    expectRows("RETURN [(1,2,3,4)]", expected);
+}
+
+// Two embeddings of different lengths: each element carries its own run, so the second is
+// not read against the first's length.
+TEST_F(ReturnHeterogeneousListTest, returnsTwoEmbeddingsOfDifferentLengths) {
+    const Rows expected = {{"[(1, 2), (3, 4, 5)]"}};
+    expectRows("RETURN [(1,2), (3,4,5)]", expected);
+}
+
+TEST_F(ReturnHeterogeneousListTest, returnsFractionalEmbeddingElements) {
+    const Rows expected = {{"[(0.5, -1.25), 20.3]"}};
+    expectRows("RETURN [(0.5, -1.25), 20.3]", expected);
+}
+
+// The same literal as a column of its own and as an element of the list beside it: the two
+// read the same run of floats.
+TEST_F(ReturnHeterogeneousListTest, returnsTheEmbeddingBesideTheListHoldingIt) {
+    const Rows expected = {{"(1, 2, 3)", "[(1, 2, 3)]"}};
+    expectRows("RETURN (1,2,3), [(1,2,3)]", expected);
+}
+
+// An embedding inside a nested list is written while the parent is still being filled, so
+// the child's run has to stay put as the parent's remaining elements land after it.
+TEST_F(ReturnHeterogeneousListTest, keepsAnEmbeddingInsideANestedList) {
+    const Rows expected = {{"[[(1, 2)], 3]"}};
+    expectRows("RETURN [[(1,2)], 3]", expected);
+}
+
+TEST_F(ReturnHeterogeneousListTest, returnsAnEmbeddingBesideANull) {
+    const Rows expected = {{"[null, (1, 2)]"}};
+    expectRows("RETURN [null, (1,2)]", expected);
+}
+
+// The list is a value, not a source: it stands for the one matched row rather than
+// spreading over the elements it holds.
+TEST_F(ReturnHeterogeneousListTest, returnsTheListBesideAMatchedRow) {
+    const Rows expected = {{"[true, (1, 2)]", "Remy"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' RETURN [true, (1,2)], n.name", expected);
+}
+
+// One row per matched node, each holding the same list: SimpleGraph holds 18 nodes.
+TEST_F(ReturnHeterogeneousListTest, repeatsTheListForEveryMatchedNode) {
+    constexpr uint64_t nodeCount = 18;
+
+    Rows expected;
+    for (uint64_t nodeID = 0; nodeID < nodeCount; nodeID++) {
+        expected.push_back({std::to_string(nodeID), "[20.3, (1, 2, 3, 4)]"});
+    }
+
+    expectRows("MATCH (n) RETURN n, [20.3, (1,2,3,4)]", expected);
+}
+
+// The embedding as a grouping key beside the tally of its rows: the count reads the
+// column, so the embedding is laid out per row rather than only projected.
+TEST_F(ReturnHeterogeneousListTest, countsTheRowsOfAnEmbeddingKey) {
+    const Rows expected = {{"(1, 2, 3)", "1"}};
+    expectNamedRows("RETURN (1,2,3) AS l, count(l) AS n", {"l", "n"}, expected);
+}
+
+// The same query over an embedding whose floats are all equal. MLIR uniques an all-equal
+// dense buffer down to one element, so the run has to be read back through the length its
+// type carries rather than through the bytes the attribute stored.
+TEST_F(ReturnHeterogeneousListTest, countsTheRowsOfARepeatedEmbeddingKey) {
+    const Rows expected = {{"(1, 1, 1)", "1"}};
+    expectNamedRows("RETURN (1,1,1) AS l, count(l) AS n", {"l", "n"}, expected);
+}
+
+// The embedding constant stands for every matched row, so its tally is the relation's 18
+// and not the one row the cell is on its own.
+TEST_F(ReturnHeterogeneousListTest, countsTheMatchedRowsAnEmbeddingStandsFor) {
+    const Rows expected = {{"18"}};
+    expectNamedRows("MATCH (n) RETURN count((1,2,3)) AS c", {"c"}, expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/StringRowSink.cpp
+++ b/test/query/ir/StringRowSink.cpp
@@ -84,6 +84,18 @@ std::string elementText(const ListElementView& element) {
     throw std::runtime_error("StringRowSink met an unknown list element tag");
 }
 
+// A type-erased column of tagged scalars - the column a heterogeneous UNWIND drives - reads
+// each cell through the tag it carries rather than through the column's type.
+bool textOfListElement(const Column* chunk, size_t rowIndex, std::string& text) {
+    const auto* column = dynamic_cast<const ColumnVector<ListElementView>*>(chunk);
+    if (!column) {
+        return false;
+    }
+
+    text = elementText(column->getRaw()[rowIndex]);
+    return true;
+}
+
 // A list cell reads as its elements joined by ", ", in the order the list holds them.
 bool textOfList(const Column* chunk, size_t rowIndex, std::string& text) {
     const auto* column = dynamic_cast<const ColumnVector<ListView>*>(chunk);
@@ -171,6 +183,8 @@ std::string StringRowSink::cellText(const Column* chunk, size_t rowIndex) {
     } else if (textOfOptional<double>(chunk, rowIndex, text)) {
         return text;
     } else if (textOfOptional<std::string_view>(chunk, rowIndex, text)) {
+        return text;
+    } else if (textOfListElement(chunk, rowIndex, text)) {
         return text;
     } else if (textOfList(chunk, rowIndex, text)) {
         return text;

--- a/test/query/ir/UnwindHeterogeneousListTest.cpp
+++ b/test/query/ir/UnwindHeterogeneousListTest.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+using ColumnNames = std::vector<std::string>;
+
+constexpr uint64_t simpleGraphNodeCount = 18;
+
+// The three elements of the reported list, as the cells they render to: a bool, a string
+// and an integer, each keeping its own type in the one column.
+const std::vector<std::string> reportedElements = {"true", "string", "10"};
+
+// Every node of SimpleGraph - they are numbered 0 through 17 - paired with @param element.
+void fillNodeRowsWithElement(std::string_view element, Rows& rows) {
+    for (uint64_t nodeID = 0; nodeID < simpleGraphNodeCount; nodeID++) {
+        rows.push_back({std::to_string(nodeID), std::string(element)});
+    }
+}
+
+}
+
+// The query test suite's unwind-hetero-list case on the v3 engine:
+// UNWIND [true, "string", 10] AS row MATCH (n) RETURN n, row
+//
+// The UNWIND comes first, so the elements drive and the node scan is what runs for each of
+// them - where the same pairs written the other way round, MATCH before UNWIND, scan once
+// and unwind per node. Neither is an ORDER BY, but the two walk the pairs in opposite
+// orders, and the elements share no type either way: the unwound column is type-erased and
+// each cell carries its own tag.
+class UnwindHeterogeneousListTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    void expectNamedRows(std::string_view query, const ColumnNames& names, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getNames(), names) << "query: " << query;
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// unwind-hetero-list: every element paired with every node, the elements leading
+TEST_F(UnwindHeterogeneousListTest, unwindsTheReportedList) {
+    Rows expected;
+    for (const std::string& element : reportedElements) {
+        fillNodeRowsWithElement(element, expected);
+    }
+
+    expectNamedRows("UNWIND [true, \"string\", 10] AS row MATCH (n) RETURN n, row", {"n", "row"}, expected);
+}
+
+// The same pairs with the MATCH driving instead: the nodes lead and each unwinds the three
+// elements, so the rows come out node by node rather than element by element.
+TEST_F(UnwindHeterogeneousListTest, pairsTheSameRowsNodeByNodeWhenTheMatchDrives) {
+    Rows expected;
+    for (uint64_t nodeID = 0; nodeID < simpleGraphNodeCount; nodeID++) {
+        for (const std::string& element : reportedElements) {
+            expected.push_back({std::to_string(nodeID), element});
+        }
+    }
+
+    expectRows("MATCH (n) UNWIND [true, \"string\", 10] AS row RETURN n, row", expected);
+}
+
+TEST_F(UnwindHeterogeneousListTest, countsThePairsOfTheReportedList) {
+    const Rows expected = {{std::to_string(reportedElements.size() * simpleGraphNodeCount)}};
+    expectRows("UNWIND [true, \"string\", 10] AS row MATCH (n) RETURN count(*)", expected);
+}
+
+// The scan the elements drive is a filtered one: only Remy (0) survives it, so each element
+// keeps the one row rather than 18.
+TEST_F(UnwindHeterogeneousListTest, pairsEveryElementWithAFilteredMatch) {
+    Rows expected;
+    for (const std::string& element : reportedElements) {
+        expected.push_back({"0", element});
+    }
+
+    expectRows("UNWIND [true, \"string\", 10] AS row MATCH (n) WHERE n.name = 'Remy' RETURN n, row", expected);
+}
+
+// The unwound column as a grouping key: cells of three different types group apart, each
+// tallying the nodes it was paired with.
+TEST_F(UnwindHeterogeneousListTest, talliesTheNodesOfEachElement) {
+    Rows expected;
+    for (const std::string& element : reportedElements) {
+        expected.push_back({element, std::to_string(simpleGraphNodeCount)});
+    }
+
+    expectRows("UNWIND [true, \"string\", 10] AS row MATCH (n) RETURN row, count(n)", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Implement the embedding literal as a list element and the average of a heterogeneous unwind.

```
RETURN [true, "i love turingdb", 20.3, (1,2,3,4)] AS list
RETURN [(1,2,3,4)]
RETURN [(1,2), (3,4,5)]
RETURN [(0.5, -1.25), 20.3]
RETURN (1,2,3), [(1,2,3)]
RETURN [[(1,2)], 3]
RETURN [null, (1,2)]
MATCH (n) WHERE n.name = 'Remy' RETURN [true, (1,2)], n.name
MATCH (n) RETURN n, [20.3, (1,2,3,4)]
RETURN (1,2,3) AS l, count(l) AS n
RETURN (1,1,1) AS l, count(l) AS n
MATCH (n) RETURN count((1,2,3)) AS c

UNWIND [true, "string", 10] AS row MATCH (n) RETURN n, row
MATCH (n) UNWIND [true, "string", 10] AS row RETURN n, row
UNWIND [true, "string", 10] AS row MATCH (n) RETURN count(*)
UNWIND [true, "string", 10] AS row MATCH (n) WHERE n.name = 'Remy' RETURN n, row
UNWIND [true, "string", 10] AS row MATCH (n) RETURN row, count(n)

unwind [1.2,2.2, 1.1] as rg return avg(rg)
unwind [333, 1000, 200] as rg return avg(rg)
UNWIND [1, 2] AS rg RETURN avg(rg)
UNWIND [2.5] AS rg RETURN avg(rg)
unwind [1.2,2.2, 1.1] as rg return sum(rg), count(rg), avg(rg)
UNWIND [1.0, 2.0, 3.0] AS rg MATCH (n) WHERE n.name = 'Remy' RETURN avg(rg)
UNWIND [1.0, 2.0] AS rg MATCH (n) RETURN avg(rg)
UNWIND [1.0, 1.0, 2.0] AS rg RETURN rg, avg(rg)

UNWIND [1, 2.5] AS x RETURN avg(x)
UNWIND [1, 2.5, 4] AS x RETURN avg(x)
UNWIND [1.0, null, 2.0] AS x RETURN avg(x)
UNWIND [null, null] AS x RETURN avg(x)
UNWIND [] AS x RETURN avg(x)
UNWIND [1, 'two'] AS x RETURN avg(x)
UNWIND [1, 1, 2.5] AS x RETURN avg(DISTINCT x)
UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN n, avg(x)
UNWIND [1, 2.5] AS x MATCH (n) WHERE n.age = 32 RETURN n, avg(x)
UNWIND [1, 1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN n, avg(DISTINCT x)
UNWIND [1, 1.0, 2.5] AS x RETURN x, avg(x)

MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN avg(n.age)
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN count(n.age)
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN sum(n.age)
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN min(n.age), max(n.age)
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN avg(n.age) + 10
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN n.name, avg(n.age)
MATCH (n) WHERE n.age IS NULL RETURN avg(n.age)
MATCH (n) WHERE n.age IS NULL RETURN count(n), count(n.age)
MATCH (n) WHERE n.age IS NULL RETURN sum(n.age)
MATCH (n) WHERE n.age IS NULL RETURN min(n.age), max(n.age)
MATCH (n) WHERE n.age IS NULL RETURN avg(n.age) + 10
MATCH (n) WHERE n.age IS NULL RETURN n.name, avg(n.age)
MATCH (n) RETURN avg(n.age)

RETURN avg(42)
RETURN avg(42.5)
RETURN avg(42) + 1
RETURN sum(42), count(42)
MATCH (n) RETURN avg(42)
MATCH (n) RETURN sum(42), count(42)
MATCH (n) RETURN avg(DISTINCT 42)
MATCH (n) WHERE n.age = 32 RETURN n, avg(42)
MATCH (n) WHERE n.name = 'THIS IS NOT A NAME' RETURN avg(42)
```
