### PR TITLE
MLIR: implement generalised UNWIND

### DIFF
--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -9,6 +9,7 @@ set(ast_sources
     ProcedureLookup.cpp
 
     decl/DeclContext.cpp
+    decl/ListShape.cpp
     decl/PatternData.cpp
     decl/VarDecl.cpp
 

--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -78,31 +78,54 @@ void FunctionDecls::initDefault() {
     collectIntegers->setArguments({EvaluatedType::Integer});
     collectIntegers->setReturnTypes({{EvaluatedType::List}});
     collectIntegers->setIsAggregate(true);
+    collectIntegers->setCollectsItsArgument(true);
 
     FunctionSignature* collectDoubles = createFunction("collect");
     collectDoubles->setArguments({EvaluatedType::Double});
     collectDoubles->setReturnTypes({{EvaluatedType::List}});
     collectDoubles->setIsAggregate(true);
+    collectDoubles->setCollectsItsArgument(true);
 
     FunctionSignature* collectStrings = createFunction("collect");
     collectStrings->setArguments({EvaluatedType::String});
     collectStrings->setReturnTypes({{EvaluatedType::List}});
     collectStrings->setIsAggregate(true);
+    collectStrings->setCollectsItsArgument(true);
 
     FunctionSignature* collectBools = createFunction("collect");
     collectBools->setArguments({EvaluatedType::Bool});
     collectBools->setReturnTypes({{EvaluatedType::List}});
     collectBools->setIsAggregate(true);
+    collectBools->setCollectsItsArgument(true);
 
     FunctionSignature* collectNodes = createFunction("collect");
     collectNodes->setArguments({EvaluatedType::NodePattern});
     collectNodes->setReturnTypes({{EvaluatedType::List}});
     collectNodes->setIsAggregate(true);
+    collectNodes->setCollectsItsArgument(true);
 
     FunctionSignature* collectEdges = createFunction("collect");
     collectEdges->setArguments({EvaluatedType::EdgePattern});
     collectEdges->setReturnTypes({{EvaluatedType::List}});
     collectEdges->setIsAggregate(true);
+    collectEdges->setCollectsItsArgument(true);
+
+    // A list collects into a list of lists: one level deeper over the same innermost
+    // elements, so unwinding it twice hands those elements back with their own type.
+    FunctionSignature* collectLists = createFunction("collect");
+    collectLists->setArguments({EvaluatedType::List});
+    collectLists->setReturnTypes({{EvaluatedType::List}});
+    collectLists->setIsAggregate(true);
+    collectLists->setCollectsItsArgument(true);
+
+    // A type-erased cell collects too: the list gathers the values the cells hold, each
+    // keeping its own type, so the list is homogeneous in nothing and hands tagged
+    // scalars back out.
+    FunctionSignature* collectListItems = createFunction("collect");
+    collectListItems->setArguments({EvaluatedType::ListItem});
+    collectListItems->setReturnTypes({{EvaluatedType::List}});
+    collectListItems->setIsAggregate(true);
+    collectListItems->setCollectsItsArgument(true);
 
     // collect(null) is a query that can be asked: every row's null is dropped, so the list
     // comes out empty, and the overload is what keeps the answer from being an argument error
@@ -110,6 +133,7 @@ void FunctionDecls::initDefault() {
     collectNulls->setArguments({EvaluatedType::Null});
     collectNulls->setReturnTypes({{EvaluatedType::List}});
     collectNulls->setIsAggregate(true);
+    collectNulls->setCollectsItsArgument(true);
 
     // count(null) is a query that can be asked: a null is never charged, so the tally is
     // zero, and the overload is what keeps the answer from being an argument error
@@ -212,6 +236,16 @@ void FunctionDecls::initDefault() {
     sumDouble->setArguments({EvaluatedType::Double});
     sumDouble->setReturnTypes({{EvaluatedType::Double}});
     sumDouble->setIsAggregate(true);
+
+    // A type-erased cell carries its number's type per row. Mixed numeric tags are what
+    // leaves a list type-erased, and Cypher sums those to a float, so this reduces to one
+    // whichever tags turn up - and errors on a cell that is no number at all. Only the
+    // MLIR engine folds such a column, so the overload is v3-only as avg's is.
+    FunctionSignature* sumListItems = createFunction("sum");
+    sumListItems->setArguments({EvaluatedType::ListItem});
+    sumListItems->setReturnTypes({{EvaluatedType::Double}});
+    sumListItems->setIsAggregate(true);
+    sumListItems->setIsV3Only(true);
 
     // Conversion functions
     FunctionSignature* toInteger = createFunction("toInteger");

--- a/query/AST/FunctionSignature.h
+++ b/query/AST/FunctionSignature.h
@@ -70,6 +70,10 @@ public:
 
     bool isV3Only() const { return _isV3Only; }
 
+    // Whether the list this returns holds the values of its own argument, so a caller
+    // reading an element back knows the type it has - collect, and nothing else today.
+    bool collectsItsArgument() const { return _collectsItsArgument; }
+
     size_t getMinArgCount() const { return _requiredArgCount; }
 
     void setArguments(ArgumentTypes&& args) {
@@ -88,6 +92,8 @@ public:
 
     void setIsV3Only(bool v3Only) { _isV3Only = v3Only; }
 
+    void setCollectsItsArgument(bool collects) { _collectsItsArgument = collects; }
+
 private:
     std::string_view _fullName;
     ArgumentTypes _argumentTypes;
@@ -95,6 +101,7 @@ private:
     size_t _requiredArgCount {0};
     bool _isAggregate {false};
     bool _isProcedure {false};
+    bool _collectsItsArgument {false};
 
     // An overload only the MLIR engine answers: the legacy planner either cannot lay its
     // argument out or reduces it over the wrong rows, so it never matches there

--- a/query/AST/decl/ListShape.cpp
+++ b/query/AST/decl/ListShape.cpp
@@ -1,0 +1,46 @@
+#include "ListShape.h"
+
+using namespace db;
+
+ListShape::ListShape() {
+}
+
+ListShape::ListShape(EvaluatedType leafType, size_t depth)
+    : _leafType(leafType),
+    _depth(depth)
+{
+}
+
+EvaluatedType ListShape::unwoundType() const {
+    if (_depth > 1) {
+        return EvaluatedType::List;
+    }
+
+    if (_depth == 1 && _leafType != EvaluatedType::Invalid) {
+        return _leafType;
+    }
+
+    return EvaluatedType::ListItem;
+}
+
+ListShape ListShape::unwound() const {
+    if (_depth <= 1) {
+        return ListShape();
+    }
+
+    return ListShape(_leafType, _depth - 1);
+}
+
+ListShape ListShape::collecting(EvaluatedType type, const ListShape& shape) {
+    if (type == EvaluatedType::List) {
+        return ListShape(shape.getLeafType(), shape.getDepth() + 1);
+    }
+
+    // A tagged scalar names no type its list could be homogeneous in, so the list it
+    // gathers into hands tagged scalars back out.
+    if (type == EvaluatedType::ListItem) {
+        return ListShape(EvaluatedType::Invalid, 1);
+    }
+
+    return ListShape(type, 1);
+}

--- a/query/AST/decl/ListShape.cpp
+++ b/query/AST/decl/ListShape.cpp
@@ -14,9 +14,7 @@ ListShape::ListShape(EvaluatedType leafType, size_t depth)
 EvaluatedType ListShape::unwoundType() const {
     if (_depth > 1) {
         return EvaluatedType::List;
-    }
-
-    if (_depth == 1 && _leafType != EvaluatedType::Invalid) {
+    } else if (_depth == 1 && _leafType != EvaluatedType::Invalid) {
         return _leafType;
     }
 
@@ -34,11 +32,9 @@ ListShape ListShape::unwound() const {
 ListShape ListShape::collecting(EvaluatedType type, const ListShape& shape) {
     if (type == EvaluatedType::List) {
         return ListShape(shape.getLeafType(), shape.getDepth() + 1);
-    }
-
-    // A tagged scalar names no type its list could be homogeneous in, so the list it
-    // gathers into hands tagged scalars back out.
-    if (type == EvaluatedType::ListItem) {
+    } else if (type == EvaluatedType::ListItem) {
+        // A tagged scalar names no type its list could be homogeneous in, so the list it
+        // gathers into hands tagged scalars back out.
         return ListShape(EvaluatedType::Invalid, 1);
     }
 

--- a/query/AST/decl/ListShape.h
+++ b/query/AST/decl/ListShape.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "decl/EvaluatedType.h"
+
+namespace db {
+
+/**
+ * @brief How deeply a list-typed expression nests, and the one type its innermost
+ * elements share.
+ *
+ * A list is homogeneous or it is nothing: either every element carries the same type -
+ * at every level - or the list hands out tagged scalars and the leaf type is Invalid.
+ * That makes a nested list type two numbers rather than a tree: `[[1, 2], [3]]` is depth
+ * 2 over Integer, and it is the shape an UNWIND reads to know what it binds.
+ */
+class ListShape {
+public:
+    ListShape();
+    ListShape(EvaluatedType leafType, size_t depth);
+
+    EvaluatedType getLeafType() const { return _leafType; }
+    size_t getDepth() const { return _depth; }
+
+    bool isList() const { return _depth > 0; }
+
+    // The type one UNWIND of this shape binds its variable to, and the shape that
+    // variable then has: a list one level shallower, or the leaf type at the bottom.
+    // A leaf no type names binds a tagged scalar, as does unwinding a non-list.
+    EvaluatedType unwoundType() const;
+    ListShape unwound() const;
+
+    // The shape a collect of an expression of @param type and @param shape gathers into:
+    // one level deeper than what it collects.
+    static ListShape collecting(EvaluatedType type, const ListShape& shape);
+
+private:
+    EvaluatedType _leafType {EvaluatedType::Invalid};
+    size_t _depth {0};
+};
+
+}

--- a/query/AST/decl/VarDecl.h
+++ b/query/AST/decl/VarDecl.h
@@ -3,6 +3,7 @@
 #include <string_view>
 
 #include "decl/EvaluatedType.h"
+#include "decl/ListShape.h"
 
 namespace db {
 
@@ -22,13 +23,22 @@ public:
     void setIsUnwound(bool isUnwound) { _isUnwound = isUnwound; }
     void setType(EvaluatedType type) { _type = type; }
 
+    void setListShape(const ListShape& shape) { _listShape = shape; }
+
     EvaluatedType getType() const { return _type; }
+
+    // How deeply a List-typed variable nests and what its innermost elements are. A
+    // barrier publishes it beside the type, so an UNWIND behind the barrier binds its
+    // variable to the elements' own type rather than to tagged scalars.
+    const ListShape& getListShape() const { return _listShape; }
+
     const std::string_view& getName() const { return _name; }
     bool isUnnamed() const { return _isUnnamed; }
     bool isUnwound() const { return _isUnwound; }
 
 private:
     EvaluatedType _type {EvaluatedType::Invalid};
+    ListShape _listShape;
     std::string_view _name;
     bool _isUnnamed {false};
     bool _isUnwound {false};

--- a/query/AST/expr/Expr.h
+++ b/query/AST/expr/Expr.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "decl/EvaluatedType.h"
+#include "decl/ListShape.h"
 
 #include "EnumToString.h"
 
@@ -41,6 +42,10 @@ public:
 
     virtual EvaluatedType getType() const { return _type; }
 
+    // How deeply a List-typed expression nests and what its innermost elements are.
+    // What an UNWIND of this expression binds its variable to.
+    const ListShape& getListShape() const { return _listShape; }
+
     const VarDecl* getExprVarDecl() const { return _exprVarDecl; }
 
     std::string_view getName() const {
@@ -48,6 +53,8 @@ public:
     }
 
     void setType(EvaluatedType type) { _type = type; }
+
+    void setListShape(const ListShape& shape) { _listShape = shape; }
 
     void setExprVarDecl(const VarDecl* decl) { _exprVarDecl = decl; }
 
@@ -88,6 +95,7 @@ private:
     const VarDecl* _exprVarDecl {nullptr};
     Kind _exprKind {Kind::BINARY};
     EvaluatedType _type {EvaluatedType::Invalid};
+    ListShape _listShape;
     Flags _flags {Flags::NONE};
     std::string_view _name;
 };

--- a/query/AST/stmt/UnwindStmt.cpp
+++ b/query/AST/stmt/UnwindStmt.cpp
@@ -1,10 +1,36 @@
 #include "UnwindStmt.h"
 
+#include <algorithm>
+
 #include "CypherAST.h"
+#include "Literal.h"
+#include "expr/LiteralExpr.h"
 
 using namespace db;
 
+namespace {
+
+bool isLiteralExpr(const Expr* expr) {
+    if (expr->getKind() != Expr::Kind::LITERAL) {
+        return false;
+    }
+
+    const Literal* literal = static_cast<const LiteralExpr*>(expr)->getLiteral();
+    if (literal->getKind() != Literal::Kind::LIST) {
+        return true;
+    }
+
+    const ListLiteral::Items& items = static_cast<const ListLiteral*>(literal)->items();
+    return std::ranges::all_of(items, isLiteralExpr);
+}
+
+}
+
 UnwindStmt::~UnwindStmt() {
+}
+
+bool UnwindStmt::unwindsLiteral() const {
+    return isLiteralExpr(_arg);
 }
 
 UnwindStmt* UnwindStmt::create(CypherAST* ast, Expr* expr, Symbol* sym) {

--- a/query/AST/stmt/UnwindStmt.h
+++ b/query/AST/stmt/UnwindStmt.h
@@ -15,11 +15,16 @@ public:
 
     Kind getKind() const final { return Kind::UNWIND; }
 
-    const Expr* arg() const { return _arg; }
+    Expr* arg() const { return _arg; }
     const Symbol* symbol() const { return _symbol; }
     const VarDecl* getDecl() const { return _decl; }
 
     void setDecl(const VarDecl* decl) { _decl = decl; }
+
+    /// Whether every row this UNWIND emits is known at plan time: the argument is a
+    /// literal, and a list literal's items are literals too, at any depth. Anything else
+    /// is evaluated per row, against the rows already in flight.
+    bool unwindsLiteral() const;
 
 private:
     Expr* _arg {nullptr};

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -314,7 +314,9 @@ void CypherAnalyzer::openWithScope(Projection* projection) {
     for (const Projection::ReturnItem& returnItem : projection->items()) {
         if (const auto* declPtr = std::get_if<VarDecl*>(&returnItem)) {
             const VarDecl* decl = *declPtr;
-            projection->addPublishedDecl(scope->getOrCreateNamedVariable(_ast, decl->getType(), decl->getName()));
+            VarDecl* published = scope->getOrCreateNamedVariable(_ast, decl->getType(), decl->getName());
+            published->setListShape(decl->getListShape());
+            projection->addPublishedDecl(published);
             continue;
         }
 
@@ -322,7 +324,9 @@ void CypherAnalyzer::openWithScope(Projection* projection) {
         const std::optional<std::string_view> name = projection->getName(item);
         bioassert(name.has_value(), "Projected item of a WITH without a name.");
 
-        projection->addPublishedDecl(scope->getOrCreateNamedVariable(_ast, item->getType(), *name));
+        VarDecl* published = scope->getOrCreateNamedVariable(_ast, item->getType(), *name);
+        published->setListShape(item->getListShape());
+        projection->addPublishedDecl(published);
     }
 
     _ctxt = scope;

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -26,6 +26,50 @@
 
 using namespace db;
 
+namespace {
+
+// The shape of the list these elements make: depth 1 over the one type they share, or
+// one level deeper than the lists they are. Elements that share no type - an empty list,
+// a mix of types, lists of differing shape - leave the leaf Invalid, which is what makes
+// the list hand out tagged scalars.
+ListShape sharedListShape(std::span<Expr* const> elements) {
+    if (elements.empty()) {
+        return ListShape(EvaluatedType::Invalid, 1);
+    }
+
+    const auto differingType = [](const Expr* a, const Expr* b) {
+        return a->getType() != b->getType();
+    };
+
+    const bool homogeneous = std::ranges::adjacent_find(elements, differingType) == end(elements);
+    if (!homogeneous) {
+        return ListShape(EvaluatedType::Invalid, 1);
+    }
+
+    const Expr* first = elements.front();
+    const EvaluatedType shared = first->getType();
+
+    if (shared == EvaluatedType::List) {
+        const auto differingShape = [](const Expr* a, const Expr* b) {
+            const ListShape& left = a->getListShape();
+            const ListShape& right = b->getListShape();
+            return left.getDepth() != right.getDepth() || left.getLeafType() != right.getLeafType();
+        };
+
+        if (std::ranges::adjacent_find(elements, differingShape) != end(elements)) {
+            return ListShape(EvaluatedType::Invalid, 1);
+        }
+    }
+
+    if (!convertibleToValueType(shared) && shared != EvaluatedType::List) {
+        return ListShape(EvaluatedType::Invalid, 1);
+    }
+
+    return ListShape::collecting(shared, first->getListShape());
+}
+
+}
+
 ExprAnalyzer::ExprAnalyzer(CypherAST* ast, const GraphView& graphView)
     : _ast(ast),
     _graphView(graphView),
@@ -380,6 +424,7 @@ void ExprAnalyzer::analyzeSymbolExpr(SymbolExpr* expr) {
 
     expr->setDecl(varDecl);
     expr->setType(varDecl->getType());
+    expr->setListShape(varDecl->getListShape());
     expr->setExprVarDecl(varDecl);
 
     // For now, variable expressions cannot be evaluated at compile time
@@ -808,6 +853,13 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
             expr->setType(EvaluatedType::Tuple);
         }
 
+        // A collect's list holds the values of its argument, so it is one level deeper
+        // than what it gathers - what an UNWIND of the list binds its variable to.
+        if (signature->collectsItsArgument() && !providedArgs.empty()) {
+            const Expr* collected = providedArgs.front();
+            expr->setListShape(ListShape::collecting(collected->getType(), collected->getListShape()));
+        }
+
         if (signature->isAggregate()) {
             if (isAggregate) {
                 throwError(fmt::format("Aggregate functions may not be nested: the argument of "
@@ -963,6 +1015,8 @@ void ExprAnalyzer::analyzeListElements(Expr* expr, std::span<Expr* const> elemen
             expr->setAggregate();
         }
     }
+
+    expr->setListShape(sharedListShape(elements));
 }
 
 void ExprAnalyzer::analyzeMapEntries(Expr* expr, const MapLiteral* map) {

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -944,14 +944,13 @@ void ExprAnalyzer::analyzeListExpr(ListExpr* expr) {
 
 void ExprAnalyzer::analyzeListElements(Expr* expr, std::span<Expr* const> elements) {
     for (Expr* element : elements) {
-        const Expr::Kind elementKind = element->getKind();
-        const bool elementLiteral = elementKind == Expr::Kind::LITERAL;
+        // Analyzed before the literal check, so an element that is ill-formed - a name no
+        // pattern declares - is reported as that rather than as the gap it also falls in
+        analyzeExpr(element);
 
-        if (!elementLiteral) {
+        if (element->getKind() != Expr::Kind::LITERAL) {
             throwError("Non-literal list elements are not yet supported", element);
         }
-
-        analyzeExpr(element);
 
         // An element is an expression of its own, so its flags are the list's. Elements
         // are literals today, and a map literal is one: the {age: n.age} of

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -665,11 +665,21 @@ void ExprAnalyzer::analyzeStringExpr(StringExpr* expr) {
     analyzeExpr(lhs);
     analyzeExpr(rhs);
 
-    if (lhs->getType() != EvaluatedType::String || rhs->getType() != EvaluatedType::String) {
+    const EvaluatedType lhsType = lhs->getType();
+    const EvaluatedType rhsType = rhs->getType();
+
+    // A type-erased cell carries its own type, so the characters it holds are read row by
+    // row, exactly as an equality against one is. Only the MLIR engine runs such a test.
+    const bool lhsReadsAsString = lhsType == EvaluatedType::String
+                               || (_isV3 && lhsType == EvaluatedType::ListItem);
+    const bool rhsReadsAsString = rhsType == EvaluatedType::String
+                               || (_isV3 && rhsType == EvaluatedType::ListItem);
+
+    if (!lhsReadsAsString || !rhsReadsAsString) {
         const std::string error = fmt::format(
             "String expressions operands must be strings, not '{}' and '{}'",
-            EvaluatedTypeName::value(lhs->getType()),
-            EvaluatedTypeName::value(rhs->getType()));
+            EvaluatedTypeName::value(lhsType),
+            EvaluatedTypeName::value(rhsType));
 
         throwError(error, expr);
     }

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -1,5 +1,6 @@
 #include "ReadStmtAnalyzer.h"
 
+#include <algorithm>
 #include <string_view>
 
 #include "AnalyzeException.h"
@@ -52,6 +53,54 @@
 #include "FatalException.h"
 
 using namespace db;
+
+namespace {
+
+// A tagged scalar carries its type per row rather than in the plan, so no property type
+// rules it out: the comparison the constraint becomes settles it row by row, as the same
+// test written as a WHERE does.
+bool constraintTypeCompatible(ValueType propertyType, EvaluatedType exprType) {
+    return exprType == EvaluatedType::ListItem
+           || ExprAnalyzer::propTypeCompatible(propertyType, exprType);
+}
+
+// The type each row an UNWIND emits carries: the one type a homogeneous literal list's
+// elements share, the type of anything that is not a list (spread to its singleton), and
+// otherwise a tagged scalar, since a list carries no element type of its own.
+EvaluatedType unwoundItemType(const Expr* arg) {
+    if (arg->getType() != EvaluatedType::List) {
+        return arg->getType();
+    }
+
+    if (arg->getKind() != Expr::Kind::LITERAL) {
+        return EvaluatedType::ListItem;
+    }
+
+    const Literal* literal = static_cast<const LiteralExpr*>(arg)->getLiteral();
+    if (literal->getKind() != Literal::Kind::LIST) {
+        return EvaluatedType::ListItem;
+    }
+
+    const ListLiteral::Items& items = static_cast<const ListLiteral*>(literal)->items();
+    if (items.empty()) {
+        return EvaluatedType::ListItem;
+    }
+
+    const auto differingType = [](const Expr* a, const Expr* b) {
+        return a->getType() != b->getType();
+    };
+
+    const bool homogeneous = std::ranges::adjacent_find(items, differingType) == end(items);
+    if (!homogeneous) {
+        return EvaluatedType::ListItem;
+    }
+
+    // A list of lists has no ValueType to restrict to, so it stays tagged scalars
+    const EvaluatedType homogeneity = items.front()->getType();
+    return convertibleToValueType(homogeneity) ? homogeneity : EvaluatedType::ListItem;
+}
+
+}
 
 ReadStmtAnalyzer::ReadStmtAnalyzer(CypherAST* ast, GraphView graphView)
     : _ast(ast),
@@ -381,7 +430,7 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
                 throwError(fmt::format("Unknown property: {}", propName->getName()), nodePattern);
             }
 
-            if (!ExprAnalyzer::propTypeCompatible(propType->_valueType, expr->getType())) {
+            if (!constraintTypeCompatible(propType->_valueType, expr->getType())) {
                 throwError(fmt::format("Cannot evaluate node property: types '{}' and '{}' are incompatible",
                                        ValueTypeName::value(propType->_valueType),
                                        EvaluatedTypeName::value(expr->getType())),
@@ -452,7 +501,7 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
                 throwError(fmt::format("Unknown property: {}", propName->getName()), edgePattern);
             }
 
-            if (!ExprAnalyzer::propTypeCompatible(propType->_valueType, expr->getType())) {
+            if (!constraintTypeCompatible(propType->_valueType, expr->getType())) {
                 throwError(fmt::format("Cannot evaluate edge property: types '{}' and '{}' are incompatible",
                                        ValueTypeName::value(propType->_valueType),
                                        EvaluatedTypeName::value(expr->getType())),
@@ -592,63 +641,10 @@ void ReadStmtAnalyzer::analyze(const ShortestPathStmt* spSt) {
 }
 
 void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
-    const Expr* arg = unwind->arg();
+    Expr* arg = unwind->arg();
     bioassert(arg, "Invalid argument");
 
-    {
-        const Expr::Kind argKind = arg->getKind();
-        const bool isLiteral = argKind == Expr::Kind::LITERAL;
-
-        if (!isLiteral) {
-            throwError("Non-literal UNWIND expressions are not yet supported.", arg);
-        }
-    }
-
-    const auto* litArg = static_cast<const LiteralExpr*>(arg);
-
-    const Literal* lit = litArg->getLiteral();
-    bioassert(lit, "Invalid literal.");
-
-    const Literal::Kind litKind = lit->getKind();
-    const bool isList = litKind == Literal::Kind::LIST;
-
-    /// Non-lists can be unwound, it just turns the argument into a singleton list
-    if (!isList) {
-        // TODO: Implement
-        throwError("Non-list arguments to UNWIND are not yet supported", litArg);
-    }
-
-    const auto* list = static_cast<const ListLiteral*>(lit);
-    const ListLiteral::Items& items = list->items();
-    for (Expr* ele : items) {
-        _exprAnalyzer->analyzeExpr(ele);
-    }
-
-    EvaluatedType itemType = EvaluatedType::ListItem;
-    if (!items.empty()) {
-        // Check for homogeneity: update evaluated type if found
-        const auto differingType = [](const Expr* a, const Expr* b) {
-            return a->getType() != b->getType();
-        };
-
-        const auto typeIt = std::ranges::adjacent_find(items, differingType);
-        const bool homogeneous = typeIt == end(items);
-
-        if (homogeneous) {
-            // List is homogeneous and non empty: perform type restriction
-            const Expr* item = items.front();
-            const EvaluatedType homogeneity = item->getType();
-            // Could be a list of lists: there is no ValueType::List -> do not treat as
-            // homogeneous
-            const bool isValueType = convertibleToValueType(homogeneity);
-
-            const bool canBeHomogeneous = isValueType;
-
-            if (canBeHomogeneous) {
-                itemType = homogeneity;
-            }
-        }
-    }
+    _exprAnalyzer->analyzeExpr(arg);
 
     const Symbol* symbol = unwind->symbol();
     bioassert(symbol, "Invalid symbol.");
@@ -661,7 +657,7 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
         throwError(fmt::format("Variable '{}' is already declared", symName), unwind);
     }
 
-    VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, itemType, symName);
+    VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, unwoundItemType(arg), symName);
     decl->setIsUnwound(true);
 
     unwind->setDecl(decl);

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -1,6 +1,5 @@
 #include "ReadStmtAnalyzer.h"
 
-#include <algorithm>
 #include <string_view>
 
 #include "AnalyzeException.h"
@@ -64,40 +63,15 @@ bool constraintTypeCompatible(ValueType propertyType, EvaluatedType exprType) {
            || ExprAnalyzer::propTypeCompatible(propertyType, exprType);
 }
 
-// The type each row an UNWIND emits carries: the one type a homogeneous literal list's
-// elements share, the type of anything that is not a list (spread to its singleton), and
-// otherwise a tagged scalar, since a list carries no element type of its own.
+// The type each row an UNWIND emits carries: one level out of a list's shape - however
+// the list was built - and the type of anything that is not a list, spread to its
+// singleton.
 EvaluatedType unwoundItemType(const Expr* arg) {
     if (arg->getType() != EvaluatedType::List) {
         return arg->getType();
     }
 
-    if (arg->getKind() != Expr::Kind::LITERAL) {
-        return EvaluatedType::ListItem;
-    }
-
-    const Literal* literal = static_cast<const LiteralExpr*>(arg)->getLiteral();
-    if (literal->getKind() != Literal::Kind::LIST) {
-        return EvaluatedType::ListItem;
-    }
-
-    const ListLiteral::Items& items = static_cast<const ListLiteral*>(literal)->items();
-    if (items.empty()) {
-        return EvaluatedType::ListItem;
-    }
-
-    const auto differingType = [](const Expr* a, const Expr* b) {
-        return a->getType() != b->getType();
-    };
-
-    const bool homogeneous = std::ranges::adjacent_find(items, differingType) == end(items);
-    if (!homogeneous) {
-        return EvaluatedType::ListItem;
-    }
-
-    // A list of lists has no ValueType to restrict to, so it stays tagged scalars
-    const EvaluatedType homogeneity = items.front()->getType();
-    return convertibleToValueType(homogeneity) ? homogeneity : EvaluatedType::ListItem;
+    return arg->getListShape().unwoundType();
 }
 
 }
@@ -657,10 +631,14 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
         throwError(fmt::format("Variable '{}' is already declared", symName), unwind);
     }
 
-    VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, unwoundItemType(arg), symName);
-    decl->setIsUnwound(true);
+    VarDecl* itemDecl = _ctxt->getOrCreateNamedVariable(_ast, unwoundItemType(arg), symName);
+    itemDecl->setIsUnwound(true);
 
-    unwind->setDecl(decl);
+    unwind->setDecl(itemDecl);
+
+    // Unwinding a list of lists leaves a list, so the variable carries the shape it has
+    // left: what a second UNWIND of it reads to know its own elements.
+    itemDecl->setListShape(arg->getListShape().unwound());
 }
 
 void ReadStmtAnalyzer::throwError(std::string_view msg, const void* obj) const {

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -620,6 +620,10 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
 
     _exprAnalyzer->analyzeExpr(arg);
 
+    if (arg->isAggregate()) {
+        throwError("Invalid use of aggregate expression in this context", unwind);
+    }
+
     const Symbol* symbol = unwind->symbol();
     bioassert(symbol, "Invalid symbol.");
 

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -624,6 +624,8 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
         throwError("Invalid use of aggregate expression in this context", unwind);
     }
 
+    throwOnNonListLiteral(arg);
+
     const Symbol* symbol = unwind->symbol();
     bioassert(symbol, "Invalid symbol.");
 
@@ -643,6 +645,25 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
     // Unwinding a list of lists leaves a list, so the variable carries the shape it has
     // left: what a second UNWIND of it reads to know its own elements.
     itemDecl->setListShape(arg->getListShape().unwound());
+}
+
+void ReadStmtAnalyzer::throwOnNonListLiteral(const Expr* arg) const {
+    if (arg->getKind() != Expr::Kind::LITERAL) {
+        return;
+    }
+
+    const Literal::Kind literalKind = static_cast<const LiteralExpr*>(arg)->getLiteral()->getKind();
+    const bool unwindsAList = literalKind == Literal::Kind::LIST;
+
+    // Unwinding null yields no row rather than a type error, so it is the one literal
+    // that is no list and still passes
+    const bool unwindsNull = literalKind == Literal::Kind::NULL_LITERAL;
+
+    if (!unwindsAList && !unwindsNull) {
+        throwError(fmt::format("UNWIND requires a list, not '{}'",
+                               EvaluatedTypeName::value(arg->getType())),
+                   arg);
+    }
 }
 
 void ReadStmtAnalyzer::throwError(std::string_view msg, const void* obj) const {

--- a/query/analyzer/ReadStmtAnalyzer.h
+++ b/query/analyzer/ReadStmtAnalyzer.h
@@ -27,6 +27,7 @@ class ShortestPathStmt;
 class GraphMetadata;
 class UnwindStmt;
 class YieldItems;
+class Expr;
 
 class ReadStmtAnalyzer {
 public:
@@ -74,6 +75,11 @@ private:
     // The predicate a YIELD ... WHERE filters the rows its statement produced with. Shared
     // by every statement that yields, since what a yield binds is what the predicate reads.
     void analyzeYieldFilter(const YieldItems* yieldItems);
+
+    // Rejects a literal UNWIND argument that is no list: a literal carries its type at
+    // plan time, so anything but a list - null aside, which unwinds into no row - is a
+    // type error rather than a value to spread over rows
+    void throwOnNonListLiteral(const Expr* arg) const;
 
     [[noreturn]] void throwError(std::string_view msg, const void* obj = 0) const;
 };

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -562,10 +562,24 @@ void DBProgramGenerator::addConstScanNodes(const VariableDependency* var, const 
 void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind) {
     bioassert(!_part._varMap.contains(var), "UnwindConst for registered variable");
 
-    const ListLiteral* list = unwindListOrThrow(unwind);
+    // Only a literal UNWIND opens a dataflow of its own, and the dependency graph roots no
+    // other kind here, so anything else is hand-built input this path cannot lower.
+    const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
+    if (!literalExpr) {
+        throw TuringException("A non-literal UNWIND expression does not open a dataflow of its own.");
+    }
+
+    // A list unwinds into its elements; any other literal is the single row that value is,
+    // and a null into no row at all.
+    const Literal* literal = literalExpr->getLiteral();
+    const Literal::Kind literalKind = literal->getKind();
 
     llvm::SmallVector<mlir::Attribute> elements;
-    translateListElements(list, elements);
+    if (literalKind == Literal::Kind::LIST) {
+        translateListElements(static_cast<const ListLiteral*>(literal), elements);
+    } else if (literalKind != Literal::Kind::NULL_LITERAL) {
+        elements.push_back(listElementAttr(literal));
+    }
 
     const mlir::Type sharedType = sharedAttrType(elements);
     const mlir::Type elementType = sharedType ? sharedType
@@ -881,8 +895,7 @@ void DBProgramGenerator::generatePart(std::span<Stmt* const> stmts) {
     closeBoundMerges();
     resolveEdgeIdentities();
     generateCSVLoads(stmts);
-    generatePropertyConstraints(stmts);
-    generateFiltersCallsAndSearches(stmts);
+    generateStatementOperations(stmts);
     resolveYieldedIdentities();
 }
 
@@ -1849,10 +1862,11 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
     _part._drivenRoot = drivenRoot;
 }
 
-void DBProgramGenerator::generateFiltersCallsAndSearches(std::span<Stmt* const> stmts) {
+void DBProgramGenerator::generateStatementOperations(std::span<Stmt* const> stmts) {
     // In statement order, so a call or a search reading what an earlier one yielded sees
-    // it, and a MATCH's WHERE reading a yielded value is generated once the statement has
-    // bound it - the reading statements are generated in the order the query writes them.
+    // it, a MATCH's constraints and WHERE reading a yielded or unwound value are generated
+    // once the statement that binds it has run, and an UNWIND expands the rows the
+    // statements ahead of it left in flight.
     bool matchSeen = false;
     for (const Stmt* stmt : stmts) {
         const Stmt::Kind kind = stmt->getKind();
@@ -1862,6 +1876,7 @@ void DBProgramGenerator::generateFiltersCallsAndSearches(std::span<Stmt* const> 
             matchSeen = true;
 
             const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
+            generateMatchConstraints(matchStmt);
             generateMatchFilter(matchStmt);
             generateMatchOrderBy(matchStmt);
             generateMatchWindow(matchStmt);
@@ -1869,6 +1884,14 @@ void DBProgramGenerator::generateFiltersCallsAndSearches(std::span<Stmt* const> 
             generateCall(static_cast<const CallStmt*>(stmt));
         } else if (kind == Stmt::Kind::VECTOR_SEARCH && !drivesTheTraversal) {
             generateVectorSearch(static_cast<const VectorSearchStmt*>(stmt));
+        } else if (kind == Stmt::Kind::UNWIND) {
+            const UnwindStmt* unwindStmt = static_cast<const UnwindStmt*>(stmt);
+
+            // A literal UNWIND opened a dataflow of its own during the traversal, which
+            // the cross product has already paired with the rows beside it.
+            if (!unwindStmt->unwindsLiteral()) {
+                generateUnwind(unwindStmt);
+            }
         }
     }
 }
@@ -2024,7 +2047,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
             // is what the call op names; the symbol's name is what the query calls it,
             // which is the alias when the YIELD renamed it.
             yieldedNames.push_back(_opBuilder.getStringAttr(symbol->getOriginalName()));
-            yielded.push_back({item->getDecl(), symbol->getName(), mlir::Value {}});
+            yielded.push_back({item->getDecl(), symbol->getName(), mlir::Value {}, /*isResult=*/true});
         }
     } else {
         // A call naming no return value produces every one the procedure declares, under
@@ -2033,7 +2056,7 @@ void DBProgramGenerator::generateCall(const CallStmt* callStmt) {
         // gets here: the analyzer requires a YIELD of any call inside a query.
         for (const FunctionReturnType& returnType : signature->returnTypes()) {
             yieldedNames.push_back(_opBuilder.getStringAttr(returnType.getName()));
-            yielded.push_back({nullptr, returnType.getName(), mlir::Value {}});
+            yielded.push_back({nullptr, returnType.getName(), mlir::Value {}, /*isResult=*/true});
         }
     }
 
@@ -2307,8 +2330,45 @@ void DBProgramGenerator::publishVectorSearchYields(const YieldItems* yieldItems,
         // the column, and the analyzer has already rejected every name but these two.
         const bool isScore = symbol->getOriginalName() == vectorSearchScoreYield;
 
-        _part._yieldedColumns.push_back({item->getDecl(), symbol->getName(), isScore ? scores : ids});
+        _part._yieldedColumns.push_back({item->getDecl(),
+                                         symbol->getName(),
+                                         isScore ? scores : ids,
+                                         /*isResult=*/true});
     }
+}
+
+void DBProgramGenerator::generateUnwind(const UnwindStmt* unwind) {
+    const Symbol* symbol = unwind->symbol();
+    bioassert(symbol, "UNWIND without a variable.");
+
+    VariableColumnMap variableColumns;
+    collectVariableColumns(variableColumns);
+
+    const mlir::Value source = getOrTranslateExprColumn(variableColumns, unwind->arg());
+
+    // Everything already in flight rides through the carry set, replicated once per row
+    // the cell beside it unwound into, so the rest of the query still reads it row-aligned
+    // with the elements.
+    InFlightColumns inFlight;
+    collectInFlightColumns(inFlight);
+
+    // The element column's value type is the source's to decide and is resolved during
+    // lowering, as a property fetch's value column is. A carried column keeps its own
+    // type: the unwind replicates its rows, it never retypes them.
+    llvm::SmallVector<mlir::Type> resultTypes {mlir::db::ColumnType::get(_mlirCtxt)};
+    for (const mlir::Value column : inFlight._columns) {
+        resultTypes.push_back(column.getType());
+    }
+
+    auto unwindOp = _opBuilder.create<mlir::db::Unwind>(_opBuilder.getUnknownLoc(),
+                                                        resultTypes,
+                                                        source,
+                                                        mlir::ValueRange {inFlight._columns});
+
+    const mlir::Operation::result_range results = unwindOp.getResults();
+    rebindInFlightColumns(results, /*firstResult=*/1, inFlight);
+
+    _part._yieldedColumns.push_back({unwind->getDecl(), symbol->getName(), results[0], /*isResult=*/false});
 }
 
 void DBProgramGenerator::generateYieldFilter(const YieldItems* yieldItems) {
@@ -2817,6 +2877,12 @@ void DBProgramGenerator::generateYieldedOutput(const SinglePartQuery* query) {
     llvm::SmallVector<mlir::Value> yielded;
     llvm::SmallVector<llvm::StringRef> yieldedNames;
     for (const YieldedColumn& yieldedColumn : _part._yieldedColumns) {
+        // An UNWIND's elements ride here so the rest of the part reads them, but they are
+        // no result of their own: a query with no projection returns nothing.
+        if (!yieldedColumn._isResult) {
+            continue;
+        }
+
         yielded.push_back(yieldedColumn._column);
         yieldedNames.push_back(llvm::StringRef(yieldedColumn._name.data(), yieldedColumn._name.size()));
     }
@@ -3286,48 +3352,39 @@ void DBProgramGenerator::applyPredicateFilters(std::span<const Expr* const> pred
     }
 }
 
-void DBProgramGenerator::generatePropertyConstraints(std::span<Stmt* const> stmts) {
+void DBProgramGenerator::generateMatchConstraints(const MatchStmt* matchStmt) {
+    const Pattern* pattern = matchStmt->getPattern();
+
     std::vector<const Expr*> constraintExprs;
 
-    for (const Stmt* stmt : stmts) {
-        if (stmt->getKind() != Stmt::Kind::MATCH) {
-            continue;
+    for (const PatternElement* element : pattern->elements()) {
+        const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
+        const NodePatternData* rootData = rootNode->getData();
+
+        if (rootData) {
+            for (const EntityPropertyConstraint& constraint : rootData->exprConstraints()) {
+                constraintExprs.push_back(constraint._expr);
+            }
         }
 
-        const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
-        const Pattern* pattern = matchStmt->getPattern();
-
-        constraintExprs.clear();
-
-        for (const PatternElement* element : pattern->elements()) {
-            const NodePattern* rootNode = static_cast<const NodePattern*>(element->getRootEntity());
-            const NodePatternData* rootData = rootNode->getData();
-
-            if (rootData) {
-                for (const EntityPropertyConstraint& constraint : rootData->exprConstraints()) {
+        for (auto [edgePattern, nodePattern] : element->getElementChain()) {
+            const EdgePatternData* edgeData = edgePattern->getData();
+            if (edgeData) {
+                for (const EntityPropertyConstraint& constraint : edgeData->exprConstraints()) {
                     constraintExprs.push_back(constraint._expr);
                 }
             }
 
-            for (auto [edgePattern, nodePattern] : element->getElementChain()) {
-                const EdgePatternData* edgeData = edgePattern->getData();
-                if (edgeData) {
-                    for (const EntityPropertyConstraint& constraint : edgeData->exprConstraints()) {
-                        constraintExprs.push_back(constraint._expr);
-                    }
-                }
-
-                const NodePatternData* nodeData = nodePattern->getData();
-                if (nodeData) {
-                    for (const EntityPropertyConstraint& constraint : nodeData->exprConstraints()) {
-                        constraintExprs.push_back(constraint._expr);
-                    }
+            const NodePatternData* nodeData = nodePattern->getData();
+            if (nodeData) {
+                for (const EntityPropertyConstraint& constraint : nodeData->exprConstraints()) {
+                    constraintExprs.push_back(constraint._expr);
                 }
             }
         }
-
-        applyPredicateFilters(constraintExprs);
     }
+
+    applyPredicateFilters(constraintExprs);
 }
 
 void DBProgramGenerator::applyConstraints(const VariableDependency* var) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2271,8 +2271,8 @@ void DBProgramGenerator::generateVectorSearch(const VectorSearchStmt* vectorSear
     const mlir::DenseF32ArrayAttr queryVectorAttr =
         _opBuilder.getDenseF32ArrayAttr(llvm::ArrayRef<float> {queryValues.data(), queryValues.size()});
 
-    const llvm::StringRef indexName {vectorSearchStmt->getIndexName().data(),
-                                     vectorSearchStmt->getIndexName().size()};
+    const std::string_view searchedIndex = vectorSearchStmt->getIndexName();
+    const llvm::StringRef indexName {searchedIndex.data(), searchedIndex.size()};
     const uint64_t neighbourCount = vectorSearchStmt->getK();
 
     const mlir::db::ColumnType idType = allocColumnType(mlir::storage::NodeIDType::get(_mlirCtxt));

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -879,6 +879,13 @@ bool DBProgramGenerator::closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* co
             return false;
         } else if (kind == Stmt::Kind::MATCH) {
             return true;
+        } else if (kind == Stmt::Kind::UNWIND) {
+            // A literal UNWIND opens a dataflow of its own, multiplying the rows the cut
+            // applies to exactly as a following MATCH does. One evaluated per row does not.
+            const UnwindStmt* unwindStmt = static_cast<const UnwindStmt*>(next);
+            if (unwindStmt->unwindsLiteral()) {
+                return true;
+            }
         }
     }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -149,15 +149,21 @@ const std::unordered_map<std::string_view, BinaryFunctionEmitter> binaryFunction
     {"euclidean_distance", &emitBinaryFunction<mlir::db::EuclideanDistance>},
 };
 
-// The analyzer restricts UNWIND to a literal list, so anything else here is a statement
-// it let through and neither of the sources built from one can lower.
-const ListLiteral* unwindListOrThrow(const UnwindStmt* unwind) {
+// The list a literal UNWIND spreads, null for the one literal that is no list and still
+// analyzes - `UNWIND null`, which spreads into no row. Anything else here is a statement
+// the analyzer let through and neither of the sources built from one can lower.
+const ListLiteral* literalUnwindList(const UnwindStmt* unwind) {
     const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
     if (!literalExpr) {
         throw TuringException("Non-literal UNWIND expressions are not yet supported.");
     }
 
-    const ListLiteral* list = dynamic_cast<const ListLiteral*>(literalExpr->getLiteral());
+    const Literal* literal = literalExpr->getLiteral();
+    if (literal->getKind() == Literal::Kind::NULL_LITERAL) {
+        return nullptr;
+    }
+
+    const ListLiteral* list = dynamic_cast<const ListLiteral*>(literal);
     if (!list) {
         throw TuringException("Non-list arguments to UNWIND are not yet supported.");
     }
@@ -536,10 +542,12 @@ void DBProgramGenerator::addYieldedColumn(const VariableDependency* var, mlir::V
 void DBProgramGenerator::addConstScanNodes(const VariableDependency* var, const UnwindStmt* unwind) {
     bioassert(!_part._varMap.contains(var), "ConstScanNodes for registered variable");
 
-    const ListLiteral* list = unwindListOrThrow(unwind);
+    const ListLiteral* list = literalUnwindList(unwind);
 
     llvm::SmallVector<mlir::Attribute> elements;
-    translateListElements(list, elements);
+    if (list) {
+        translateListElements(list, elements);
+    }
 
     llvm::SmallVector<int64_t> nodeIDs;
     nodeIDs.reserve(elements.size());
@@ -566,29 +574,11 @@ void DBProgramGenerator::addConstScanNodes(const VariableDependency* var, const 
 void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind) {
     bioassert(!_part._varMap.contains(var), "UnwindConst for registered variable");
 
-    // Only a literal UNWIND opens a dataflow of its own, and the dependency graph roots no
-    // other kind here, so anything else is hand-built input this path cannot lower.
-    const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
-    if (!literalExpr) {
-        throw TuringException("A non-literal UNWIND expression does not open a dataflow of its own.");
-    }
-
-    // A list unwinds into its elements; any other literal is the single row that value is,
-    // and a null into no row at all.
-    const Literal* literal = literalExpr->getLiteral();
-    const Literal::Kind literalKind = literal->getKind();
+    const ListLiteral* list = literalUnwindList(unwind);
 
     llvm::SmallVector<mlir::Attribute> elements;
-    if (literalKind == Literal::Kind::LIST) {
-        translateListElements(static_cast<const ListLiteral*>(literal), elements);
-    } else if (literalKind != Literal::Kind::NULL_LITERAL) {
-        const mlir::Attribute argument = literalAttr(literal);
-        if (!argument) {
-            throw TuringException("Only booleans, integers, floats, strings, nulls, embeddings and "
-                                  "lists are supported as an UNWIND argument.");
-        }
-
-        elements.push_back(argument);
+    if (list) {
+        translateListElements(list, elements);
     }
 
     const mlir::Type sharedType = sharedAttrType(elements);
@@ -935,6 +925,7 @@ void DBProgramGenerator::runPasses() {
     mlir::PassManager passManager(_mlirCtxt);
     passManager.addPass(mlir::db::createFuseScanByLabel());
     passManager.addPass(mlir::db::createPushDownFilters());
+    passManager.addPass(mlir::db::createFuseUnwindEquality());
     passManager.addPass(mlir::db::createFuseScanByNodeIDs());
     passManager.addPass(mlir::db::createTrimUnreadColumns());
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -225,6 +225,17 @@ const YieldClause* yieldClauseOf(const Stmt* stmt) {
     return static_cast<const VectorSearchStmt*>(stmt)->getYield();
 }
 
+// The variables a statement binds of its own: the return values a YIELD names, and the
+// element an UNWIND spreads.
+void collectStatementVariables(const Stmt* stmt, llvm::SmallVectorImpl<const VarDecl*>& variables) {
+    if (stmt->getKind() == Stmt::Kind::UNWIND) {
+        variables.push_back(static_cast<const UnwindStmt*>(stmt)->getDecl());
+        return;
+    }
+
+    collectYieldVariables(yieldClauseOf(stmt), variables);
+}
+
 // The ops values are transitively defined by: the chain that has to travel with them for
 // them to stay usable where they land.
 void collectDefiningOps(mlir::ValueRange values, llvm::DenseSet<mlir::Operation*>& ops) {
@@ -734,6 +745,27 @@ void DBProgramGenerator::walkEdge(const VariableDependency* src,
         results.push_back(column.getType());
     }
 
+    // A column a barrier published rides the expansion too, when the traversal it drives is
+    // generated where that column was bound: the hop replicates a row once per edge, so it
+    // comes along or it stops matching the rows beside it. A published pattern variable is
+    // walked by the component instead and is already in the carry set.
+    llvm::SmallVector<const VariableDependency*> carriedBound;
+    for (const VariableDependency* var : _vdg.boundVars()) {
+        const bool walkedHere = var == src || llvm::is_contained(carrySet, var);
+        if (walkedHere) {
+            continue;
+        }
+
+        const mlir::Value column = _part._varMap[var].back();
+        if (!isRowAlignedHere(column) || yieldsConstantColumn(column)) {
+            continue;
+        }
+
+        carriedBound.push_back(var);
+        operands.push_back(column);
+        results.push_back(column.getType());
+    }
+
     const auto loc = _opBuilder.getUnknownLoc();
     auto op = _opBuilder.create<EdgeOp>(loc, results, operands);
 
@@ -775,6 +807,11 @@ void DBProgramGenerator::walkEdge(const VariableDependency* src,
     const size_t yieldOffset = edgeTypeOffset + carriedEdgeTypes.size();
     for (size_t i = 0; i < carriedYields.size(); i++) {
         _part._yieldedColumns[carriedYields[i]]._column = op.getResult(yieldOffset + i);
+    }
+
+    const size_t boundOffset = yieldOffset + carriedYields.size();
+    for (size_t i = 0; i < carriedBound.size(); i++) {
+        registerValue(carriedBound[i], op.getResult(boundOffset + i));
     }
 }
 
@@ -990,6 +1027,17 @@ void DBProgramGenerator::generateTraversal(std::span<Stmt* const> stmts) {
 
     const VariableDependencyGraph::BoundVars& bound = _vdg.boundVars();
     if (_part._drivenRoot) {
+        // A column the barrier published holds its rows already, so it opens no component
+        // of its own: it stands in the main block beside the rows the leading statements
+        // bound, and rides with them into any island crossed with them.
+        for (const VariableDependency* var : bound) {
+            defined.insert(var);
+
+            if (!yieldsConstantColumn(_part._varMap.at(var).back())) {
+                mainComponent._vars.push_back(var);
+            }
+        }
+
         translateComponent(_part._drivenRoot, defined, mainComponent._vars);
     } else if (!bound.empty()) {
         throwOnRematchedBoundEdge();
@@ -1804,10 +1852,18 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
         return;
     }
 
-    // A part that continues from a WITH already has a dataflow to extend, so what a
-    // statement yields is paired with the rows of that one after the traversal rather than
-    // driving it
-    if (!_vdg.boundVars().empty()) {
+    // A pattern variable a barrier published is a dataflow this part extends, so what a
+    // statement binds is paired with its rows after the traversal rather than driving it.
+    // A published value is no such dataflow - it is read, the way an UNWIND reads the list
+    // it spreads - and the rows a statement turns it into can drive.
+    const auto bindsAValue = [](const VariableDependency* bound) {
+        const VarDecl* decl = bound->getDecl();
+        const EvaluatedType type = decl ? decl->getType() : EvaluatedType::Invalid;
+
+        return type != EvaluatedType::NodePattern && type != EvaluatedType::EdgePattern;
+    };
+
+    if (!std::ranges::all_of(_vdg.boundVars(), bindsAValue)) {
         return;
     }
 
@@ -1819,6 +1875,13 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
             break;
         } else if (kind == Stmt::Kind::CALL || kind == Stmt::Kind::VECTOR_SEARCH) {
             leading.push_back(stmt);
+        } else if (kind == Stmt::Kind::UNWIND) {
+            // A literal UNWIND is a dataflow of its own that the dependency graph already
+            // roots, and seeds the pattern node it names from there.
+            const UnwindStmt* unwindStmt = static_cast<const UnwindStmt*>(stmt);
+            if (!unwindStmt->unwindsLiteral()) {
+                leading.push_back(stmt);
+            }
         }
     }
 
@@ -1829,9 +1892,17 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
     llvm::SmallVector<const VariableDependency*> componentRoots;
     collectComponentRoots(componentRoots);
 
+    // A published value opens no traversal: it rides the rows as a column of its own, so
+    // it is no island for the driven component to be crossed with.
+    const auto opensNoTraversal = [this](const VariableDependency* root) {
+        return llvm::is_contained(_vdg.boundVars(), root);
+    };
+
+    llvm::erase_if(componentRoots, opensNoTraversal);
+
     llvm::SmallVector<const VarDecl*> yieldedVariables;
     for (const Stmt* stmt : leading) {
-        collectYieldVariables(yieldClauseOf(stmt), yieldedVariables);
+        collectStatementVariables(stmt, yieldedVariables);
     }
 
     // Any variable they bound can open the component, not only the one the graph lists
@@ -1864,10 +1935,14 @@ void DBProgramGenerator::generateLeadingYields(std::span<Stmt* const> stmts) {
     }
 
     for (const Stmt* stmt : leading) {
-        if (stmt->getKind() == Stmt::Kind::CALL) {
+        const Stmt::Kind kind = stmt->getKind();
+
+        if (kind == Stmt::Kind::CALL) {
             generateCall(static_cast<const CallStmt*>(stmt));
-        } else {
+        } else if (kind == Stmt::Kind::VECTOR_SEARCH) {
             generateVectorSearch(static_cast<const VectorSearchStmt*>(stmt));
+        } else {
+            generateUnwind(static_cast<const UnwindStmt*>(stmt));
         }
     }
 
@@ -1896,7 +1971,7 @@ void DBProgramGenerator::generateStatementOperations(std::span<Stmt* const> stmt
             generateCall(static_cast<const CallStmt*>(stmt));
         } else if (kind == Stmt::Kind::VECTOR_SEARCH && !drivesTheTraversal) {
             generateVectorSearch(static_cast<const VectorSearchStmt*>(stmt));
-        } else if (kind == Stmt::Kind::UNWIND) {
+        } else if (kind == Stmt::Kind::UNWIND && !drivesTheTraversal) {
             const UnwindStmt* unwindStmt = static_cast<const UnwindStmt*>(stmt);
 
             // A literal UNWIND opened a dataflow of its own during the traversal, which

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -208,9 +208,13 @@ void collectYieldVariables(const YieldClause* yield, llvm::SmallVectorImpl<const
 
 // The YIELD of a statement that binds variables of its own: a CALL or a VECTOR SEARCH.
 const YieldClause* yieldClauseOf(const Stmt* stmt) {
-    if (stmt->getKind() == Stmt::Kind::CALL) {
+    const Stmt::Kind kind = stmt->getKind();
+
+    if (kind == Stmt::Kind::CALL) {
         return static_cast<const CallStmt*>(stmt)->getYield();
     }
+
+    bioassert(kind == Stmt::Kind::VECTOR_SEARCH, "Only a CALL or a VECTOR SEARCH binds a YIELD.");
 
     return static_cast<const VectorSearchStmt*>(stmt)->getYield();
 }
@@ -578,7 +582,13 @@ void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const Unw
     if (literalKind == Literal::Kind::LIST) {
         translateListElements(static_cast<const ListLiteral*>(literal), elements);
     } else if (literalKind != Literal::Kind::NULL_LITERAL) {
-        elements.push_back(listElementAttr(literal));
+        const mlir::Attribute argument = literalAttr(literal);
+        if (!argument) {
+            throw TuringException("Only booleans, integers, floats, strings, nulls, embeddings and "
+                                  "lists are supported as an UNWIND argument.");
+        }
+
+        elements.push_back(argument);
     }
 
     const mlir::Type sharedType = sharedAttrType(elements);
@@ -610,7 +620,7 @@ void DBProgramGenerator::translateListElements(const ListLiteral* list,
     }
 }
 
-mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
+mlir::Attribute DBProgramGenerator::literalAttr(const Literal* literal) {
     const Literal::Kind kind = literal->getKind();
 
     if (kind == Literal::Kind::NULL_LITERAL) {
@@ -626,13 +636,17 @@ mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
         return _opBuilder.getArrayAttr(nestedElements);
     }
 
-    const mlir::TypedAttr scalarAttr = scalarLiteralAttr(literal);
-    if (!scalarAttr) {
+    return scalarLiteralAttr(literal);
+}
+
+mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
+    const mlir::Attribute element = literalAttr(literal);
+    if (!element) {
         throw TuringException("Only booleans, integers, floats, strings, nulls, embeddings and "
                               "lists are supported as list elements.");
     }
 
-    return scalarAttr;
+    return element;
 }
 
 mlir::Value DBProgramGenerator::translateListLiteral(const ListLiteral* list) {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -503,8 +503,13 @@ private:
     void translateListElements(const ListLiteral* list,
                                llvm::SmallVectorImpl<mlir::Attribute>& elements);
 
-    // The attribute one list element rides on: a typed attribute for a scalar, a unit
-    // attribute for a null, a nested array attribute for a nested list
+    // The attribute a literal rides on: a typed attribute for a scalar, a unit attribute
+    // for a null, a dense array for an embedding, a nested array attribute for a list -
+    // and a null attribute for a literal kind no attribute carries
+    mlir::Attribute literalAttr(const Literal* literal);
+
+    // The same attribute, for a literal written as one element of a list, which every
+    // element has to have
     mlir::Attribute listElementAttr(const Literal* literal);
 
     // The column holding a list literal's value: the one list, standing for every row

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -70,13 +70,16 @@ public:
     // and its ORDER BY read
     using VariableColumnMap = std::unordered_map<const VarDecl*, mlir::Value>;
 
-    // A column a CALL produced for one of its yielded return values, under the declaration
-    // the query knows it by and the name it is output under. A standalone call naming no
-    // YIELD declares nothing, so its columns carry a null declaration.
+    // A column bound under a name rather than by a pattern - what a CALL or a VECTOR SEARCH
+    // yielded, what an UNWIND of an expression bound - under the declaration the query
+    // knows it by and the name it is output under. A standalone call naming no YIELD
+    // declares nothing, so its columns carry a null declaration. _isResult marks the ones
+    // that stand in for a projection.
     struct YieldedColumn {
         const VarDecl* _decl {nullptr};
         std::string_view _name;
         mlir::Value _column;
+        bool _isResult {false};
     };
 
     // A column a part cut hands to the part below it, under the declaration and the name
@@ -287,10 +290,15 @@ private:
     // A standalone CALL ends no projection: what it yielded is the result
     void generateYieldedOutput(const SinglePartQuery* query);
 
-    // Emits each MATCH's WHERE, each CALL and each VECTOR SEARCH of a part in the order the
-    // query writes them, so a predicate or an argument reading what a statement yielded is
-    // generated once that statement has bound it.
-    void generateFiltersCallsAndSearches(std::span<Stmt* const> stmts);
+    // Emits what each statement of a part contributes over the rows the traversal matched -
+    // a MATCH's constraints, WHERE and cuts, a CALL, a VECTOR SEARCH, an UNWIND - in the
+    // order the query writes them, so a statement reading what an earlier one bound is
+    // generated once that one has bound it.
+    void generateStatementOperations(std::span<Stmt* const> stmts);
+
+    // Emits the filters a MATCH's inline property constraints ask for - `(n {age: 32})` -
+    // one predicate per constrained property of its pattern
+    void generateMatchConstraints(const MatchStmt* matchStmt);
     void generateMatchFilter(const MatchStmt* matchStmt);
 
     // Emits the Sort a MATCH's ORDER BY asks for, over everything in flight: the rows the
@@ -445,8 +453,6 @@ private:
     mlir::Value translateAggregateInput(const Expr* argExpr,
                                         const VariableColumnMap* variableColumns);
 
-    void generatePropertyConstraints(std::span<Stmt* const> stmts);
-
     void applyPredicateFilters(std::span<const Expr* const> predicates);
 
     void generateGroupAggregate(const Projection* projection);
@@ -510,13 +516,17 @@ private:
     // the graph's nodes: the variable takes those rows over as its own
     void addYieldedColumn(const VariableDependency* var, mlir::Value column);
 
-    // Opens a dataflow from an UNWIND's literal list, the way addScanNodes opens one
+    // Opens a dataflow from an UNWIND's literal elements, the way addScanNodes opens one
     // from the graph's nodes
     void addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind);
 
     // Opens a dataflow from the nodes an UNWIND's literal list names, for a variable a
     // pattern uses as a node: the list seeds the traversal instead of feeding it values
     void addConstScanNodes(const VariableDependency* var, const UnwindStmt* unwind);
+
+    // Expands the rows in flight through an UNWIND whose expression is evaluated per row,
+    // binding its variable to the elements those rows unwound into
+    void generateUnwind(const UnwindStmt* unwind);
 
     void filterAllColumns(mlir::Value predicate);
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -679,6 +679,28 @@ LogicalResult UnwindCollect::verify() {
     return success();
 }
 
+// A carried column comes back replicated, never retyped, so the carry set and the
+// results past the element column must match one for one.
+LogicalResult Unwind::verify() {
+    const OperandRange carriedColumns = getColumnsToFilter();
+    const Operation::result_range carriedResults = getCarried();
+
+    if (carriedColumns.size() != carriedResults.size()) {
+        return emitOpError("expects one carried result per carried column, but has ")
+               << carriedResults.size() << " for " << carriedColumns.size();
+    }
+
+    for (size_t carriedIndex = 0; carriedIndex < carriedColumns.size(); carriedIndex++) {
+        if (carriedColumns[carriedIndex].getType() != carriedResults[carriedIndex].getType()) {
+            return emitOpError("carried result ") << carriedIndex
+                                                  << " must have the same type as carried column "
+                                                  << carriedIndex;
+        }
+    }
+
+    return success();
+}
+
 // The unwound column's element type is the homogeneity verdict: a type-erased
 // list_element column accepts any elements, a typed one requires them to share that one
 // type - the shared check the const_list verifier runs too.

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -260,6 +260,48 @@ def VectorSearch : TuringOp<"vector_search", [Pure]> {
 }
 
 /**
+* Unwind
+*/
+def Unwind : TuringOp<"unwind", [Pure]> {
+  let summary = "Produce one row per element of a value computed for each input row";
+
+  let description = [{
+    `UNWIND <expr> AS x` where the expression is evaluated per row rather than known
+    at plan time - the general form db.unwind_const is the literal special case of. It
+    reads one source column and expands the rows in flight through it:
+
+      %x, %n = db.unwind(%names, {%node}) : (!db.column<none>, !db.column<!storage.node_id>)
+                                        -> (!db.column<none>, !db.column<!storage.node_id>)
+
+    Each source cell contributes the rows Cypher unwinds it into: a list one row per
+    element, a null none at all, and any other value the single row that value is - the
+    singleton an UNWIND of a scalar spreads to. A tagged scalar is read the same way, so
+    a cell that is itself a list unwinds one level deeper. `columns_to_filter` is the
+    carry set, as on db.get_out_edges: each carried column comes back replicated, its
+    cell repeated once per row its source cell produced, so everything in flight stays
+    row-aligned with the elements. A constant source stands for every carried row, so it
+    expands each of them.
+
+    The element column's type is the source's to decide and is resolved during
+    lowering, as a property fetch's value column is: unwinding a list yields a
+    type-erased !storage.list_element column of tagged scalars, matching Cypher's LIST
+    OF ANY, while a source that is already a scalar column keeps its own type - the
+    singleton is the value it already holds.
+  }];
+
+  let arguments = (ins Column:$source, Variadic<Column>:$columns_to_filter);
+  let results   = (outs Column:$element, Variadic<Column>:$carried);
+  let hasVerifier = 1;
+
+  // The carry set prints in braces, as db.get_out_edges' does; the source and the
+  // result types follow as a function type, so the element column's type is spelled
+  // beside the ones the carried columns keep.
+  let assemblyFormat = [{
+    `(` $source `,` `{` $columns_to_filter `}` `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : TuringOp<"scan_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -790,6 +790,8 @@ std::optional<CarrySetLayout> carrySetLayout(Operation* op) {
         return CarrySetLayout {._operandOffset = 1, ._resultOffset = hopFixedResultCount};
     } else if (isa<FilterOp>(op)) {
         return CarrySetLayout {._operandOffset = 1, ._resultOffset = 0};
+    } else if (isa<Unwind>(op)) {
+        return CarrySetLayout {._operandOffset = 1, ._resultOffset = 1};
     } else if (isa<Limit, Skip, Sort, GroupAggregate, Collect>(op)) {
         return CarrySetLayout {._operandOffset = 0, ._resultOffset = 0};
     }

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -10,6 +10,7 @@
 
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -24,6 +25,7 @@ namespace mlir::db {
 
 #define GEN_PASS_DEF_FUSESCANBYLABEL
 #define GEN_PASS_DEF_PUSHDOWNFILTERS
+#define GEN_PASS_DEF_FUSEUNWINDEQUALITY
 #define GEN_PASS_DEF_FUSESCANBYNODEIDS
 #define GEN_PASS_DEF_TRIMUNREADCOLUMNS
 #include "DBPasses.h.inc"
@@ -397,6 +399,241 @@ bool collectNodeIDDisjunction(Value mask, Value scanColumn, llvm::SmallVectorImp
     nodeIDs.push_back(nodeID);
     return true;
 }
+
+// The unwind factor of a cross product whose elements reach nothing but one equality
+// against a column of the other factor, and the ops that equality is rebuilt from.
+struct UnwindEqualityCross {
+    CrossProduct _product {nullptr};
+    UnwindConst _unwind {nullptr};
+    Region* _relationFactor {nullptr};
+    bool _unwindOnTheLeft {false};
+    Value _unwoundColumn;
+    Value _comparedColumn;
+    EqOp _equality {nullptr};
+    FilterOp _filter {nullptr};
+};
+
+// The constant unwind a factor is nothing but, null for any other factor. Anything else
+// in the region would be dropped along with it, so the unwind has to be all there is
+// besides the yield of its one column.
+UnwindConst matchUnwindFactor(Region& factor) {
+    Block& block = factor.front();
+    if (block.getOperations().size() != 2) {
+        return nullptr;
+    }
+
+    Yield yield = dyn_cast<Yield>(block.getTerminator());
+    if (!yield || yield.getColumns().size() != 1) {
+        return nullptr;
+    }
+
+    return yield.getColumns().front().getDefiningOp<UnwindConst>();
+}
+
+// Whether one comparison per element stands in for what the unwound column is compared to.
+// A heterogeneous list rides the type-erased column whose cells are compared by the tag
+// each carries, which no set of typed comparisons reproduces, and a repeated element emits
+// the rows it matches once per copy, which a membership test does not express.
+bool elementsCompareDistinctly(UnwindConst unwind) {
+    const ColumnType column = cast<ColumnType>(unwind.getResult().getType());
+    if (isa<storage::ListElementType>(column.getType())) {
+        return false;
+    }
+
+    llvm::SmallDenseSet<Attribute, 8> seen;
+    for (const Attribute element : unwind.getElements()) {
+        if (!isa<IntegerAttr, FloatAttr, StringAttr>(element)) {
+            return false;
+        }
+
+        if (!seen.insert(element).second) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// The one equality among the users of @param unwoundColumn, provided nothing else reads it
+// but the filter that equality masks - so dropping the unwind leaves no other reader behind.
+EqOp matchSoleEquality(Value unwoundColumn, FilterOp& filter) {
+    EqOp equality;
+    for (Operation* const user : unwoundColumn.getUsers()) {
+        const EqOp candidate = dyn_cast<EqOp>(user);
+        if (!candidate) {
+            continue;
+        }
+
+        if (equality) {
+            return nullptr;
+        }
+
+        equality = candidate;
+    }
+
+    if (!equality || !equality.getResult().hasOneUse()) {
+        return nullptr;
+    }
+
+    filter = dyn_cast<FilterOp>(*equality.getResult().getUsers().begin());
+    if (!filter || filter.getMask() != equality.getResult()) {
+        return nullptr;
+    }
+
+    for (Operation* const user : unwoundColumn.getUsers()) {
+        const bool testsTheColumn = user == equality.getOperation();
+        const bool carriesTheColumn = user == filter.getOperation();
+
+        if (!testsTheColumn && !carriesTheColumn) {
+            return nullptr;
+        }
+    }
+
+    return equality;
+}
+
+std::optional<UnwindEqualityCross> matchUnwindEqualityCross(CrossProduct product) {
+    Region& leftFactor = product.getLeftFactor();
+    Region& rightFactor = product.getRightFactor();
+
+    const UnwindConst leftUnwind = matchUnwindFactor(leftFactor);
+    const UnwindConst rightUnwind = matchUnwindFactor(rightFactor);
+
+    // Two unwind factors have no relation between them to fold either into.
+    if (static_cast<bool>(leftUnwind) == static_cast<bool>(rightUnwind)) {
+        return std::nullopt;
+    }
+
+    UnwindEqualityCross match;
+    match._product = product;
+    match._unwind = leftUnwind ? leftUnwind : rightUnwind;
+    match._relationFactor = leftUnwind ? &rightFactor : &leftFactor;
+    match._unwindOnTheLeft = static_cast<bool>(leftUnwind);
+
+    if (!elementsCompareDistinctly(match._unwind)) {
+        return std::nullopt;
+    }
+
+    // The results are the left factor's yielded columns followed by the right factor's, so
+    // an unwind on the left contributes the first and one on the right the last.
+    const size_t unwoundIndex = match._unwindOnTheLeft ? 0 : product.getResults().size() - 1;
+    match._unwoundColumn = product.getResult(unwoundIndex);
+
+    match._equality = matchSoleEquality(match._unwoundColumn, match._filter);
+    if (!match._equality) {
+        return std::nullopt;
+    }
+
+    const Value lhs = match._equality.getLhs();
+    match._comparedColumn = lhs == match._unwoundColumn ? match._equality.getRhs() : lhs;
+
+    // The compared column has to outlive the product: one the product yields is replaced
+    // as the factor is inlined, and one defined inside a factor is dropped with it. A value
+    // computed from a yielded column - a property fetch - is neither.
+    Operation* const comparedDef = match._comparedColumn.getDefiningOp();
+    const bool outlivesTheProduct = comparedDef
+                                    && comparedDef != product.getOperation()
+                                    && comparedDef->getParentRegion() == product->getParentRegion();
+
+    if (!outlivesTheProduct) {
+        return std::nullopt;
+    }
+
+    return match;
+}
+
+// Moves the relation factor's ops out to where the product stood and rewires the results
+// it contributed to the columns it yielded, leaving the product's own results unread.
+void inlineRelationFactor(CrossProduct product, Region& relationFactor, bool unwindOnTheLeft) {
+    Block& relationBlock = relationFactor.front();
+    Yield relationYield = cast<Yield>(relationBlock.getTerminator());
+
+    const llvm::SmallVector<Value> yielded(relationYield.getColumns().begin(),
+                                           relationYield.getColumns().end());
+
+    Block* const parentBlock = product->getBlock();
+    parentBlock->getOperations().splice(Block::iterator(product),
+                                        relationBlock.getOperations(),
+                                        relationBlock.begin(),
+                                        Block::iterator(relationYield));
+
+    // The unwound column is the product's first result or its last, so the relation's run
+    // from the other end.
+    const size_t firstRelationResult = unwindOnTheLeft ? 1 : 0;
+    for (size_t index = 0; index < yielded.size(); index++) {
+        product.getResult(firstRelationResult + index).replaceAllUsesWith(yielded[index]);
+    }
+}
+
+Value buildElementDisjunction(UnwindEqualityCross& match, mlir::OpBuilder& builder) {
+    const Location loc = match._equality.getLoc();
+    const Type boolColumnType = match._equality.getResult().getType();
+
+    builder.setInsertionPoint(match._equality);
+
+    Value mask;
+    for (const Attribute element : match._unwind.getElements()) {
+        ConstantOp constant = builder.create<ConstantOp>(loc, element);
+        EqOp equality = builder.create<EqOp>(loc, boolColumnType, match._comparedColumn, constant.getResult());
+
+        if (!mask) {
+            mask = equality.getResult();
+            continue;
+        }
+
+        mask = builder.create<OrOp>(loc, boolColumnType, mask, equality.getResult()).getResult();
+    }
+
+    return mask;
+}
+
+void fuseUnwindEquality(UnwindEqualityCross& match, mlir::OpBuilder& builder) {
+    inlineRelationFactor(match._product, *match._relationFactor, match._unwindOnTheLeft);
+
+    const Value mask = buildElementDisjunction(match, builder);
+
+    // The elements the rows carried are gone, and on every row the filter keeps they were
+    // the compared value: it takes their place, so a projection of the unwound variable
+    // still reads what that row matched.
+    llvm::SmallVector<Value> columns;
+    llvm::SmallVector<Type> resultTypes;
+    for (const Value column : match._filter.getColumnsToFilter()) {
+        const Value kept = column == match._unwoundColumn ? match._comparedColumn : column;
+
+        columns.push_back(kept);
+        resultTypes.push_back(kept.getType());
+    }
+
+    builder.setInsertionPoint(match._filter);
+    FilterOp fused = builder.create<FilterOp>(match._filter.getLoc(), resultTypes, mask, columns);
+
+    for (size_t index = 0; index < resultTypes.size(); index++) {
+        match._filter.getResult(index).replaceAllUsesWith(fused.getResult(index));
+    }
+
+    match._filter.erase();
+    match._equality.erase();
+    match._product.erase();
+}
+
+struct FuseUnwindEquality : public impl::FuseUnwindEqualityBase<FuseUnwindEquality> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        // Collect matches first: fusing erases ops, which would invalidate the walk.
+        llvm::SmallVector<UnwindEqualityCross> matches;
+        root->walk([&matches](CrossProduct product) {
+            if (const std::optional<UnwindEqualityCross> match = matchUnwindEqualityCross(product)) {
+                matches.push_back(*match);
+            }
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (UnwindEqualityCross& match : matches) {
+            fuseUnwindEquality(match, builder);
+        }
+    }
+};
 
 struct NodeIDScanChain {
     Operation* _source {nullptr};

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -454,6 +454,16 @@ bool elementsCompareDistinctly(UnwindConst unwind) {
     return true;
 }
 
+// Whether the rows can go on reading the elements through the column they were compared
+// to. On every row the filter keeps the two hold the same value, so a property column
+// stands in for the elements it matched; an entity column does not, since a node equals a
+// node ID by the number it carries and a projection would print the node instead.
+bool standsInForTheElements(Value comparedColumn) {
+    const ColumnType column = cast<ColumnType>(comparedColumn.getType());
+
+    return !isa<storage::NodeIDType, storage::EdgeIDType>(column.getType());
+}
+
 // The one equality among the users of @param unwoundColumn, provided nothing else reads it
 // but the filter that equality masks - so dropping the unwind leaves no other reader behind.
 EqOp matchSoleEquality(Value unwoundColumn, FilterOp& filter) {
@@ -527,15 +537,41 @@ std::optional<UnwindEqualityCross> matchUnwindEqualityCross(CrossProduct product
     const Value lhs = match._equality.getLhs();
     match._comparedColumn = lhs == match._unwoundColumn ? match._equality.getRhs() : lhs;
 
-    // The compared column has to outlive the product: one the product yields is replaced
-    // as the factor is inlined, and one defined inside a factor is dropped with it. A value
-    // computed from a yielded column - a property fetch - is neither.
+    // The compared column has to be one the rows still carry once the product is gone:
+    // a column the relation yields, or a value computed from one. A column defined inside
+    // a factor is dropped with it.
     Operation* const comparedDef = match._comparedColumn.getDefiningOp();
-    const bool outlivesTheProduct = comparedDef
-                                    && comparedDef != product.getOperation()
+    const bool survivesTheProduct = comparedDef
                                     && comparedDef->getParentRegion() == product->getParentRegion();
 
-    if (!outlivesTheProduct) {
+    if (!survivesTheProduct) {
+        return std::nullopt;
+    }
+
+    // Codegen carries every column in flight, so the filter holding the elements does not
+    // mean anything reads them: an unused result is dropped rather than stood in for, and
+    // only a column something does read has to be one the compared column can replace.
+    const Operation::operand_range carried = match._filter.getColumnsToFilter();
+    const ResultRange filtered = match._filter.getFilteredColumns();
+
+    size_t survivingColumns = 0;
+    for (size_t index = 0; index < carried.size(); index++) {
+        const bool holdsTheElements = carried[index] == match._unwoundColumn;
+
+        if (holdsTheElements && filtered[index].use_empty()) {
+            continue;
+        }
+
+        if (holdsTheElements && !standsInForTheElements(match._comparedColumn)) {
+            return std::nullopt;
+        }
+
+        survivingColumns++;
+    }
+
+    // A filter of nothing cuts nothing, so the elements were all it carried and the rows
+    // it kept are read from the relation directly.
+    if (survivingColumns == 0) {
         return std::nullopt;
     }
 
@@ -590,25 +626,40 @@ Value buildElementDisjunction(UnwindEqualityCross& match, mlir::OpBuilder& build
 void fuseUnwindEquality(UnwindEqualityCross& match, mlir::OpBuilder& builder) {
     inlineRelationFactor(match._product, *match._relationFactor, match._unwindOnTheLeft);
 
+    // Inlining rewired every use of the columns the relation contributed, the equality's
+    // own operand among them, so the compared column is read back rather than remembered.
+    const Value lhs = match._equality.getLhs();
+    match._comparedColumn = lhs == match._unwoundColumn ? match._equality.getRhs() : lhs;
+
     const Value mask = buildElementDisjunction(match, builder);
 
-    // The elements the rows carried are gone, and on every row the filter keeps they were
-    // the compared value: it takes their place, so a projection of the unwound variable
-    // still reads what that row matched.
+    // The elements the rows carried are gone. On every row the filter keeps they were the
+    // compared value, so that column takes their place where something still reads them,
+    // and the slot goes away where nothing does.
+    const Operation::operand_range carried = match._filter.getColumnsToFilter();
+    const ResultRange filtered = match._filter.getFilteredColumns();
+
     llvm::SmallVector<Value> columns;
     llvm::SmallVector<Type> resultTypes;
-    for (const Value column : match._filter.getColumnsToFilter()) {
-        const Value kept = column == match._unwoundColumn ? match._comparedColumn : column;
+    llvm::SmallVector<size_t> keptColumns;
+    for (size_t index = 0; index < carried.size(); index++) {
+        const bool holdsTheElements = carried[index] == match._unwoundColumn;
+        if (holdsTheElements && filtered[index].use_empty()) {
+            continue;
+        }
+
+        const Value kept = holdsTheElements ? match._comparedColumn : carried[index];
 
         columns.push_back(kept);
         resultTypes.push_back(kept.getType());
+        keptColumns.push_back(index);
     }
 
     builder.setInsertionPoint(match._filter);
     FilterOp fused = builder.create<FilterOp>(match._filter.getLoc(), resultTypes, mask, columns);
 
-    for (size_t index = 0; index < resultTypes.size(); index++) {
-        match._filter.getResult(index).replaceAllUsesWith(fused.getResult(index));
+    for (size_t index = 0; index < keptColumns.size(); index++) {
+        filtered[keptColumns[index]].replaceAllUsesWith(fused.getResult(index));
     }
 
     match._filter.erase();

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -13,6 +13,11 @@ def PushDownFilters : Pass<"push_down_filters"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def FuseUnwindEquality : Pass<"fuse_unwind_equality"> {
+    let summary = "Replace a constant unwind crossed into one equality by that equality's disjunction";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 def FuseScanByNodeIDs : Pass<"fuse_scan_by_node_ids"> {
     let summary = "Fuse a node scan and its node-ID disjunction filter into a const_scan_nodes";
     let dependentDialects = ["mlir::db::DB"];

--- a/query/ir/dialect/db/DBTypes.td
+++ b/query/ir/dialect/db/DBTypes.td
@@ -57,6 +57,6 @@ def ColumnOwnedStrings : ColumnOf<"::mlir::storage::OwnedStringType", "owned_str
 
 // The distance a vector search scored a neighbour at; the neighbour itself is a node,
 // so it rides the node ID column above.
-def ColumnDoubles : ColumnOf<"::mlir::FloatType", "f64">;
+def ColumnDoubles : ColumnOf<"::mlir::Float64Type", "f64">;
 
 #endif // TURINGDB_TYPES

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -538,13 +538,19 @@ LogicalResult AggregateUpdate::verify() {
     const Type accumulatorType = cast<AggregateStateType>(getState().getType()).getElementType();
 
     // A type-erased column of tagged cells has no one value type: every cell is read
-    // through its own tag. Only avg folds one, since its f64 accumulator is the same
-    // whatever the tags were, where sum/min/max hold the reduced value in the input's
-    // own type and so have to know it.
+    // through its own tag. Only sum and avg fold one, into the f64 a reduction over mixed
+    // numeric tags lands on, where min/max hold the reduced value in the input's own type
+    // and so have to know it.
     const auto rowsChunk = cast<ChunkType>(getRows().getType());
     const bool taggedCells = isa<storage::ListElementType>(rowsChunk.getElementType());
-    if (taggedCells && !isAvg) {
-        return emitOpError("only avg folds a column of tagged cells");
+    if (taggedCells) {
+        if (!isAvg && kind != storage::AggregateKind::Sum) {
+            return emitOpError("only sum and avg fold a column of tagged cells");
+        }
+
+        if (!isa<Float64Type>(accumulatorType)) {
+            return emitOpError("a reduction over type-erased cells must fold into an f64 accumulator state");
+        }
     }
 
     // Every other input is a property value chunk; its value type is what the fold

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -168,6 +168,46 @@ def VectorSearch : NLOp<"vector_search", [Pure, InferTypeOpAdaptor]> {
 }
 
 /**
+* Unwind
+*/
+// Pure: expanding a chunk of values is deterministic; the per-element fan-out is in the nl.for.
+def Unwind : NLOp<"unwind", [Pure]> {
+  let summary = "Create a database iterator that expands a chunk of values, one row per element";
+  let description = [{
+    Imperative counterpart of db.unwind. Each step of an enclosing nl.for fills one
+    chunk of unwound elements plus one chunk per carried column, gathered so a carried
+    cell repeats once per row its source cell produced:
+
+      %rows = nl.unwind(%names, {%nodes})
+                : (!nl.chunk<!storage.list<!storage.string>>, !nl.chunk<!storage.node_id>)
+                -> !nl.iter<!nl.chunk<!storage.list_element>, !nl.chunk<!storage.node_id>>
+      nl.for %x, %n in %rows : !nl.iter<!nl.chunk<!storage.list_element>, !nl.chunk<!storage.node_id>> {
+        nl.output(%x, %n) : !nl.chunk<!storage.list_element>, !nl.chunk<!storage.node_id>
+      }
+
+    A list cell contributes one row per element, a null cell none, and any other cell
+    the single row it is - a tagged scalar included, so a list_element cell that is
+    itself a list unwinds one level deeper. Unlike nl.unwind_const it reads an input
+    chunk, so it nests in the loop that binds it, the way nl.get_out_edges nests in the
+    loop binding its nodes. The element chunk type follows the source's - a list unwinds
+    into the type-erased list_element chunk, a scalar column into its own - and, like
+    nl.collect's, is spelled out rather than inferred.
+  }];
+
+  // `columns_to_filter`: the variadic carry set, after the fixed source, mirroring
+  // nl.get_out_edges.
+  let arguments = (ins NLChunk:$source, Variadic<NLChunk>:$columns_to_filter);
+  let results   = (outs NLIterator:$result);
+
+  // The source chunk's element type decides the element chunk's, and the carried types
+  // vary from call to call, so operands and result print as a function type - as
+  // nl.broadcast_constant's do - rather than the result alone.
+  let assemblyFormat = [{
+    `(` $source `,` `{` $columns_to_filter `}` `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : NLOp<"scan_edges", [Pure, InferTypeOpAdaptor]> {

--- a/query/ir/frontend/cypher/VariableDependencyGraph.cpp
+++ b/query/ir/frontend/cypher/VariableDependencyGraph.cpp
@@ -199,11 +199,17 @@ void VariableDependencyGraph::registerUnwindStmt(const UnwindStmt* stmt) {
     const VarDecl* decl = stmt->getDecl();
     bioassert(decl, "UNWIND without a declaration.");
 
-    // An UNWIND variable is bound to a list rather than to a pattern, so it depends on
-    // no other variable and enters the graph isolated - a root of its own connected
-    // component, whose dataflow the code generator opens from the list. The lookup is what
-    // registerPatternElement does: two variables of one declaration would leave every
-    // resolver picking one of them by container order.
+    // An UNWIND over an expression evaluated per row expands the rows already in flight,
+    // so its variable is bound where the statement is written rather than by a dataflow
+    // of its own - it is no root, and the graph does not carry it.
+    if (!stmt->unwindsLiteral()) {
+        return;
+    }
+
+    // A literal list depends on no other variable and enters the graph isolated - a root
+    // of its own connected component, whose dataflow the code generator opens from the
+    // list. The lookup is what registerPatternElement does: two variables of one
+    // declaration would leave every resolver picking one of them by container order.
     VariableDependency* unwindVar = findVariable(decl);
     if (!unwindVar) {
         unwindVar = newVariable(decl);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -106,6 +106,82 @@ void fillHomogeneousChunk(Column* output, ValueType valueType, const ListView li
     ValueTypeDispatcher {valueType}.execute(fill);
 }
 
+// The rows one cell of a list column unwinds into: one per element, so an empty list
+// contributes none.
+size_t unwindListElementCount(const Column* source, size_t row) {
+    const auto* lists = static_cast<const ColumnVector<ListView>*>(source);
+    return (*lists)[row].size();
+}
+
+// The rows one cell of a nullable value column unwinds into: the single row a present
+// value is, and none for a null - Cypher's UNWIND of a null.
+template <typename Primitive>
+size_t unwindOptElementCount(const Column* source, size_t row) {
+    const auto* values = static_cast<const ColumnOptVector<Primitive>*>(source);
+    return (*values)[row].has_value() ? 1 : 0;
+}
+
+// The rows one cell of a column holding a value in every row unwinds into: the single
+// row that value is.
+size_t unwindValueElementCount(const Column* source, size_t row) {
+    return 1;
+}
+
+// Copy the tagged elements one step covers out of a list column into the type-erased
+// element column: each output row is the element at its position in the list its source
+// row holds.
+void unwindListElementEmit(const Column* source,
+                           const ColumnVector<size_t>* rows,
+                           const ColumnVector<size_t>* positions,
+                           Column* output) {
+    const std::vector<ListView>& lists = static_cast<const ColumnVector<ListView>*>(source)->getRaw();
+    const std::vector<size_t>& rowsRaw = rows->getRaw();
+    const std::vector<size_t>& positionsRaw = positions->getRaw();
+
+    std::vector<ListElementView>& outputRaw = static_cast<ColumnVector<ListElementView>*>(output)->getRaw();
+    outputRaw.resize(rowsRaw.size());
+
+    for (size_t index = 0; index < rowsRaw.size(); index++) {
+        outputRaw[index] = lists[rowsRaw[index]].elements()[positionsRaw[index]];
+    }
+}
+
+// The rows one cell of a type-erased column unwinds into: a tagged list its elements, a
+// tagged null none, and any other tagged scalar the single row it is.
+size_t unwindTaggedElementCount(const Column* source, size_t row) {
+    const auto* elements = static_cast<const ColumnVector<ListElementView>*>(source);
+    const ListElementView element = (*elements)[row];
+    const ListBufferTypeTag tag = element.getTag();
+
+    if (tag == ListBufferTypeTag::ListView) {
+        return element.getAs<ListView>().size();
+    }
+
+    return tag == ListBufferTypeTag::Null ? 0 : 1;
+}
+
+// Fill the element chunk from a type-erased column: a cell holding a nested list gives up
+// the element at this row's position, and any other cell is itself the element.
+void unwindTaggedElementEmit(const Column* source,
+                             const ColumnVector<size_t>* rows,
+                             const ColumnVector<size_t>* positions,
+                             Column* output) {
+    const std::vector<ListElementView>& elements = static_cast<const ColumnVector<ListElementView>*>(source)->getRaw();
+    const std::vector<size_t>& rowsRaw = rows->getRaw();
+    const std::vector<size_t>& positionsRaw = positions->getRaw();
+
+    std::vector<ListElementView>& outputRaw = static_cast<ColumnVector<ListElementView>*>(output)->getRaw();
+    outputRaw.resize(rowsRaw.size());
+
+    for (size_t index = 0; index < rowsRaw.size(); index++) {
+        const ListElementView element = elements[rowsRaw[index]];
+
+        outputRaw[index] = element.getTag() == ListBufferTypeTag::ListView
+                               ? element.getAs<ListView>().elements()[positionsRaw[index]]
+                               : element;
+    }
+}
+
 template <typename Functor>
 Functor makeFunctor(NLExecutionContext* context) {
     if constexpr (std::is_constructible_v<Functor, GraphView>) {
@@ -2900,6 +2976,88 @@ void NLExecutor::runVectorSearchLoop(NLExecutionContext* context, NLFunctionData
     }
 }
 
+void NLExecutor::runUnwindLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLUnwindLoopData* loopData = static_cast<NLUnwindLoopData*>(data);
+    const Column* source = loopData->getSource();
+    const size_t sourceRows = source->size();
+
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    const NLUnwindElementCountFunction elementCount = loopData->getElementCountFunc();
+    const NLUnwindElementEmitFunction elementEmit = loopData->getElementEmitFunc();
+    const size_t chunkSize = context->getChunkSize();
+
+    // A null limit leaves the loop unbounded, exactly as in runUnwindConstLoop.
+    const NLLimitState* limit = loopData->getLimit();
+
+    ColumnVector<size_t>* rows = loopData->getRows();
+    ColumnVector<size_t>* positions = loopData->getPositions();
+
+    // Walk every (row, element) pair in row order. sourceRow / elementIndex is the cursor
+    // into that flattened sequence; a cell contributing nothing - a null, an empty list -
+    // is skipped, so it emits no row. The cursor is local to this call, so an unwind
+    // nested in an outer loop restarts on every one of its steps.
+    size_t sourceRow = 0;
+    size_t elementIndex = 0;
+    size_t rowElements = 0;
+
+    const auto openNextRow = [&]() {
+        while (sourceRow < sourceRows) {
+            rowElements = elementCount(source, sourceRow);
+            if (rowElements > 0) {
+                return;
+            }
+
+            sourceRow++;
+        }
+    };
+
+    openNextRow();
+
+    const auto runIteration = [&]() {
+        std::vector<size_t>& rowsRaw = rows->getRaw();
+        std::vector<size_t>& positionsRaw = positions->getRaw();
+        rowsRaw.clear();
+        positionsRaw.clear();
+
+        // Fill up to chunkSize rows, each the next (row, element) pair.
+        while (rowsRaw.size() < chunkSize && sourceRow < sourceRows) {
+            rowsRaw.push_back(sourceRow);
+            positionsRaw.push_back(elementIndex);
+            elementIndex++;
+
+            if (elementIndex == rowElements) {
+                elementIndex = 0;
+                sourceRow++;
+                openNextRow();
+            }
+        }
+
+        // A source whose cells hold more than the element drains through its own emit;
+        // any other holds the elements already and rides the carry set, gathered by the
+        // source row like everything else in flight.
+        if (elementEmit) {
+            elementEmit(source, rows, positions, loopData->getElementOutput());
+        }
+
+        for (const NLCarriedColumn& carriedColumn : loopData->carriedColumns()) {
+            const auto gatherFunc = carriedColumn.getGatherFunc();
+            gatherFunc(carriedColumn.getInput(), rows, carriedColumn.getOutput());
+        }
+
+        runBody(context, loopBody);
+    };
+
+    if (limit) {
+        while (sourceRow < sourceRows && limit->getRemaining() > 0) {
+            runIteration();
+        }
+    } else {
+        while (sourceRow < sourceRows) {
+            runIteration();
+        }
+    }
+}
+
 void NLExecutor::runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data) {
     NLScanEdgesLoopData* loopData = static_cast<NLScanEdgesLoopData*>(data);
     const NLStmtContainer* loopBody = loopData->getStmts();
@@ -3752,6 +3910,37 @@ NLCollectFoldFunction NLExecutor::selectCollectDistinctFold(ValueType valueType)
     }
 
     return nullptr;
+}
+
+NLUnwindElementCountFunction NLExecutor::selectListUnwindElementCount() {
+    return &unwindListElementCount;
+}
+
+NLUnwindElementCountFunction NLExecutor::selectOptUnwindElementCount(ValueType valueType) {
+    NLUnwindElementCountFunction selected = nullptr;
+
+    const auto select = [&]<SupportedType T>() {
+        selected = &unwindOptElementCount<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return selected;
+}
+
+NLUnwindElementCountFunction NLExecutor::selectValueUnwindElementCount() {
+    return &unwindValueElementCount;
+}
+
+NLUnwindElementEmitFunction NLExecutor::selectListUnwindElementEmit() {
+    return &unwindListElementEmit;
+}
+
+NLUnwindElementCountFunction NLExecutor::selectTaggedUnwindElementCount() {
+    return &unwindTaggedElementCount;
+}
+
+NLUnwindElementEmitFunction NLExecutor::selectTaggedUnwindElementEmit() {
+    return &unwindTaggedElementEmit;
 }
 
 NLUnwindCollectValueEmitFunction NLExecutor::selectUnwindCollectValueEmit(ValueType valueType) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -146,6 +146,56 @@ void unwindListElementEmit(const Column* source,
     }
 }
 
+// Copy the elements one step covers out of a list column into a typed value column: each
+// output row is the element at its position in the list its source row holds. The list's
+// element type is the column's, so every element is present and shares that type - the
+// tag check is what holds a list whose elements disagree with it to that promise.
+template <typename Primitive>
+void unwindListValueEmit(const Column* source,
+                         const ColumnVector<size_t>* rows,
+                         const ColumnVector<size_t>* positions,
+                         Column* output) {
+    const std::vector<ListView>& lists = static_cast<const ColumnVector<ListView>*>(source)->getRaw();
+    const std::vector<size_t>& rowsRaw = rows->getRaw();
+    const std::vector<size_t>& positionsRaw = positions->getRaw();
+
+    std::vector<std::optional<Primitive>>& outputRaw = static_cast<ColumnOptVector<Primitive>*>(output)->getRaw();
+    outputRaw.resize(rowsRaw.size());
+
+    constexpr ListBufferTypeTag expectedTag = TypeToListBufferTag<Primitive>::Tag;
+
+    for (size_t index = 0; index < rowsRaw.size(); index++) {
+        const ListElementView element = lists[rowsRaw[index]].elements()[positionsRaw[index]];
+        bioassert(element.getTag() == expectedTag, "Unwound element does not have the unwound list's value type.");
+
+        outputRaw[index] = element.getAs<Primitive>();
+    }
+}
+
+// The present-in-every-row sibling of unwindListValueEmit: an entity ID and a nested list
+// are always there, so the elements drain into a plain column rather than a nullable one.
+template <typename Element>
+void unwindListPlainEmit(const Column* source,
+                         const ColumnVector<size_t>* rows,
+                         const ColumnVector<size_t>* positions,
+                         Column* output) {
+    const std::vector<ListView>& lists = static_cast<const ColumnVector<ListView>*>(source)->getRaw();
+    const std::vector<size_t>& rowsRaw = rows->getRaw();
+    const std::vector<size_t>& positionsRaw = positions->getRaw();
+
+    std::vector<Element>& outputRaw = static_cast<ColumnVector<Element>*>(output)->getRaw();
+    outputRaw.resize(rowsRaw.size());
+
+    constexpr ListBufferTypeTag expectedTag = TypeToListBufferTag<Element>::Tag;
+
+    for (size_t index = 0; index < rowsRaw.size(); index++) {
+        const ListElementView element = lists[rowsRaw[index]].elements()[positionsRaw[index]];
+        bioassert(element.getTag() == expectedTag, "Unwound element does not have the unwound list's element type.");
+
+        outputRaw[index] = element.getAs<Element>();
+    }
+}
+
 // The rows one cell of a type-erased column unwinds into: a tagged list its elements, a
 // tagged null none, and any other tagged scalar the single row it is.
 size_t unwindTaggedElementCount(const Column* source, size_t row) {
@@ -1180,6 +1230,58 @@ void aggregateUpdateMinMax(NLAggregateState* state, const Column* input) {
     }
 }
 
+// The number a tagged cell holds, whatever numeric type its tag names. A reduction over
+// a type-erased column is defined over numbers only, so any other tag is a query error -
+// the check the static column types make for a typed column, made per row here.
+double taggedNumericValue(const ListElementView element) {
+    switch (element.getTag()) {
+        case ListBufferTypeTag::Int:
+            return static_cast<double>(element.getAs<types::Int64::Primitive>());
+        break;
+
+        case ListBufferTypeTag::UInt:
+            return static_cast<double>(element.getAs<types::UInt64::Primitive>());
+        break;
+
+        case ListBufferTypeTag::Double:
+            return element.getAs<types::Double::Primitive>();
+        break;
+
+        default:
+            throw IRException("sum/avg over type-erased cells requires a numeric column");
+        break;
+    }
+}
+
+// Fold a chunk of tagged cells into a running f64 sum, counting the ones folded so avg
+// reads the same accumulator. A cell tagged null is skipped, as a null value column row
+// is. Mixed numeric tags are what makes a column type-erased, and Cypher sums those to a
+// float, so the accumulator is an f64 whichever tags turn up.
+template <bool CountsRows>
+void aggregateUpdateNumericTagged(NLAggregateState* state, const Column* input) {
+    auto* accumulator = static_cast<ColumnOptVector<double>*>(state->getAccumulator());
+    std::optional<double>& current = accumulator->getRaw().front();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    double running = current.value();
+    size_t seen = 0;
+
+    for (const ListElementView element : inputRaw) {
+        if (element.getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        running += taggedNumericValue(element);
+        seen++;
+    }
+
+    current = running;
+
+    if constexpr (CountsRows) {
+        state->addCount(seen);
+    }
+}
+
 // Fold a chunk's present values into an avg accumulator: a running f64 sum plus a
 // count of the non-null rows (the input primitive is widened to f64). avg divides
 // the two at the emit step, so both are accumulated here.
@@ -1226,53 +1328,6 @@ void aggregateResultAvg(const NLAggregateState* state, Column* output) {
         const double average = accumulator->getRaw().front().value() / static_cast<double>(count);
         outputRaw.assign(1, std::optional<double>(average));
     }
-}
-
-// The number one tagged cell holds, widened to the f64 an average accumulates in. A cell
-// of any other type is no number to average, which is an error rather than a cell to skip
-// - only a null cell is skipped, by the folds below, before they read it.
-double listElementAsDouble(const ListElementView element) {
-    switch (element.getTag()) {
-        case ListBufferTypeTag::Int:
-            return static_cast<double>(element.getAs<types::Int64::Primitive>());
-        break;
-
-        case ListBufferTypeTag::UInt:
-            return static_cast<double>(element.getAs<types::UInt64::Primitive>());
-        break;
-
-        case ListBufferTypeTag::Double:
-            return element.getAs<types::Double::Primitive>();
-        break;
-
-        default:
-            throw IRException("avg requires a numeric column");
-        break;
-    }
-}
-
-// Fold a type-erased chunk's numeric cells into an avg accumulator: the tagged-cell
-// sibling of aggregateUpdateAvg, reading each cell through its own tag so that an integer
-// and a double element both charge the one running f64 sum. A null cell is skipped, as an
-// absent value of a nullable column is.
-void aggregateUpdateAvgElements(NLAggregateState* state, const Column* input) {
-    auto* accumulator = static_cast<ColumnOptVector<double>*>(state->getAccumulator());
-    std::optional<double>& current = accumulator->getRaw().front();
-    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
-
-    double running = current.value();
-    size_t seen = 0;
-    for (const ListElementView element : inputRaw) {
-        if (element.getTag() == ListBufferTypeTag::Null) {
-            continue;
-        }
-
-        running += listElementAsDouble(element);
-        seen++;
-    }
-
-    current = running;
-    state->addCount(seen);
 }
 
 // The fold handler for a sum over a column of this value type. sum adds the
@@ -1470,6 +1525,44 @@ void groupFoldSumDistinct(Column* accumulator,
     }
 }
 
+// Fold a group's tagged cells into its running f64 sum, tallying the ones folded so avg
+// divides by the same count. The type-erased sibling of groupFoldSum / groupFoldAvg: the
+// cells carry a type each, so the number each holds is read by its tag.
+template <bool CountsRows, bool Distinct>
+void groupFoldNumericTagged(Column* accumulator,
+                            std::vector<uint64_t>& counts,
+                            const Column* input,
+                            const std::vector<size_t>& groups,
+                            NLGroupDistinctTally& distinct) {
+    auto& raw = static_cast<ColumnOptVector<double>*>(accumulator)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const ListElementView element = inputRaw[row];
+        if (element.getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        const size_t group = groups[row];
+
+        if constexpr (Distinct) {
+            distinct.beginKey(group);
+            distinctAppendElementBytes(distinct.getKey(), element);
+
+            if (!distinct.insertIfNew()) {
+                continue;
+            }
+        }
+
+        std::optional<double>& running = raw[group];
+        running = running.value() + taggedNumericValue(element);
+
+        if constexpr (CountsRows) {
+            counts[group]++;
+        }
+    }
+}
+
 // Fold a chunk's present values into per-group min (IsMax false) or max (IsMax
 // true) accumulators. The first present value of a group seeds it; a later value
 // replaces it when more extreme. A group with no present value stays null.
@@ -1555,61 +1648,6 @@ void groupFoldAvgDistinct(Column* accumulator,
 
         std::optional<double>& running = raw[group];
         running = running.value() + static_cast<double>(*value);
-        counts[group]++;
-    }
-}
-
-// Fold a type-erased chunk's numeric cells into per-group avg accumulators: the
-// tagged-cell sibling of groupFoldAvg.
-void groupFoldAvgListElement(Column* accumulator,
-                             std::vector<uint64_t>& counts,
-                             const Column* input,
-                             const std::vector<size_t>& groups,
-                             NLGroupDistinctTally& distinct) {
-    auto& raw = static_cast<ColumnOptVector<double>*>(accumulator)->getRaw();
-    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
-
-    for (size_t row = 0; row < inputRaw.size(); row++) {
-        const ListElementView element = inputRaw[row];
-        if (element.getTag() == ListBufferTypeTag::Null) {
-            continue;
-        }
-
-        const size_t group = groups[row];
-        std::optional<double>& running = raw[group];
-        running = running.value() + listElementAsDouble(element);
-        counts[group]++;
-    }
-}
-
-// The distinct sibling of groupFoldAvgListElement (avg(DISTINCT x) over tagged cells):
-// cells are keyed by value across tags, as a DISTINCT over the same column keys them, so
-// the 1 and the 1.0 of one group are charged once between them.
-void groupFoldAvgDistinctListElement(Column* accumulator,
-                                     std::vector<uint64_t>& counts,
-                                     const Column* input,
-                                     const std::vector<size_t>& groups,
-                                     NLGroupDistinctTally& distinct) {
-    auto& raw = static_cast<ColumnOptVector<double>*>(accumulator)->getRaw();
-    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
-
-    for (size_t row = 0; row < inputRaw.size(); row++) {
-        const ListElementView element = inputRaw[row];
-        if (element.getTag() == ListBufferTypeTag::Null) {
-            continue;
-        }
-
-        const size_t group = groups[row];
-
-        distinct.beginKey(group);
-        distinctAppendElementBytes(distinct.getKey(), element);
-
-        if (!distinct.insertIfNew()) {
-            continue;
-        }
-
-        std::optional<double>& running = raw[group];
-        running = running.value() + listElementAsDouble(element);
         counts[group]++;
     }
 }
@@ -1852,6 +1890,166 @@ void collectEntityFoldDistinct(Column* values,
 
         distinct.beginKey(group);
         distinctAppendValueBytes(distinct.getKey(), inputRaw[row].getValue());
+
+        if (!distinct.insertIfNew()) {
+            continue;
+        }
+
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
+        groupPositions[group].push_back(position);
+    }
+}
+
+// The list-buffer value a tagged cell holds, read back as the type its tag names, so a
+// collect of type-erased cells buffers each one under the type it came in with.
+ListBuffer<>::ListItemVariant taggedListItem(const ListElementView element) {
+    const ListBufferTypeTag tag = element.getTag();
+
+    switch (tag) {
+        case ListBufferTypeTag::Int:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::Int64::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::UInt:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::UInt64::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::Double:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::Double::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::Bool:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::Bool::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::String:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::String::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::Embedding:
+            return ListBuffer<>::ListItemVariant {element.getAs<types::Embedding::Primitive>()};
+        break;
+
+        case ListBufferTypeTag::ListView:
+            return ListBuffer<>::ListItemVariant {element.getAs<ListView>()};
+        break;
+
+        case ListBufferTypeTag::Null:
+            return ListBuffer<>::ListItemVariant {element.getAs<PropertyNull>()};
+        break;
+
+        case ListBufferTypeTag::NodeID:
+            return ListBuffer<>::ListItemVariant {element.getAs<NodeID>()};
+        break;
+
+        case ListBufferTypeTag::EdgeID:
+            return ListBuffer<>::ListItemVariant {element.getAs<EdgeID>()};
+        break;
+
+        case ListBufferTypeTag::INVALID:
+            throw IRException("cannot collect an untagged element");
+        break;
+    }
+
+    throw IRException("Unknown ListBufferTypeTag");
+}
+
+// The type-erased sibling of collectFold: a tagged cell is there in every row, but one
+// tagged null is the null Cypher's collect drops, so only the rest join the group's list.
+void collectTaggedFold(Column* values,
+                       const Column* input,
+                       const std::vector<size_t>& groups,
+                       std::vector<std::vector<size_t>>& groupPositions,
+                       NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<ListElementView>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (inputRaw[row].getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
+        groupPositions[groups[row]].push_back(position);
+    }
+}
+
+// The dedup sibling: a tagged cell keys by the value its tag names, so the same number
+// reached under two tags keys once - the ordering rules read these cells the same way.
+void collectTaggedFoldDistinct(Column* values,
+                               const Column* input,
+                               const std::vector<size_t>& groups,
+                               std::vector<std::vector<size_t>>& groupPositions,
+                               NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<ListElementView>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListElementView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (inputRaw[row].getTag() == ListBufferTypeTag::Null) {
+            continue;
+        }
+
+        const size_t group = groups[row];
+
+        distinct.beginKey(group);
+        distinctAppendElementBytes(distinct.getKey(), inputRaw[row]);
+
+        if (!distinct.insertIfNew()) {
+            continue;
+        }
+
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
+        groupPositions[group].push_back(position);
+    }
+}
+
+// The type-erased sibling of collectListEmit: each buffered cell goes into the list
+// buffer as the value its own tag names, so the list keeps the types it gathered.
+void collectTaggedListEmit(const Column* values,
+                           const std::vector<std::vector<size_t>>& groupPositions,
+                           size_t begin,
+                           size_t count,
+                           ListBuffer<>& listBuffer,
+                           Column* output) {
+    const auto& valuesRaw = static_cast<const ColumnVector<ListElementView>*>(values)->getRaw();
+    auto& outputRaw = static_cast<ColumnVector<ListView>*>(output)->getRaw();
+
+    outputRaw.clear();
+    outputRaw.reserve(count);
+
+    std::vector<ListBuffer<>::ListItemVariant> elements;
+    for (size_t index = 0; index < count; index++) {
+        const std::vector<size_t>& positions = groupPositions[begin + index];
+
+        elements.clear();
+        elements.reserve(positions.size());
+        for (const size_t position : positions) {
+            elements.push_back(taggedListItem(valuesRaw[position]));
+        }
+
+        outputRaw.push_back(listBuffer.insert(elements));
+    }
+}
+
+// The list sibling of collectEntityFoldDistinct: two cells are the same value when their
+// elements are, so a cell keys by the list serialized element by element rather than by
+// the ListView's own span, which two equal lists never share.
+void collectListFoldDistinct(Column* values,
+                             const Column* input,
+                             const std::vector<size_t>& groups,
+                             std::vector<std::vector<size_t>>& groupPositions,
+                             NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<ListView>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<ListView>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        const size_t group = groups[row];
+
+        distinct.beginKey(group);
+        distinctAppendListBytes(distinct.getKey(), inputRaw[row]);
 
         if (!distinct.insertIfNew()) {
             continue;
@@ -3935,6 +4133,29 @@ NLUnwindElementEmitFunction NLExecutor::selectListUnwindElementEmit() {
     return &unwindListElementEmit;
 }
 
+NLUnwindElementEmitFunction NLExecutor::selectListUnwindValueEmit(ValueType valueType) {
+    NLUnwindElementEmitFunction selected = nullptr;
+
+    const auto select = [&]<SupportedType T>() {
+        selected = &unwindListValueEmit<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return selected;
+}
+
+NLUnwindElementEmitFunction NLExecutor::selectListUnwindNodeEmit() {
+    return &unwindListPlainEmit<NodeID>;
+}
+
+NLUnwindElementEmitFunction NLExecutor::selectListUnwindEdgeEmit() {
+    return &unwindListPlainEmit<EdgeID>;
+}
+
+NLUnwindElementEmitFunction NLExecutor::selectListUnwindListEmit() {
+    return &unwindListPlainEmit<ListView>;
+}
+
 NLUnwindElementCountFunction NLExecutor::selectTaggedUnwindElementCount() {
     return &unwindTaggedElementCount;
 }
@@ -4020,6 +4241,24 @@ void NLExecutor::selectCollectEntityHandlers(NLChunkKind kind,
             throw IRException("collect does not support this chunk kind");
         break;
     }
+}
+
+// A list cell is present in every row, so it folds the way an entity ID does; only the
+// dedup differs, keying on the elements rather than on the cell.
+void NLExecutor::selectCollectListHandlers(bool distinctValues,
+                                           NLCollectFoldFunction& fold,
+                                           NLCollectListEmitFunction& listEmit) {
+    fold = distinctValues ? &collectListFoldDistinct : &collectEntityFold<ListView>;
+    listEmit = &collectListEmit<ListView>;
+}
+
+// A type-erased cell carries its own type, so the fold drops the ones tagged null and the
+// emit writes each survivor back under the type its tag names.
+void NLExecutor::selectCollectTaggedHandlers(bool distinctValues,
+                                             NLCollectFoldFunction& fold,
+                                             NLCollectListEmitFunction& listEmit) {
+    fold = distinctValues ? &collectTaggedFoldDistinct : &collectTaggedFold;
+    listEmit = &collectTaggedListEmit;
 }
 
 void NLExecutor::runUnwindCollectLoop(NLExecutionContext* context, NLFunctionData* data) {
@@ -4243,24 +4482,6 @@ NLKeyAppendFunction NLExecutor::selectListElementKeyAppendFunction() {
 
 NLCountFunction NLExecutor::selectListElementCountFunction() {
     return &countNonNullElementsColumn;
-}
-
-NLAggregateUpdateFunction NLExecutor::selectListElementAggregateUpdate(AggregateKind kind) {
-    if (kind != AggregateKind::Avg) {
-        throw IRException("only avg reduces a column of tagged cells");
-    }
-
-    return &aggregateUpdateAvgElements;
-}
-
-NLGroupAggregateFoldFunction NLExecutor::selectListElementGroupAggregateFold(GroupAggregateKind kind) {
-    if (kind == GroupAggregateKind::Avg) {
-        return &groupFoldAvgListElement;
-    } else if (kind == GroupAggregateKind::AvgDistinct) {
-        return &groupFoldAvgDistinctListElement;
-    }
-
-    throw IRException("only avg reduces a column of tagged cells");
 }
 
 NLGroupKeyGatherFunction NLExecutor::selectListElementGroupKeyGatherFunction() {
@@ -4505,6 +4726,29 @@ NLAggregateUpdateFunction NLExecutor::selectAggregateUpdate(AggregateKind kind, 
     return nullptr;
 }
 
+// The reduction of a type-erased column: only sum and avg are defined over one, both
+// into the f64 accumulator mixed numeric tags reduce to. min/max would have to hand back
+// the winning cell in its own type, which no static result type names.
+NLAggregateUpdateFunction NLExecutor::selectTaggedAggregateUpdate(AggregateKind kind) {
+    switch (kind) {
+        case AggregateKind::Sum:
+            return &aggregateUpdateNumericTagged</*CountsRows=*/false>;
+        break;
+
+        case AggregateKind::Avg:
+            return &aggregateUpdateNumericTagged</*CountsRows=*/true>;
+        break;
+
+        case AggregateKind::Min:
+        case AggregateKind::Max:
+            throw IRException("min/max over type-erased cells is not supported");
+        break;
+    }
+
+    bioassert(false, "Unhandled aggregate kind");
+    return nullptr;
+}
+
 NLAggregateResultFunction NLExecutor::selectAggregateResult(AggregateKind kind, ValueType resultType) {
     if (kind == AggregateKind::Avg) {
         // avg always emits an f64 (the running sum divided by the count), whatever
@@ -4566,6 +4810,35 @@ NLGroupAggregateGrowFunction NLExecutor::selectGroupAggregateGrow(GroupAggregate
     }
 
     bioassert(false, "Unhandled group aggregate kind");
+    return nullptr;
+}
+
+// The grouped reduction of a type-erased column: sum and avg only, both into the f64
+// accumulator mixed numeric tags reduce to - the grouped sibling of
+// selectTaggedAggregateUpdate.
+NLGroupAggregateFoldFunction NLExecutor::selectTaggedGroupAggregateFold(GroupAggregateKind kind) {
+    switch (kind) {
+        case GroupAggregateKind::Sum:
+            return &groupFoldNumericTagged</*CountsRows=*/false, /*Distinct=*/false>;
+        break;
+
+        case GroupAggregateKind::SumDistinct:
+            return &groupFoldNumericTagged</*CountsRows=*/false, /*Distinct=*/true>;
+        break;
+
+        case GroupAggregateKind::Avg:
+            return &groupFoldNumericTagged</*CountsRows=*/true, /*Distinct=*/false>;
+        break;
+
+        case GroupAggregateKind::AvgDistinct:
+            return &groupFoldNumericTagged</*CountsRows=*/true, /*Distinct=*/true>;
+        break;
+
+        default:
+            throw IRException("min/max over type-erased cells is not supported");
+        break;
+    }
+
     return nullptr;
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -4815,7 +4815,8 @@ NLGroupAggregateGrowFunction NLExecutor::selectGroupAggregateGrow(GroupAggregate
 
 // The grouped reduction of a type-erased column: sum and avg only, both into the f64
 // accumulator mixed numeric tags reduce to - the grouped sibling of
-// selectTaggedAggregateUpdate.
+// selectTaggedAggregateUpdate. A switch (not a default) over every kind so a new one is a
+// compile error here rather than being reported as an unsupported min/max.
 NLGroupAggregateFoldFunction NLExecutor::selectTaggedGroupAggregateFold(GroupAggregateKind kind) {
     switch (kind) {
         case GroupAggregateKind::Sum:
@@ -4834,11 +4835,19 @@ NLGroupAggregateFoldFunction NLExecutor::selectTaggedGroupAggregateFold(GroupAgg
             return &groupFoldNumericTagged</*CountsRows=*/true, /*Distinct=*/true>;
         break;
 
-        default:
+        case GroupAggregateKind::Min:
+        case GroupAggregateKind::Max:
             throw IRException("min/max over type-erased cells is not supported");
+        break;
+
+        case GroupAggregateKind::Count:
+        case GroupAggregateKind::CountDistinct:
+        case GroupAggregateKind::CountRows:
+            bioassert(false, "A tally of type-erased cells has its own fold");
         break;
     }
 
+    bioassert(false, "Unhandled group aggregate kind");
     return nullptr;
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -3217,10 +3217,16 @@ void NLExecutor::runUnwindLoop(NLExecutionContext* context, NLFunctionData* data
         rowsRaw.clear();
         positionsRaw.clear();
 
-        // Fill up to chunkSize rows, each the next (row, element) pair.
+        // Fill up to chunkSize rows, each the next (row, element) pair. Which element of
+        // its cell a row took is the emit handler's to read, so a source without one -
+        // whose cells are the elements already - has no position to record.
         while (rowsRaw.size() < chunkSize && sourceRow < sourceRows) {
             rowsRaw.push_back(sourceRow);
-            positionsRaw.push_back(elementIndex);
+
+            if (elementEmit) {
+                positionsRaw.push_back(elementIndex);
+            }
+
             elementIndex++;
 
             if (elementIndex == rowElements) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -44,13 +44,14 @@ public:
     size_t getChunkSize() const { return _chunkSize; }
     CommitWriteBuffer* getWriteBuffer() const { return _writeBuffer; }
 
-    // The server-level facilities only the system commands reach for; null for a
-    // program with none, which is every ordinary query
+    // The server-level facilities the system commands reach for. Every query the server
+    // runs carries one, ordinary reads included; it is null only for a caller that hands
+    // the interpreter none, as the IR tests do.
     const NLSystemContext* getSystem() const { return _system; }
 
     // The vector indexes a search reads, borrowed from the session's accessor. They are
     // the one store outside the graph an ordinary query reaches, so - unlike the rest of
-    // the system context - a dataflow loop reads them; null for a session that opened no
+    // the system context - a dataflow loop reads them; null when the session opened no
     // accessor, which the search reports as a user-facing error.
     vec::VectorDatabase* getVectorDatabase() const;
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -105,6 +105,11 @@ public:
     // leaves it unbounded.
     static void runVectorSearchLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    // The per-row sibling of runUnwindConstLoop: expand the loop data's source column,
+    // emitting one row per element of each of its cells - none for a null - one chunk at
+    // a time, with the carry set gathered by the source row each emitted row came from.
+    static void runUnwindLoop(NLExecutionContext* context, NLFunctionData* data);
+
     static void runScanEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetOutEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
     static void runGetInEdgesLoop(NLExecutionContext* context, NLFunctionData* data);
@@ -452,6 +457,21 @@ public:
     // The unwind value-emit / collect list-emit for a column of this value type: the
     // drain-side siblings of selectCollectFold, baked from the same value type.
     static NLUnwindCollectValueEmitFunction selectUnwindCollectValueEmit(ValueType valueType);
+
+    // The row counts an nl.unwind reads its source column with: a list column drains its
+    // elements, a type-erased column drains a cell tagged as a list and drops one tagged
+    // null, a nullable value column drops its nulls, and a column holding a value in every
+    // row spreads each of them to the single row it is.
+    static NLUnwindElementCountFunction selectListUnwindElementCount();
+    static NLUnwindElementCountFunction selectTaggedUnwindElementCount();
+    static NLUnwindElementCountFunction selectOptUnwindElementCount(ValueType valueType);
+    static NLUnwindElementCountFunction selectValueUnwindElementCount();
+
+    // The drains filling an nl.unwind's element chunk from a column whose cells hold more
+    // than the element. A scalar column needs none: its cells are the elements, gathered
+    // through the carry set.
+    static NLUnwindElementEmitFunction selectListUnwindElementEmit();
+    static NLUnwindElementEmitFunction selectTaggedUnwindElementEmit();
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
 
     // The fold and list-emit for an entity chunk of this kind, whose elements carry a

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -414,10 +414,9 @@ public:
     static NLAggregateResetFunction selectAggregateReset(AggregateKind kind, ValueType accumulatorType);
     static NLAggregateUpdateFunction selectAggregateUpdate(AggregateKind kind, ValueType inputType);
 
-    // The siblings of selectAggregateUpdate / selectGroupAggregateFold for a type-erased
-    // column, whose cells carry their own tags rather than sharing one value type
-    static NLAggregateUpdateFunction selectListElementAggregateUpdate(AggregateKind kind);
-    static NLGroupAggregateFoldFunction selectListElementGroupAggregateFold(GroupAggregateKind kind);
+    // The sibling reading a type-erased input column: sum and avg reduce its numeric
+    // cells into the f64 accumulator, whatever tags they carry.
+    static NLAggregateUpdateFunction selectTaggedAggregateUpdate(AggregateKind kind);
     static NLAggregateResultFunction selectAggregateResult(AggregateKind kind, ValueType resultType);
 
     // The grouped counterparts, selected for one aggregate of a grouped
@@ -432,6 +431,10 @@ public:
     // value's bytes - so, unlike count, an embedding column is rejected.
     static NLGroupAggregateGrowFunction selectGroupAggregateGrow(GroupAggregateKind kind, ValueType accumulatorType);
     static NLGroupAggregateFoldFunction selectGroupAggregateFold(GroupAggregateKind kind, ValueType inputType);
+
+    // The sibling reading a type-erased input column: sum and avg reduce its numeric
+    // cells into the f64 accumulator, whatever tags they carry.
+    static NLGroupAggregateFoldFunction selectTaggedGroupAggregateFold(GroupAggregateKind kind);
     static NLGroupAggregateFoldFunction selectGroupCountAllFold();
     static NLGroupAggregateFoldFunction selectGroupCountDistinctFold(ValueType inputType);
     static NLGroupAggregateFoldFunction selectGroupCountDistinctChunkFold(NLChunkKind kind);
@@ -468,9 +471,14 @@ public:
     static NLUnwindElementCountFunction selectValueUnwindElementCount();
 
     // The drains filling an nl.unwind's element chunk from a column whose cells hold more
-    // than the element. A scalar column needs none: its cells are the elements, gathered
-    // through the carry set.
+    // than the element: a drained list fills the column its own element type names, and
+    // only one whose elements share no type fills the type-erased column. A scalar column
+    // needs none - its cells are the elements, gathered through the carry set.
     static NLUnwindElementEmitFunction selectListUnwindElementEmit();
+    static NLUnwindElementEmitFunction selectListUnwindValueEmit(ValueType valueType);
+    static NLUnwindElementEmitFunction selectListUnwindNodeEmit();
+    static NLUnwindElementEmitFunction selectListUnwindEdgeEmit();
+    static NLUnwindElementEmitFunction selectListUnwindListEmit();
     static NLUnwindElementEmitFunction selectTaggedUnwindElementEmit();
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
 
@@ -478,6 +486,17 @@ public:
     // node or edge ID. An edge-type ID is no entity, so the kind is rejected.
     static void selectCollectEntityHandlers(NLChunkKind kind,
                                             bool distinctValues,
+                                            NLCollectFoldFunction& fold,
+                                            NLCollectListEmitFunction& listEmit);
+
+    // The handlers a collect of a list column reads: the cells nest into a list of lists.
+    static void selectCollectListHandlers(bool distinctValues,
+                                          NLCollectFoldFunction& fold,
+                                          NLCollectListEmitFunction& listEmit);
+
+    // The handlers a collect of a type-erased column reads: each cell keeps the type its
+    // tag names, and a cell tagged null is dropped as Cypher's collect drops a null.
+    static void selectCollectTaggedHandlers(bool distinctValues,
                                             NLCollectFoldFunction& fold,
                                             NLCollectListEmitFunction& listEmit);
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -490,6 +490,76 @@ private:
     NLStmtContainer _stmts;
 };
 
+// The rows one cell of an unwound column contributes: a list its element count, a null
+// none, and any other value the single row it is. One per source column shape, selected
+// during translation.
+using NLUnwindElementCountFunction = size_t (*)(const Column* source, size_t row);
+
+// Fill the element chunk of one nl.unwind step from a column whose cells hold more than
+// the element: output row i is the element at positions[i] of the cell at rows[i].
+using NLUnwindElementEmitFunction = void (*)(const Column* source,
+                                             const ColumnVector<size_t>* rows,
+                                             const ColumnVector<size_t>* positions,
+                                             Column* output);
+
+// nl.for over nl.unwind data: the per-element expansion of a value column. Holds the
+// source column with the handler counting the rows each of its cells contributes, the
+// drain filling the element chunk, and the carry set gathered by each emitted row's
+// source row - the same NLCarriedColumn shape the edge loops use. The scratch columns
+// hold, per emitted row of the current step, the source row it came from and the
+// position of the element inside that row's cell.
+class NLUnwindLoopData : public NLFunctionData {
+public:
+    using CarriedColumns = std::vector<NLCarriedColumn>;
+
+    // @param elementEmit and @param elementOutput are null when the source's cells are
+    // themselves the elements: they are then gathered through the carry set like any
+    // other column.
+    NLUnwindLoopData(const Column* source,
+                     NLUnwindElementCountFunction elementCount,
+                     NLUnwindElementEmitFunction elementEmit,
+                     Column* elementOutput)
+        : _source(source),
+        _elementCount(elementCount),
+        _elementEmit(elementEmit),
+        _elementOutput(elementOutput)
+    {
+    }
+
+    const Column* getSource() const { return _source; }
+    NLUnwindElementCountFunction getElementCountFunc() const { return _elementCount; }
+    NLUnwindElementEmitFunction getElementEmitFunc() const { return _elementEmit; }
+    Column* getElementOutput() const { return _elementOutput; }
+
+    const CarriedColumns& carriedColumns() const { return _carriedColumns; }
+
+    void addCarriedColumn(const NLCarriedColumn& carried) {
+        _carriedColumns.push_back(carried);
+    }
+
+    ColumnVector<size_t>* getRows() { return &_rows; }
+    ColumnVector<size_t>* getPositions() { return &_positions; }
+
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    const Column* _source {nullptr};
+    NLUnwindElementCountFunction _elementCount {nullptr};
+    NLUnwindElementEmitFunction _elementEmit {nullptr};
+    Column* _elementOutput {nullptr};
+
+    NLLimitState* _limit {nullptr};
+    CarriedColumns _carriedColumns;
+    NLStmtContainer _stmts;
+
+    ColumnVector<size_t> _rows;
+    ColumnVector<size_t> _positions;
+};
+
 // nl.scan_edges loop data: the edge sibling of NLScanLoopData. A source loop
 // (no input column, no carry set), so - unlike NLEdgeLoopData - it holds only
 // the four fixed output chunks a step fills (sources, edge IDs, edge type IDs,

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -859,6 +859,22 @@ void NLTranslator::translateVectorSearchLoop(const IteratorConfig& config,
     translateBlock(loopBody, loopData->getStmts());
 }
 
+NLUnwindElementEmitFunction NLTranslator::selectListUnwindEmit(mlir::Type chunkType) {
+    const mlir::Type elementType = mlir::cast<nl::ChunkType>(chunkType).getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        return NLExecutor::selectListUnwindValueEmit(valueTypeFromElementType(nullableType.getValueType()));
+    } else if (mlir::isa<storage::NodeIDType>(elementType)) {
+        return NLExecutor::selectListUnwindNodeEmit();
+    } else if (mlir::isa<storage::EdgeIDType>(elementType)) {
+        return NLExecutor::selectListUnwindEdgeEmit();
+    } else if (mlir::isa<storage::ListType>(elementType)) {
+        return NLExecutor::selectListUnwindListEmit();
+    }
+
+    return NLExecutor::selectListUnwindElementEmit();
+}
+
 void NLTranslator::translateUnwindLoop(const IteratorConfig& config,
                                        mlir::Block& loopBody,
                                        NLLimitState* limit,
@@ -881,7 +897,7 @@ void NLTranslator::translateUnwindLoop(const IteratorConfig& config,
 
     if (llvm::isa<storage::ListType>(sourceElement)) {
         elementCount = NLExecutor::selectListUnwindElementCount();
-        elementEmit = NLExecutor::selectListUnwindElementEmit();
+        elementEmit = selectListUnwindEmit(elementValue.getType());
     } else if (llvm::isa<storage::ListElementType>(sourceElement)) {
         elementCount = NLExecutor::selectTaggedUnwindElementCount();
         elementEmit = NLExecutor::selectTaggedUnwindElementEmit();
@@ -2244,22 +2260,24 @@ void NLTranslator::buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKin
             // kinds keep the shape of the kind they mirror and differ only in the
             // fold, which charges each of a group's values once.
             //
-            // A type-erased column is the exception: its cells carry their own tags, so
-            // only avg folds one (lowering rejects the others) and it accumulates in the
-            // f64 an average is whatever those tags were.
-            const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
-            const bool taggedCells = mlir::isa<storage::ListElementType>(chunk.getElementType());
+            // A type-erased input carries a type per cell, so it reduces by tag into the
+            // f64 its mixed numeric tags land on rather than into the input's own type.
+            const mlir::Type reducedElement = mlir::cast<nl::ChunkType>(chunkType).getElementType();
+            const bool reducesTaggedCells = mlir::isa<storage::ListElementType>(reducedElement);
 
-            const ValueType inputType = taggedCells ? ValueType::Double
-                                                    : nullableChunkValueType(chunkType);
-            const bool accumulatesAsDouble = (kind == GroupAggregateKind::Avg)
+            const bool accumulatesAsDouble = reducesTaggedCells
+                                          || (kind == GroupAggregateKind::Avg)
                                           || (kind == GroupAggregateKind::AvgDistinct);
+
+            const ValueType inputType = reducesTaggedCells ? ValueType::Double
+                                                           : nullableChunkValueType(chunkType);
             const ValueType accumulatorType = accumulatesAsDouble ? ValueType::Double : inputType;
 
             aggregate._accumulator = allocOptColumnForValueType(accumulatorType);
             aggregate._grow = NLExecutor::selectGroupAggregateGrow(kind, accumulatorType);
-            aggregate._fold = taggedCells ? NLExecutor::selectListElementGroupAggregateFold(kind)
-                                          : NLExecutor::selectGroupAggregateFold(kind, inputType);
+            aggregate._fold = reducesTaggedCells
+                                  ? NLExecutor::selectTaggedGroupAggregateFold(kind)
+                                  : NLExecutor::selectGroupAggregateFold(kind, inputType);
             aggregate._emit = NLExecutor::selectGroupAggregateEmit(kind, accumulatorType);
         }
         break;
@@ -2471,6 +2489,22 @@ void NLTranslator::translateCollectUpdate(nl::CollectUpdate update, NLStmtContai
                                      : NLExecutor::selectCollectFold(valueType);
             value._unwindCollectEmit = NLExecutor::selectUnwindCollectValueEmit(valueType);
             value._listEmit = NLExecutor::selectCollectListEmit(valueType);
+        } else if (mlir::isa<storage::ListType>(element)) {
+            NLCollectFoldFunction fold = nullptr;
+            NLCollectListEmitFunction listEmit = nullptr;
+            NLExecutor::selectCollectListHandlers(isDistinct, fold, listEmit);
+
+            value._buffer = allocListColumn();
+            value._fold = fold;
+            value._listEmit = listEmit;
+        } else if (mlir::isa<storage::ListElementType>(element)) {
+            NLCollectFoldFunction fold = nullptr;
+            NLCollectListEmitFunction listEmit = nullptr;
+            NLExecutor::selectCollectTaggedHandlers(isDistinct, fold, listEmit);
+
+            value._buffer = allocListElementColumn();
+            value._fold = fold;
+            value._listEmit = listEmit;
         } else {
             const NLChunkKind kind = getChunkKind(column.getType());
 
@@ -3050,7 +3084,7 @@ NLAggregateUpdateFunction NLTranslator::selectAggregateUpdateForChunkType(Aggreg
                                                                          mlir::Type chunkType) {
     const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
     if (mlir::isa<storage::ListElementType>(chunk.getElementType())) {
-        return NLExecutor::selectListElementAggregateUpdate(kind);
+        return NLExecutor::selectTaggedAggregateUpdate(kind);
     }
 
     return NLExecutor::selectAggregateUpdate(kind, nullableChunkValueType(chunkType));

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -465,6 +465,15 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             config._neighbourCount = vectorSearch.getK();
             config._queryVector = vectorSearch.getQueryVector();
             _iteratorConfigs[vectorSearch.getResult()] = config;
+        } else if (nl::Unwind unwind = mlir::dyn_cast<nl::Unwind>(operation)) {
+            IteratorConfig config;
+            config._kind = IteratorKind::Unwind;
+            config._source = unwind.getSource();
+
+            const mlir::OperandRange carriedColumns = unwind.getColumnsToFilter();
+            config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
+
+            _iteratorConfigs[unwind.getResult()] = config;
         } else if (nl::ProcedureInit procedureInit = mlir::dyn_cast<nl::ProcedureInit>(operation)) {
             IteratorConfig config;
             config._kind = IteratorKind::ProcedureInit;
@@ -665,6 +674,10 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         // A vector search is a plain source too, so a downstream LIMIT can bound its
         // loop through the ordinary early-exit.
         translateVectorSearchLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::Unwind) {
+        // An unwind expands the rows it is given rather than accumulating them, so - like
+        // a hop - a downstream LIMIT can bound its loop through the ordinary early-exit.
+        translateUnwindLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::ProcedureInit) {
         translateProcedureInitLoop(config, loopBody, limit, body);
     } else {
@@ -842,6 +855,74 @@ void NLTranslator::translateVectorSearchLoop(const IteratorConfig& config,
     loopData->setLimit(limit);
 
     body->emplaceStmt(&NLExecutor::runVectorSearchLoop, loopData);
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+void NLTranslator::translateUnwindLoop(const IteratorConfig& config,
+                                       mlir::Block& loopBody,
+                                       NLLimitState* limit,
+                                       NLStmtContainer* body) {
+    const mlir::Value sourceValue = config._source;
+    const Column* source = getColumn(sourceValue);
+
+    const nl::ChunkType sourceChunk = mlir::cast<nl::ChunkType>(sourceValue.getType());
+    const mlir::Type sourceElement = sourceChunk.getElementType();
+
+    // An unwind binds the elements first, then one variable per carried column.
+    const mlir::Value elementValue = loopBody.getArgument(0);
+
+    // A column whose cells hold more than the element - a list, or a tagged scalar that
+    // may itself be a list - drains through its own emit. A scalar column already holds
+    // one element per cell, so its element column is the source's own rows gathered by
+    // the step: a carried column like the rest, and no drain here.
+    NLUnwindElementCountFunction elementCount = nullptr;
+    NLUnwindElementEmitFunction elementEmit = nullptr;
+
+    if (llvm::isa<storage::ListType>(sourceElement)) {
+        elementCount = NLExecutor::selectListUnwindElementCount();
+        elementEmit = NLExecutor::selectListUnwindElementEmit();
+    } else if (llvm::isa<storage::ListElementType>(sourceElement)) {
+        elementCount = NLExecutor::selectTaggedUnwindElementCount();
+        elementEmit = NLExecutor::selectTaggedUnwindElementEmit();
+    } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(sourceElement)) {
+        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+        elementCount = NLExecutor::selectOptUnwindElementCount(valueType);
+    } else {
+        elementCount = NLExecutor::selectValueUnwindElementCount();
+    }
+
+    Column* const elementOutput = elementEmit ? allocColumn(elementValue) : nullptr;
+
+    NLUnwindLoopData* loopData = _program->allocFunctionData<NLUnwindLoopData>(source,
+                                                                               elementCount,
+                                                                               elementEmit,
+                                                                               elementOutput);
+    loopData->setLimit(limit);
+
+    const size_t chunkSize = _program->getChunkSize();
+    loopData->getRows()->reserve(chunkSize);
+    loopData->getPositions()->reserve(chunkSize);
+
+    if (!elementEmit) {
+        const NLCarriedColumn elementColumn(source,
+                                            allocColumn(elementValue),
+                                            selectGatherForChunkType(sourceChunk));
+        loopData->addCarriedColumn(elementColumn);
+    }
+
+    const size_t carriedCount = config._carriedColumns.size();
+    for (size_t carriedIndex = 0; carriedIndex < carriedCount; carriedIndex++) {
+        const mlir::Value carriedValue = config._carriedColumns[carriedIndex];
+        const mlir::Value loopVariable = loopBody.getArgument(static_cast<unsigned>(1 + carriedIndex));
+
+        const NLCarriedColumn carriedColumn(getColumn(carriedValue),
+                                            allocColumn(loopVariable),
+                                            selectGatherForChunkType(loopVariable.getType()));
+        loopData->addCarriedColumn(carriedColumn);
+    }
+
+    body->emplaceStmt(&NLExecutor::runUnwindLoop, loopData);
 
     translateBlock(loopBody, loopData->getStmts());
 }

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -249,6 +249,10 @@ private:
                              NLLimitState* limit,
                              NLStmtContainer* body);
 
+    // The drain filling an nl.unwind's element chunk from a list column: the chunk's own
+    // element type is what the list resolved to, so it names the column the drain fills
+    static NLUnwindElementEmitFunction selectListUnwindEmit(mlir::Type chunkType);
+
     // Materialize a literal element array - an nl.unwind_const's or an nl.const_list's -
     // into a ListView in the query-scoped ListBuffer, which the unwind loop then reads
     // chunk by chunk and a constant list keeps whole. A nested array is materialized

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -56,6 +56,7 @@ private:
         UnwindConst,
         LoadCSV,
         VectorSearch,
+        Unwind,
         ProcedureInit,
     };
 
@@ -121,6 +122,10 @@ private:
         mlir::ArrayAttr _csvFields;
         bool _csvHasHeaders {false};
         bool _csvSkipOnError {false};
+
+        // The column an Unwind iterator expands, one row per element of each of its
+        // cells; null for the other kinds.
+        mlir::Value _source;
     };
 
     NLProgram* _program {nullptr};
@@ -234,6 +239,15 @@ private:
                                    mlir::Block& loopBody,
                                    NLLimitState* limit,
                                    NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.unwind iterator: allocate the element loop
+    // variable and one per carried column, pick the handlers that read the source
+    // column's shape, and record the expansion loop statement. The per-row sibling of
+    // translateUnwindConstLoop - it reads an input chunk and carries the rows in flight.
+    void translateUnwindLoop(const IteratorConfig& config,
+                             mlir::Block& loopBody,
+                             NLLimitState* limit,
+                             NLStmtContainer* body);
 
     // Materialize a literal element array - an nl.unwind_const's or an nl.const_list's -
     // into a ListView in the query-scoped ListBuffer, which the unwind loop then reads

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -997,9 +997,8 @@ void DBLowering::lowerUnwind(mlir::db::Unwind unwind) {
 
     // A constant source holds one cell standing for every row rather than one per row, so
     // it is laid out over the rows it expands - the carried ones, or the single row a
-    // scope of constants alone is when there are none.
-    const mlir::Value cardinality = carriedChunks.empty() ? _innermostCardinality
-                                                          : carriedChunks.front();
+    // scope of constants alone is.
+    const mlir::Value cardinality = cardinalityDriver(carriedChunks);
     const mlir::Value sourceChunk = rowAlignedChunk(mapValue(unwind.getSource()), cardinality);
 
     // Inserted into the deepest block, where every operand is bound - as lowerFilter's is
@@ -2776,14 +2775,7 @@ void DBLowering::lowerFilter(mlir::db::FilterOp filter) {
     // mask has exactly as many rows as they do - the driving relation's when a column of
     // it is what the cut carries, and the single row a projection of constants is when
     // nothing drives it.
-    mlir::Value maskDriver = _innermostCardinality;
-    for (const mlir::Value columnChunk : columnChunks) {
-        if (!yieldsConstantColumn(columnChunk)) {
-            maskDriver = columnChunk;
-            break;
-        }
-    }
-
+    const mlir::Value maskDriver = cardinalityDriver(columnChunks);
     const mlir::Value maskChunk = rowAlignedChunk(mapValue(filter.getMask()), maskDriver);
 
     // Inserted into the deepest block, where all operands are defined
@@ -3046,6 +3038,16 @@ mlir::Value DBLowering::nullableValueChunk(mlir::Value chunk) {
     }
 
     return _builder.create<nl::ToNullable>(_builder.getUnknownLoc(), resultType, chunk).getResult();
+}
+
+mlir::Value DBLowering::cardinalityDriver(llvm::ArrayRef<mlir::Value> chunks) const {
+    for (const mlir::Value chunk : chunks) {
+        if (!yieldsConstantColumn(chunk)) {
+            return chunk;
+        }
+    }
+
+    return _innermostCardinality;
 }
 
 mlir::Value DBLowering::rowAlignedChunk(mlir::Value chunk, mlir::Value cardinality) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -556,9 +556,7 @@ bool dropsRows(mlir::Operation* operation) {
 bool drainsToItsOwnElementType(mlir::Type listElement) {
     if (mlir::isa<storage::NodeIDType, storage::EdgeIDType, storage::StringType, storage::ListType>(listElement)) {
         return true;
-    }
-
-    if (mlir::isa<mlir::Float64Type>(listElement)) {
+    } else if (mlir::isa<mlir::Float64Type>(listElement)) {
         return true;
     }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -682,6 +682,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerLoadCSV(loadCSV);
     } else if (mlir::db::VectorSearch vectorSearch = mlir::dyn_cast<mlir::db::VectorSearch>(operation)) {
         lowerVectorSearch(vectorSearch);
+    } else if (mlir::db::Unwind unwind = mlir::dyn_cast<mlir::db::Unwind>(operation)) {
+        lowerUnwind(unwind);
     } else if (mlir::db::ScanEdges scanEdges = mlir::dyn_cast<mlir::db::ScanEdges>(operation)) {
         lowerScanEdges(scanEdges);
     } else if (mlir::db::GetOutEdges getOutEdges = mlir::dyn_cast<mlir::db::GetOutEdges>(operation)) {
@@ -937,6 +939,60 @@ void DBLowering::lowerVectorSearch(mlir::db::VectorSearch vectorSearch) {
                                                                     vectorSearch.getKAttr(),
                                                                     vectorSearch.getQueryVectorAttr());
     buildLoopForSource(neighbours.getResult(), vectorSearch.getOperation());
+}
+
+mlir::Type DBLowering::unwoundElementType(mlir::MLIRContext* context, mlir::Type sourceElement) {
+    // A list drains into the type-erased column of tagged scalars: its elements carry
+    // their own type. Any other source keeps the column it already rides - its cells are
+    // the elements, and a tagged cell holding a list gives up tagged scalars again.
+    if (llvm::isa<storage::ListType>(sourceElement)) {
+        return storage::ListElementType::get(context);
+    }
+
+    return sourceElement;
+}
+
+void DBLowering::lowerUnwind(mlir::db::Unwind unwind) {
+    llvm::SmallVector<mlir::Value, 4> carriedChunks;
+    for (const mlir::Value carriedColumn : unwind.getColumnsToFilter()) {
+        carriedChunks.push_back(mapValue(carriedColumn));
+    }
+
+    // A constant source holds one cell standing for every row rather than one per row, so
+    // it is laid out over the rows it expands - the carried ones, or the single row a
+    // scope of constants alone is when there are none.
+    const mlir::Value cardinality = carriedChunks.empty() ? _innermostCardinality
+                                                          : carriedChunks.front();
+    const mlir::Value sourceChunk = rowAlignedChunk(mapValue(unwind.getSource()), cardinality);
+
+    // Inserted into the deepest block, where every operand is bound - as lowerFilter's is
+    mlir::Value insertionReference = sourceChunk;
+    for (const mlir::Value carriedChunk : carriedChunks) {
+        mlir::Block* const block = deeperBlock(insertionReference, carriedChunk);
+        if (ownerBlock(carriedChunk) == block) {
+            insertionReference = carriedChunk;
+        }
+    }
+
+    setInsertionInto(ownerBlock(insertionReference));
+
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::Type sourceElement = mlir::cast<nl::ChunkType>(sourceChunk.getType()).getElementType();
+
+    llvm::SmallVector<mlir::Type, 4> chunkTypes;
+    chunkTypes.push_back(nl::ChunkType::get(context, unwoundElementType(context, sourceElement)));
+
+    for (const mlir::Value carriedChunk : carriedChunks) {
+        chunkTypes.push_back(carriedChunk.getType());
+    }
+
+    const nl::IteratorType iteratorType = nl::IteratorType::get(context, chunkTypes);
+
+    nl::Unwind rows = _builder.create<nl::Unwind>(_builder.getUnknownLoc(),
+                                                  iteratorType,
+                                                  sourceChunk,
+                                                  carriedChunks);
+    buildLoopForSource(rows.getResult(), unwind.getOperation());
 }
 
 void DBLowering::lowerScanEdges(mlir::db::ScanEdges scanEdges) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -264,9 +264,10 @@ nl::ChunkType procedureChunkType(mlir::OpBuilder& builder, ProcedureType procedu
 // inputElement is the tagged cell itself. avg always reduces to an f64; sum,
 // min and max keep the input's own type. Throws for a value type the reduction
 // cannot handle: sum/avg need a numeric column, min/max an orderable one (so a
-// string sum, a bool sum or an embedding min is rejected, matching Cypher). A
-// tagged cell is numeric only once read, so only avg - whose result type does not
-// depend on what the tags were - accepts one.
+// string sum, a bool sum or an embedding min is rejected, matching Cypher). A tagged
+// cell is numeric only once read, so sum and avg accept one - both landing on the f64
+// mixed numeric tags reduce to - where min/max would have to hand the winning cell back
+// under its own type, which no single result type names.
 mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
                                       storage::AggregateKind kind,
                                       mlir::Type inputElement) {
@@ -280,10 +281,10 @@ mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
 
     switch (kind) {
         case storage::AggregateKind::Sum: {
-            if (!isNumeric) {
+            if (!isNumeric && !isTaggedCell) {
                 throw IRException("db.sum requires a numeric column");
             }
-            return inputElement;
+            return isTaggedCell ? builder.getF64Type() : inputElement;
         }
         break;
 
@@ -510,6 +511,7 @@ bool opensSourceLoop(mlir::Operation* operation) {
                      mlir::db::UnwindConst,
                      mlir::db::LoadCSV,
                      mlir::db::VectorSearch,
+                     mlir::db::Unwind,
                      mlir::db::ScanNodesByLabel,
                      mlir::db::ScanEdges,
                      mlir::db::GetOutEdges,
@@ -544,6 +546,25 @@ bool dropsRows(mlir::Operation* operation) {
                      mlir::db::Skip,
                      mlir::db::Limit,
                      mlir::db::RemoveDuplicates>(operation);
+}
+
+// The list element types an unwind can drain into a column of that very type: the entity
+// IDs, the value types a nullable value chunk is laid out for, and a nested list, which
+// drains into a list column one level shallower. An unresolved element, an embedding, or
+// the list_element a heterogeneous list holds drains as tagged scalars instead - none of
+// them names a column shape the drain could fill.
+bool drainsToItsOwnElementType(mlir::Type listElement) {
+    if (mlir::isa<storage::NodeIDType, storage::EdgeIDType, storage::StringType, storage::ListType>(listElement)) {
+        return true;
+    }
+
+    if (mlir::isa<mlir::Float64Type>(listElement)) {
+        return true;
+    }
+
+    const auto intType = mlir::dyn_cast<mlir::IntegerType>(listElement);
+
+    return intType && (intType.getWidth() == 1 || intType.getWidth() == 64);
 }
 
 }
@@ -942,14 +963,30 @@ void DBLowering::lowerVectorSearch(mlir::db::VectorSearch vectorSearch) {
 }
 
 mlir::Type DBLowering::unwoundElementType(mlir::MLIRContext* context, mlir::Type sourceElement) {
-    // A list drains into the type-erased column of tagged scalars: its elements carry
-    // their own type. Any other source keeps the column it already rides - its cells are
-    // the elements, and a tagged cell holding a list gives up tagged scalars again.
-    if (llvm::isa<storage::ListType>(sourceElement)) {
+    // Any source but a list keeps the column it already rides - its cells are the
+    // elements, and a tagged cell holding a list gives up tagged scalars again.
+    const auto listType = mlir::dyn_cast<storage::ListType>(sourceElement);
+    if (!listType) {
+        return sourceElement;
+    }
+
+    // The elements of a list whose type is known are that type, so the unwind hands the
+    // rest of the query a column it can read as one - a node stays a node, an integer an
+    // integer. Only a list whose elements share no such type drains into the type-erased
+    // column of tagged scalars.
+    const mlir::Type listElement = listType.getElementType();
+    if (!drainsToItsOwnElementType(listElement)) {
         return storage::ListElementType::get(context);
     }
 
-    return sourceElement;
+    // An entity ID and a nested list are present in every row they are drained from, so
+    // they ride a plain chunk; a value rides the nullable one every value-chunk consumer
+    // dispatches on, as lowerUnwindConst's homogeneous list does.
+    if (mlir::isa<storage::NodeIDType, storage::EdgeIDType, storage::ListType>(listElement)) {
+        return listElement;
+    }
+
+    return storage::NullableType::get(context, listElement);
 }
 
 void DBLowering::lowerUnwind(mlir::db::Unwind unwind) {
@@ -1802,16 +1839,17 @@ void DBLowering::lowerGroupAggregate(mlir::db::GroupAggregate groupAggregate) {
 
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
         const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
+        const size_t chunkIndex = keyCount + aggregateIndex;
 
         // A type-erased column of tagged cells is folded as it stands, like a count's
         // input: every cell carries its own tag, so there is no one value type to read
         // the column as.
-        const mlir::Value aggregateChunk = chunks[keyCount + aggregateIndex];
+        const mlir::Value aggregateChunk = chunks[chunkIndex];
         const mlir::Type aggregateElement = mlir::cast<nl::ChunkType>(aggregateChunk.getType()).getElementType();
         const bool taggedCells = mlir::isa<storage::ListElementType>(aggregateElement);
 
         if (reducesValues(kind) && !taggedCells) {
-            chunks[keyCount + aggregateIndex] = nullableValueChunk(aggregateChunk);
+            chunks[chunkIndex] = nullableValueChunk(aggregateChunk);
         }
     }
 
@@ -1902,14 +1940,19 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
         chunks[inputIndex] = rowAlignedChunk(chunks[inputIndex], cardinality);
     }
 
-    // An entity column collects as the IDs it carries, which every row holds: only a
-    // scalar value column is read as nullable, the way a property fetch is.
+    // An entity column collects as the IDs it carries, a list column as the cells it
+    // holds, and a type-erased one as the tagged cells - all present in every row, the
+    // tagged null among them, which the fold drops rather than the column. Only a scalar
+    // value column is read as nullable, the way a property fetch is.
     for (size_t valueIndex = 0; valueIndex < valueCount; valueIndex++) {
         const size_t chunkIndex = keyCount + valueIndex;
         const mlir::Type collectedElement = mlir::cast<nl::ChunkType>(chunks[chunkIndex].getType()).getElementType();
-        const bool collectsEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(collectedElement);
+        const bool collectsCellsPresentInEveryRow = mlir::isa<storage::NodeIDType,
+                                                              storage::EdgeIDType,
+                                                              storage::ListType,
+                                                              storage::ListElementType>(collectedElement);
 
-        if (!collectsEntity) {
+        if (!collectsCellsPresentInEveryRow) {
             chunks[chunkIndex] = nullableValueChunk(chunks[chunkIndex]);
         }
     }

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -416,9 +416,10 @@ private:
 
     mlir::Value nullableValueChunk(mlir::Value chunk);
 
-    // The chunk element type an unwind of @param sourceElement produces: the type-erased
-    // list_element of tagged scalars when a list is drained, and the source's own element
-    // otherwise, its cells being the elements themselves
+    // The chunk element type an unwind of @param sourceElement produces: a drained list
+    // gives up the type its own elements carry, falling back to the type-erased
+    // list_element when they share none, and any other source keeps its own element,
+    // its cells being the elements themselves
     static mlir::Type unwoundElementType(mlir::MLIRContext* context, mlir::Type sourceElement);
 
     // The nl chunk a db value lowered to, and the block that holds a chunk

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -181,6 +181,7 @@ private:
     void lowerUnwindConst(mlir::db::UnwindConst unwindConst);
     void lowerLoadCSV(mlir::db::LoadCSV loadCSV);
     void lowerVectorSearch(mlir::db::VectorSearch vectorSearch);
+    void lowerUnwind(mlir::db::Unwind unwind);
     void lowerScanEdges(mlir::db::ScanEdges scanEdges);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
     void lowerGetInEdges(mlir::db::GetInEdges getInEdges);
@@ -414,6 +415,11 @@ private:
     mlir::Value rowAlignedChunk(mlir::Value chunk, mlir::Value cardinality);
 
     mlir::Value nullableValueChunk(mlir::Value chunk);
+
+    // The chunk element type an unwind of @param sourceElement produces: the type-erased
+    // list_element of tagged scalars when a list is drained, and the source's own element
+    // otherwise, its cells being the elements themselves
+    static mlir::Type unwoundElementType(mlir::MLIRContext* context, mlir::Type sourceElement);
 
     // The nl chunk a db value lowered to, and the block that holds a chunk
     mlir::Value mapValue(mlir::Value dbValue) const;

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -3,6 +3,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -399,6 +400,11 @@ private:
     // count a cut over constants alone charges, and the count every cut chained after it
     // reads in turn.
     void rowAlignCutChunks(llvm::SmallVectorImpl<mlir::Value>& chunks);
+
+    // The chunk whose rows the constants of a step are laid out over: the first of
+    // @param chunks carrying rows of its own, and the innermost loop's cardinality when
+    // every one of them is a constant, or there are none.
+    mlir::Value cardinalityDriver(llvm::ArrayRef<mlir::Value> chunks) const;
 
     // Follows the cardinality driver through a step that narrows the relation, from the
     // chunk it read in @param inputChunks to the narrowed chunk standing for it in

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -1238,11 +1238,22 @@ void ReadStmtGenerator::generateUnwindStmt(const UnwindStmt* stmt) {
     const VarDecl* var = _declContext->getDecl(symbolName);
     bioassert(var, "Null variable for UNWIND.");
 
-    const auto* litArg = dynamic_cast<const LiteralExpr*>(arg);
-    bioassert(litArg, "Non-literal argument.");
+    if (!stmt->unwindsLiteral()) {
+        throwError("UNWIND of an expression evaluated per row is only supported by the MLIR "
+                   "query engine.",
+                   arg);
+    }
+
+    const auto* litArg = static_cast<const LiteralExpr*>(arg);
     const Literal* lit = litArg->getLiteral();
     bioassert(lit, "Null literal");
+
     const auto* list = dynamic_cast<const ListLiteral*>(lit);
+    if (!list) {
+        throwError("UNWIND of a value that is not a list is only supported by the MLIR query "
+                   "engine.",
+                   arg);
+    }
 
     const ListLiteral::Items& items = list->items();
 

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -245,7 +245,13 @@ struct PairRestrictions<Op> {
         OptionalKindPairs<types::String::Primitive, types::String::Primitive>::Pairs,
         OptionalKindPairs<types::String::Primitive, types::String::OwningPrimitive>::Pairs,
         OptionalKindPairs<types::String::OwningPrimitive, types::String::Primitive>::Pairs,
-        OptionalKindPairs<types::String::OwningPrimitive, types::String::OwningPrimitive>::Pairs
+        OptionalKindPairs<types::String::OwningPrimitive, types::String::OwningPrimitive>::Pairs,
+
+        // A type-erased cell against a string, or against another cell, read by its tag
+        ListElementKindPairs<types::String::Primitive>::Pairs,
+        ListElementKindPairs<types::String::OwningPrimitive>::Pairs,
+
+        std::tuple<KindPair<ListElementView, ListElementView>>
     >;
 
     using AllowedMixed = AllowedMixedList<>;

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -467,24 +467,59 @@ struct TuringXor {
     }
 };
 
-struct StringStartsWith {
+// The characters a string predicate reads out of one operand. A type-erased cell holds
+// them only when it is tagged as a string: one holding a number, a nested list or a null
+// has none, so no string predicate can match it.
+inline std::optional<types::String::Primitive> predicateText(const types::String::Primitive value) {
+    return value;
+}
+
+inline std::optional<types::String::Primitive> predicateText(const types::String::OwningPrimitive& value) {
+    return value;
+}
+
+inline std::optional<types::String::Primitive> predicateText(const ListElementView element) {
+    if (element.getTag() != ListBufferTypeTag::String) {
+        return std::nullopt;
+    }
+
+    return element.getAs<types::String::Primitive>();
+}
+
+/**
+ * @brief Applies a string test @param F to the characters each operand holds, whichever of
+ * the string column kinds - or type-erased cells - the operands are.
+ */
+template <typename F>
+struct StringPredicate {
     template <typename T, typename U>
-    bool operator()(const T& text, U&& prefix) const {
-        return text.starts_with(std::forward<U>(prefix));
+    bool operator()(const T& text, const U& pattern) const {
+        const std::optional<types::String::Primitive> textView = predicateText(text);
+        const std::optional<types::String::Primitive> patternView = predicateText(pattern);
+
+        if (!textView || !patternView) {
+            return false;
+        }
+
+        return F {}(*textView, *patternView);
+    }
+};
+
+struct StringStartsWith {
+    bool operator()(const types::String::Primitive text, const types::String::Primitive prefix) const {
+        return text.starts_with(prefix);
     }
 };
 
 struct StringEndsWith {
-    template <typename T, typename U>
-    bool operator()(const T& text, U&& suffix) const {
-        return text.ends_with(std::forward<U>(suffix));
+    bool operator()(const types::String::Primitive text, const types::String::Primitive suffix) const {
+        return text.ends_with(suffix);
     }
 };
 
 struct StringContains {
-    template <typename T, typename U>
-    bool operator()(const T& text, U&& pattern) const {
-        return text.find(std::forward<U>(pattern)) != T::npos;
+    bool operator()(const types::String::Primitive text, const types::String::Primitive pattern) const {
+        return text.find(pattern) != types::String::Primitive::npos;
     }
 };
 
@@ -503,8 +538,8 @@ using And = BinaryPredicate<std::logical_and<>>;
 using Or = BinaryPredicate<std::logical_or<>>;
 using Xor = BinaryPredicate<TuringXor>;
 
-using StartsWith = BinaryPredicate<StringStartsWith>;
-using EndsWith = BinaryPredicate<StringEndsWith>;
-using Contains = BinaryPredicate<StringContains>;
+using StartsWith = BinaryPredicate<StringPredicate<StringStartsWith>>;
+using EndsWith = BinaryPredicate<StringPredicate<StringEndsWith>>;
+using Contains = BinaryPredicate<StringPredicate<StringContains>>;
 
 }

--- a/test/query-test-suite/tests/unwind-property-expression.json
+++ b/test/query-test-suite/tests/unwind-property-expression.json
@@ -1,0 +1,17 @@
+{
+  "enabled": true,
+  "remote-enabled": false,
+  "graph": "simpledb",
+  "query": "MATCH (n) UNWIND n.age AS a RETURN n.name, a",
+  "expect": {
+    "plan": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n) UNWIND n.age AS a RETURN n.name, a\n       |                  ^^^^^\n-------* UNWIND of an expression evaluated per row is only supported by the MLIR query engine.",
+    "result": "PLAN ERROR\n-------* Query error\n     1 | MATCH (n) UNWIND n.age AS a RETURN n.name, a\n       |                  ^^^^^\n-------* UNWIND of an expression evaluated per row is only supported by the MLIR query engine.",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n) UNWIND n.age AS a RETURN n.name, a\\n       |                  ^^^^^\\n-------* UNWIND of an expression evaluated per row is only supported by the MLIR query engine.\"}"
+  },
+  "tags": [
+    "errors",
+    "unwind",
+    "lists"
+  ],
+  "write-required": false
+}

--- a/test/query-test-suite/tests/unwind-scalar.json
+++ b/test/query-test-suite/tests/unwind-scalar.json
@@ -4,9 +4,9 @@
   "graph": "simpledb",
   "query": "UNWIND 5 AS x RETURN x",
   "expect": {
-    "plan": "PLAN ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.",
-    "result": "PLAN ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.",
-    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | UNWIND 5 AS x RETURN x\\n       |        ^\\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.\"}"
+    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND requires a list, not 'Integer'",
+    "result": "ANALYZE ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND requires a list, not 'Integer'",
+    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | UNWIND 5 AS x RETURN x\\n       |        ^\\n-------* UNWIND requires a list, not 'Integer'\"}"
   },
   "tags": [
     "errors",

--- a/test/query-test-suite/tests/unwind-scalar.json
+++ b/test/query-test-suite/tests/unwind-scalar.json
@@ -1,0 +1,17 @@
+{
+  "enabled": true,
+  "remote-enabled": false,
+  "graph": "simpledb",
+  "query": "UNWIND 5 AS x RETURN x",
+  "expect": {
+    "plan": "PLAN ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.",
+    "result": "PLAN ERROR\n-------* Query error\n     1 | UNWIND 5 AS x RETURN x\n       |        ^\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | UNWIND 5 AS x RETURN x\\n       |        ^\\n-------* UNWIND of a value that is not a list is only supported by the MLIR query engine.\"}"
+  },
+  "tags": [
+    "errors",
+    "unwind",
+    "lists"
+  ],
+  "write-required": false
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -898,6 +898,28 @@ target_link_libraries(test_query_ir_cypher_unwind PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_cypher_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_cypher_unwind_expr CypherUnwindExprTest.cpp)
+target_link_libraries(test_query_ir_cypher_unwind_expr PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s
+        turing_ir_test_rows_s
+        MLIRParser)
+target_include_directories(test_query_ir_cypher_unwind_expr PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cypher_list_literal CypherListLiteralTest.cpp)
 target_link_libraries(test_query_ir_cypher_list_literal PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -898,6 +898,27 @@ target_link_libraries(test_query_ir_cypher_unwind PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_cypher_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_unwind_value_filter_codegen UnwindValueFilterCodegenTest.cpp)
+target_link_libraries(test_query_ir_unwind_value_filter_codegen PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_storage_s
+        turing_ir_test_rows_s
+        MLIRParser)
+target_include_directories(test_query_ir_unwind_value_filter_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cypher_unwind_expr CypherUnwindExprTest.cpp)
 target_link_libraries(test_query_ir_cypher_unwind_expr PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -898,6 +898,27 @@ target_link_libraries(test_query_ir_cypher_unwind PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_cypher_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_unwind_collect_seed UnwindCollectSeedTest.cpp)
+target_link_libraries(test_query_ir_unwind_collect_seed PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_storage_s
+        turing_ir_test_rows_s
+        MLIRParser)
+target_include_directories(test_query_ir_unwind_collect_seed PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_unwind_value_filter_codegen UnwindValueFilterCodegenTest.cpp)
 target_link_libraries(test_query_ir_unwind_value_filter_codegen PRIVATE
         turing_db_s

--- a/test/query/ir/CallUnwindTest.cpp
+++ b/test/query/ir/CallUnwindTest.cpp
@@ -38,6 +38,18 @@ TEST_F(CallUnwindTest, unwindAfterACall) {
     EXPECT_EQ(rows, unwoundEdgeTypes);
 }
 
+// The yielded column is no list, so each of its rows unwinds to the single value it holds.
+TEST_F(CallUnwindTest, unwindsAYieldedValue) {
+    StringRowSink sink;
+    runQuery("CALL db.edgeTypes() YIELD edgeType UNWIND edgeType AS unwoundType RETURN unwoundType", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<StringRowSink::Row> expected {{"INTERESTED_IN"}, {"KNOWS_WELL"}};
+    EXPECT_EQ(rows, expected);
+}
+
 // One node per row of the unwound list crossed with the yields: two cells, two edge types.
 TEST_F(CallUnwindTest, unwindThenCallThenCreate) {
     runWrite("UNWIND [1, 2] AS x CALL db.edgeTypes() YIELD edgeType CREATE (m:Combo)");

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -766,3 +766,11 @@ TEST_F(CypherUnwindExprTest, rejectsSummingANonNumericCell) {
 TEST_F(CypherUnwindExprTest, rejectsAnUnwoundVariableThatIsAlreadyDeclared) {
     expectRejected("MATCH (n) UNWIND n.age AS n RETURN n", "already declared");
 }
+
+// An aggregate folds the rows a projection groups, so it names no value an UNWIND could
+// spread: the list has to be published by a WITH first
+TEST_F(CypherUnwindExprTest, rejectsAnAggregateUnwindArgument) {
+    expectRejected("MATCH (n) UNWIND collect(n.name) AS x RETURN x", "aggregate");
+    expectRejected("MATCH (n) UNWIND count(n) AS x RETURN x", "aggregate");
+    expectRejected("MATCH (n) UNWIND count(n) + 1 AS x RETURN x", "aggregate");
+}

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -767,6 +767,16 @@ TEST_F(CypherUnwindExprTest, rejectsAnUnwoundVariableThatIsAlreadyDeclared) {
     expectRejected("MATCH (n) UNWIND n.age AS n RETURN n", "already declared");
 }
 
+// The argument is not a list here, so what is rejected is the argument itself: a message
+// about the elements of a list would send the reader looking for a list they never wrote
+TEST_F(CypherUnwindExprTest, rejectsAnUnrepresentableUnwindArgumentAsTheArgument) {
+    expectRejected("UNWIND {a: 1} AS x RETURN x", "as an UNWIND argument");
+}
+
+TEST_F(CypherUnwindExprTest, rejectsAnUnrepresentableListElementAsAnElement) {
+    expectRejected("UNWIND [{a: 1}] AS x RETURN x", "as list elements");
+}
+
 // An aggregate folds the rows a projection groups, so it names no value an UNWIND could
 // spread: the list has to be published by a WITH first
 TEST_F(CypherUnwindExprTest, rejectsAnAggregateUnwindArgument) {

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -227,6 +227,273 @@ TEST_F(CypherUnwindExprTest, unwindsAnEmptyCollectToNoRow) {
                {});
 }
 
+TEST_F(CypherUnwindExprTest, unwindsACollectedIntegerList) {
+    // The tags the collect wrote are the ones the unwind reads back, so every value type
+    // it can fold is a path of its own. Only Remy and Adam carry an age.
+    expectRows("MATCH (n:Person) WITH collect(n.age) AS ages UNWIND ages AS a RETURN a",
+               {{"32"}, {"32"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsACollectedBooleanList) {
+    expectRows("MATCH (n:Person) WITH collect(n.isFrench) AS flags UNWIND flags AS f RETURN f",
+               {{"true"}, {"true"}, {"true"}, {"true"},
+                {"false"}, {"false"}, {"false"}, {"false"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsACollectedDoubleList) {
+    expectRowsInOrder("UNWIND [1.5, 2.5] AS v WITH collect(v) AS values "
+                      "UNWIND values AS x RETURN x",
+                      {{"1.500000"}, {"2.500000"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsACollectedEdgeProperty) {
+    // A collect drops the rows whose property is absent, so the eleven edges carrying no
+    // proficiency reach neither the list nor the unwind.
+    expectRows("MATCH ()-[e:INTERESTED_IN]->() WITH collect(e.proficiency) AS levels "
+               "UNWIND levels AS level RETURN level",
+               {{"expert"}, {"expert"}, {"expert"}, {"moderate"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsADistinctCollect) {
+    // The collect dedups, so each interest is one element and the unwind emits it once -
+    // Computers and the three Gym rows collapse before the expansion rather than after.
+    expectRows("MATCH (:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(DISTINCT i.name) AS names "
+               "UNWIND names AS name RETURN name",
+               {{"Ghosts"}, {"Computers"}, {"Eighties"}, {"Bio"}, {"Cooking"}, {"Padel"},
+                {"Animals"}, {"Gym"}, {"JiuJitsu"}, {"Travel"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsEmptyGroupsBesideNonEmptyOnes) {
+    // Six of the eight people carry no age, so their group's list is empty and the unwind
+    // walks past it to the next cell that holds one.
+    expectRows("MATCH (n:Person) WITH n.name AS name, collect(n.age) AS ages "
+               "UNWIND ages AS age RETURN name, age",
+               {{"Remy", "32"}, {"Adam", "32"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsACollectedNodeAsANode) {
+    // A list of nodes gives up nodes, so the element reads its properties the way the
+    // matched variable it was collected from does.
+    expectRows("MATCH (n:Person) WITH collect(n) AS people UNWIND people AS person "
+               "RETURN person.name",
+               {{"Remy"}, {"Adam"}, {"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"},
+                {"Cyrus"}, {"Doruk"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsACollectedEdgeAsAnEdge) {
+    expectRows("MATCH ()-[e:KNOWS_WELL]->() WITH collect(e) AS edges UNWIND edges AS edge "
+               "RETURN edge.name, edge.duration",
+               {{"Remy -> Adam", "20"}, {"Adam -> Remy", "20"}, {"Ghosts -> Remy", "200"}});
+}
+
+TEST_F(CypherUnwindExprTest, traversesFromACollectedNodeAfterUnwinding) {
+    // The element is a node, so a later pattern binds it and hops off it - the collect
+    // and the expansion leave the variable as good as the one the MATCH bound.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "WITH collect(p) AS people "
+               "UNWIND people AS person "
+               "MATCH (person)-[:INTERESTED_IN]->(i:Interest) "
+               "RETURN person.name, i.name",
+               {{"Adam", "Bio"}, {"Adam", "Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsADistinctCollectOfNodes) {
+    // Ten interests are reached by fifteen edges, so the collect's dedup is what the
+    // count behind the expansion reports.
+    expectRows("MATCH (:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(DISTINCT i) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN count(interest)",
+               {{"10"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAGroupedCollectOfNodes) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN person, interest.name",
+               {{"Remy", "Ghosts"}, {"Remy", "Computers"}, {"Remy", "Eighties"},
+                {"Adam", "Bio"}, {"Adam", "Cooking"},
+                {"Maxime", "Bio"}, {"Maxime", "Padel"},
+                {"Luc", "Animals"}, {"Luc", "Computers"},
+                {"Martina", "Cooking"},
+                {"Suhas", "Gym"}, {"Suhas", "JiuJitsu"},
+                {"Cyrus", "Gym"}, {"Cyrus", "Travel"},
+                {"Doruk", "Gym"}});
+}
+
+TEST_F(CypherUnwindExprTest, reducesOverACollectedElement) {
+    // The elements are the integers the collect gathered, so they reduce like any other
+    // integer column rather than only being counted.
+    expectRows("MATCH ()-[e]->() WITH collect(e.duration) AS durations "
+               "UNWIND durations AS duration "
+               "RETURN sum(duration), min(duration), max(duration), count(duration)",
+               {{"325", "10", "200", "8"}});
+}
+
+TEST_F(CypherUnwindExprTest, averagesACollectedElement) {
+    expectRows("MATCH (n:Person) WITH collect(n.age) AS ages UNWIND ages AS age "
+               "RETURN avg(age)",
+               {{"32.000000"}});
+}
+
+TEST_F(CypherUnwindExprTest, computesOverACollectedElement) {
+    expectRows("MATCH (n:Person) WITH collect(n.age) AS ages UNWIND ages AS age "
+               "RETURN age + 1",
+               {{"33"}, {"33"}});
+}
+
+TEST_F(CypherUnwindExprTest, ordersACollectedElementByItsOwnType) {
+    // 200 sorts after 20 rather than between 15 and 20, so the elements are ordered as
+    // the integers they are.
+    expectRowsInOrder("MATCH ()-[e]->() WITH collect(e.duration) AS durations "
+                      "UNWIND durations AS duration "
+                      "RETURN duration ORDER BY duration",
+                      {{"10"}, {"15"}, {"20"}, {"20"}, {"20"}, {"20"}, {"20"}, {"200"}});
+}
+
+TEST_F(CypherUnwindExprTest, recollectsAnUnwoundElement) {
+    // The round trip: what a collect gathered comes back out of the expansion as the same
+    // values, so a second collect gathers them again.
+    expectRows("MATCH (i:Interest) WITH collect(i.name) AS names "
+               "UNWIND names AS name "
+               "WITH collect(name) AS again "
+               "RETURN again",
+               {{"[Computers, Eighties, Bio, Cooking, Ghosts, Padel, Animals, Gym, Travel, JiuJitsu]"}});
+}
+
+TEST_F(CypherUnwindExprTest, collectsAListIntoAListOfLists) {
+    // A list cell collects like any other value, nesting one list inside another.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "WITH collect(interests) AS nested "
+               "RETURN nested",
+               {{"[[Bio, Cooking]]"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAListOfListsOneLevel) {
+    // The outer list gives up its cells, each still a list of its own.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "WITH collect(interests) AS nested "
+               "UNWIND nested AS one "
+               "RETURN one",
+               {{"[Bio, Cooking]"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAListOfListsToItsLeaves) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "WITH collect(interests) AS nested "
+               "UNWIND nested AS one UNWIND one AS interest "
+               "RETURN interest",
+               {{"Bio"}, {"Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsEveryGroupsListOutOfANestedCollect) {
+    // One inner list per person, gathered into one outer list and drained back down to
+    // the fifteen names the groups were built from.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "WITH collect(interests) AS nested "
+               "UNWIND nested AS one UNWIND one AS interest "
+               "RETURN count(interest)",
+               {{"15"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsANestedNodeListToItsNodes) {
+    // The nodes survive both levels: the outer list gives up lists of nodes and the inner
+    // one the nodes themselves, so the leaf reads its properties.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH p.name AS person, collect(i) AS interests "
+               "WITH collect(interests) AS nested "
+               "UNWIND nested AS one UNWIND one AS interest "
+               "RETURN interest.name",
+               {{"Bio"}, {"Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, traversesFromANodeUnwoundOutOfANestedList) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH p.name AS person, collect(i) AS interests "
+               "WITH collect(interests) AS nested "
+               "UNWIND nested AS one UNWIND one AS interest "
+               "MATCH (interest)<-[:INTERESTED_IN]-(fan:Person) "
+               "RETURN interest.name, fan.name",
+               {{"Bio", "Adam"}, {"Bio", "Maxime"},
+                {"Cooking", "Adam"}, {"Cooking", "Martina"}});
+}
+
+TEST_F(CypherUnwindExprTest, reducesOverTheLeafOfANestedList) {
+    expectRows("MATCH ()-[e]->() WITH collect(e.duration) AS durations "
+               "WITH collect(durations) AS nested "
+               "UNWIND nested AS one UNWIND one AS duration "
+               "RETURN sum(duration)",
+               {{"325"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsThreeLevelsOfCollectedLists) {
+    // Nothing caps the nesting: each collect goes one level deeper and each UNWIND one
+    // level back out, down to the values the innermost list holds.
+    expectRowsInOrder("UNWIND [1, 2] AS v "
+                      "WITH collect(v) AS ones "
+                      "WITH collect(ones) AS twos "
+                      "WITH collect(twos) AS threes "
+                      "UNWIND threes AS a UNWIND a AS b UNWIND b AS c "
+                      "RETURN c",
+                      {{"1"}, {"2"}});
+}
+
+TEST_F(CypherUnwindExprTest, collectsAHeterogeneousElement) {
+    // The elements share no type, so each is gathered under the one its own tag names.
+    expectRows("UNWIND [10, 'a'] AS v RETURN collect(v)", {{"[10, a]"}});
+}
+
+TEST_F(CypherUnwindExprTest, collectsANestedListElement) {
+    expectRows("UNWIND [[1, 2], [3]] AS l RETURN collect(l)", {{"[[1, 2], [3]]"}});
+}
+
+TEST_F(CypherUnwindExprTest, dropsNullsCollectingAHeterogeneousElement) {
+    // A cell tagged null is the null Cypher's collect drops, exactly as a typed collect
+    // drops an absent property.
+    expectRows("UNWIND [1, null, 2] AS v RETURN collect(v)", {{"[1, 2]"}});
+}
+
+TEST_F(CypherUnwindExprTest, dedupsAHeterogeneousCollect) {
+    expectRows("UNWIND [1, 'a', 1, 'a', 2] AS v RETURN collect(DISTINCT v)", {{"[1, a, 2]"}});
+}
+
+TEST_F(CypherUnwindExprTest, roundTripsAHeterogeneousElementThroughACollect) {
+    expectRowsInOrder("UNWIND [10, 'a'] AS v WITH collect(v) AS values "
+                      "UNWIND values AS x RETURN x",
+                      {{"10"}, {"a"}});
+}
+
+TEST_F(CypherUnwindExprTest, dedupsEqualListsInACollect) {
+    // Two groups build the same list from different rows, so DISTINCT keeps one of it:
+    // two list cells are the same value when their elements are, never by sharing a cell.
+    const std::string_view collected = "UNWIND [1, 2] AS key "
+                                       "MATCH (p:Person) WHERE p.name = 'Adam' "
+                                       "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+                                       "WITH key, collect(i.name) AS interests ";
+
+    expectRows(std::string(collected).append("WITH collect(DISTINCT interests) AS nested "
+                                             "UNWIND nested AS one RETURN one"),
+               {{"[Bio, Cooking]"}});
+
+    expectRows(std::string(collected).append("WITH collect(interests) AS nested "
+                                             "UNWIND nested AS one RETURN one"),
+               {{"[Bio, Cooking]"}, {"[Bio, Cooking]"}});
+}
+
+TEST_F(CypherUnwindExprTest, reducesOverAListLiteralPublishedByAWith) {
+    // The barrier publishes the element type with the list, so a literal read through a
+    // variable reduces exactly as the same literal written into the UNWIND does.
+    expectRows("WITH [10, 20] AS numbers UNWIND numbers AS x RETURN sum(x)", {{"30"}});
+    expectRows("WITH [10, 20] AS numbers UNWIND numbers AS x RETURN x + 1",
+               {{"11"}, {"21"}});
+}
+
 TEST_F(CypherUnwindExprTest, crossesTheUnwoundElementsWithAFollowingMatch) {
     expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
                "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
@@ -235,6 +502,29 @@ TEST_F(CypherUnwindExprTest, crossesTheUnwoundElementsWithAFollowingMatch) {
                "MATCH (n) WHERE n.name = interest "
                "RETURN n.name",
                {{"Bio"}, {"Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, carriesANodeAndAnEdgePastTheUnwind) {
+    // Entity columns ride the carry set as values do, so the node and the edge of each
+    // group come back beside the element their own row's cell unwound into.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[e:INTERESTED_IN]->(i:Interest) "
+               "WITH p, e, collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN p.name, e.name, interest",
+               {{"Adam", "Adam -> Bio", "Bio"}, {"Adam", "Adam -> Cooking", "Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, traversesFromANodeCarriedPastTheUnwind) {
+    // The carried node is still a node behind the expansion, so a later MATCH hops off it
+    // once per element it was replicated for.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p, collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "MATCH (p)-[:KNOWS_WELL]->(other) "
+               "RETURN interest, other.name",
+               {{"Bio", "Remy"}, {"Cooking", "Remy"}});
 }
 
 TEST_F(CypherUnwindExprTest, filtersAFollowingMatchOnAnInlinePropertyConstraint) {
@@ -271,6 +561,19 @@ TEST_F(CypherUnwindExprTest, cutsTheUnwoundElements) {
                       "UNWIND interests AS interest "
                       "RETURN interest ORDER BY interest SKIP 1 LIMIT 1",
                       {{"Eighties"}});
+}
+
+TEST_F(CypherUnwindExprTest, cutsTheUnwoundElementsWithoutASort) {
+    // No sort stands between the cut and the expansion, so the limit bounds the expansion
+    // itself: it stops once three elements are out, whatever chunk size it reaches them in.
+    const Rows firstThree {{"Computers"}, {"Eighties"}, {"Bio"}};
+    const std::string_view query = "MATCH (i:Interest) WITH collect(i.name) AS names "
+                                   "UNWIND names AS name RETURN name LIMIT 3";
+
+    expectRowsInOrder(query, firstThree);
+    expectRowsInOrder(query, firstThree, /*chunkSize=*/1);
+    expectRowsInOrder(query, firstThree, /*chunkSize=*/2);
+    expectRowsInOrder(query, firstThree, /*chunkSize=*/4);
 }
 
 TEST_F(CypherUnwindExprTest, dedupsTheUnwoundElements) {
@@ -315,6 +618,36 @@ TEST_F(CypherUnwindExprTest, chainsTwoExpressionUnwinds) {
                {{"32", "33"}});
 }
 
+TEST_F(CypherUnwindExprTest, unwindsTheSameCollectedListTwice) {
+    // Both unwinds read the one list, and the second expands the rows the first produced,
+    // so the elements come back crossed with themselves.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS a UNWIND interests AS b "
+               "RETURN a, b",
+               {{"Bio", "Bio"}, {"Bio", "Cooking"},
+                {"Cooking", "Bio"}, {"Cooking", "Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsTwoListsOfOneProjection) {
+    // Two collects of the same projection, each expanded in turn: the second list rides
+    // the first expansion's carry set before unwinding over it.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) WHERE p.name = 'Adam' "
+               "WITH collect(p.name) AS people, collect(i.name) AS interests "
+               "UNWIND people AS person UNWIND interests AS interest "
+               "RETURN person, interest",
+               {{"Adam", "Bio"}, {"Adam", "Bio"},
+                {"Adam", "Cooking"}, {"Adam", "Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAListLiteralPublishedByAWith) {
+    // The list is a literal, but the UNWIND reads it through a variable, so it takes the
+    // per-row path over a constant column with nothing in flight to carry.
+    expectRowsInOrder("WITH [1, 2, 3] AS numbers UNWIND numbers AS x RETURN x",
+                      {{"1"}, {"2"}, {"3"}});
+}
+
 TEST_F(CypherUnwindExprTest, unwindsAcrossChunkBoundaries) {
     // One chunk per element, so the loop re-enters its body for every row it emits and
     // the carried key is gathered afresh each time.
@@ -331,6 +664,19 @@ TEST_F(CypherUnwindExprTest, unwindsAcrossChunkBoundaries) {
                 {"Cyrus", "Gym"}, {"Cyrus", "Travel"},
                 {"Doruk", "Gym"}},
                /*chunkSize=*/1);
+}
+
+TEST_F(CypherUnwindExprTest, unwindsOneCollectedCellAcrossChunkBoundaries) {
+    // A single ungrouped cell holding every interest, cut at sizes that do not divide its
+    // ten elements: the expansion resumes inside the cell it was halfway through.
+    const Rows interests {{"Computers"}, {"Eighties"}, {"Bio"}, {"Cooking"}, {"Ghosts"},
+                          {"Padel"}, {"Animals"}, {"Gym"}, {"Travel"}, {"JiuJitsu"}};
+    const std::string_view query = "MATCH (i:Interest) WITH collect(i.name) AS names "
+                                   "UNWIND names AS name RETURN name";
+
+    expectRowsInOrder(query, interests, /*chunkSize=*/3);
+    expectRowsInOrder(query, interests, /*chunkSize=*/4);
+    expectRowsInOrder(query, interests, /*chunkSize=*/7);
 }
 
 TEST_F(CypherUnwindExprTest, publishesTheUnwoundElementAtAFollowingBarrier) {
@@ -360,6 +706,61 @@ TEST_F(CypherUnwindExprTest, unwindsTaggedCellsBesideTheCellTheyCameFrom) {
     // outer cell rides the carry set, so it repeats beside each of them.
     expectRowsInOrder("UNWIND [1, 'a', [2, 3]] AS l UNWIND l AS x RETURN l, x",
                       {{"1", "1"}, {"a", "a"}, {"[2, 3]", "2"}, {"[2, 3]", "3"}});
+}
+
+TEST_F(CypherUnwindExprTest, sumsAHeterogeneousElement) {
+    // Mixed numeric tags are what leaves the list type-erased, and Cypher adds those to a
+    // float, so the cells reduce by tag into one.
+    expectRows("UNWIND [1, 2.5] AS v RETURN sum(v)", {{"3.500000"}});
+}
+
+TEST_F(CypherUnwindExprTest, averagesAHeterogeneousElement) {
+    expectRows("UNWIND [1, 2.5] AS v RETURN avg(v)", {{"1.750000"}});
+}
+
+TEST_F(CypherUnwindExprTest, sumsTheDistinctCellsOfAHeterogeneousElement) {
+    expectRows("UNWIND [1, 2.5, 1] AS v RETURN sum(DISTINCT v)", {{"3.500000"}});
+}
+
+TEST_F(CypherUnwindExprTest, sumsAHeterogeneousElementOutOfACollect) {
+    expectRows("UNWIND [1, 2.5] AS v WITH collect(v) AS values "
+               "UNWIND values AS x RETURN sum(x)",
+               {{"3.500000"}});
+}
+
+TEST_F(CypherUnwindExprTest, sumsAHeterogeneousElementPerGroup) {
+    expectRows("UNWIND [1, 2.5] AS v MATCH (n:Person) WHERE n.name = 'Remy' "
+               "RETURN n.name, sum(v), avg(v)",
+               {{"Remy", "3.500000", "1.750000"}});
+}
+
+TEST_F(CypherUnwindExprTest, sumsNoHeterogeneousCellToZero) {
+    expectRows("UNWIND [] AS v RETURN sum(v)", {{"0.000000"}});
+}
+
+TEST_F(CypherUnwindExprTest, collectsEachTagOfAHeterogeneousElement) {
+    // Every cell goes back into the list under the type its own tag names, so a bool
+    // stays a bool and a double a double beside whatever they were mixed with.
+    expectRows("UNWIND [true, 1] AS v RETURN collect(v)", {{"[true, 1]"}});
+    expectRows("UNWIND [1.5, 'a'] AS v RETURN collect(v)", {{"[1.500000, a]"}});
+}
+
+TEST_F(CypherUnwindExprTest, averagesTheDistinctCellsOfAHeterogeneousElement) {
+    expectRows("UNWIND [1, 2.5, 1] AS v RETURN avg(DISTINCT v)", {{"1.750000"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsANestedEdgeListToItsEdges) {
+    expectRows("MATCH ()-[e:KNOWS_WELL]->() WITH collect(e) AS edges "
+               "WITH collect(edges) AS nested "
+               "UNWIND nested AS one UNWIND one AS edge "
+               "RETURN edge.name",
+               {{"Remy -> Adam"}, {"Adam -> Remy"}, {"Ghosts -> Remy"}});
+}
+
+TEST_F(CypherUnwindExprTest, rejectsSummingANonNumericCell) {
+    // The cells carry a type each, so the check the column types make for a typed
+    // reduction is made per row instead - and a string is no number in either.
+    expectRejected("UNWIND [10, 'a'] AS v RETURN sum(v)", "requires a numeric column");
 }
 
 TEST_F(CypherUnwindExprTest, rejectsAnUnwoundVariableThatIsAlreadyDeclared) {

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -140,28 +140,35 @@ protected:
     Graph* _graph {nullptr};
 };
 
-TEST_F(CypherUnwindExprTest, unwindsAScalarLiteralToOneRow) {
-    expectRows("UNWIND 5 AS x RETURN x", {{"5"}});
+TEST_F(CypherUnwindExprTest, rejectsAScalarLiteral) {
+    expectRejected("UNWIND 5 AS x RETURN x", "UNWIND requires a list");
 }
 
-TEST_F(CypherUnwindExprTest, unwindsEachScalarLiteralKindToOneRow) {
-    expectRows("UNWIND 'text' AS x RETURN x", {{"text"}});
-    expectRows("UNWIND true AS x RETURN x", {{"true"}});
-    expectRows("UNWIND 2.5 AS x RETURN x", {{"2.500000"}});
+TEST_F(CypherUnwindExprTest, rejectsEachScalarLiteralKind) {
+    expectRejected("UNWIND 'text' AS x RETURN x", "UNWIND requires a list, not 'String'");
+    expectRejected("UNWIND true AS x RETURN x", "UNWIND requires a list, not 'Bool'");
+    expectRejected("UNWIND 2.5 AS x RETURN x", "UNWIND requires a list, not 'Double'");
 }
 
+TEST_F(CypherUnwindExprTest, rejectsAScalarLiteralBesideAMatch) {
+    expectRejected("MATCH (n:Person) WHERE n.name = 'Remy' UNWIND 7 AS x RETURN n.name, x",
+                   "UNWIND requires a list");
+}
+
+// Unwinding null is the one literal that is no list and still analyzes: Cypher spreads it
+// into no row rather than calling it a type error.
 TEST_F(CypherUnwindExprTest, unwindsNullToNoRow) {
     expectRows("UNWIND null AS x RETURN x", {});
 }
 
-TEST_F(CypherUnwindExprTest, unwindsAConstantExpressionToOneRow) {
-    expectRows("UNWIND 2 + 3 AS x RETURN x", {{"5"}});
+TEST_F(CypherUnwindExprTest, unwindsNullBesideAMatchToNoRow) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' UNWIND null AS x RETURN n.name, x", {});
 }
 
-TEST_F(CypherUnwindExprTest, unwindsAScalarLiteralBesideAMatch) {
-    // The scalar is one element, so each matched row comes back exactly once beside it.
-    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' UNWIND 7 AS x RETURN n.name, x",
-               {{"Remy", "7"}});
+// Only a literal is typed at plan time, so the rule reaches no further: an expression
+// evaluating to a scalar still spreads to the single row that value is.
+TEST_F(CypherUnwindExprTest, unwindsAConstantExpressionToOneRow) {
+    expectRows("UNWIND 2 + 3 AS x RETURN x", {{"5"}});
 }
 
 TEST_F(CypherUnwindExprTest, unwindsAPropertyToOneRowPerPresentValue) {
@@ -787,7 +794,7 @@ TEST_F(CypherUnwindExprTest, rejectsAnUnwoundVariableThatIsAlreadyDeclared) {
 // The argument is not a list here, so what is rejected is the argument itself: a message
 // about the elements of a list would send the reader looking for a list they never wrote
 TEST_F(CypherUnwindExprTest, rejectsAnUnrepresentableUnwindArgumentAsTheArgument) {
-    expectRejected("UNWIND {a: 1} AS x RETURN x", "as an UNWIND argument");
+    expectRejected("UNWIND {a: 1} AS x RETURN x", "UNWIND requires a list, not 'Map'");
 }
 
 TEST_F(CypherUnwindExprTest, rejectsAnUnrepresentableListElementAsAnElement) {

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -728,6 +728,23 @@ TEST_F(CypherUnwindExprTest, sumsAHeterogeneousElementOutOfACollect) {
                {{"3.500000"}});
 }
 
+// The distinct siblings of the reduction above, charged once per distinct cell of the
+// group: 1, 2.5 and 1 again reduce as the two values they are.
+TEST_F(CypherUnwindExprTest, reducesTheDistinctCellsOfAHeterogeneousElementPerGroup) {
+    expectRows("UNWIND [1, 2.5, 1] AS v MATCH (n:Person) WHERE n.name = 'Remy' "
+               "RETURN n.name, sum(DISTINCT v), avg(DISTINCT v)",
+               {{"Remy", "3.500000", "1.750000"}});
+}
+
+// min and max name no type a static result column could be, so a tagged cell is no
+// argument for them: it is the signature that turns the query away, ahead of the
+// reduction that has no fold for the pair.
+TEST_F(CypherUnwindExprTest, rejectsMinMaxOverAHeterogeneousElement) {
+    expectRejected("UNWIND [10, 'a'] AS v RETURN min(v)", "Invalid arguments for function 'min'");
+    expectRejected("MATCH (n) UNWIND [10, 'a'] AS v RETURN n.name, max(v)",
+                   "Invalid arguments for function 'max'");
+}
+
 TEST_F(CypherUnwindExprTest, sumsAHeterogeneousElementPerGroup) {
     expectRows("UNWIND [1, 2.5] AS v MATCH (n:Person) WHERE n.name = 'Remy' "
                "RETURN n.name, sum(v), avg(v)",

--- a/test/query/ir/CypherUnwindExprTest.cpp
+++ b/test/query/ir/CypherUnwindExprTest.cpp
@@ -1,0 +1,367 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "IRTestRows.h"
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// UNWIND of an expression evaluated per row - a property, a variable a WITH published, a
+// value a CALL yielded, an arithmetic result - rather than of a literal list known at
+// plan time. Each test asserts the rows a query returns, so the whole frontend, the
+// lowering and the interpreter are on the path.
+class CypherUnwindExprTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    void runQuery(std::string_view query, Rows& rows, size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        RowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+
+        rows = sink.rows();
+    }
+
+    // The rows in the order the query emits them, which is what an ORDER BY pins
+    void expectRowsInOrder(std::string_view query,
+                           const Rows& expected,
+                           size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        Rows actual;
+        runQuery(query, actual, chunkSize);
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRows(std::string_view query,
+                    const Rows& expected,
+                    size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        Rows actual;
+        runQuery(query, actual, chunkSize);
+        std::sort(actual.begin(), actual.end());
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRejected(std::string_view query, std::string_view reason) {
+        Rows rows;
+
+        try {
+            runQuery(query, rows);
+        } catch (const TuringException& error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(reason), std::string::npos)
+                << "query: " << query << "\nerror: " << message;
+            return;
+        }
+
+        ADD_FAILURE() << "query was accepted: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(CypherUnwindExprTest, unwindsAScalarLiteralToOneRow) {
+    expectRows("UNWIND 5 AS x RETURN x", {{"5"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsEachScalarLiteralKindToOneRow) {
+    expectRows("UNWIND 'text' AS x RETURN x", {{"text"}});
+    expectRows("UNWIND true AS x RETURN x", {{"true"}});
+    expectRows("UNWIND 2.5 AS x RETURN x", {{"2.500000"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsNullToNoRow) {
+    expectRows("UNWIND null AS x RETURN x", {});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAConstantExpressionToOneRow) {
+    expectRows("UNWIND 2 + 3 AS x RETURN x", {{"5"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAScalarLiteralBesideAMatch) {
+    // The scalar is one element, so each matched row comes back exactly once beside it.
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' UNWIND 7 AS x RETURN n.name, x",
+               {{"Remy", "7"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAPropertyToOneRowPerPresentValue) {
+    // A property is no list, so each row spreads to the single value it holds - and a row
+    // whose property is absent unwinds to nothing. Only Remy and Adam carry an age.
+    expectRows("MATCH (n) UNWIND n.age AS a RETURN n.name, a",
+               {{"Remy", "32"}, {"Adam", "32"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsANodeVariableToItself) {
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND n AS m RETURN m.name", {{"Remy"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAnArithmeticExpressionOverAProperty) {
+    expectRows("MATCH (n) UNWIND n.age + 1 AS a RETURN n.name, a",
+               {{"Remy", "33"}, {"Adam", "33"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAFunctionResult) {
+    // The call is no literal, so it takes the per-row path even though it reads no row:
+    // its one value stands for the single row a constant scope is.
+    expectRows("UNWIND toInteger('18') AS d RETURN d", {{"18"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAListPublishedByAWith) {
+    expectRows("MATCH (i:Interest) WITH collect(i.name) AS names UNWIND names AS x RETURN x",
+               {{"Computers"}, {"Eighties"}, {"Bio"}, {"Cooking"}, {"Ghosts"}, {"Padel"},
+                {"Animals"}, {"Gym"}, {"Travel"}, {"JiuJitsu"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAGroupedListBesideItsKey) {
+    // One list per group, so the key repeats once per element of the group's list.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN person, interest",
+               {{"Remy", "Ghosts"}, {"Remy", "Computers"}, {"Remy", "Eighties"},
+                {"Adam", "Bio"}, {"Adam", "Cooking"},
+                {"Maxime", "Bio"}, {"Maxime", "Padel"},
+                {"Luc", "Animals"}, {"Luc", "Computers"},
+                {"Martina", "Cooking"},
+                {"Suhas", "Gym"}, {"Suhas", "JiuJitsu"},
+                {"Cyrus", "Gym"}, {"Cyrus", "Travel"},
+                {"Doruk", "Gym"}});
+}
+
+TEST_F(CypherUnwindExprTest, keepsTheUnwoundListInScope) {
+    // Cypher leaves the list bound after the UNWIND, so the projection can return the
+    // whole list beside one of its elements.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN interests, interest",
+               {{"[Bio, Cooking]", "Bio"}, {"[Bio, Cooking]", "Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAnEmptyCollectToNoRow) {
+    // No row reaches the collect, so its one group holds the empty list and the unwind
+    // emits nothing - UNWIND of an empty list.
+    expectRows("MATCH (n) WHERE n.name = 'nobody' WITH collect(n.name) AS names "
+               "UNWIND names AS x RETURN x",
+               {});
+}
+
+TEST_F(CypherUnwindExprTest, crossesTheUnwoundElementsWithAFollowingMatch) {
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "MATCH (n) WHERE n.name = interest "
+               "RETURN n.name",
+               {{"Bio"}, {"Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, filtersAFollowingMatchOnAnInlinePropertyConstraint) {
+    // The same join written as an inline constraint: the tagged element is compared to the
+    // property row by row, exactly as the WHERE form is.
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' "
+               "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "MATCH (n {name: interest}) "
+               "RETURN n.name",
+               {{"Bio"}, {"Cooking"}});
+}
+
+TEST_F(CypherUnwindExprTest, filtersOnTheUnwoundElement) {
+    expectRows("MATCH (i:Interest) WITH collect(i.name) AS names "
+               "UNWIND names AS x MATCH (n) WHERE n.name = x AND x = 'Bio' RETURN n.name",
+               {{"Bio"}});
+}
+
+TEST_F(CypherUnwindExprTest, ordersTheUnwoundElements) {
+    expectRowsInOrder("MATCH (p:Person) WHERE p.name = 'Remy' "
+                      "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+                      "WITH collect(i.name) AS interests "
+                      "UNWIND interests AS interest "
+                      "RETURN interest ORDER BY interest",
+                      {{"Computers"}, {"Eighties"}, {"Ghosts"}});
+}
+
+TEST_F(CypherUnwindExprTest, cutsTheUnwoundElements) {
+    expectRowsInOrder("MATCH (p:Person) WHERE p.name = 'Remy' "
+                      "MATCH (p)-[:INTERESTED_IN]->(i:Interest) "
+                      "WITH collect(i.name) AS interests "
+                      "UNWIND interests AS interest "
+                      "RETURN interest ORDER BY interest SKIP 1 LIMIT 1",
+                      {{"Eighties"}});
+}
+
+TEST_F(CypherUnwindExprTest, dedupsTheUnwoundElements) {
+    // Computers is collected twice - Remy's and Luc's - so DISTINCT keeps one of it.
+    expectRows("MATCH (:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN DISTINCT interest",
+               {{"Ghosts"}, {"Computers"}, {"Eighties"}, {"Bio"}, {"Cooking"}, {"Padel"},
+                {"Animals"}, {"Gym"}, {"JiuJitsu"}, {"Travel"}});
+}
+
+TEST_F(CypherUnwindExprTest, countsTheUnwoundElements) {
+    expectRows("MATCH (:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN count(interest)",
+               {{"15"}});
+}
+
+TEST_F(CypherUnwindExprTest, groupsByTheUnwoundElement) {
+    expectRows("MATCH (:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN interest, count(interest)",
+               {{"Ghosts", "1"}, {"Computers", "2"}, {"Eighties", "1"}, {"Bio", "2"},
+                {"Cooking", "2"}, {"Padel", "1"}, {"Animals", "1"}, {"Gym", "3"},
+                {"JiuJitsu", "1"}, {"Travel", "1"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsALiteralListBesideAnExpressionUnwind) {
+    // The literal opens a dataflow of its own and is crossed with the rows; the property
+    // expands each of those. Only Remy carries both an age and the two crossed elements.
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [1, 2] AS i UNWIND n.age AS a "
+               "RETURN i, a",
+               {{"1", "32"}, {"2", "32"}});
+}
+
+TEST_F(CypherUnwindExprTest, chainsTwoExpressionUnwinds) {
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND n.age AS a UNWIND a + 1 AS b "
+               "RETURN a, b",
+               {{"32", "33"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsAcrossChunkBoundaries) {
+    // One chunk per element, so the loop re-enters its body for every row it emits and
+    // the carried key is gathered afresh each time.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p.name AS person, collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "RETURN person, interest",
+               {{"Remy", "Ghosts"}, {"Remy", "Computers"}, {"Remy", "Eighties"},
+                {"Adam", "Bio"}, {"Adam", "Cooking"},
+                {"Maxime", "Bio"}, {"Maxime", "Padel"},
+                {"Luc", "Animals"}, {"Luc", "Computers"},
+                {"Martina", "Cooking"},
+                {"Suhas", "Gym"}, {"Suhas", "JiuJitsu"},
+                {"Cyrus", "Gym"}, {"Cyrus", "Travel"},
+                {"Doruk", "Gym"}},
+               /*chunkSize=*/1);
+}
+
+TEST_F(CypherUnwindExprTest, publishesTheUnwoundElementAtAFollowingBarrier) {
+    // A WITH after the UNWIND republishes its elements, so the part behind the barrier
+    // reads them as a variable of its own.
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p, collect(i.name) AS interests "
+               "UNWIND interests AS interest "
+               "WITH p, interest WHERE interest = 'Gym' "
+               "RETURN p.name, interest",
+               {{"Cyrus", "Gym"}, {"Suhas", "Gym"}, {"Doruk", "Gym"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsANestedListOneLevelDeeper) {
+    // The outer UNWIND hands out tagged cells, and a cell that is itself a list unwinds
+    // into its own elements - Cypher's UNWIND applied twice.
+    expectRowsInOrder("UNWIND [[1, 2], [3]] AS l UNWIND l AS x RETURN x",
+                      {{"1"}, {"2"}, {"3"}});
+}
+
+TEST_F(CypherUnwindExprTest, dropsANullCellOfAnUnwoundList) {
+    expectRowsInOrder("UNWIND [1, null, 2] AS l UNWIND l AS x RETURN x", {{"1"}, {"2"}});
+}
+
+TEST_F(CypherUnwindExprTest, unwindsTaggedCellsBesideTheCellTheyCameFrom) {
+    // A scalar cell is its own single row; a nested list is one row per element. The
+    // outer cell rides the carry set, so it repeats beside each of them.
+    expectRowsInOrder("UNWIND [1, 'a', [2, 3]] AS l UNWIND l AS x RETURN l, x",
+                      {{"1", "1"}, {"a", "a"}, {"[2, 3]", "2"}, {"[2, 3]", "3"}});
+}
+
+TEST_F(CypherUnwindExprTest, rejectsAnUnwoundVariableThatIsAlreadyDeclared) {
+    expectRejected("MATCH (n) UNWIND n.age AS n RETURN n", "already declared");
+}

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -1208,6 +1208,32 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n) WITH collect(n.name) AS names UNWIND names AS x RETURN n, x: a list column
+// drained per row, carrying the matched nodes past it so they stay row-aligned with the
+// elements. The element column's type is resolved during lowering, so it is left
+// unresolved here.
+const char* const unwindProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %xs = db.collect(%n) keys 0 : (!db.column<!storage.node_id>) -> !db.column<!storage.list<!storage.node_id>>
+  %x, %carried = db.unwind(%xs, {%n}) : (!db.column<!storage.list<!storage.node_id>>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.node_id>)
+  db.output(%x, %carried) : !db.column<none>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A carried column coming back under another type: the unwind replicates rows, it never
+// retypes them, so the verifier rejects it.
+const char* const retypedCarryUnwindProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %xs = db.collect(%n) keys 0 : (!db.column<!storage.node_id>) -> !db.column<!storage.list<!storage.node_id>>
+  %x, %carried = db.unwind(%xs, {%n}) : (!db.column<!storage.list<!storage.node_id>>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<i64>)
+  db.output(%x, %carried) : !db.column<none>, !db.column<i64>
+  return
+}
+)mlir";
+
 // RETURN [1, 2, 3]: the same literals as a value rather than a source, so the whole list
 // is one cell. A list literal is a db.constant value like any other, carried as the array
 // of its elements; the column type is inferred from them, so it is never spelled.
@@ -1589,6 +1615,44 @@ TEST_F(DBDialectTest, verifierRejectsHomogeneousUnwindConstWithoutElements) {
     // it picks the list_element form for an empty list - so the verifier is what
     // stands between the two forms.
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyHomogeneousUnwindConstProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, parsesUnwind) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::Unwind unwind;
+    module.get().walk([&](mlir::db::Unwind op) {
+        unwind = op;
+    });
+    ASSERT_TRUE(unwind);
+
+    // One carried result per carried column, keeping its type, and the element column
+    // ahead of them with its own type still unresolved.
+    ASSERT_EQ(unwind.getColumnsToFilter().size(), 1u);
+    ASSERT_EQ(unwind.getCarried().size(), 1u);
+
+    const mlir::Type nodeColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::NodeIDType::get(&_context));
+    EXPECT_EQ(unwind.getCarried().front().getType(), nodeColumnType);
+    EXPECT_EQ(unwind.getElement().getType(), mlir::db::ColumnType::get(&_context));
+}
+
+TEST_F(DBDialectTest, unwindRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwindProgram);
+    ASSERT_TRUE(module);
+
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, verifierRejectsUnwindRetypingACarriedColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(retypedCarryUnwindProgram);
     EXPECT_FALSE(module);
 }
 

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -155,6 +155,27 @@ func.func @main() {
 }
 )mlir";
 
+// VECTOR SEARCH IN people FOR 2 (1.0, 0.0) YIELD ids, score: the distances the index
+// scored the neighbours at are f64, the one width the lowering and the interpreter build
+// the score column as.
+const char* const vectorSearchProgram = R"mlir(
+func.func @main() {
+  %ids, %scores = db.vector_search("people", 2, [1.000000e+00, 0.000000e+00]) : !db.column<!storage.node_id>, !db.column<f64>
+  db.output(%ids, %scores) : !db.column<!storage.node_id>, !db.column<f64>
+  return
+}
+)mlir";
+
+// The same search declaring its scores one float width narrower, which nothing downstream
+// would honour.
+const char* const narrowScoreVectorSearchProgram = R"mlir(
+func.func @main() {
+  %ids, %scores = db.vector_search("people", 2, [1.000000e+00, 0.000000e+00]) : !db.column<!storage.node_id>, !db.column<f32>
+  db.output(%ids, %scores) : !db.column<!storage.node_id>, !db.column<f32>
+  return
+}
+)mlir";
+
 // A factor whose region does not end in a db.yield: the parser cannot recover
 // the result types and rejects it.
 const char* const missingYieldProgram = R"mlir(
@@ -416,6 +437,27 @@ TEST_F(DBDialectTest, rejectsZeroYieldFactor) {
 
 TEST_F(DBDialectTest, rejectsFactorWithoutYield) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(missingYieldProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, acceptsAVectorSearchScoringInF64) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(vectorSearchProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::VectorSearch search;
+    module.get().walk([&](mlir::db::VectorSearch found) {
+        search = found;
+    });
+    ASSERT_TRUE(search);
+
+    const mlir::Type doubleColumnType = mlir::db::ColumnType::get(&_context, mlir::Float64Type::get(&_context));
+    EXPECT_EQ(search.getScores().getType(), doubleColumnType);
+}
+
+// The score column names the width the whole path is built for, so a narrower float is
+// rejected here rather than silently discarded on the way to the interpreter.
+TEST_F(DBDialectTest, rejectsAVectorSearchScoringInANarrowerFloat) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(narrowScoreVectorSearchProgram);
     EXPECT_FALSE(module);
 }
 

--- a/test/query/ir/IRTestRows.cpp
+++ b/test/query/ir/IRTestRows.cpp
@@ -154,6 +154,9 @@ void turing::test::renderCell(const Column* column, size_t row, std::string& out
     } else if (const auto* lists = dynamic_cast<const ColumnVector<ListView>*>(column)) {
         out.clear();
         renderList((*lists)[row], out);
+    } else if (const auto* elements = dynamic_cast<const ColumnVector<ListElementView>*>(column)) {
+        out.clear();
+        renderListElement((*elements)[row], out);
     } else if (renderValueCell<int64_t>(column, row, out)
                || renderValueCell<uint64_t>(column, row, out)
                || renderValueCell<double>(column, row, out)

--- a/test/query/ir/MatchSkipLimitTest.cpp
+++ b/test/query/ir/MatchSkipLimitTest.cpp
@@ -106,6 +106,49 @@ TEST_F(MatchSkipLimitTest, countsOnlyTheRowsTheCutLeft) {
     expectRowsInOrder("MATCH (n) LIMIT 3 RETURN count(n)", expected);
 }
 
+// A literal UNWIND after the cut spreads the window the cut left, so the cut applies to the
+// rows the match produced and not to the product the UNWIND made out of them
+TEST_F(MatchSkipLimitTest, spreadsTheLimitedRowsOverALiteralUnwind) {
+    const std::vector<StringRowSink::Row> expected {
+        {"Adam", "1"}, {"Adam", "2"}, {"Animals", "1"}, {"Animals", "2"},
+    };
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name LIMIT 2 UNWIND [1, 2] AS x "
+                      "RETURN n.name, x ORDER BY n.name, x",
+                      expected);
+}
+
+// Remy, Suhas and Travel are the three the order leaves once fifteen are passed, each
+// paired with both elements - the skipped names may not come back through the product
+TEST_F(MatchSkipLimitTest, spreadsTheRowsLeftBySkipOverALiteralUnwind) {
+    const std::vector<StringRowSink::Row> expected {
+        {"Remy", "1"}, {"Remy", "2"}, {"Suhas", "1"},
+        {"Suhas", "2"}, {"Travel", "1"}, {"Travel", "2"},
+    };
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name SKIP 15 UNWIND [1, 2] AS x "
+                      "RETURN n.name, x ORDER BY n.name, x",
+                      expected);
+}
+
+TEST_F(MatchSkipLimitTest, countsTheRowsALiteralUnwindSpreadsTheCutOver) {
+    const std::vector<StringRowSink::Row> expected {{"6"}};
+
+    expectRowsInOrder("MATCH (n) LIMIT 3 UNWIND [1, 2] AS x RETURN count(*)", expected);
+}
+
+// A WITH after the UNWIND does not stand in for the cut's own part: the product is already
+// made by the time it publishes
+TEST_F(MatchSkipLimitTest, spreadsTheLimitedRowsOverALiteralUnwindPublishedByAWith) {
+    const std::vector<StringRowSink::Row> expected {
+        {"Adam", "1"}, {"Adam", "2"}, {"Animals", "1"}, {"Animals", "2"},
+    };
+
+    expectRowsInOrder("MATCH (n) ORDER BY n.name LIMIT 2 UNWIND [1, 2] AS x "
+                      "WITH n.name AS name, x RETURN name, x ORDER BY name, x",
+                      expected);
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -620,6 +620,49 @@ TEST_F(NLDialectTest, loadCSVRoundTripsThroughTextualForm) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
+// nl.unwind spells its iterator type too: the element chunk follows the source's element
+// type - a list drains into the type-erased list_element chunk - and each carried chunk
+// comes back after it, keeping the type it had.
+TEST_F(NLDialectTest, unwindBuildsElementAndCarriedChunkIterator) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::ArrayAttr elements = builder.getArrayAttr({builder.getI64IntegerAttr(1),
+                                                           builder.getI64IntegerAttr(2)});
+    mlir::nl::Constant source = builder.create<mlir::nl::Constant>(loc, elements);
+    mlir::nl::Constant carried = builder.create<mlir::nl::Constant>(loc, builder.getI64IntegerAttr(7));
+
+    const mlir::Type elementChunkType = mlir::nl::ChunkType::get(&_context, mlir::storage::ListElementType::get(&_context));
+    const mlir::Type iteratorType = mlir::nl::IteratorType::get(&_context,
+                                                                {elementChunkType, carried.getResult().getType()});
+
+    mlir::nl::Unwind unwind = builder.create<mlir::nl::Unwind>(loc,
+                                                               iteratorType,
+                                                               source.getResult(),
+                                                               mlir::ValueRange {carried.getResult()});
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_EQ(unwind.getResult().getType(), iteratorType);
+    EXPECT_EQ(unwind.getColumnsToFilter().size(), 1u);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+
+    // Printing then re-parsing yields a module that still verifies, so the nl.unwind
+    // printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module->print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed =
+        mlir::parseSourceString<mlir::ModuleOp>(printed, mlir::ParserConfig(&_context));
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
 // A list literal is an nl.constant value: it holds the whole list rather than spreading it
 // over rows, so it produces a chunk of that list type - inferred from the elements, since an
 // array attribute carries none of its own. A nested list rides one element as an array.

--- a/test/query/ir/NestedAggregateProjectionTest.cpp
+++ b/test/query/ir/NestedAggregateProjectionTest.cpp
@@ -139,5 +139,5 @@ TEST_F(NestedAggregateProjectionTest, generatesAnAggregateInsideAnExpression) {
 }
 
 TEST_F(NestedAggregateProjectionTest, rejectsAListHoldingAnAggregateBesideAGroupingKey) {
-    expectRejected("MATCH (n) RETURN DISTINCT n, [count(n.age0)]", nonLiteralListElementReason);
+    expectRejected("MATCH (n) RETURN DISTINCT n, [count(n.age)]", nonLiteralListElementReason);
 }

--- a/test/query/ir/QueryInterpreterV3ErrorTest.cpp
+++ b/test/query/ir/QueryInterpreterV3ErrorTest.cpp
@@ -62,6 +62,17 @@ protected:
     std::unique_ptr<QueryInterpreterV3> _interpreter;
 };
 
+// A codegen rejection is a TuringException and reaches the user as it was written: an
+// expression kind the generator has no column for names itself, rather than being dressed
+// up as the internal failure the case below is.
+TEST_F(QueryInterpreterV3ErrorTest, reportsUnsupportedExpressionRejectionAsIs) {
+    QueryStatus status;
+    runQuery("MATCH (n) RETURN n:Person", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
+    EXPECT_EQ(status.getError(), "Unsupported expression: ENTITY_TYPES");
+}
+
 // An internal generator failure is a FatalException and must keep reading as
 // one, rather than being dressed up as a deliberate rejection. A map literal
 // reading a row is one: the key varies, so it is not dropped as a constant, and

--- a/test/query/ir/StringPredicateTest.cpp
+++ b/test/query/ir/StringPredicateTest.cpp
@@ -220,6 +220,34 @@ TEST_F(StringPredicateTest, aggregatesOverDobStringPredicates) {
                {{"2", "32"}});
 }
 
+TEST_F(StringPredicateTest, taggedListElementOperands) {
+    // A heterogeneous list hands out cells that carry their own type, so the predicate is
+    // tested per row: a cell holding a string matches on its characters, and a cell holding
+    // anything else has none to match.
+    expectRows("UNWIND ['C', 5] AS v MATCH (n) WHERE n.name STARTS WITH v RETURN n.name",
+               {{"Computers"}, {"Cooking"}, {"Cyrus"}});
+
+    expectRows("UNWIND ['ties', 7] AS v MATCH (n) WHERE n.name ENDS WITH v RETURN n.name",
+               {{"Eighties"}});
+
+    expectRows("UNWIND ['oo', 7] AS v MATCH (n) WHERE n.name CONTAINS v RETURN n.name",
+               {{"Cooking"}});
+
+    expectRows("UNWIND [1, 2.5] AS v MATCH (n) WHERE n.name STARTS WITH v RETURN n.name", {});
+}
+
+TEST_F(StringPredicateTest, taggedListElementOnBothSides) {
+    expectRows("UNWIND ['Remy', 1] AS a UNWIND ['Rem', 2] AS b "
+               "MATCH (n) WHERE n.name = a AND n.name STARTS WITH b RETURN n.name",
+               {{"Remy"}});
+}
+
+TEST_F(StringPredicateTest, taggedListElementAgainstALiteral) {
+    expectRows("UNWIND ['Remy', 1] AS v MATCH (n) WHERE n.name = v AND v STARTS WITH 'Rem' "
+               "RETURN n.name",
+               {{"Remy"}});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/TrimUnreadColumnsTest.cpp
+++ b/test/query/ir/TrimUnreadColumnsTest.cpp
@@ -91,6 +91,37 @@ TEST_F(TrimUnreadColumnsTest, dropsTheCarrySetOfAHopNothingReads) {
     EXPECT_EQ(outputs.front().getColumns().front(), secondHop.getTgtids());
 }
 
+// MATCH (n) WITH collect(n) AS l UNWIND l AS x MATCH (x)-->(b) RETURN b, with the list the
+// unwind spread riding beside the elements it hands out
+const char* const unwoundListCarry = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %list = db.collect(%n) keys 0 : (!db.column<!storage.node_id>) -> !db.column<!storage.list<!storage.node_id>>
+  %x, %lc = db.unwind(%list, {%list}) : (!db.column<!storage.list<!storage.node_id>>, !db.column<!storage.list<!storage.node_id>>) -> (!db.column<!storage.node_id>, !db.column<!storage.list<!storage.node_id>>)
+  %s, %e, %et, %t = db.get_out_edges(%x, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%t) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// An unwind replicates each carried cell once per element it hands out, so a list nothing
+// reads past it is work done for no column.
+TEST_F(TrimUnreadColumnsTest, dropsTheCarrySetOfAnUnwindNothingReads) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(unwoundListCarry);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::Unwind> unwinds = collect<mlir::db::Unwind>(*module);
+    ASSERT_EQ(unwinds.size(), 1u);
+    mlir::db::Unwind unwind = unwinds.front();
+
+    // The elements it hands out are its one result; the list rides no further.
+    EXPECT_EQ(unwind.getColumnsToFilter().size(), 0u);
+    EXPECT_EQ(unwind->getNumResults(), 1u);
+    EXPECT_TRUE(unwind.getElement().hasOneUse());
+}
+
 // MATCH (a)-->(b) WHERE b.age > 3 RETURN b
 const char* const filteredTarget = R"mlir(
 func.func @main() {

--- a/test/query/ir/UnwindCollectSeedTest.cpp
+++ b/test/query/ir/UnwindCollectSeedTest.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    size_t count = 0;
+    module.walk([&count](OpType) {
+        count++;
+    });
+
+    return count;
+}
+
+}
+
+// A MATCH that walks out of a variable an UNWIND bound expands the rows the unwind emitted
+// rather than the graph's: the elements open the traversal, the way a CALL's yielded nodes
+// do, so no scan of every node is crossed with them and filtered back down.
+class UnwindCollectSeedTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        RowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+
+        Rows actual = sink.rows();
+        std::sort(actual.begin(), actual.end());
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(UnwindCollectSeedTest, aCollectedNodeOpensTheTraversal) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (p:Person) WITH collect(p) AS people UNWIND people AS person "
+                 "MATCH (person)-[:INTERESTED_IN]->(i) RETURN i.name");
+
+    // The unwound nodes are the hop's input, so the second MATCH crosses nothing and adds
+    // no scan of its own: the one left is the labelled scan the collect gathered.
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::Unwind>(*module), 1u);
+}
+
+TEST_F(UnwindCollectSeedTest, theUnwoundNodeIsTheHopsInput) {
+    mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (p:Person) WITH collect(p) AS people UNWIND people AS person "
+                 "MATCH (person)-[:INTERESTED_IN]->(i) RETURN i.name");
+
+    mlir::db::Unwind unwind;
+    module->walk([&unwind](mlir::db::Unwind found) {
+        unwind = found;
+    });
+    ASSERT_TRUE(unwind);
+
+    mlir::db::GetOutEdges hop;
+    module->walk([&hop](mlir::db::GetOutEdges found) {
+        hop = found;
+    });
+    ASSERT_TRUE(hop);
+
+    EXPECT_EQ(hop.getInputNodes(), unwind.getElement());
+}
+
+// A pattern reaching the unwound variable from its other end is walked backwards from it,
+// so it opens the traversal just the same.
+TEST_F(UnwindCollectSeedTest, aCollectedNodeOpensTheTraversalAsThePatternTarget) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (p:Interest) WITH collect(p) AS interests UNWIND interests AS interest "
+                 "MATCH (n)-[:INTERESTED_IN]->(interest) RETURN n.name");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+}
+
+TEST_F(UnwindCollectSeedTest, expandsEachCollectedNodeOnce) {
+    expectRows("MATCH (p:Person) WHERE p.name = 'Remy' WITH collect(p) AS people "
+               "UNWIND people AS person MATCH (person)-[:INTERESTED_IN]->(i) RETURN i.name",
+               {{"Computers"}, {"Eighties"}, {"Ghosts"}});
+}
+
+TEST_F(UnwindCollectSeedTest, projectsTheUnwoundNodeBesideWhatItReached) {
+    expectRows("MATCH (p:Person) WHERE p.name = 'Adam' WITH collect(p) AS people "
+               "UNWIND people AS person MATCH (person)-[:INTERESTED_IN]->(i) "
+               "RETURN person.name, i.name",
+               {{"Adam", "Bio"}, {"Adam", "Cooking"}});
+}
+
+TEST_F(UnwindCollectSeedTest, expandsAnEmptyCollectToNoRow) {
+    expectRows("MATCH (p:Person) WHERE p.name = 'nobody' WITH collect(p) AS people "
+               "UNWIND people AS person MATCH (person)-[:INTERESTED_IN]->(i) RETURN i.name",
+               {});
+}

--- a/test/query/ir/UnwindNodeSeedCodegenTest.cpp
+++ b/test/query/ir/UnwindNodeSeedCodegenTest.cpp
@@ -188,9 +188,28 @@ TEST_F(UnwindNodeSeedCodegenTest, rejectsASeedUsedAsANodeAfterAWith) {
 }
 
 // An UNWIND naming no pattern node still binds a column of values, whatever the query then
-// compares it to.
-TEST_F(UnwindNodeSeedCodegenTest, valueUnwindStaysAnUnwindConst) {
+// compares it to - so codegen crosses that column with the scan and filters. Comparing it
+// to the node itself makes the filter a node-ID disjunction once fuse_unwind_equality has
+// folded the elements into it, which fuse_scan_by_node_ids then reads: the seed a pattern
+// naming the variable spells out directly, reached from the other side.
+TEST_F(UnwindNodeSeedCodegenTest, aValueUnwindComparedToTheNodeFusesIntoAConstScan) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (n) WHERE n = x RETURN n");
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(collect<mlir::db::ConstScanNodes>(*module).front(), nodeIDs);
+    const std::vector<int64_t> expected {2, 5};
+    EXPECT_EQ(nodeIDs, expected);
+}
+
+// The elements are read as well as compared here, and a node column cannot stand in for
+// them: it equals a node ID by the number it carries, so the projection would print the
+// node rather than the integer the query unwound.
+TEST_F(UnwindNodeSeedCodegenTest, aProjectedValueUnwindStaysAnUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (n) WHERE n = x RETURN n, x");
 
     EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 1u);
     EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 0u);

--- a/test/query/ir/UnwindValueFilterCodegenTest.cpp
+++ b/test/query/ir/UnwindValueFilterCodegenTest.cpp
@@ -223,6 +223,38 @@ TEST_F(UnwindValueFilterCodegenTest, repeatedElementsEmitOneRowEach) {
                {{"Remy", "32"}, {"Remy", "32"}, {"Adam", "32"}, {"Adam", "32"}});
 }
 
+// Node IDs compared against the node itself fold the same way, and the disjunction that
+// leaves is what fuse_scan_by_node_ids reads: the listed nodes are scanned directly rather
+// than every node being crossed with the list and filtered back down.
+TEST_F(UnwindValueFilterCodegenTest, nodeIDElementsFuseIntoAConstScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [0, 1] AS x MATCH (n) WHERE n = x RETURN n");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, scansTheListedNodes) {
+    expectRows("UNWIND [0, 1] AS x MATCH (n) WHERE n = x RETURN n.name",
+               {{"Remy"}, {"Adam"}});
+}
+
+// A node equals a node ID by the number it carries, not by type, so a projection of the
+// element cannot read the node column that matched it: the product stands instead.
+TEST_F(UnwindValueFilterCodegenTest, projectedNodeIDElementsKeepTheProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [0, 1] AS x MATCH (n) WHERE n = x RETURN n.name, x");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, projectsTheNodeIDElementsBesideWhatTheyMatched) {
+    expectRows("UNWIND [0, 1] AS x MATCH (n) WHERE n = x RETURN n.name, x",
+               {{"Remy", "0"}, {"Adam", "1"}});
+}
+
 // A mixed list rides the type-erased column whose cells are compared by their own tag, so
 // a string cell simply matches no age - which one typed comparison per element, against a
 // column of integers, cannot express.

--- a/test/query/ir/UnwindValueFilterCodegenTest.cpp
+++ b/test/query/ir/UnwindValueFilterCodegenTest.cpp
@@ -1,0 +1,271 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    size_t count = 0;
+    module.walk([&count](OpType) {
+        count++;
+    });
+
+    return count;
+}
+
+}
+
+// An UNWIND of a literal list whose elements are only compared against a property is the
+// disjunction that comparison spells out, so the db program the query compiles to reads
+// the same as the OR's - one scan, filtered - with no product of the list against it.
+class UnwindValueFilterCodegenTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        RowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+
+        Rows actual = sink.rows();
+        std::sort(actual.begin(), actual.end());
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(UnwindValueFilterCodegenTest, inlineConstraintCompilesToADisjunction) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, 99] AS a MATCH (n {age: a}) RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+
+    // One equality per element, folded into the single mask the one filter reads.
+    EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 2u);
+    EXPECT_EQ(countOps<mlir::db::OrOp>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, whereEqualityCompilesToADisjunction) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, 99] AS a MATCH (n) WHERE n.age = a RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::OrOp>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, aSingleElementNeedsNoDisjunction) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32] AS a MATCH (n {age: a}) RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::OrOp>(*module), 0u);
+}
+
+// A repeated element emits the row it matches once per copy, which a disjunction - a set
+// membership - cannot express, so the product stands.
+TEST_F(UnwindValueFilterCodegenTest, repeatedElementsKeepTheProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, 32] AS a MATCH (n {age: a}) RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, anEmptyListKeepsTheProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [] AS a MATCH (n {age: a}) RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 1u);
+}
+
+// A null element is no value to compare against - and neither is a nested list - so the
+// list is left to the column it already rides.
+TEST_F(UnwindValueFilterCodegenTest, aNullElementKeepsTheProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, null] AS a MATCH (n {age: a}) RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 1u);
+}
+
+// The elements reach the projection as well as the comparison, so dropping the unwind has
+// to leave the rows carrying what it bound - which the property they matched now stands for.
+TEST_F(UnwindValueFilterCodegenTest, projectsTheElementEachRowMatched) {
+    expectRows("UNWIND [32, 99] AS a MATCH (n {age: a}) RETURN n.name, a",
+               {{"Remy", "32"}, {"Adam", "32"}});
+}
+
+TEST_F(UnwindValueFilterCodegenTest, filtersAWhereEqualityAgainstTheElements) {
+    expectRows("UNWIND [32, 99] AS a MATCH (n) WHERE n.age = a RETURN n.name, a",
+               {{"Remy", "32"}, {"Adam", "32"}});
+}
+
+TEST_F(UnwindValueFilterCodegenTest, matchesNothingWhenNoElementIsHeld) {
+    expectRows("UNWIND [98, 99] AS a MATCH (n {age: a}) RETURN n.name, a", {});
+}
+
+// The product the rewrite declines to touch still has to emit one row per copy.
+TEST_F(UnwindValueFilterCodegenTest, repeatedElementsEmitOneRowEach) {
+    expectRows("UNWIND [32, 32] AS a MATCH (n {age: a}) RETURN n.name, a",
+               {{"Remy", "32"}, {"Remy", "32"}, {"Adam", "32"}, {"Adam", "32"}});
+}
+
+// A mixed list rides the type-erased column whose cells are compared by their own tag, so
+// a string cell simply matches no age - which one typed comparison per element, against a
+// column of integers, cannot express.
+TEST_F(UnwindValueFilterCodegenTest, heterogeneousElementsKeepTheProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, 'x'] AS a MATCH (n) WHERE n.age = a RETURN n.name, a");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, dropsTheElementsWhenNothingProjectsThem) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32, 99] AS a MATCH (n {age: a}) RETURN n.name");
+
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+}
+
+// A part that continues from a WITH crosses the rows it published with the unwind and its
+// scan, so that unwind is a factor of an inner product rather than of the one its equality
+// reads - which this match does not see through. The leading part still folds.
+TEST_F(UnwindValueFilterCodegenTest, foldsOnlyTheUnwindThatIsAFactorOfItsOwnProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("UNWIND [32] AS a MATCH (n {age: a}) "
+                 "WITH n UNWIND ['Remy'] AS nm MATCH (m {name: nm}) RETURN n.name, m.name");
+
+    // The published rows crossed with the second part's own product of the list and its scan.
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 2u);
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 1u);
+}
+
+TEST_F(UnwindValueFilterCodegenTest, filtersTwoUnwindsOfOneQuery) {
+    expectRows("UNWIND [32] AS a MATCH (n {age: a}) "
+               "WITH n UNWIND ['Remy'] AS nm MATCH (m {name: nm}) RETURN n.name, m.name",
+               {{"Remy", "Remy"}, {"Adam", "Remy"}});
+}
+
+TEST_F(UnwindValueFilterCodegenTest, projectsThePropertyBesideTheElementItMatched) {
+    expectRows("UNWIND [32, 99] AS a MATCH (n {age: a}) RETURN n.name, n.age, a",
+               {{"Remy", "32", "32"}, {"Adam", "32", "32"}});
+}
+
+TEST_F(UnwindValueFilterCodegenTest, filtersAStringPropertyAgainstTheElements) {
+    expectRows("UNWIND ['Remy', 'Adam'] AS nm MATCH (n {name: nm}) RETURN n.name, nm",
+               {{"Remy", "Remy"}, {"Adam", "Adam"}});
+}

--- a/test/query/ir/VectorSearchCompositionTest.cpp
+++ b/test/query/ir/VectorSearchCompositionTest.cpp
@@ -264,6 +264,23 @@ TEST_F(VectorSearchCompositionTest, searchDrivesTwoChainedCalls) {
                 {"Ghosts", "Remy"}});
 }
 
+// Both statements ahead of the MATCH bind variables of their own, so the root the
+// traversal is driven from is looked for across a VECTOR SEARCH's YIELD and a CALL's
+// alike: Remy is the neighbour, its out-neighbours are what the sample hands the MATCH,
+// and the MATCH walks one hop on from each of them.
+TEST_F(VectorSearchCompositionTest, aSearchAndACallTogetherDriveTheMatchTheyYieldInto) {
+    loadPeopleVectors();
+
+    expectRows(std::string(searchOne) + "YIELD ids "
+               + std::string(sampleWhole) +
+               "MATCH (tgt)-->(m) "
+               "RETURN tgt.name, m.name",
+               {{"Adam", "Remy"},
+                {"Adam", "Bio"},
+                {"Adam", "Cooking"},
+                {"Ghosts", "Remy"}});
+}
+
 TEST_F(VectorSearchCompositionTest, countsTheNeighboursTheSearchReported) {
     loadPeopleVectors();
 


### PR DESCRIPTION
Implement generalised UNWIND.

```
UNWIND [1, 2, 3] AS x RETURN x

+---+
| x |
+---+
| 1 |
| 2 |
| 3 |
+---+

UNWIND [1, null] AS x RETURN x

+------+
| x    |
+------+
| 1    |
| null |
+------+

UNWIND null AS x RETURN x

+---+
| x |
+---+
+---+
(no rows)

UNWIND 5 AS x RETURN x

ANALYZE ERROR
-------* Query error
     1 | UNWIND 5 AS x RETURN x
       |        ^
-------* UNWIND requires a list, not 'Integer'

UNWIND [[1, 2], [3]] AS l UNWIND l AS x RETURN x

+---+
| x |
+---+
| 1 |
| 2 |
| 3 |
+---+

MATCH (n) UNWIND n.age AS a RETURN n.name, a

+--------+----+
| n.name | a  |
+--------+----+
| Remy   | 32 |
| Adam   | 32 |
+--------+----+

MATCH (n:Person) WITH collect(n.age) AS ages UNWIND ages AS a RETURN a

+----+
| a  |
+----+
| 32 |
| 32 |
+----+

MATCH (n) UNWIND [10, 20] AS x RETURN n, x

+-----+-----+
| n   | x   |
+-----+-----+
| 0   | 10  |
| 0   | 20  |
| 1   | 10  |
| ... | ... |
+-----+-----+
(36 rows)

MATCH (p:Person) WHERE p.name = 'Adam'
MATCH (p)-[:INTERESTED_IN]->(i:Interest)
WITH collect(i.name) AS interests
UNWIND interests AS interest
MATCH (n) WHERE n.name = interest
RETURN n.name

+---------+
| n.name  |
+---------+
| Bio     |
| Cooking |
+---------+

UNWIND [1, 2.5] AS v RETURN sum(v)

+--------+
| sum(v) |
+--------+
| 3.5    |
+--------+
```

The elements a literal spreads are known at plan time, so a MATCH reading them is
planned against the values themselves rather than against a column crossed with it.

```
UNWIND [32, 99] AS a MATCH (n {age: a}) RETURN n.name, a

was     %0:2 = db.cross_product factor { db.unwind_const([32, 99]) }
                                factor { db.scan_nodes() }
        %1 = db.get_node_properties(%0#1, "age")
        %2 = db.eq %1, %0#0
        %3:2 = db.filter(%2, {%0#1, %0#0})

now     %0 = db.scan_nodes()
        %1 = db.get_node_properties(%0, "age")
        %2 = db.constant(32 : i64)
        %3 = db.eq %1, %2
        %4 = db.constant(99 : i64)
        %5 = db.eq %1, %4
        %6 = db.or %3, %5
        %7:2 = db.filter(%6, {%0, %1})

        the plan MATCH (n) WHERE n.age = 32 OR n.age = 99 already got, and the age
        is fetched once per node rather than once per (node, element) pair


UNWIND [5, 2] AS x MATCH (n) WHERE n = x RETURN n

was     %0:2 = db.cross_product factor { db.unwind_const([5, 2]) }
                                factor { db.scan_nodes() }
        %1 = db.eq %0#1, %0#0
        %2:2 = db.filter(%1, {%0#1, %0#0})

now     %0 = db.const_scan_nodes([2, 5])

        the disjunction the elements fold into is a node-ID one, which the const
        scan pass then seeds from - two nodes read instead of every node crossed


MATCH (p:Person) WITH collect(p) AS people
UNWIND people AS person MATCH (person)-[:INTERESTED_IN]->(i) RETURN i.name

was     %0:4 = db.cross_product factor { db.scan_nodes_by_label(["Person"])
                                         db.collect(...) }
                                factor { db.scan_nodes()
                                         db.get_out_edges(...)
                                         db.filter(...) }
        %element, %carried:4 = db.unwind(%0#0, {...})
        %1 = db.eq %carried#2, %element
        %2:5 = db.filter(%1, {...})

now     %0 = db.scan_nodes_by_label(["Person"])
        %1 = db.collect(%0) keys 0
        %element, %carried = db.unwind(%1, {%1})
        %2:4 = db.get_out_edges(%element, {%carried})

        the unwound nodes are the hop's input, so the whole graph is no longer
        expanded and filtered back down to them
```

A rewrite is declined wherever it would not give the same rows.

```
UNWIND [32, 32] AS a MATCH (n {age: a})        a repeated element emits its rows
                                               once per copy; a membership test
                                               emits them once

UNWIND [32, 'x'] AS a MATCH (n) WHERE n.age = a
                                               a mixed list rides a type-erased
                                               column compared by each cell's tag

UNWIND [] AS a MATCH (n {age: a})              nothing to compare against

UNWIND [5, 2] AS x MATCH (n) WHERE n = x RETURN n, x
                                               the elements are read as well as
                                               compared, and a node column cannot
                                               stand in for them: it equals a node
                                               ID by the number it carries
```
