### PR TITLE
MLIR: Fix cone calculation

### DIFF
--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -192,35 +192,32 @@ struct MaskCone {
     llvm::SmallSetVector<Value, 4> _inputs;
 };
 
-// Gathers the mask's compute cone and the external columns feeding it. The cone ops
-// come back in topological (block) order, ready to clone.
+// Gathers the mask's compute cone and the external columns feeding it. Valid
+// even when the cone spans blocks.
+void collectConePostOrder(Value value, llvm::SmallPtrSet<Operation*, 8>& visited, MaskCone& cone) {
+    Operation* const def = value.getDefiningOp();
+
+    if (!def || !isMaskComputeOp(def)) {
+        cone._inputs.insert(value);
+        return;
+    }
+
+    if (!visited.insert(def).second) {
+        return;
+    }
+
+    for (const Value operand : def->getOperands()) {
+        collectConePostOrder(operand, visited, cone);
+    }
+
+    cone._ops.push_back(def);
+}
+
 MaskCone collectMaskCone(Value mask) {
     MaskCone cone;
 
-    llvm::SmallPtrSet<Operation*, 8> inCone;
-    llvm::SmallVector<Value, 8> worklist {mask};
-    while (!worklist.empty()) {
-        const Value value = worklist.pop_back_val();
-        Operation* const def = value.getDefiningOp();
-
-        if (!def || !isMaskComputeOp(def)) {
-            cone._inputs.insert(value);
-            continue;
-        }
-
-        if (!inCone.insert(def).second) {
-            continue;
-        }
-
-        cone._ops.push_back(def);
-        for (const Value operand : def->getOperands()) {
-            worklist.push_back(operand);
-        }
-    }
-
-    llvm::sort(cone._ops, [](Operation* lhs, Operation* rhs) {
-        return lhs->isBeforeInBlock(rhs);
-    });
+    llvm::SmallPtrSet<Operation*, 8> visited;
+    collectConePostOrder(mask, visited, cone);
 
     return cone;
 }

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -241,6 +241,42 @@ TEST_F(PushDownFilterTest, sinksPredicateIntoCrossProductFactor) {
     EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
 }
 
+// MATCH (n {name: 'Remy'}), (m) RETURN n, m
+const char* const hoistedConstantInFactorPredicate = R"mlir(
+func.func @main() {
+  %c = db.constant("Remy" : !storage.string)
+  %0:2 = db.cross_product factor {
+    %n = db.scan_nodes() : !db.column<!storage.node_id>
+    %name = db.get_node_properties(%n, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    %mask = db.eq %name, %c : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+    %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %nf : !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, gathersMaskConeSpanningBlocks) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(hoistedConstantInFactorPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+
+    mlir::db::CrossProduct product = filter.getOperation()->getParentOfType<mlir::db::CrossProduct>();
+    ASSERT_TRUE(product);
+
+    ASSERT_EQ(filter.getColumnsToFilter().size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(filter.getColumnsToFilter().front().getDefiningOp()));
+}
+
 // MATCH (a)<--(n)-->(m) WHERE n.age = 32 RETURN a, n, m
 const char* const inEdgeNeighbourPredicate = R"mlir(
 func.func @main() {


### PR DESCRIPTION
Cone calculation previously relied on all operands being in the same block. Now performs a post-order over op blocks.