### PR TITLE
MLIR: Fix chunk type to be owning string

### DIFF
--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -50,8 +50,8 @@ mlir::Value emitNLUnaryFunction(mlir::OpBuilder& builder,
     return builder.create<NLOp>(loc, resultType, input).getResult();
 }
 
-mlir::Type stringFunctionElement(mlir::OpBuilder& builder) {
-    return storage::StringType::get(builder.getContext());
+mlir::Type ownedStringFunctionElement(mlir::OpBuilder& builder) {
+    return storage::OwnedStringType::get(builder.getContext());
 }
 
 mlir::Type integerFunctionElement(mlir::OpBuilder& builder) {
@@ -106,11 +106,11 @@ struct UnaryFunctionLowering {
 };
 
 const std::unordered_map<std::string_view, UnaryFunctionLowering> unaryFunctionLowerings = {
-    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &stringFunctionElement,  ResultNullability::FollowsInput}},
-    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &stringFunctionElement,  ResultNullability::FollowsInput}},
-    {"db.to_integer", {&emitNLUnaryFunction<nl::ToInteger>, &integerFunctionElement, ResultNullability::AlwaysNullable}},
-    {"db.to_float",   {&emitNLUnaryFunction<nl::ToFloat>,   &floatFunctionElement,   ResultNullability::AlwaysNullable}},
-    {"db.to_boolean", {&emitNLUnaryFunction<nl::ToBoolean>, &booleanFunctionElement, ResultNullability::AlwaysNullable}},
+    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &ownedStringFunctionElement, ResultNullability::FollowsInput}},
+    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &ownedStringFunctionElement, ResultNullability::FollowsInput}},
+    {"db.to_integer", {&emitNLUnaryFunction<nl::ToInteger>, &integerFunctionElement,     ResultNullability::AlwaysNullable}},
+    {"db.to_float",   {&emitNLUnaryFunction<nl::ToFloat>,   &floatFunctionElement,       ResultNullability::AlwaysNullable}},
+    {"db.to_boolean", {&emitNLUnaryFunction<nl::ToBoolean>, &booleanFunctionElement,     ResultNullability::AlwaysNullable}},
 };
 
 const UnaryFunctionLowering* lookupUnaryFunctionLowering(mlir::Operation& operation) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -400,6 +400,27 @@ target_link_libraries(test_query_ir_order_by PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_order_by PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_order_by_labels OrderByLabelsTest.cpp)
+target_link_libraries(test_query_ir_order_by_labels PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        MLIRParser)
+target_include_directories(test_query_ir_order_by_labels PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cross_product_cut CrossProductCutTest.cpp)
 target_link_libraries(test_query_ir_cross_product_cut PRIVATE
         turing_db_s

--- a/test/query/ir/OrderByLabelsTest.cpp
+++ b/test/query/ir/OrderByLabelsTest.cpp
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnVector.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+class OwnedStringSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* strings = dynamic_cast<const ColumnVector<std::string>*>(chunks[0]);
+        ASSERT_NE(strings, nullptr);
+
+        const auto& raw = strings->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _values.push_back(raw[rowIndex]);
+        }
+    }
+
+    const std::vector<std::string>& values() const { return _values; }
+
+private:
+    std::vector<std::string> _values;
+};
+
+}
+
+class OrderByLabelsTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, NLOutputSink* sink) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        mlir::MLIRContext context;
+        mlir::OwningOpRef<mlir::ModuleOp> module;
+
+        {
+            const FrozenCommitTx transaction = _graph->openTransaction();
+            const GraphView view = transaction.viewGraph();
+
+            CypherAST ast(procedures, query);
+
+            CypherParser parser(&ast);
+            parser.parse(query);
+
+            CypherAnalyzer analyzer(&ast, view);
+            analyzer.setV3();
+            analyzer.analyze();
+
+            context.getOrLoadDialect<mlir::func::FuncDialect>();
+            context.getOrLoadDialect<mlir::storage::Storage>();
+            context.getOrLoadDialect<mlir::db::DB>();
+            context.getOrLoadDialect<mlir::nl::NL>();
+
+            mlir::OpBuilder builder(&context);
+            module = mlir::ModuleOp::create(builder.getUnknownLoc());
+            mlir::ModuleOp moduleOp = module.get();
+
+            DBProgramGenerator generator(&moduleOp);
+            generator.generate(&ast);
+        }
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module.get(), &view, sink, &memory);
+        interpreter.run();
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(OrderByLabelsTest, ownedLabelStringSortsWithoutCrash) {
+    OwnedStringSink sink;
+    runQuery("MATCH (n) RETURN labels(n) ORDER BY labels(n)", &sink);
+
+    const std::vector<std::string>& values = sink.values();
+
+    EXPECT_EQ(values.size(), 18u);
+    EXPECT_TRUE(std::is_sorted(values.begin(), values.end()));
+
+    for (const std::string& value : values) {
+        EXPECT_FALSE(value.empty());
+    }
+}


### PR DESCRIPTION
Fixes segfault with `match (n) return labels(n) order by labels(n)`