### PR TITLE
MLIR: fuse node-ID disjunction filters into const_scan_nodes

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -862,6 +862,7 @@ void DBProgramGenerator::runPasses() {
     mlir::PassManager passManager(_mlirCtxt);
     passManager.addPass(mlir::db::createFuseScanByLabel());
     passManager.addPass(mlir::db::createPushDownFilters());
+    passManager.addPass(mlir::db::createFuseScanByNodeIDs());
 
     if (mlir::failed(passManager.run(*_module))) {
         throw FatalException("DB pass pipeline failed");

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -398,8 +398,11 @@ struct NodeIDScanChain {
 };
 
 bool matchNodeIDScanChain(FilterOp filter, NodeIDScanChain& chain) {
+    // The filter is replaced by a source, which yields the listed nodes and nothing else.
+    // Any other column it carries (a property read before the WHERE, say) has no filtered
+    // counterpart in that source to be rewired to, so such a filter has to stay.
     const Operation::operand_range columns = filter.getColumnsToFilter();
-    if (columns.empty()) {
+    if (columns.size() != 1) {
         return false;
     }
 
@@ -411,16 +414,6 @@ bool matchNodeIDScanChain(FilterOp filter, NodeIDScanChain& chain) {
 
     if (ScanNodesByLabel scanByLabel = dyn_cast<ScanNodesByLabel>(chain._source)) {
         chain._labels = scanByLabel.getLabels();
-    }
-
-    // The filter is replaced by a source, which yields the listed nodes and nothing else.
-    // Any other column it carries (a property read before the WHERE, say) has no filtered
-    // counterpart in that source to be rewired to, so such a filter has to stay.
-    const bool carriesScanOnly = llvm::all_of(columns, [&](const Value column) {
-        return column == scanColumn;
-    });
-    if (!carriesScanOnly) {
-        return false;
     }
 
     if (!collectNodeIDDisjunction(filter.getMask(), scanColumn, chain._nodeIDs)) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -413,8 +413,9 @@ bool matchNodeIDScanChain(FilterOp filter, NodeIDScanChain& chain) {
         chain._labels = scanByLabel.getLabels();
     }
 
-    // A carried column other than the scan is row-aligned with it and would be left
-    // behind by a source that reads nothing.
+    // The filter is replaced by a source, which yields the listed nodes and nothing else.
+    // Any other column it carries (a property read before the WHERE, say) has no filtered
+    // counterpart in that source to be rewired to, so such a filter has to stay.
     const bool carriesScanOnly = llvm::all_of(columns, [&](const Value column) {
         return column == scanColumn;
     });

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,5 +1,6 @@
 #include "DBPasses.h"
 
+#include <algorithm>
 #include <optional>
 
 #include "mlir/IR/Builders.h"
@@ -18,6 +19,7 @@ namespace mlir::db {
 
 #define GEN_PASS_DEF_FUSESCANBYLABEL
 #define GEN_PASS_DEF_PUSHDOWNFILTERS
+#define GEN_PASS_DEF_FUSESCANBYNODEIDS
 #include "DBPasses.h.inc"
 
 namespace {
@@ -343,6 +345,146 @@ struct PushDownFilters : public impl::PushDownFiltersBase<PushDownFilters> {
             }
 
             pushDownPredicate(filter, *pushable, builder);
+        }
+    }
+};
+
+bool collectNodeIDDisjunction(Value mask, Value scanColumn, llvm::SmallVectorImpl<int64_t>& nodeIDs) {
+    if (OrOp disjunction = mask.getDefiningOp<OrOp>()) {
+        return collectNodeIDDisjunction(disjunction.getLhs(), scanColumn, nodeIDs)
+            && collectNodeIDDisjunction(disjunction.getRhs(), scanColumn, nodeIDs);
+    }
+
+    EqOp equality = mask.getDefiningOp<EqOp>();
+    if (!equality) {
+        return false;
+    }
+
+    const Value lhs = equality.getLhs();
+    const Value rhs = equality.getRhs();
+
+    Value constantSide;
+    if (lhs == scanColumn) {
+        constantSide = rhs;
+    } else if (rhs == scanColumn) {
+        constantSide = lhs;
+    } else {
+        return false;
+    }
+
+    ConstantOp constant = constantSide.getDefiningOp<ConstantOp>();
+    if (!constant) {
+        return false;
+    }
+
+    const IntegerAttr literal = dyn_cast<IntegerAttr>(constant.getValue());
+    if (!literal || !literal.getType().isSignlessInteger(64)) {
+        return false;
+    }
+
+    const int64_t nodeID = literal.getInt();
+    if (nodeID < 0) {
+        return false;
+    }
+
+    nodeIDs.push_back(nodeID);
+    return true;
+}
+
+struct NodeIDScanChain {
+    Operation* _source {nullptr};
+    ArrayAttr _labels;
+    llvm::SmallVector<int64_t> _nodeIDs;
+};
+
+bool matchNodeIDScanChain(FilterOp filter, NodeIDScanChain& chain) {
+    const Operation::operand_range columns = filter.getColumnsToFilter();
+    if (columns.empty()) {
+        return false;
+    }
+
+    const Value scanColumn = columns.front();
+    chain._source = scanColumn.getDefiningOp();
+    if (!chain._source || !isa<ScanNodes, ScanNodesByLabel>(chain._source)) {
+        return false;
+    }
+
+    if (ScanNodesByLabel scanByLabel = dyn_cast<ScanNodesByLabel>(chain._source)) {
+        chain._labels = scanByLabel.getLabels();
+    }
+
+    // A carried column other than the scan is row-aligned with it and would be left
+    // behind by a source that reads nothing.
+    const bool carriesScanOnly = llvm::all_of(columns, [&](const Value column) {
+        return column == scanColumn;
+    });
+    if (!carriesScanOnly) {
+        return false;
+    }
+
+    if (!collectNodeIDDisjunction(filter.getMask(), scanColumn, chain._nodeIDs)) {
+        return false;
+    }
+
+    // A scan yields each node once in ID order, so the filter did too.
+    llvm::sort(chain._nodeIDs);
+    chain._nodeIDs.erase(std::unique(chain._nodeIDs.begin(), chain._nodeIDs.end()), chain._nodeIDs.end());
+
+    return true;
+}
+
+void fuseScanByNodeIDs(FilterOp filter, const NodeIDScanChain& chain, mlir::OpBuilder& builder) {
+    const mlir::Location loc = filter.getLoc();
+    const Type nodeColumnType = chain._source->getResult(0).getType();
+
+    builder.setInsertionPoint(filter);
+    ConstScanNodes constScan = builder.create<ConstScanNodes>(loc, nodeColumnType, chain._nodeIDs);
+    Value fused = constScan.getResult();
+
+    if (chain._labels) {
+        MLIRContext* const context = builder.getContext();
+        const Type labelSetType = ColumnType::get(context, storage::LabelSetIDType::get(context));
+        const Type boolType = ColumnType::get(context, storage::BoolType::get(context));
+
+        GetNodeLabelSet labelSet = builder.create<GetNodeLabelSet>(loc, labelSetType, fused);
+        CheckLabelConstraint check = builder.create<CheckLabelConstraint>(loc, boolType, labelSet.getResult(), chain._labels);
+
+        const llvm::SmallVector<Type> resultTypes {nodeColumnType};
+        const llvm::SmallVector<Value> columns {fused};
+        FilterOp labelFilter = builder.create<FilterOp>(loc, resultTypes, check.getResult(), columns);
+        fused = labelFilter.getResult(0);
+    }
+
+    const MaskCone cone = collectMaskCone(filter.getMask());
+
+    for (Value filtered : filter.getFilteredColumns()) {
+        filtered.replaceAllUsesWith(fused);
+    }
+    filter.erase();
+
+    for (Operation* const coneOp : llvm::reverse(cone._ops)) {
+        eraseIfUnused(coneOp);
+    }
+    eraseIfUnused(chain._source);
+}
+
+struct FuseScanByNodeIDs : public impl::FuseScanByNodeIDsBase<FuseScanByNodeIDs> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        llvm::SmallVector<FilterOp> filters;
+        root->walk([&](FilterOp filter) {
+            filters.push_back(filter);
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (FilterOp filter : filters) {
+            NodeIDScanChain chain;
+            if (!matchNodeIDScanChain(filter, chain)) {
+                continue;
+            }
+
+            fuseScanByNodeIDs(filter, chain, builder);
         }
     }
 };

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -13,4 +13,9 @@ def PushDownFilters : Pass<"push_down_filters"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def FuseScanByNodeIDs : Pass<"fuse_scan_by_node_ids"> {
+    let summary = "Fuse a node scan and its node-ID disjunction filter into a const_scan_nodes";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 #endif // TURINGDB_PASSES

--- a/samples/mlir/match_const_scan_nodes.mlir
+++ b/samples/mlir/match_const_scan_nodes.mlir
@@ -1,0 +1,7 @@
+// MATCH (n) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = db.const_scan_nodes([0, 2]) : !db.column<!storage.node_id>
+  db.output(%0) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_const_scan_nodes.nl.mlir
+++ b/samples/mlir/match_const_scan_nodes.nl.mlir
@@ -1,0 +1,9 @@
+// MATCH (n) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = nl.const_scan_nodes([0, 2])
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    nl.output(%arg0) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/match_const_scan_nodes_by_label.mlir
+++ b/samples/mlir/match_const_scan_nodes_by_label.mlir
@@ -1,0 +1,10 @@
+// MATCH (n:Person) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = db.const_scan_nodes([0, 2]) : !db.column<!storage.node_id>
+  %1 = db.get_node_label_set(%0) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %2 = db.check_label_constraint(%1, ["Person"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %3 = db.filter(%2, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%3) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_const_scan_nodes_by_label.nl.mlir
+++ b/samples/mlir/match_const_scan_nodes_by_label.nl.mlir
@@ -1,0 +1,12 @@
+// MATCH (n:Person) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = nl.const_scan_nodes([0, 2])
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %1 = nl.get_node_label_set(%arg0) : !nl.chunk<!storage.labelset_id>
+    %2 = nl.check_label_constraint(%1, [0, 1, 6, 7, 9]) : !nl.chunk<!storage.bool>
+    %3 = nl.filter %2, (%arg0) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%3) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/node_id_filter.mlir
+++ b/samples/mlir/node_id_filter.mlir
@@ -1,0 +1,13 @@
+// MATCH (n) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = db.scan_nodes() : !db.column<!storage.node_id>
+  %1 = db.constant(0 : i64)
+  %2 = db.eq %0, %1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %3 = db.constant(2 : i64)
+  %4 = db.eq %0, %3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %5 = db.or %2, %4 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %6 = db.filter(%5, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%6) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/node_id_filter.nl.mlir
+++ b/samples/mlir/node_id_filter.nl.mlir
@@ -1,0 +1,15 @@
+// MATCH (n) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = nl.constant(2 : i64)
+  %1 = nl.constant(0 : i64)
+  %2 = nl.scan_nodes()
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %3 = nl.eq %arg0, %1 : (!nl.chunk<!storage.node_id>, !nl.chunk<i64>) -> !nl.chunk<i1>
+    %4 = nl.eq %arg0, %0 : (!nl.chunk<!storage.node_id>, !nl.chunk<i64>) -> !nl.chunk<i1>
+    %5 = nl.or %3, %4 : (!nl.chunk<i1>, !nl.chunk<i1>) -> !nl.chunk<i1>
+    %6 = nl.filter %5, (%arg0) : (!nl.chunk<i1>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%6) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/node_id_filter_by_label.mlir
+++ b/samples/mlir/node_id_filter_by_label.mlir
@@ -1,0 +1,13 @@
+// MATCH (n:Person) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %1 = db.constant(0 : i64)
+  %2 = db.eq %0, %1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %3 = db.constant(2 : i64)
+  %4 = db.eq %0, %3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %5 = db.or %2, %4 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %6 = db.filter(%5, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%6) names ["n"] : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/node_id_filter_by_label.nl.mlir
+++ b/samples/mlir/node_id_filter_by_label.nl.mlir
@@ -1,0 +1,15 @@
+// MATCH (n:Person) WHERE n = 0 OR n = 2 RETURN n
+
+func.func @main() {
+  %0 = nl.constant(2 : i64)
+  %1 = nl.constant(0 : i64)
+  %2 = nl.scan_nodes_by_label(["Person"])
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %3 = nl.eq %arg0, %1 : (!nl.chunk<!storage.node_id>, !nl.chunk<i64>) -> !nl.chunk<i1>
+    %4 = nl.eq %arg0, %0 : (!nl.chunk<!storage.node_id>, !nl.chunk<i64>) -> !nl.chunk<i1>
+    %5 = nl.or %3, %4 : (!nl.chunk<i1>, !nl.chunk<i1>) -> !nl.chunk<i1>
+    %6 = nl.filter %5, (%arg0) : (!nl.chunk<i1>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
+    nl.output(%6) names ["n"] : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -161,6 +161,7 @@ add_call_v3_test(test_query_ir_call_carried_scalar CallCarriedScalarTest.cpp)
 add_call_v3_test(test_query_ir_call_writes CallWritesTest.cpp)
 add_call_v3_test(test_query_ir_call_boolean_predicates CallBooleanPredicatesTest.cpp)
 add_call_v3_test(test_query_ir_call_show_indexes CallShowIndexesTest.cpp)
+add_call_v3_test(test_query_ir_scan_by_node_ids_v3 ScanByNodeIDsV3Test.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,
 # once with a constant argument alone and once reading the chain's tail, from the query
@@ -226,6 +227,27 @@ target_link_libraries(test_query_ir_cypher_collect_input PRIVATE
 
 add_ir_tests(test_query_ir_dbdialect DBDialectTest.cpp)
 add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
+add_ir_tests(test_query_ir_fuse_scan_by_node_ids FuseScanByNodeIDsTest.cpp)
+
+# The codegen-level cases compile Cypher through the parser, analyzer and DBProgramGenerator
+# against the shared SimpleGraph fixture and read the db program the pass pipeline leaves.
+add_turing_test(test_query_ir_fuse_scan_by_node_ids_codegen FuseScanByNodeIDsCodegenTest.cpp)
+target_link_libraries(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s)
+target_include_directories(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 
 # The keyless collect drain emits its one group whether or not a row arrived, against the

--- a/test/query/ir/FuseScanByNodeIDsCodegenTest.cpp
+++ b/test/query/ir/FuseScanByNodeIDsCodegenTest.cpp
@@ -1,0 +1,194 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+void nodeIDsOf(mlir::db::ConstScanNodes constScan, std::vector<int64_t>& nodeIDs) {
+    const llvm::ArrayRef<int64_t> listed = constScan.getNodeIDs();
+    nodeIDs.assign(listed.begin(), listed.end());
+}
+
+}
+
+// Generates the db program a Cypher query compiles to, passes included, so a test reads
+// the shape the engine will lower rather than a hand-written approximation of it.
+class FuseScanByNodeIDsCodegenTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(FuseScanByNodeIDsCodegenTest, rootDisjunctionBecomesConstScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n) WHERE n = 5 OR n = 2 RETURN n");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScans.front(), nodeIDs);
+    const std::vector<int64_t> expected {2, 5};
+    EXPECT_EQ(nodeIDs, expected);
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, disjunctionOnAnExpandedRootFeedsTheHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n)-->(m) WHERE n = 1 OR n = 3 RETURN n, m");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {1, 3};
+    EXPECT_EQ(nodeIDs, expected);
+
+    // The filter sank to the scan and fused into it, so the hop expands the listed set.
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_EQ(hops.front().getInputNodes().getDefiningOp(), constScan.getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, disjunctionInACrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n), (m) WHERE n = 2 OR n = 4 RETURN n, m");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {2, 4};
+    EXPECT_EQ(nodeIDs, expected);
+
+    // The const scan sits inside a factor of the product; the other factor keeps its scan.
+    EXPECT_TRUE(constScan.getOperation()->getParentOfType<mlir::db::CrossProduct>());
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, mixedPredicateKeepsItsFilter) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n) WHERE n = 5 OR n.name = 'Remy' RETURN n");
+
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, labelledDisjunctionKeepsALabelCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n:Person) WHERE n = 2 OR n = 0 RETURN n");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {0, 2};
+    EXPECT_EQ(nodeIDs, expected);
+
+    // The Person test survives as a check over the listed nodes; no scan of any kind remains.
+    llvm::SmallVector<mlir::db::CheckLabelConstraint> checks = collect<mlir::db::CheckLabelConstraint>(*module);
+    ASSERT_EQ(checks.size(), 1u);
+    const mlir::ArrayAttr labels = checks.front().getLabels();
+    ASSERT_EQ(labels.size(), 1u);
+    EXPECT_EQ(mlir::cast<mlir::StringAttr>(labels[0]).getValue(), "Person");
+
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 0u);
+}

--- a/test/query/ir/FuseScanByNodeIDsCodegenTest.cpp
+++ b/test/query/ir/FuseScanByNodeIDsCodegenTest.cpp
@@ -192,3 +192,80 @@ TEST_F(FuseScanByNodeIDsCodegenTest, labelledDisjunctionKeepsALabelCheck) {
     EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
     EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 0u);
 }
+
+TEST_F(FuseScanByNodeIDsCodegenTest, filteredClauseCrossedWithASecondClause) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n) WHERE n = 0 OR n = 1 MATCH (m) RETURN count(*)");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {0, 1};
+    EXPECT_EQ(nodeIDs, expected);
+
+    EXPECT_TRUE(constScan.getOperation()->getParentOfType<mlir::db::CrossProduct>());
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, laterClausePredicateOnAnEarlierClauseVariable) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n) MATCH (m) WHERE n = 0 OR n = 1 RETURN count(*)");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {0, 1};
+    EXPECT_EQ(nodeIDs, expected);
+
+    // The predicate sits after the product in the query; it sinks into n's factor and fuses.
+    EXPECT_TRUE(constScan.getOperation()->getParentOfType<mlir::db::CrossProduct>());
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, bothClausesFiltered) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (n) WHERE n = 0 OR n = 1 MATCH (m) WHERE m = 3 OR m = 2 RETURN n, m");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 2u);
+
+    std::vector<int64_t> firstIDs;
+    nodeIDsOf(constScans[0], firstIDs);
+    const std::vector<int64_t> expectedFirst {0, 1};
+    EXPECT_EQ(firstIDs, expectedFirst);
+
+    std::vector<int64_t> secondIDs;
+    nodeIDsOf(constScans[1], secondIDs);
+    const std::vector<int64_t> expectedSecond {2, 3};
+    EXPECT_EQ(secondIDs, expectedSecond);
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+TEST_F(FuseScanByNodeIDsCodegenTest, filteredClauseExpandedByALaterClause) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (n) WHERE n = 0 OR n = 1 MATCH (n)-->(m) RETURN m");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScan, nodeIDs);
+    const std::vector<int64_t> expected {0, 1};
+    EXPECT_EQ(nodeIDs, expected);
+
+    // The second clause's hop expands the listed set directly.
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_EQ(hops.front().getInputNodes().getDefiningOp(), constScan.getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}

--- a/test/query/ir/FuseScanByNodeIDsTest.cpp
+++ b/test/query/ir/FuseScanByNodeIDsTest.cpp
@@ -436,3 +436,108 @@ TEST_F(FuseScanByNodeIDsTest, fusesFilterPushedDownToScan) {
     EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
     EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
 }
+
+// MATCH (n) WHERE n = 0 OR n = 1 MATCH (m) WHERE m = 3 OR m = 2 RETURN n, m, each filter in its factor
+const char* const disjunctionInBothFactors = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %n = db.scan_nodes() : !db.column<!storage.node_id>
+    %k0 = db.constant(0 : i64)
+    %e1 = db.eq %n, %k0 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %k1 = db.constant(1 : i64)
+    %e2 = db.eq %n, %k1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+    %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %nf : !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    %k3 = db.constant(3 : i64)
+    %e3 = db.eq %m, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %k2 = db.constant(2 : i64)
+    %e4 = db.eq %m, %k2 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %mask2 = db.or %e3, %e4 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+    %mf = db.filter(%mask2, {%m}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %mf : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesBothFactorsOfACrossProduct) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(disjunctionInBothFactors);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 2u);
+
+    const llvm::ArrayRef<int64_t> leftIDs = constScans[0].getNodeIDs();
+    const std::vector<int64_t> expectedLeft {0, 1};
+    EXPECT_EQ(std::vector<int64_t>(leftIDs.begin(), leftIDs.end()), expectedLeft);
+
+    const llvm::ArrayRef<int64_t> rightIDs = constScans[1].getNodeIDs();
+    const std::vector<int64_t> expectedRight {2, 3};
+    EXPECT_EQ(std::vector<int64_t>(rightIDs.begin(), rightIDs.end()), expectedRight);
+
+    // Each factor yields its own const scan.
+    llvm::SmallVector<mlir::db::CrossProduct> products = collect<mlir::db::CrossProduct>(*module);
+    ASSERT_EQ(products.size(), 1u);
+    mlir::db::CrossProduct product = products.front();
+
+    mlir::db::Yield leftYield = mlir::cast<mlir::db::Yield>(product.getLeftFactor().front().getTerminator());
+    EXPECT_EQ(leftYield.getColumns().front().getDefiningOp(), constScans[0].getOperation());
+    mlir::db::Yield rightYield = mlir::cast<mlir::db::Yield>(product.getRightFactor().front().getTerminator());
+    EXPECT_EQ(rightYield.getColumns().front().getDefiningOp(), constScans[1].getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+// MATCH (n) MATCH (m) WHERE n = 0 OR n = 1 RETURN n, m, as codegen emits it: filtered after the product
+const char* const disjunctionAfterCrossProduct = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %n = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %n : !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  %k0 = db.constant(0 : i64)
+  %e1 = db.eq %0#0, %k0 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %k1 = db.constant(1 : i64)
+  %e2 = db.eq %0#0, %k1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %nf, %mf = db.filter(%mask, {%0#0, %0#1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%nf, %mf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesDisjunctionPushedIntoCrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(disjunctionAfterCrossProduct);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDownThenFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScan.getNodeIDs();
+    const std::vector<int64_t> expected {0, 1};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    // The filter sank into the left factor and fused there; the right factor keeps its scan.
+    llvm::SmallVector<mlir::db::CrossProduct> products = collect<mlir::db::CrossProduct>(*module);
+    ASSERT_EQ(products.size(), 1u);
+    mlir::db::CrossProduct product = products.front();
+
+    mlir::db::Yield leftYield = mlir::cast<mlir::db::Yield>(product.getLeftFactor().front().getTerminator());
+    EXPECT_EQ(leftYield.getColumns().front().getDefiningOp(), constScan.getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}

--- a/test/query/ir/FuseScanByNodeIDsTest.cpp
+++ b/test/query/ir/FuseScanByNodeIDsTest.cpp
@@ -1,0 +1,438 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "StorageDialect.h"
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+}
+
+class FuseScanByNodeIDsTest : public ::testing::Test {
+protected:
+    FuseScanByNodeIDsTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool runFuse(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createFuseScanByNodeIDs());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    // The production order: a filter sinks to its scan first, then fuses into it.
+    bool runPushDownThenFuse(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createPushDownFilters());
+        passManager.addPass(mlir::db::createFuseScanByNodeIDs());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    // The module holds exactly its original scan and filter and no const scan.
+    void expectUntouched(mlir::ModuleOp module) {
+        EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::FilterOp>(module), 1u);
+        EXPECT_EQ(countOps<mlir::db::ScanNodes>(module) + countOps<mlir::db::ScanNodesByLabel>(module), 1u);
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// MATCH (n) WHERE n = 5 OR n = 2 OR n = 5 RETURN n
+const char* const repeatedDisjunction = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k5 = db.constant(5 : i64)
+  %e1 = db.eq %n, %k5 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %k2 = db.constant(2 : i64)
+  %e2 = db.eq %n, %k2 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %o1 = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %k5b = db.constant(5 : i64)
+  %e3 = db.eq %n, %k5b : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.or %o1, %e3 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesDisjunctionIntoSortedUniqueConstScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(repeatedDisjunction);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    // The listed set is the filter's: each node once, in scan order.
+    const llvm::ArrayRef<int64_t> nodeIDs = constScan.getNodeIDs();
+    const std::vector<int64_t> expected {2, 5};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    // Nothing of the scan, the filter or its mask cone survives.
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::OrOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ConstantOp>(*module), 0u);
+
+    // The output reads the const scan directly.
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_EQ(outputs.front().getColumns().size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front().getDefiningOp(), constScan.getOperation());
+}
+
+// MATCH (n) WHERE n = 3 RETURN n
+const char* const singleEquality = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k3 = db.constant(3 : i64)
+  %mask = db.eq %n, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesSingleEquality) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(singleEquality);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScans.front().getNodeIDs();
+    const std::vector<int64_t> expected {3};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+}
+
+// MATCH (n) WHERE 7 = n OR n = 3 RETURN n
+const char* const constantOnEitherSide = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k7 = db.constant(7 : i64)
+  %e1 = db.eq %k7, %n : (!db.column<i64>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %k3 = db.constant(3 : i64)
+  %e2 = db.eq %n, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, acceptsConstantOnEitherSide) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(constantOnEitherSide);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScans.front().getNodeIDs();
+    const std::vector<int64_t> expected {3, 7};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+}
+
+// MATCH (n) WHERE n = 1 OR n.age = 32 RETURN n
+const char* const propertyLeaf = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k1 = db.constant(1 : i64)
+  %e1 = db.eq %n, %k1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %k32 = db.constant(32 : i64)
+  %e2 = db.eq %age, %k32 : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, leavesPropertyLeafAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(propertyLeaf);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module);
+}
+
+// MATCH (n) WHERE n = 1 AND n = 2 RETURN n
+const char* const conjunction = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k1 = db.constant(1 : i64)
+  %e1 = db.eq %n, %k1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %k2 = db.constant(2 : i64)
+  %e2 = db.eq %n, %k2 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.and %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, leavesConjunctionAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(conjunction);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module);
+}
+
+// MATCH (n) WHERE n = -1 RETURN n
+const char* const negativeLiteral = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k = db.constant(-1 : i64)
+  %mask = db.eq %n, %k : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, leavesNegativeLiteralAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(negativeLiteral);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module);
+}
+
+// MATCH (n) WHERE n = true RETURN n
+const char* const boolLiteral = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %k = db.constant(true)
+  %mask = db.eq %n, %k : (!db.column<!storage.node_id>, !db.column<i1>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, leavesBoolLiteralAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(boolLiteral);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module);
+}
+
+// MATCH (n:Person) WHERE n = 3 RETURN n
+const char* const labelScan = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %k3 = db.constant(3 : i64)
+  %mask = db.eq %n, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%nf) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesLabelScanIntoConstScanWithLabelCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(labelScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScan.getNodeIDs();
+    const std::vector<int64_t> expected {3};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    // The label test the fused scan carried is re-applied over the listed nodes.
+    llvm::SmallVector<mlir::db::GetNodeLabelSet> labelSets = collect<mlir::db::GetNodeLabelSet>(*module);
+    ASSERT_EQ(labelSets.size(), 1u);
+    mlir::db::GetNodeLabelSet labelSet = labelSets.front();
+    EXPECT_EQ(labelSet.getInputNodes().getDefiningOp(), constScan.getOperation());
+
+    llvm::SmallVector<mlir::db::CheckLabelConstraint> checks = collect<mlir::db::CheckLabelConstraint>(*module);
+    ASSERT_EQ(checks.size(), 1u);
+    mlir::db::CheckLabelConstraint check = checks.front();
+    EXPECT_EQ(check.getLabelsetIds().getDefiningOp(), labelSet.getOperation());
+
+    const mlir::ArrayAttr labels = check.getLabels();
+    ASSERT_EQ(labels.size(), 1u);
+    EXPECT_EQ(mlir::cast<mlir::StringAttr>(labels[0]).getValue(), "Person");
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    mlir::db::FilterOp filter = filters.front();
+    EXPECT_EQ(filter.getMask().getDefiningOp(), check.getOperation());
+    ASSERT_EQ(filter.getColumnsToFilter().size(), 1u);
+    EXPECT_EQ(filter.getColumnsToFilter().front().getDefiningOp(), constScan.getOperation());
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_EQ(outputs.front().getColumns().size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front().getDefiningOp(), filter.getOperation());
+
+    // The labelled scan and the ID mask are gone.
+    EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ConstantOp>(*module), 0u);
+}
+
+// MATCH (n) WITH n, n.age AS age WHERE n = 3 RETURN n, age
+const char* const filterCarryingProperty = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %k3 = db.constant(3 : i64)
+  %mask = db.eq %n, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %nf, %agef = db.filter(%mask, {%n, %age}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<!storage.node_id>, !db.column<i64>)
+  db.output(%nf, %agef) : !db.column<!storage.node_id>, !db.column<i64>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, leavesFilterCarryingAnotherColumnAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(filterCarryingProperty);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module);
+}
+
+// MATCH (n), (m) WHERE n = 4 OR n = 2 RETURN n, m, once the filter sank into its factor
+const char* const disjunctionInFactor = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %n = db.scan_nodes() : !db.column<!storage.node_id>
+    %k4 = db.constant(4 : i64)
+    %e1 = db.eq %n, %k4 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %k2 = db.constant(2 : i64)
+    %e2 = db.eq %n, %k2 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+    %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+    %nf = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+    db.yield %nf : !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesInsideCrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(disjunctionInFactor);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScan.getNodeIDs();
+    const std::vector<int64_t> expected {2, 4};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    // The const scan took the filter's place inside the left factor, which now yields it;
+    // the right factor's scan is untouched.
+    llvm::SmallVector<mlir::db::CrossProduct> products = collect<mlir::db::CrossProduct>(*module);
+    ASSERT_EQ(products.size(), 1u);
+    mlir::db::CrossProduct product = products.front();
+
+    mlir::db::Yield leftYield = mlir::cast<mlir::db::Yield>(product.getLeftFactor().front().getTerminator());
+    ASSERT_EQ(leftYield.getColumns().size(), 1u);
+    EXPECT_EQ(leftYield.getColumns().front().getDefiningOp(), constScan.getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+}
+
+// MATCH (n)-->(m) WHERE n = 1 OR n = 3 RETURN n, m, as codegen emits it: filtered after the hop
+const char* const disjunctionAfterHop = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%n, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %k1 = db.constant(1 : i64)
+  %e1 = db.eq %s, %k1 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %k3 = db.constant(3 : i64)
+  %e2 = db.eq %s, %k3 : (!db.column<!storage.node_id>, !db.column<i64>) -> !db.column<!storage.bool>
+  %mask = db.or %e1, %e2 : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %sf, %tf = db.filter(%mask, {%s, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(FuseScanByNodeIDsTest, fusesFilterPushedDownToScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(disjunctionAfterHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDownThenFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+    mlir::db::ConstScanNodes constScan = constScans.front();
+
+    const llvm::ArrayRef<int64_t> nodeIDs = constScan.getNodeIDs();
+    const std::vector<int64_t> expected {1, 3};
+    EXPECT_EQ(std::vector<int64_t>(nodeIDs.begin(), nodeIDs.end()), expected);
+
+    // The hop now expands the const scan, and no filter is left anywhere.
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_EQ(hops.front().getInputNodes().getDefiningOp(), constScan.getOperation());
+
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+}

--- a/test/query/ir/ScanByNodeIDsV3Test.cpp
+++ b/test/query/ir/ScanByNodeIDsV3Test.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+class ScanByNodeIDsV3Test : public CallV3Test {
+};
+
+TEST_F(ScanByNodeIDsV3Test, disjunctionYieldsListedNodesInScanOrder) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 5 OR n = 2 RETURN n", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"2"}, {"5"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, singleEquality) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 0 RETURN n.name", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Remy"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, repeatedIDYieldsTheNodeOnce) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 3 OR n = 3 RETURN n", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"3"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, absentIDMatchesNothing) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 2 OR n = 99999 RETURN n", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"2"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, countsOverTheListedSet) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 3 OR n = 1 OR n = 7 RETURN count(n)", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"3"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, disjunctionOnAnExpandedRootMatchesThePropertyForm) {
+    StringRowSink byID;
+    runQuery("MATCH (n)-->(m) WHERE n = 0 OR n = 1 RETURN n, m", byID);
+
+    StringRowSink byName;
+    runQuery("MATCH (n)-->(m) WHERE n.name = 'Remy' OR n.name = 'Adam' RETURN n, m", byName);
+
+    std::vector<StringRowSink::Row> byIDRows;
+    byID.sortedRows(byIDRows);
+    std::vector<StringRowSink::Row> byNameRows;
+    byName.sortedRows(byNameRows);
+
+    EXPECT_FALSE(byIDRows.empty());
+    EXPECT_EQ(byIDRows, byNameRows);
+}
+
+TEST_F(ScanByNodeIDsV3Test, disjunctionInACrossProductFactor) {
+    StringRowSink sink;
+    runQuery("MATCH (n), (m) WHERE n = 2 OR n = 4 RETURN count(m)", sink);
+
+    // Two listed nodes crossed with every one of simpledb's 18 nodes.
+    const std::vector<StringRowSink::Row> expected {{"36"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, mixedPredicateStaysAFilter) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 5 OR n.name = 'Remy' RETURN n", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"5"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, labelledDisjunctionKeepsOnlyTheLabelledNodes) {
+    StringRowSink sink;
+    runQuery("MATCH (n:Person) WHERE n = 2 OR n = 0 RETURN n.name", sink);
+
+    // Remy (0) is a Person; Computers (2) is an Interest.
+    const std::vector<StringRowSink::Row> expected {{"Remy"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, labelledDisjunctionYieldsInScanOrder) {
+    StringRowSink sink;
+    runQuery("MATCH (n:Interest) WHERE n = 5 OR n = 0 OR n = 2 RETURN n.name", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Computers"}, {"Cooking"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, labelledDisjunctionOnAnExpandedRootMatchesThePropertyForm) {
+    StringRowSink byID;
+    runQuery("MATCH (n:Person)-->(m) WHERE n = 0 OR n = 1 OR n = 2 RETURN n, m", byID);
+
+    StringRowSink byName;
+    runQuery("MATCH (n:Person)-->(m) WHERE n.name = 'Remy' OR n.name = 'Adam' OR n.name = 'Computers' RETURN n, m", byName);
+
+    std::vector<StringRowSink::Row> byIDRows;
+    byID.sortedRows(byIDRows);
+    std::vector<StringRowSink::Row> byNameRows;
+    byName.sortedRows(byNameRows);
+
+    EXPECT_FALSE(byIDRows.empty());
+    EXPECT_EQ(byIDRows, byNameRows);
+}

--- a/test/query/ir/ScanByNodeIDsV3Test.cpp
+++ b/test/query/ir/ScanByNodeIDsV3Test.cpp
@@ -116,3 +116,93 @@ TEST_F(ScanByNodeIDsV3Test, labelledDisjunctionOnAnExpandedRootMatchesThePropert
     EXPECT_FALSE(byIDRows.empty());
     EXPECT_EQ(byIDRows, byNameRows);
 }
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchFilteredClauseCrossedWithASecondClause) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 0 OR n = 1 MATCH (m) RETURN count(*)", sink);
+
+    // Two listed nodes crossed with simpledb's 18 nodes.
+    const std::vector<StringRowSink::Row> expected {{"36"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchLaterClausePredicateOnAnEarlierVariable) {
+    StringRowSink sink;
+    runQuery("MATCH (n) MATCH (m) WHERE n = 0 OR n = 1 RETURN count(*)", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"36"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchBothClausesFiltered) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 0 OR n = 1 MATCH (m) WHERE m = 4 OR m = 2 OR m = 3 RETURN n, m", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    const std::vector<StringRowSink::Row> expected {{"0", "2"}, {"0", "3"}, {"0", "4"},
+                                                    {"1", "2"}, {"1", "3"}, {"1", "4"}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchFilteredClauseExpandedByALaterClause) {
+    StringRowSink sink;
+    runQuery("MATCH (n) WHERE n = 0 OR n = 1 MATCH (n)-->(m) RETURN m", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    // Remy's neighbours are Adam, Computers, Eighties and Ghosts; Adam's are Remy, Bio and Cooking.
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"1"}, {"2"}, {"3"}, {"4"}, {"5"}, {"6"}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchTraversalThenFilteredClauseOnTheSharedVariable) {
+    StringRowSink sink;
+    runQuery("MATCH (n)-->(m) MATCH (m) WHERE m = 2 OR m = 4 RETURN n", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    // Computers is reached from Remy (0) and Luc (9), Bio from Adam (1) and Maxime (8).
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"1"}, {"8"}, {"9"}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchLabelledFilteredClauseCrossedWithALabelledClause) {
+    StringRowSink sink;
+    runQuery("MATCH (n:Person) WHERE n = 0 OR n = 2 MATCH (m:Interest) RETURN count(*)", sink);
+
+    // Only Remy is a Person among the two listed; simpledb has 10 Interests.
+    const std::vector<StringRowSink::Row> expected {{"10"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchThreeClausesChainedFromAConstScan) {
+    StringRowSink sink;
+    runQuery("MATCH (a) WHERE a = 0 MATCH (a)-->(b) MATCH (b)-->(c) RETURN c", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    // From Remy: Adam leads to Remy, Bio and Cooking; Ghosts leads back to Remy.
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"0"}, {"4"}, {"5"}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(ScanByNodeIDsV3Test, multiMatchJoinedClauseMatchesThePropertyForm) {
+    StringRowSink byID;
+    runQuery("MATCH (n) WHERE n = 0 OR n = 9 MATCH (n)-[:INTERESTED_IN]->(i) RETURN i.name", byID);
+
+    StringRowSink byName;
+    runQuery("MATCH (n) WHERE n.name = 'Remy' OR n.name = 'Luc' MATCH (n)-[:INTERESTED_IN]->(i) RETURN i.name", byName);
+
+    std::vector<StringRowSink::Row> byIDRows;
+    byID.sortedRows(byIDRows);
+    std::vector<StringRowSink::Row> byNameRows;
+    byName.sortedRows(byNameRows);
+
+    EXPECT_FALSE(byIDRows.empty());
+    EXPECT_EQ(byIDRows, byNameRows);
+}


### PR DESCRIPTION
Add an MLIR pass turning a node scan filtered by a disjunction of node IDs into a const_scan_nodes.