### PR TITLE
MLIR: average a heterogeneous unwind beside a collect

### DIFF
--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1828,12 +1828,17 @@ void DBLowering::lowerCollect(mlir::db::Collect collect) {
     }
 
     // A reduction beside the lists reads its input as a nullable value chunk, as it does
-    // under a grouped aggregation; a count tallies rows and takes the chunk as it is.
+    // under a grouped aggregation; a count tallies rows and takes the chunk as it is, and
+    // so does a type-erased column of tagged cells, which has no one value type to be read
+    // as.
     for (size_t aggregateIndex = 0; aggregateIndex < kinds.size(); aggregateIndex++) {
         const auto kind = static_cast<storage::GroupAggregateKind>(kinds[aggregateIndex]);
+        const size_t chunkIndex = keyCount + valueCount + aggregateIndex;
 
-        if (reducesValues(kind)) {
-            const size_t chunkIndex = keyCount + valueCount + aggregateIndex;
+        const mlir::Type aggregateElement = mlir::cast<nl::ChunkType>(chunks[chunkIndex].getType()).getElementType();
+        const bool taggedCells = mlir::isa<storage::ListElementType>(aggregateElement);
+
+        if (reducesValues(kind) && !taggedCells) {
             chunks[chunkIndex] = nullableValueChunk(chunks[chunkIndex]);
         }
     }

--- a/test/query/ir/AvgUnwindTest.cpp
+++ b/test/query/ir/AvgUnwindTest.cpp
@@ -227,6 +227,20 @@ TEST_F(AvgUnwindTest, averagesEachGroupOfAMixedUnwoundCell) {
     expectRows("UNWIND [1, 1.0, 2.5] AS x RETURN x, avg(x)", expected);
 }
 
+// The cells beside a collect of the rows they were paired with: the keyless form reduces
+// every pair, so the two elements average as they do on their own.
+TEST_F(AvgUnwindTest, averagesTheMixedCellsBesideAKeylessCollect) {
+    const Rows expected = {{"Remy, Remy", "1.75"}};
+    expectRows("UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN collect(n.name), avg(x)", expected);
+}
+
+// The same beside a grouped collect: the cell is the grouping key, so each group collects
+// the row it was paired with and averages the one value it holds.
+TEST_F(AvgUnwindTest, averagesTheMixedCellsBesideAGroupedCollect) {
+    const Rows expected = {{"1", "Remy", "1"}, {"2.5", "Remy", "2.5"}};
+    expectRows("UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN x, collect(n.name), avg(x)", expected);
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }


### PR DESCRIPTION
Implement the average of a heterogeneous unwind beside a collect.

```
UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN x, collect(n.name), avg(x)
UNWIND [1, 2.5] AS x MATCH (n) WHERE n.name = 'Remy' RETURN collect(n.name), avg(x)
```