### PR TITLE
MLIR: type labels and edgeType as owned strings

### DIFF
--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -50,8 +50,8 @@ mlir::Value emitNLUnaryFunction(mlir::OpBuilder& builder,
     return builder.create<NLOp>(loc, resultType, input).getResult();
 }
 
-mlir::Type stringFunctionElement(mlir::OpBuilder& builder) {
-    return storage::StringType::get(builder.getContext());
+mlir::Type ownedStringFunctionElement(mlir::OpBuilder& builder) {
+    return storage::OwnedStringType::get(builder.getContext());
 }
 
 mlir::Type integerFunctionElement(mlir::OpBuilder& builder) {
@@ -106,11 +106,11 @@ struct UnaryFunctionLowering {
 };
 
 const std::unordered_map<std::string_view, UnaryFunctionLowering> unaryFunctionLowerings = {
-    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &stringFunctionElement,  ResultNullability::FollowsInput}},
-    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &stringFunctionElement,  ResultNullability::FollowsInput}},
-    {"db.to_integer", {&emitNLUnaryFunction<nl::ToInteger>, &integerFunctionElement, ResultNullability::AlwaysNullable}},
-    {"db.to_float",   {&emitNLUnaryFunction<nl::ToFloat>,   &floatFunctionElement,   ResultNullability::AlwaysNullable}},
-    {"db.to_boolean", {&emitNLUnaryFunction<nl::ToBoolean>, &booleanFunctionElement, ResultNullability::AlwaysNullable}},
+    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &ownedStringFunctionElement, ResultNullability::FollowsInput}},
+    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &ownedStringFunctionElement, ResultNullability::FollowsInput}},
+    {"db.to_integer", {&emitNLUnaryFunction<nl::ToInteger>, &integerFunctionElement,     ResultNullability::AlwaysNullable}},
+    {"db.to_float",   {&emitNLUnaryFunction<nl::ToFloat>,   &floatFunctionElement,       ResultNullability::AlwaysNullable}},
+    {"db.to_boolean", {&emitNLUnaryFunction<nl::ToBoolean>, &booleanFunctionElement,     ResultNullability::AlwaysNullable}},
 };
 
 const UnaryFunctionLowering* lookupUnaryFunctionLowering(mlir::Operation& operation) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -159,6 +159,7 @@ add_call_v3_test(test_query_ir_call_carried_scalar CallCarriedScalarTest.cpp)
 add_call_v3_test(test_query_ir_call_writes CallWritesTest.cpp)
 add_call_v3_test(test_query_ir_call_boolean_predicates CallBooleanPredicatesTest.cpp)
 add_call_v3_test(test_query_ir_call_show_indexes CallShowIndexesTest.cpp)
+add_call_v3_test(test_query_ir_order_by_labels OrderByLabelsTest.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,
 # once with a constant argument alone and once reading the chain's tail, from the query

--- a/test/query/ir/OrderByLabelsTest.cpp
+++ b/test/query/ir/OrderByLabelsTest.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+// labels() and edgeType() fill columns of owned strings, so a sort keyed on one has to
+// buffer and compare owned strings rather than the borrowed ones a property read yields.
+class OrderByLabelsTest : public CallV3Test {
+};
+
+TEST_F(OrderByLabelsTest, ordersByTheProjectedLabels) {
+    StringRowSink sink;
+    runQuery("MATCH (n) RETURN labels(n) ORDER BY labels(n)", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Interest"},
+                                                    {"Interest"},
+                                                    {"Interest"},
+                                                    {"Interest"},
+                                                    {"Interest"},
+                                                    {"Interest"},
+                                                    {"Interest, Exotic"},
+                                                    {"Interest, Exotic, Supernatural, SleepDisturber"},
+                                                    {"Interest, SleepDisturber"},
+                                                    {"Person, Bioinformatics"},
+                                                    {"Person, Bioinformatics"},
+                                                    {"Person, Founder, Bioinformatics"},
+                                                    {"Person, Sales"},
+                                                    {"Person, SoftwareEngineering"},
+                                                    {"Person, SoftwareEngineering"},
+                                                    {"Person, SoftwareEngineering"},
+                                                    {"Person, SoftwareEngineering, Founder"},
+                                                    {"SoftwareEngineering, Interest"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+// The key is not projected, so it rides along as an extra sorted column
+TEST_F(OrderByLabelsTest, ordersByTheLabelsTheReturnDoesNotCarry) {
+    StringRowSink sink;
+    runQuery("MATCH (n:Person) RETURN n.name ORDER BY labels(n) DESC, n.name", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Remy"},
+                                                    {"Cyrus"},
+                                                    {"Luc"},
+                                                    {"Suhas"},
+                                                    {"Doruk"},
+                                                    {"Adam"},
+                                                    {"Martina"},
+                                                    {"Maxime"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+// Remy's four out-edges: one KNOWS_WELL, three INTERESTED_IN
+TEST_F(OrderByLabelsTest, ordersByTheProjectedEdgeType) {
+    StringRowSink sink;
+    runQuery("MATCH (n {name: 'Remy'})-[e]->(m) RETURN edgeType(e) ORDER BY edgeType(e)", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"INTERESTED_IN"}, {"INTERESTED_IN"}, {"INTERESTED_IN"}, {"KNOWS_WELL"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}


### PR DESCRIPTION
Fix the ORDER BY labels(n) segfault.