### PR TITLE
MLIR: test multi MATCH statements

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2567,8 +2567,14 @@ void DBProgramGenerator::publishInFlightColumns() {
     VariableColumnMap variableColumns;
     collectVariableColumns(variableColumns);
 
-    llvm::SmallVector<std::pair<std::string_view, mlir::Value>> published {variableColumns.begin(),
-                                                                          variableColumns.end()};
+    // Each name is copied out: the variables holding them are the ones this clears, and the
+    // part below is opened with them
+    llvm::SmallVector<std::pair<std::string, mlir::Value>> published;
+    published.reserve(variableColumns.size());
+
+    for (const auto& [name, column] : variableColumns) {
+        published.emplace_back(name, column);
+    }
 
     // Under a name order rather than the map's, so the same query generates the same IR
     std::ranges::sort(published, [](const auto& left, const auto& right) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -778,11 +778,13 @@ void DBProgramGenerator::generateQueryParts(const SinglePartQuery* query) {
     // columns that projection publishes are all the statements after it can read
     size_t partBegin = 0;
     for (size_t index = 0; index < stmts.size(); index++) {
-        if (stmts[index]->getKind() == Stmt::Kind::WITH) {
+        const Stmt* stmt = stmts[index];
+
+        if (stmt->getKind() == Stmt::Kind::WITH) {
             generatePart(stmts.subspan(partBegin, index - partBegin));
-            generateWith(static_cast<const WithStmt*>(stmts[index]));
+            generateWith(static_cast<const WithStmt*>(stmt));
             partBegin = index + 1;
-        } else if (closesPartOnItsCut(stmts, index)) {
+        } else if (closesPartOnItsCut(stmt, stmts.subspan(index + 1))) {
             generatePart(stmts.subspan(partBegin, index + 1 - partBegin));
             publishInFlightColumns();
             partBegin = index + 1;
@@ -794,8 +796,7 @@ void DBProgramGenerator::generateQueryParts(const SinglePartQuery* query) {
     }
 }
 
-bool DBProgramGenerator::closesPartOnItsCut(std::span<Stmt* const> stmts, size_t index) const {
-    const Stmt* stmt = stmts[index];
+bool DBProgramGenerator::closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* const> following) const {
     if (stmt->getKind() != Stmt::Kind::MATCH) {
         return false;
     }
@@ -807,8 +808,8 @@ bool DBProgramGenerator::closesPartOnItsCut(std::span<Stmt* const> stmts, size_t
         return false;
     }
 
-    for (size_t next = index + 1; next < stmts.size(); next++) {
-        const Stmt::Kind kind = stmts[next]->getKind();
+    for (const Stmt* next : following) {
+        const Stmt::Kind kind = next->getKind();
 
         if (kind == Stmt::Kind::WITH) {
             return false;

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -778,18 +778,46 @@ void DBProgramGenerator::generateQueryParts(const SinglePartQuery* query) {
     // columns that projection publishes are all the statements after it can read
     size_t partBegin = 0;
     for (size_t index = 0; index < stmts.size(); index++) {
-        if (stmts[index]->getKind() != Stmt::Kind::WITH) {
-            continue;
+        if (stmts[index]->getKind() == Stmt::Kind::WITH) {
+            generatePart(stmts.subspan(partBegin, index - partBegin));
+            generateWith(static_cast<const WithStmt*>(stmts[index]));
+            partBegin = index + 1;
+        } else if (closesPartOnItsCut(stmts, index)) {
+            generatePart(stmts.subspan(partBegin, index + 1 - partBegin));
+            publishInFlightColumns();
+            partBegin = index + 1;
         }
-
-        generatePart(stmts.subspan(partBegin, index - partBegin));
-        generateWith(static_cast<const WithStmt*>(stmts[index]));
-        partBegin = index + 1;
     }
 
     if (partBegin < stmts.size()) {
         generatePart(stmts.subspan(partBegin));
     }
+}
+
+bool DBProgramGenerator::closesPartOnItsCut(std::span<Stmt* const> stmts, size_t index) const {
+    const Stmt* stmt = stmts[index];
+    if (stmt->getKind() != Stmt::Kind::MATCH) {
+        return false;
+    }
+
+    const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
+    const bool carriesACut = matchStmt->hasOrderBy() || matchStmt->hasSkip() || matchStmt->hasLimit();
+
+    if (!carriesACut) {
+        return false;
+    }
+
+    for (size_t next = index + 1; next < stmts.size(); next++) {
+        const Stmt::Kind kind = stmts[next]->getKind();
+
+        if (kind == Stmt::Kind::WITH) {
+            return false;
+        } else if (kind == Stmt::Kind::MATCH) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void DBProgramGenerator::generatePart(std::span<Stmt* const> stmts) {
@@ -2531,6 +2559,26 @@ void DBProgramGenerator::publishBoundColumns(llvm::ArrayRef<llvm::StringRef> nam
 
         const std::string_view boundName {name.data(), name.size()};
         registerValue(_vdg.registerBoundVariable(boundName), columns[index]);
+    }
+}
+
+void DBProgramGenerator::publishInFlightColumns() {
+    VariableColumnMap variableColumns;
+    collectVariableColumns(variableColumns);
+
+    llvm::SmallVector<std::pair<std::string_view, mlir::Value>> published {variableColumns.begin(),
+                                                                          variableColumns.end()};
+
+    // Under a name order rather than the map's, so the same query generates the same IR
+    std::ranges::sort(published, [](const auto& left, const auto& right) {
+        return left.first < right.first;
+    });
+
+    _part = PartScope {};
+    _vdg.clear();
+
+    for (const auto& [name, column] : published) {
+        registerValue(_vdg.registerBoundVariable(name), column);
     }
 }
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -135,6 +135,11 @@ private:
     // One query part: the statements between two WITH barriers
     void generatePart(std::span<Stmt* const> stmts);
 
+    // Whether the statement at this index closes a part on the cut it carries: a MATCH
+    // whose ORDER BY, SKIP or LIMIT reads the rows that MATCH produced, which a later
+    // MATCH of the same part would otherwise have crossed into them first
+    bool closesPartOnItsCut(std::span<Stmt* const> stmts, size_t index) const;
+
     void generateTraversal(std::span<Stmt* const> stmts);
 
     // A barrier leaves behind the traversal an edge's column was published under, so a
@@ -299,6 +304,10 @@ private:
 
     void publishBoundColumns(llvm::ArrayRef<llvm::StringRef> names,
                              llvm::ArrayRef<mlir::Value> columns);
+
+    // Publishes every column in scope under the name it already carries, so the part that
+    // follows a cut reads them the way it reads what a WITH published
+    void publishInFlightColumns();
 
     // The column each variable in scope is bound to, under the name it carries: the
     // traversal variables, what a CALL yielded, what a CREATE wrote, and each edge

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -135,10 +135,10 @@ private:
     // One query part: the statements between two WITH barriers
     void generatePart(std::span<Stmt* const> stmts);
 
-    // Whether the statement at this index closes a part on the cut it carries: a MATCH
-    // whose ORDER BY, SKIP or LIMIT reads the rows that MATCH produced, which a later
-    // MATCH of the same part would otherwise have crossed into them first
-    bool closesPartOnItsCut(std::span<Stmt* const> stmts, size_t index) const;
+    // Whether this statement closes a part on the cut it carries: a MATCH whose ORDER BY,
+    // SKIP or LIMIT reads the rows that MATCH produced, which a later MATCH of the same
+    // part would otherwise have crossed into them first
+    bool closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* const> following) const;
 
     void generateTraversal(std::span<Stmt* const> stmts);
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1295,3 +1295,14 @@ target_link_libraries(test_query_ir_avg_literal PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_avg_literal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_multi_match MultiMatchTest.cpp)
+target_link_libraries(test_query_ir_multi_match PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_multi_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/MultiMatchTest.cpp
+++ b/test/query/ir/MultiMatchTest.cpp
@@ -1,0 +1,362 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Consecutive MATCH clauses, where a query names one MATCH straight after another with no
+// WITH between them: the clauses that share a variable join on it, and the ones that share
+// nothing cross. simpledb holds 18 nodes - 8 Persons and 10 Interests - over 18 edges, 3
+// of them KNOWS_WELL and 15 INTERESTED_IN.
+class MultiMatchTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    // Runs a writing query in its own change and submits it, so a following read sees it
+    void applyWrite(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// Two clauses sharing no variable and carrying no filter cross into every ordered pair of
+// the 18 nodes
+TEST_F(MultiMatchTest, crossesTwoUnfilteredClauses) {
+    expectCounts("MATCH (a) MATCH (b) RETURN count(*)", {324});
+}
+
+TEST_F(MultiMatchTest, crossesTwoLabelledClauses) {
+    expectCounts("MATCH (a:Person) MATCH (b:Interest) RETURN count(*)", {80});
+}
+
+TEST_F(MultiMatchTest, crossesTwoSingleRowClauses) {
+    expectRows("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Adam'}) RETURN a.name, b.name",
+               {{"Remy", "Adam"}});
+}
+
+// The second clause is a traversal rather than a scan, so the pair count is the number of
+// KNOWS_WELL edges
+TEST_F(MultiMatchTest, crossesAClauseWithATraversal) {
+    expectCounts("MATCH (a:Person {name: 'Remy'}) MATCH (b)-[:KNOWS_WELL]->(c) RETURN count(*)", {3});
+}
+
+TEST_F(MultiMatchTest, crossesTwoTraversals) {
+    expectCounts("MATCH (a)-[:KNOWS_WELL]->(b) MATCH (c)-[:INTERESTED_IN]->(d) RETURN count(*)", {45});
+}
+
+// A clause matching nothing empties the cross product, whatever the other one produced
+TEST_F(MultiMatchTest, keepsNothingWhenAClauseMatchesNothing) {
+    expectRows("MATCH (a:Person) MATCH (b:Person {name: 'Nobody'}) RETURN a.name", {});
+}
+
+TEST_F(MultiMatchTest, crossesThreeSingleRowClauses) {
+    expectRows("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Adam'}) "
+               "MATCH (c:Interest {name: 'Gym'}) RETURN a.name, b.name, c.name",
+               {{"Remy", "Adam", "Gym"}});
+}
+
+TEST_F(MultiMatchTest, crossesFourSingleRowClauses) {
+    expectCounts("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Adam'}) "
+                 "MATCH (c:Interest {name: 'Gym'}) MATCH (d:Interest {name: 'Travel'}) "
+                 "RETURN count(*)",
+                 {1});
+}
+
+// Three clauses chained on shared nodes walk three edges. Only Remy, Adam and Ghosts have
+// both an in and an out edge, so only they can stand in the middle of such a walk
+TEST_F(MultiMatchTest, chainsThreeClausesOnSharedNodes) {
+    expectCounts("MATCH (a)-->(b) MATCH (b)-->(c) MATCH (c)-->(d) RETURN count(*)", {16});
+}
+
+// Remy knows Adam well, and Adam is interested in Bio and Cooking
+TEST_F(MultiMatchTest, chainsThreeClausesFromAPinnedStart) {
+    expectRows("MATCH (a:Person {name: 'Remy'}) MATCH (a)-[:KNOWS_WELL]->(b) "
+               "MATCH (b)-[:INTERESTED_IN]->(i) RETURN i.name",
+               {{"Bio"}, {"Cooking"}});
+}
+
+// The two joined clauses produce eight rows - Adam's two interests once, Remy's three twice
+// - which the disjoint third clause crosses without multiplying
+TEST_F(MultiMatchTest, mixesAJoinedAndADisjointClause) {
+    expectCounts("MATCH (a)-[:KNOWS_WELL]->(b) MATCH (b)-[:INTERESTED_IN]->(i) "
+                 "MATCH (t:Interest {name: 'Travel'}) RETURN count(*)",
+                 {8});
+}
+
+// The third clause joins back to the first one's variable over the disjoint clause between
+// them: Remy is interested in Computers, Eighties and Ghosts
+TEST_F(MultiMatchTest, joinsBackToTheFirstClauseAcrossADisjointOne) {
+    expectRows("MATCH (a:Person {name: 'Remy'}) MATCH (x:Person {name: 'Luc'}) "
+               "MATCH (a)-[:INTERESTED_IN]->(i) RETURN i.name",
+               {{"Computers"}, {"Eighties"}, {"Ghosts"}});
+}
+
+TEST_F(MultiMatchTest, ordersTheCrossProductOfTwoClauses) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name",
+                      {{"Adam"}, {"Cyrus"}, {"Doruk"}, {"Luc"}, {"Martina"}, {"Maxime"}, {"Remy"}, {"Suhas"}});
+}
+
+TEST_F(MultiMatchTest, limitsTheOrderedCrossProduct) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name LIMIT 3",
+                      {{"Adam"}, {"Cyrus"}, {"Doruk"}});
+}
+
+TEST_F(MultiMatchTest, skipsIntoTheOrderedCrossProduct) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name SKIP 6",
+                      {{"Remy"}, {"Suhas"}});
+}
+
+TEST_F(MultiMatchTest, cutsAWindowOutOfTheOrderedCrossProduct) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) "
+                      "RETURN b.name ORDER BY b.name SKIP 2 LIMIT 3",
+                      {{"Doruk"}, {"Luc"}, {"Martina"}});
+}
+
+TEST_F(MultiMatchTest, ordersTheCrossProductDescending) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Interest) "
+                      "RETURN b.name ORDER BY b.name DESC LIMIT 2",
+                      {{"Travel"}, {"Padel"}});
+}
+
+// Adam and Cyrus are the two Persons the order leaves, and the single-row second clause
+// crosses each of them once
+TEST_F(MultiMatchTest, cutsTheFirstClauseBeforeTheSecond) {
+    expectRowsInOrder("MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (b:Interest {name: 'Gym'}) "
+                      "RETURN a.name",
+                      {{"Adam"}, {"Cyrus"}});
+}
+
+// The LIMIT cuts the clause that carries it, so the second clause crosses the two Persons
+// the order left with all ten Interests
+TEST_F(MultiMatchTest, limitsOnlyTheClauseThatCarriesTheLimit) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (b:Interest) RETURN count(*)", {20});
+}
+
+// The SKIP side of the same: six Persons passed leaves two for the second clause to cross
+TEST_F(MultiMatchTest, skipsOnlyInTheClauseThatCarriesTheSkip) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name SKIP 6 MATCH (b:Interest) RETURN count(*)", {20});
+}
+
+// Two clauses joined on the node between them walk two edges twelve ways
+TEST_F(MultiMatchTest, countsTheRowsTwoJoinedClausesProduce) {
+    expectCounts("MATCH (a)-->(b) MATCH (b)-->(c) RETURN count(*)", {12});
+}
+
+// Those twelve rows start at three nodes only: Remy walks on through Adam and Ghosts, and
+// Adam and Ghosts both walk on through Remy
+TEST_F(MultiMatchTest, distinctsAcrossASecondClause) {
+    expectRows("MATCH (a)-->(b) MATCH (b)-->(c) RETURN DISTINCT a.name",
+               {{"Adam"}, {"Ghosts"}, {"Remy"}});
+}
+
+TEST_F(MultiMatchTest, distinctsTheCrossProduct) {
+    expectRows("MATCH (a:Person) MATCH (b:Interest) RETURN DISTINCT a.name",
+               {{"Adam"}, {"Cyrus"}, {"Doruk"}, {"Luc"}, {"Martina"}, {"Maxime"}, {"Remy"}, {"Suhas"}});
+}
+
+// The clause after the cut joins onto the variable the cut clause bound, so it expands the
+// two Persons the order left: Adam's two interests and Cyrus's two
+TEST_F(MultiMatchTest, joinsOnTheCutClauseVariable) {
+    expectRows("MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (a)-[:INTERESTED_IN]->(i) "
+               "RETURN a.name, i.name",
+               {{"Adam", "Bio"}, {"Adam", "Cooking"}, {"Cyrus", "Gym"}, {"Cyrus", "Travel"}});
+}
+
+// The cut sits on the middle clause of three, so it cuts the sixty-four pairs the first two
+// produced rather than the eight Persons the clause itself matched. Adam is the first name
+// of the order, and he stands as b in eight of those pairs, so both rows it leaves are his
+TEST_F(MultiMatchTest, cutsTheMiddleClauseOfThree) {
+    expectRowsInOrder("MATCH (a:Person) MATCH (b:Person) ORDER BY b.name LIMIT 2 "
+                      "MATCH (c:Interest {name: 'Gym'}) RETURN b.name",
+                      {{"Adam"}, {"Adam"}});
+}
+
+// The same with the first clause pinned to one row, so the pairs the cut reads are Remy
+// against each Person and the two it leaves are the first two names of the order
+TEST_F(MultiMatchTest, cutsTheMiddleClauseOfThreeFromAPinnedFirstClause) {
+    expectRowsInOrder("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) ORDER BY b.name LIMIT 2 "
+                      "MATCH (c:Interest {name: 'Gym'}) RETURN b.name",
+                      {{"Adam"}, {"Cyrus"}});
+}
+
+// The edge the cut clause bound is still readable after the cut, and the two KNOWS_WELL
+// edges the order leaves are Adam's and Ghosts's
+TEST_F(MultiMatchTest, carriesAnEdgeVariableAcrossTheCut) {
+    expectRowsInOrder("MATCH (a)-[e:KNOWS_WELL]->(b) ORDER BY e.name LIMIT 2 "
+                      "MATCH (c:Interest {name: 'Gym'}) RETURN e.name",
+                      {{"Adam -> Remy"}, {"Ghosts -> Remy"}});
+}
+
+// Two cuts in a row: three Persons cross ten Interests into thirty rows, of which the
+// second cut leaves two for the third clause to cross
+TEST_F(MultiMatchTest, takesBothCutsOfThreeClauses) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name LIMIT 3 MATCH (b:Interest) ORDER BY b.name LIMIT 2 "
+                 "MATCH (c:Person {name: 'Remy'}) RETURN count(*)",
+                 {2});
+}
+
+TEST_F(MultiMatchTest, createsAnEdgeBetweenTwoClauses) {
+    applyWrite("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Doruk'}) "
+               "CREATE (a)-[:MENTORS]->(b)");
+
+    expectRows("MATCH (a)-[:MENTORS]->(b) RETURN a.name, b.name", {{"Remy", "Doruk"}});
+}
+
+// One node per crossed row, which is one per Interest
+TEST_F(MultiMatchTest, createsANodePerCrossedRow) {
+    applyWrite("MATCH (a:Person {name: 'Remy'}) MATCH (b:Interest) CREATE (:Tag {name: b.name})");
+
+    expectCounts("MATCH (t:Tag) RETURN count(*)", {10});
+}
+
+TEST_F(MultiMatchTest, setsAPropertyFromTheOtherClause) {
+    applyWrite("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Doruk'}) SET b.dob = a.dob");
+
+    expectRows("MATCH (p:Person {name: 'Doruk'}) RETURN p.dob", {{"18/01"}});
+}
+
+// The SET runs on every crossed row, so all ten Interests carry the property afterwards
+// rather than the six that already held it
+TEST_F(MultiMatchTest, setsAPropertyOnEveryCrossedRow) {
+    applyWrite("MATCH (a:Person {name: 'Remy'}) MATCH (i:Interest) SET i.isReal = true");
+
+    expectCounts("MATCH (i:Interest {isReal: true}) RETURN count(*)", {10});
+}
+
+// The edges come from the first clause and the second one crosses them once, so Cyrus's two
+// interests are deleted out of the fifteen
+TEST_F(MultiMatchTest, deletesTheEdgesTheFirstClauseBound) {
+    applyWrite("MATCH (a:Person {name: 'Cyrus'})-[e:INTERESTED_IN]->(i) "
+               "MATCH (b:Person {name: 'Doruk'}) DELETE e");
+
+    expectCounts("MATCH (a)-[:INTERESTED_IN]->(b) RETURN count(*)", {13});
+}
+
+TEST_F(MultiMatchTest, detachDeletesANodeTheSecondClauseBound) {
+    applyWrite("MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Martina'}) DETACH DELETE b");
+
+    expectCounts("MATCH (p:Person) RETURN count(*)", {7});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Test multiple match statements in a query

```Cypher
MATCH (a)
MATCH (b)
RETURN count(*)

MATCH (a:Person)
MATCH (b:Interest) 
RETURN count(*)

MATCH (a:Person {name: 'Remy'})
MATCH (b:Person {name: 'Adam'}) 
RETURN a.name, b.name

MATCH (a:Person {name: 'Remy'})
MATCH (b)-[:KNOWS_WELL]->(c)
RETURN count(*)

MATCH (a)-[:KNOWS_WELL]->(b) 
MATCH (c)-[:INTERESTED_IN]->(d) 
RETURN count(*)

MATCH (a:Person) 
MATCH (b:Person {name: 'Nobody'}) 
RETURN a.name

MATCH (a:Person {name: 'Remy'}) 
MATCH (b:Person {name: 'Adam'}) 
MATCH (c:Interest {name: 'Gym'}) 
RETURN a.name, b.name, c.name

MATCH (a:Person {name: 'Remy'}) 
MATCH (b:Person {name: 'Adam'}) 
MATCH (c:Interest {name: 'Gym'}) 
MATCH (d:Interest {name: 'Travel'}) 
RETURN count(*)

MATCH (a)-->(b) 
MATCH (b)-->(c) 
MATCH (c)-->(d) 
RETURN count(*)

MATCH (a:Person {name: 'Remy'}) 
MATCH (a)-[:KNOWS_WELL]->(b) 
MATCH (b)-[:INTERESTED_IN]->(i) 
RETURN i.name

MATCH (a)-[:KNOWS_WELL]->(b) 
MATCH (b)-[:INTERESTED_IN]->(i) 
MATCH (t:Interest {name: 'Travel'}) 
RETURN count(*)

MATCH (a:Person {name: 'Remy'}) 
MATCH (x:Person {name: 'Luc'}) 
MATCH (a)-[:INTERESTED_IN]->(i) 
RETURN i.name

MATCH (a:Person {name: 'Remy'}) 
MATCH (b:Person) 
RETURN b.name 
ORDER BY b.name

MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name LIMIT 3
MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name SKIP 6
MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) RETURN b.name ORDER BY b.name SKIP 2 LIMIT 3
MATCH (a:Person {name: 'Remy'}) MATCH (b:Interest) RETURN b.name ORDER BY b.name DESC LIMIT 2

MATCH (a)-->(b) MATCH (b)-->(c) RETURN count(*)
MATCH (a)-->(b) MATCH (b)-->(c) RETURN DISTINCT a.name
MATCH (a:Person) MATCH (b:Interest) RETURN DISTINCT a.name

MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (b:Interest {name: 'Gym'}) RETURN a.name
MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (b:Interest) RETURN count(*)
MATCH (a:Person) ORDER BY a.name SKIP 6 MATCH (b:Interest) RETURN count(*)
MATCH (a:Person) ORDER BY a.name LIMIT 2 MATCH (a)-[:INTERESTED_IN]->(i) RETURN a.name, i.name
MATCH (a:Person) MATCH (b:Person) ORDER BY b.name LIMIT 2 MATCH (c:Interest {name: 'Gym'}) RETURN b.name
MATCH (a:Person {name: 'Remy'}) MATCH (b:Person) ORDER BY b.name LIMIT 2 MATCH (c:Interest {name: 'Gym'}) RETURN b.name
MATCH (a)-[e:KNOWS_WELL]->(b) ORDER BY e.name LIMIT 2 MATCH (c:Interest {name: 'Gym'}) RETURN e.name
MATCH (a:Person) ORDER BY a.name LIMIT 3 MATCH (b:Interest) ORDER BY b.name LIMIT 2 MATCH (c:Person {name: 'Remy'}) RETURN count(*)

MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Doruk'}) CREATE (a)-[:MENTORS]->(b)
MATCH (a:Person {name: 'Remy'}) MATCH (b:Interest) CREATE (:Tag {name: b.name})
MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Doruk'}) SET b.dob = a.dob
MATCH (a:Person {name: 'Remy'}) MATCH (i:Interest) SET i.isReal = true
MATCH (a:Person {name: 'Cyrus'})-[e:INTERESTED_IN]->(i) MATCH (b:Person {name: 'Doruk'}) DELETE e
MATCH (a:Person {name: 'Remy'}) MATCH (b:Person {name: 'Martina'}) DETACH DELETE b
```
