### PR TITLE
Implement `STARTS WITH`, `ENDS WITH`, `CONTAINS`

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -3076,6 +3076,11 @@ void DBProgramGenerator::translateExpr(const Expr* expr) {
         }
         break;
 
+        case Expr::Kind::STRING: {
+            translateStringExpr(expr);
+        }
+        break;
+
         case Expr::Kind::FUNCTION_INVOCATION: {
             const FunctionInvocationExpr* funcExpr = static_cast<const FunctionInvocationExpr*>(expr);
             translateFunctionInvocationExpr(expr, funcExpr);
@@ -3084,7 +3089,6 @@ void DBProgramGenerator::translateExpr(const Expr* expr) {
 
         case Expr::Kind::INDEX:
         case Expr::Kind::LIST:
-        case Expr::Kind::STRING:
         case Expr::Kind::ENTITY_TYPES:
         case Expr::Kind::PATH:
             throw TuringException(fmt::format("Unsupported expression: {}",
@@ -3207,6 +3211,41 @@ void DBProgramGenerator::translateBinaryExpr(const Expr* expr, const BinaryExpr*
         break;
 
         case BinaryOperator::_SIZE:
+        break;
+    }
+}
+
+void DBProgramGenerator::translateStringExpr(const Expr* expr) {
+    const StringExpr* strExpr = static_cast<const StringExpr*>(expr);
+
+    const Expr* lhsExpr = strExpr->getLHS();
+    const Expr* rhsExpr = strExpr->getRHS();
+
+    translateExpr(lhsExpr);
+    translateExpr(rhsExpr);
+
+    bioassert(_part._exprMap.contains(lhsExpr), "String operation with unknown LHS operand.");
+    bioassert(_part._exprMap.contains(rhsExpr), "String operation with unknown RHS operand.");
+
+    const mlir::Value lhs = _part._exprMap.at(lhsExpr);
+    const mlir::Value rhs = _part._exprMap.at(rhsExpr);
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+
+    const StringOperator op = strExpr->getStringOperator();
+
+    switch (op) {
+        case StringOperator::StartsWith:
+            _part._exprMap[expr] = _opBuilder.create<mlir::db::StartsWithOp>(loc, boolType, lhs, rhs).getResult();
+        break;
+        case StringOperator::EndsWith:
+            _part._exprMap[expr] = _opBuilder.create<mlir::db::EndsWithOp>(loc, boolType, lhs, rhs).getResult();
+        break;
+        case StringOperator::Contains:
+            _part._exprMap[expr] = _opBuilder.create<mlir::db::ContainsOp>(loc, boolType, lhs, rhs).getResult();
+        break;
+        case StringOperator::_SIZE:
+            throw TuringException("Unknown string operator.");
         break;
     }
 }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -399,6 +399,7 @@ private:
     void translateExpr(const Expr* expr);
     void translateUnaryExpr(const Expr* expr, const UnaryExpr* unaryExpr);
     void translateBinaryExpr(const Expr* expr, const BinaryExpr* binExpr);
+    void translateStringExpr(const Expr* expr);
     void translateFunctionInvocationExpr(const Expr* expr, const FunctionInvocationExpr* funcExpr);
 
     void translateFunctionExpr(const Expr* expr, const FunctionInvocation* invocation);

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1120,6 +1120,18 @@ def LteOp : PredicateOp<"lte", [Pure]> {
   let summary = "Row-wise less-than-or-equal comparison of two value columns";
 }
 
+def StartsWithOp : PredicateOp<"starts_with", [Pure]> {
+  let summary = "Row-wise test of whether each string column value starts with the given prefix";
+}
+
+def EndsWithOp : PredicateOp<"ends_with", [Pure]> {
+  let summary = "Row-wise test of whether each string column value ends with the given suffix";
+}
+
+def ContainsOp : PredicateOp<"contains", [Pure]> {
+  let summary = "Row-wise test of whether each string column value contains the given substring";
+}
+
 def FilterOp : TuringOp<"filter", [Pure]> {
   let summary = "Keep only the rows where the mask is true, filtering carried columns alongside";
 

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -181,6 +181,7 @@ Value climbToLineageAnchor(Value column) {
 
 bool isMaskComputeOp(Operation* op) {
     return isa<EqOp, NeqOp, GtOp, LtOp, GteOp, LteOp,
+               StartsWithOp, EndsWithOp, ContainsOp,
                AndOp, OrOp, XorOp, NotOp,
                AddOp, SubOp, MulOp, DivOp, ModOp, PowOp,
                ConstantOp,

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1348,6 +1348,42 @@ def Lte : NLOp<"lte", [Pure, ConstantThroughOperands, RowAlignedThroughOperands]
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
 }
 
+def StartsWith : NLOp<"starts_with", [Pure, ConstantThroughOperands, RowAlignedThroughOperands]> {
+  let summary = "Row-wise test of whether each string chunk value starts with the given prefix";
+  let description = [{
+      %r = nl.starts_with %x, %y : (!nl.chunk<!storage.string>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+  }];
+
+  let arguments = (ins NLChunk:$lhs, NLChunk:$rhs);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
+def EndsWith : NLOp<"ends_with", [Pure, ConstantThroughOperands, RowAlignedThroughOperands]> {
+  let summary = "Row-wise test of whether each string chunk value ends with the given suffix";
+  let description = [{
+      %r = nl.ends_with %x, %y : (!nl.chunk<!storage.string>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+  }];
+
+  let arguments = (ins NLChunk:$lhs, NLChunk:$rhs);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
+def Contains : NLOp<"contains", [Pure, ConstantThroughOperands, RowAlignedThroughOperands]> {
+  let summary = "Row-wise test of whether each string chunk value contains the given substring";
+  let description = [{
+      %r = nl.contains %x, %y : (!nl.chunk<!storage.string>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+  }];
+
+  let arguments = (ins NLChunk:$lhs, NLChunk:$rhs);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
 def And : NLOp<"and", [Pure, ConstantThroughOperands, RowAlignedThroughOperands]> {
   let summary = "Row-wise logical AND of two boolean chunks";
   let description = [{

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -340,6 +340,36 @@ struct BinaryOpTraits<OP_XOR> {
 };
 
 template <>
+struct BinaryOpTraits<OP_STARTS_WITH> {
+    using Functor = StartsWith;
+
+    template <typename ResCol, typename LhsCol, typename RhsCol>
+    static void exec(ResCol* result, const LhsCol* lhs, const RhsCol* rhs) {
+        BinaryPredicates::exec<Functor>(result, lhs, rhs);
+    }
+};
+
+template <>
+struct BinaryOpTraits<OP_ENDS_WITH> {
+    using Functor = EndsWith;
+
+    template <typename ResCol, typename LhsCol, typename RhsCol>
+    static void exec(ResCol* result, const LhsCol* lhs, const RhsCol* rhs) {
+        BinaryPredicates::exec<Functor>(result, lhs, rhs);
+    }
+};
+
+template <>
+struct BinaryOpTraits<OP_CONTAINS> {
+    using Functor = Contains;
+
+    template <typename ResCol, typename LhsCol, typename RhsCol>
+    static void exec(ResCol* result, const LhsCol* lhs, const RhsCol* rhs) {
+        BinaryPredicates::exec<Functor>(result, lhs, rhs);
+    }
+};
+
+template <>
 struct BinaryOpTraits<OP_FUNC_COSINE_SIMILARITY> {
     using Functor = CosineSimilarityFunction;
 
@@ -4631,5 +4661,8 @@ template NLBinaryFn NLExecutor::selectBinary<OP_AND>(const Column* lhs, const Co
 template NLBinaryFn NLExecutor::selectBinary<OP_OR>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
 template NLBinaryFn NLExecutor::selectBinary<OP_NOT_EQUAL>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
 template NLBinaryFn NLExecutor::selectBinary<OP_XOR>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
+template NLBinaryFn NLExecutor::selectBinary<OP_STARTS_WITH>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
+template NLBinaryFn NLExecutor::selectBinary<OP_ENDS_WITH>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
+template NLBinaryFn NLExecutor::selectBinary<OP_CONTAINS>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
 template NLBinaryFn NLExecutor::selectBinary<OP_FUNC_COSINE_SIMILARITY>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);
 template NLBinaryFn NLExecutor::selectBinary<OP_FUNC_EUCLIDEAN_DISTANCE>(const Column* lhs, const Column* rhs, LocalMemory* memory, Column*& result);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -467,6 +467,12 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateBinaryOp<OP_GREATER_THAN_OR_EQUAL>(gte, body);
         } else if (nl::Lte lte = mlir::dyn_cast<nl::Lte>(operation)) {
             translateBinaryOp<OP_LESS_THAN_OR_EQUAL>(lte, body);
+        } else if (nl::StartsWith startsWith = mlir::dyn_cast<nl::StartsWith>(operation)) {
+            translateBinaryOp<OP_STARTS_WITH>(startsWith, body);
+        } else if (nl::EndsWith endsWith = mlir::dyn_cast<nl::EndsWith>(operation)) {
+            translateBinaryOp<OP_ENDS_WITH>(endsWith, body);
+        } else if (nl::Contains containsOp = mlir::dyn_cast<nl::Contains>(operation)) {
+            translateBinaryOp<OP_CONTAINS>(containsOp, body);
         } else if (nl::And andOp = mlir::dyn_cast<nl::And>(operation)) {
             translateBinaryOp<OP_AND>(andOp, body);
         } else if (nl::Or orOp = mlir::dyn_cast<nl::Or>(operation)) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -757,6 +757,12 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerBinaryOp<nl::Gte>(operation, BinaryResultKind::Boolean);
     } else if (mlir::isa<mlir::db::LteOp>(operation)) {
         lowerBinaryOp<nl::Lte>(operation, BinaryResultKind::Boolean);
+    } else if (mlir::isa<mlir::db::StartsWithOp>(operation)) {
+        lowerBinaryOp<nl::StartsWith>(operation, BinaryResultKind::Boolean);
+    } else if (mlir::isa<mlir::db::EndsWithOp>(operation)) {
+        lowerBinaryOp<nl::EndsWith>(operation, BinaryResultKind::Boolean);
+    } else if (mlir::isa<mlir::db::ContainsOp>(operation)) {
+        lowerBinaryOp<nl::Contains>(operation, BinaryResultKind::Boolean);
     } else if (mlir::isa<mlir::db::AndOp>(operation)) {
         lowerBinaryOp<nl::And>(operation, BinaryResultKind::Boolean);
     } else if (mlir::isa<mlir::db::OrOp>(operation)) {

--- a/query/pipeline/processors/ExprProgram.cpp
+++ b/query/pipeline/processors/ExprProgram.cpp
@@ -132,6 +132,9 @@ void ExprProgram::evalBinaryInstr(const Instruction& instr) {
 
         case OP_MOD:
         case OP_POW:
+        case OP_STARTS_WITH:
+        case OP_ENDS_WITH:
+        case OP_CONTAINS:
         case OP_PROJECT:
         case OP_IN:
             throw FatalException(
@@ -186,6 +189,9 @@ void ExprProgram::evalUnaryInstr(const Instruction& instr) {
         case OP_DIV:
         case OP_MOD:
         case OP_POW:
+        case OP_STARTS_WITH:
+        case OP_ENDS_WITH:
+        case OP_CONTAINS:
         case OP_PROJECT:
         case OP_IN:
         case OP_XOR:
@@ -250,6 +256,9 @@ void ExprProgram::evalFunction(const Instruction& instr) {
         case OP_DIV:
         case OP_MOD:
         case OP_POW:
+        case OP_STARTS_WITH:
+        case OP_ENDS_WITH:
+        case OP_CONTAINS:
         case OP_PROJECT:
         case OP_IN:
         case OP_MINUS:

--- a/query/plan/ExprProgramGenerator.cpp
+++ b/query/plan/ExprProgramGenerator.cpp
@@ -701,6 +701,9 @@ Column* ExprProgramGenerator::allocUnaryResultCol(ColumnOperator op, const Colum
         case OP_DIV:
         case OP_MOD:
         case OP_POW:
+        case OP_STARTS_WITH:
+        case OP_ENDS_WITH:
+        case OP_CONTAINS:
         case OP_PROJECT:
         case OP_IN:
         case OP_XOR:

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -233,6 +233,23 @@ struct PairRestrictions<Op> {
 };
 
 template <ColumnOperator Op>
+    requires (Op == OP_STARTS_WITH) || (Op == OP_ENDS_WITH) || (Op == OP_CONTAINS)
+struct PairRestrictions<Op> {
+    using Allowed = GenerateKindPairList<
+        OptionalKindPairs<types::String::Primitive, types::String::Primitive>::Pairs,
+        OptionalKindPairs<types::String::Primitive, types::String::OwningPrimitive>::Pairs,
+        OptionalKindPairs<types::String::OwningPrimitive, types::String::OwningPrimitive>::Pairs
+    >;
+
+    using AllowedMixed = AllowedMixedList<>;
+
+    using Excluded = ExcludedContainers<
+        ContainerKind::code<ColumnSet>(),
+        ContainerKind::code<ColumnMask>()
+    >;
+};
+
+template <ColumnOperator Op>
     requires (Op == OP_AND) || (Op == OP_OR) || (Op == OP_XOR)
 struct PairRestrictions<Op> {
     using Allowed = GenerateKindPairList<

--- a/storage/columns/BinaryOperators.h
+++ b/storage/columns/BinaryOperators.h
@@ -187,27 +187,6 @@ struct Power {
     }
 };
 
-struct StartsWith {
-    template <StringLike T, StringLike U>
-    bool operator()(const T& text, U&& prefix) const {
-        return text.starts_with(std::forward<U>(prefix));
-    }
-};
-
-struct EndsWith {
-    template <StringLike T, StringLike U>
-    bool operator()(const T& text, U&& suffix) const {
-        return text.ends_with(std::forward<U>(suffix));
-    }
-};
-
-struct Contains {
-    template <StringLike T, StringLike U>
-    bool operator()(const T& text, U&& pattern) const {
-        return text.find(std::forward<U>(pattern)) != T::npos;
-    }
-};
-
 }
 
 using Add = BinaryOp<std::plus<>>;

--- a/storage/columns/BinaryOperators.h
+++ b/storage/columns/BinaryOperators.h
@@ -195,9 +195,6 @@ using Mul = BinaryOp<std::multiplies<>>;
 using Div = BinaryOp<SafeDivides>;
 using Mod = BinaryOp<SafeModulo>;
 using Pow = BinaryOp<Power>;
-using StartsWith = BinaryOp<StartsWith>;
-using EndsWith = BinaryOp<EndsWith>;
-using Contains = BinaryOp<Contains>;
 
 }
 

--- a/storage/columns/BinaryOperators.h
+++ b/storage/columns/BinaryOperators.h
@@ -187,6 +187,27 @@ struct Power {
     }
 };
 
+struct StartsWith {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& prefix) const {
+        return text.starts_with(std::forward<U>(prefix));
+    }
+};
+
+struct EndsWith {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& suffix) const {
+        return text.ends_with(std::forward<U>(suffix));
+    }
+};
+
+struct Contains {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& pattern) const {
+        return text.find(std::forward<U>(pattern)) != T::npos;
+    }
+};
+
 }
 
 using Add = BinaryOp<std::plus<>>;
@@ -195,6 +216,9 @@ using Mul = BinaryOp<std::multiplies<>>;
 using Div = BinaryOp<SafeDivides>;
 using Mod = BinaryOp<SafeModulo>;
 using Pow = BinaryOp<Power>;
+using StartsWith = BinaryOp<StartsWith>;
+using EndsWith = BinaryOp<EndsWith>;
+using Contains = BinaryOp<Contains>;
 
 }
 

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -467,6 +467,27 @@ struct TuringXor {
     }
 };
 
+struct StartsWith {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& prefix) const {
+        return text.starts_with(std::forward<U>(prefix));
+    }
+};
+
+struct EndsWith {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& suffix) const {
+        return text.ends_with(std::forward<U>(suffix));
+    }
+};
+
+struct Contains {
+    template <StringLike T, StringLike U>
+    bool operator()(const T& text, U&& pattern) const {
+        return text.find(std::forward<U>(pattern)) != T::npos;
+    }
+};
+
 }
 
 using Eq = BinaryPredicate<TuringEqual>;
@@ -481,5 +502,9 @@ using Lte = BinaryPredicate<std::less_equal<>>;
 using And = BinaryPredicate<std::logical_and<>>;
 using Or = BinaryPredicate<std::logical_or<>>;
 using Xor = BinaryPredicate<TuringXor>;
+
+using StartsWith = BinaryPredicate<StartsWith>;
+using EndsWith = BinaryPredicate<EndsWith>;
+using Contains = BinaryPredicate<Contains>;
 
 }

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -467,22 +467,22 @@ struct TuringXor {
     }
 };
 
-struct StartsWith {
-    template <StringLike T, StringLike U>
+struct StringStartsWith {
+    template <typename T, typename U>
     bool operator()(const T& text, U&& prefix) const {
         return text.starts_with(std::forward<U>(prefix));
     }
 };
 
-struct EndsWith {
-    template <StringLike T, StringLike U>
+struct StringEndsWith {
+    template <typename T, typename U>
     bool operator()(const T& text, U&& suffix) const {
         return text.ends_with(std::forward<U>(suffix));
     }
 };
 
-struct Contains {
-    template <StringLike T, StringLike U>
+struct StringContains {
+    template <typename T, typename U>
     bool operator()(const T& text, U&& pattern) const {
         return text.find(std::forward<U>(pattern)) != T::npos;
     }
@@ -503,8 +503,8 @@ using And = BinaryPredicate<std::logical_and<>>;
 using Or = BinaryPredicate<std::logical_or<>>;
 using Xor = BinaryPredicate<TuringXor>;
 
-using StartsWith = BinaryPredicate<StartsWith>;
-using EndsWith = BinaryPredicate<EndsWith>;
-using Contains = BinaryPredicate<Contains>;
+using StartsWith = BinaryPredicate<StringStartsWith>;
+using EndsWith = BinaryPredicate<StringEndsWith>;
+using Contains = BinaryPredicate<StringContains>;
 
 }

--- a/storage/columns/ColumnOperator.h
+++ b/storage/columns/ColumnOperator.h
@@ -30,6 +30,10 @@ enum ColumnOperator : uint8_t {
     OP_MOD,
     OP_POW,
 
+    OP_STARTS_WITH,
+    OP_ENDS_WITH,
+    OP_CONTAINS,
+
     OP_PROJECT,
     OP_IN,
 
@@ -81,6 +85,10 @@ constexpr ColumnOperatorType getOperatorType(ColumnOperator op) {
         case OP_DIV:
         case OP_MOD:
         case OP_POW:
+
+        case OP_STARTS_WITH:
+        case OP_ENDS_WITH:
+        case OP_CONTAINS:
 
         case OP_PROJECT:
         case OP_IN:
@@ -137,6 +145,10 @@ using ColumnOperatorDescription = EnumToString<ColumnOperator>::Create<
     EnumStringPair<ColumnOperator::OP_DIV, "DIV">,
     EnumStringPair<ColumnOperator::OP_MOD, "MOD">,
     EnumStringPair<ColumnOperator::OP_POW, "POW">,
+
+    EnumStringPair<ColumnOperator::OP_STARTS_WITH, "STARTS_WITH">,
+    EnumStringPair<ColumnOperator::OP_ENDS_WITH, "ENDS_WITH">,
+    EnumStringPair<ColumnOperator::OP_CONTAINS, "CONTAINS">,
 
     EnumStringPair<ColumnOperator::OP_PROJECT, "PROJECT">,
     EnumStringPair<ColumnOperator::OP_IN, "IN">,

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1198,6 +1198,17 @@ target_link_libraries(test_query_ir_aggregate_with_return_items PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_aggregate_with_return_items PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_string_predicates StringPredicateTest.cpp)
+target_sources(test_query_ir_string_predicates PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_string_predicates PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_string_predicates PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_pattern_loop PatternLoopTest.cpp)
 target_sources(test_query_ir_pattern_loop PRIVATE StringRowSink.cpp)
 target_link_libraries(test_query_ir_pattern_loop PRIVATE

--- a/test/query/ir/QueryInterpreterV3ErrorTest.cpp
+++ b/test/query/ir/QueryInterpreterV3ErrorTest.cpp
@@ -62,16 +62,6 @@ protected:
     std::unique_ptr<QueryInterpreterV3> _interpreter;
 };
 
-// An expression kind the generator has no translation for is rejected with a plain
-// TuringException: the user must see that message as-is.
-TEST_F(QueryInterpreterV3ErrorTest, reportsUnsupportedExpressionRejectionAsIs) {
-    QueryStatus status;
-    runQuery("MATCH (n) WHERE n.name STARTS WITH 'R' RETURN n", status);
-
-    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
-    EXPECT_EQ(status.getError(), "Unsupported expression: STRING");
-}
-
 // An internal generator failure is a FatalException and must keep reading as
 // one, rather than being dressed up as a deliberate rejection. A map literal
 // reading a row is one: the key varies, so it is not dropped as a constant, and

--- a/test/query/ir/StringPredicateTest.cpp
+++ b/test/query/ir/StringPredicateTest.cpp
@@ -122,6 +122,104 @@ TEST_F(StringPredicateTest, combinedWithPropertyPredicates) {
                {{"Adam"}});
 }
 
+TEST_F(StringPredicateTest, countOverOrOfStringPredicates) {
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' OR n.name STARTS WITH 'A' RETURN count(n)",
+               {{"5"}});
+
+    expectRows("MATCH (n) WHERE n.name ENDS WITH 's' OR n.name STARTS WITH 'G' RETURN count(n)",
+               {{"7"}});
+
+    expectRows("MATCH (n) WHERE n.name CONTAINS 'oo' OR n.name ENDS WITH 'l' RETURN count(n)",
+               {{"3"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' OR n.name STARTS WITH 'A' RETURN count(*)",
+               {{"5"}});
+}
+
+TEST_F(StringPredicateTest, countMixingStringAndPropertyPredicates) {
+    expectRows("MATCH (n:Person) WHERE n.name ENDS WITH 's' OR n.isFrench = true RETURN count(n)",
+               {{"6"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'M' OR n.hasPhD = false RETURN count(n)",
+               {{"5"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' OR n.isReal = false RETURN count(n)",
+               {{"4"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'M' AND n.hasPhD = false RETURN count(n)",
+               {{"1"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name ENDS WITH 's' AND n.isFrench = false RETURN count(n)",
+               {{"2"}});
+
+    expectRows("MATCH (n) WHERE n.name CONTAINS 'o' AND n.isReal = true RETURN count(n)",
+               {{"2"}});
+}
+
+TEST_F(StringPredicateTest, sumOfAgeUnderStringPredicates) {
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'R' OR n.name STARTS WITH 'A' RETURN sum(n.age)",
+               {{"64"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name ENDS WITH 'y' OR n.hasPhD = true RETURN sum(n.age)",
+               {{"64"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'S' OR n.name STARTS WITH 'D' RETURN sum(n.age)",
+               {{"0"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'Z' RETURN sum(n.age)",
+               {{"0"}});
+}
+
+TEST_F(StringPredicateTest, countAndSumTogether) {
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'R' OR n.name ENDS WITH 'm' RETURN count(n), sum(n.age)",
+               {{"2", "64"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name ENDS WITH 's' OR n.isFrench = true RETURN count(n), sum(n.age)",
+               {{"6", "64"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'R' OR n.name STARTS WITH 'S' RETURN count(n), count(n.age)",
+               {{"2", "1"}});
+}
+
+TEST_F(StringPredicateTest, aggregatesOverEdgeStringPredicates) {
+    expectRows("MATCH (a)-[e]->(b) WHERE e.name STARTS WITH 'Remy' RETURN count(e), sum(e.duration)",
+               {{"4", "60"}});
+
+    expectRows("MATCH (a)-[e]->(b) WHERE e.name STARTS WITH 'Remy' OR e.name STARTS WITH 'Ghosts' RETURN sum(e.duration)",
+               {{"260"}});
+
+    expectRows("MATCH (a)-[e]->(b) WHERE e.name ENDS WITH 'Gym' RETURN count(e), sum(e.duration)",
+               {{"3", "0"}});
+}
+
+TEST_F(StringPredicateTest, parenthesizedAndOrPermutations) {
+    expectRows("MATCH (n:Person) WHERE (n.name STARTS WITH 'M' OR n.name STARTS WITH 'R') AND n.hasPhD = true RETURN count(n)",
+               {{"2"}});
+
+    expectRows("MATCH (n:Person) WHERE (n.name ENDS WITH 's' OR n.name ENDS WITH 'y') AND n.isFrench = false RETURN count(n)",
+               {{"2"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' AND (n.name ENDS WITH 's' OR n.name ENDS WITH 'g') RETURN count(n)",
+               {{"3"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'R' OR n.name STARTS WITH 'A' OR n.name STARTS WITH 'M' RETURN count(n), sum(n.age)",
+               {{"4", "64"}});
+}
+
+TEST_F(StringPredicateTest, aggregatesOverDobStringPredicates) {
+    expectRows("MATCH (n:Person) WHERE n.dob STARTS WITH '18' RETURN count(n)",
+               {{"2"}});
+
+    expectRows("MATCH (n:Person) WHERE n.dob ENDS WITH '05' OR n.dob ENDS WITH '07' RETURN count(n)",
+               {{"2"}});
+
+    expectRows("MATCH (n:Person) WHERE n.dob CONTAINS '/0' RETURN count(n), sum(n.age)",
+               {{"4", "64"}});
+
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'A' OR n.dob STARTS WITH '24' RETURN count(n), sum(n.age)",
+               {{"2", "32"}});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/StringPredicateTest.cpp
+++ b/test/query/ir/StringPredicateTest.cpp
@@ -1,0 +1,127 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+class StringPredicateTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRows(std::string_view query, std::vector<StringRowSink::Row> expected) {
+        StringRowSink sink;
+        QueryStatus status;
+
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        std::sort(expected.begin(), expected.end());
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(StringPredicateTest, startsWithLiteralPrefix) {
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' RETURN n.name",
+               {{"Computers"}, {"Cooking"}, {"Cyrus"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'A' RETURN n.name",
+               {{"Adam"}, {"Animals"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'Rem' RETURN n.name",
+               {{"Remy"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'Z' RETURN n.name",
+               {});
+}
+
+TEST_F(StringPredicateTest, endsWithLiteralSuffix) {
+    expectRows("MATCH (n) WHERE n.name ENDS WITH 'o' RETURN n.name",
+               {{"Bio"}});
+
+    expectRows("MATCH (n) WHERE n.name ENDS WITH 'm' RETURN n.name",
+               {{"Adam"}, {"Gym"}});
+
+    expectRows("MATCH (n) WHERE n.name ENDS WITH 'ties' RETURN n.name",
+               {{"Eighties"}});
+}
+
+TEST_F(StringPredicateTest, containsLiteralSubstring) {
+    expectRows("MATCH (n) WHERE n.name CONTAINS 'oo' RETURN n.name",
+               {{"Cooking"}});
+
+    expectRows("MATCH (n) WHERE n.name CONTAINS 'us' RETURN n.name",
+               {{"Cyrus"}});
+
+    expectRows("MATCH (n) WHERE n.name CONTAINS 'o' RETURN n.name",
+               {{"Computers"}, {"Bio"}, {"Cooking"}, {"Ghosts"}, {"Doruk"}});
+}
+
+TEST_F(StringPredicateTest, nonLiteralPropertyOperands) {
+    expectRows("MATCH (n:Person) WHERE n.name CONTAINS n.name RETURN n.name",
+               {{"Remy"}, {"Adam"}, {"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
+
+    expectRows("MATCH (a)-[e]->(b) WHERE a.name = 'Remy' AND e.name STARTS WITH a.name RETURN e.name",
+               {{"Remy -> Adam"}, {"Remy -> Ghosts"}, {"Remy -> Computers"}, {"Remy -> Eighties"}});
+}
+
+TEST_F(StringPredicateTest, combinedWithBooleanPredicates) {
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'C' AND n.name ENDS WITH 's' RETURN n.name",
+               {{"Computers"}, {"Cyrus"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'A' OR n.name STARTS WITH 'G' RETURN n.name",
+               {{"Adam"}, {"Animals"}, {"Ghosts"}, {"Gym"}});
+}
+
+TEST_F(StringPredicateTest, combinedWithPropertyPredicates) {
+    expectRows("MATCH (n:Person) WHERE n.name STARTS WITH 'M' AND n.isFrench = true RETURN n.name",
+               {{"Maxime"}});
+
+    expectRows("MATCH (n) WHERE n.name STARTS WITH 'A' AND n.age = 32 RETURN n.name",
+               {{"Adam"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Implements the Cypher `STARTS WITH`, `ENDS WITH`, and `CONTAINS` string operations for the MLIR V3 interpreter. Remains unsupported in v2.

Uses C++ standard library algorithms