### PR TITLE
MLIR: test the v3 shapes no suite case reached

### DIFF
--- a/test/query/ir/AggregateWithReturnItemsTest.cpp
+++ b/test/query/ir/AggregateWithReturnItemsTest.cpp
@@ -85,6 +85,29 @@ TEST_F(AggregateWithReturnItemsTest, averagesWithinTheGroupOfEachReturnedNode) {
     expectRows("MATCH (n) RETURN avg(n.age), n", expected);
 }
 
+// The mirror of the average above with the key written first: the item order moves the
+// columns, not the grouping, so each node still averages its own age alone
+TEST_F(AggregateWithReturnItemsTest, averagesWithinTheGroupOfEachReturnedNodeWithTheKeyFirst) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t node = 0; node < nodeCount; node++) {
+        const std::string age = node <= 1 ? "32" : "null";
+        expected.push_back({std::to_string(node), age});
+    }
+
+    expectRows("MATCH (n) RETURN n, avg(n.age)", expected);
+}
+
+// count(*) beside a grouping key tallies the rows of that key's group, which for a single
+// pattern is the one row each node matched - not the eighteen the whole match holds
+TEST_F(AggregateWithReturnItemsTest, countsTheOneRowOfEachReturnedNode) {
+    std::vector<StringRowSink::Row> expected;
+    for (size_t node = 0; node < nodeCount; node++) {
+        expected.push_back({std::to_string(node), "1"});
+    }
+
+    expectRows("MATCH (n) RETURN n, count(*)", expected);
+}
+
 // count-m-return-n: the two patterns cross into a row per pair of nodes, so each of the
 // eighteen groups counts the eighteen m it was paired with
 TEST_F(AggregateWithReturnItemsTest, countsThePairsOfEachReturnedNode) {
@@ -112,6 +135,14 @@ TEST_F(AggregateWithReturnItemsTest, countsEveryPairOnceWhenBothItemsAggregate) 
     std::vector<StringRowSink::Row> expected {{"324", "324"}};
 
     expectRows("MATCH (n), (m) RETURN COUNT(n), COUNT(m)", expected);
+}
+
+// The ungrouped baseline of the two above: with no item beside it, the tally is the whole
+// cross product rather than one group of it
+TEST_F(AggregateWithReturnItemsTest, countsEveryPairWithoutAGroupingKey) {
+    std::vector<StringRowSink::Row> expected {{"324"}};
+
+    expectRows("MATCH (n), (m) RETURN count(*)", expected);
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/ConstantPredicateProjectionTest.cpp
+++ b/test/query/ir/ConstantPredicateProjectionTest.cpp
@@ -175,6 +175,17 @@ TEST_F(ConstantPredicateProjectionTest, emitsTheConstantForEveryMatchedRowWhenTh
     expectRows("MATCH (n) WHERE NOT FALSE RETURN NOT FALSE", expected);
 }
 
+// The other literal under the same two predicates: which constant the projection computes
+// leaves untouched how many rows the filter keeps
+TEST_F(ConstantPredicateProjectionTest, emitsTheOtherConstantForEveryMatchedRowThePredicateKeeps) {
+    const BoolRows expected(18, {false});
+    expectRows("MATCH (n) WHERE NOT FALSE RETURN NOT TRUE", expected);
+}
+
+TEST_F(ConstantPredicateProjectionTest, emitsNothingWhenTheExcludingPredicateProjectsTheOtherConstant) {
+    expectRows("MATCH (n) WHERE NOT TRUE RETURN NOT TRUE", {});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/PatternLoopTest.cpp
+++ b/test/query/ir/PatternLoopTest.cpp
@@ -76,6 +76,42 @@ TEST_F(PatternLoopTest, matchesNothingWhenNoLoopIsThatLong) {
     expectRows("MATCH (a)-->(b)-->(c)-->(a) RETURN a, b, c;", {});
 }
 
+// The tally of the rows above, so the loop is read once through its rows and once through
+// the count they are charged to
+TEST_F(PatternLoopTest, countsTheRowsTheLoopCloses) {
+    const std::vector<StringRowSink::Row> expected {{"4"}};
+
+    expectRows("MATCH (a)-->(b)-->(a) RETURN count(*)", expected);
+}
+
+// Naming the two legs shows each is bound to an edge of its own: the hop out to b and the
+// hop back to a are answered by different edges, never one edge read twice.
+TEST_F(PatternLoopTest, bindsTheTwoLegsToDifferentEdges) {
+    const std::vector<StringRowSink::Row> expected {{"0", "1", "0", "4"},
+                                                    {"0", "6", "1", "7"},
+                                                    {"1", "0", "4", "0"},
+                                                    {"6", "0", "7", "1"}};
+
+    expectRows("MATCH (a)-[e]->(b)-[f]->(a) RETURN a, b, e, f", expected);
+}
+
+TEST_F(PatternLoopTest, namesTheNodesTheLoopRunsThrough) {
+    const std::vector<StringRowSink::Row> expected {{"Adam", "Remy"},
+                                                    {"Ghosts", "Remy"},
+                                                    {"Remy", "Adam"},
+                                                    {"Remy", "Ghosts"}};
+
+    expectRows("MATCH (a)-->(b)-->(a) RETURN a.name, b.name", expected);
+}
+
+// A loop of one hop is a self-edge, which simpledb holds none of - so the shape is matched
+// rather than waved through, as the three-hop one above is
+TEST_F(PatternLoopTest, matchesNoSelfEdge) {
+    const std::vector<StringRowSink::Row> expected {{"0"}};
+
+    expectRows("MATCH (a)-->(a) RETURN count(*)", expected);
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }


### PR DESCRIPTION
Test the loop, grouping-key and constant-predicate shapes the suite cases only reach in part.

```
MATCH (a)-->(b)-->(a) RETURN count(*)
MATCH (a)-[e]->(b)-[f]->(a) RETURN a, b, e, f
MATCH (a)-->(b)-->(a) RETURN a.name, b.name
MATCH (a)-->(a) RETURN count(*)

MATCH (n) RETURN n, avg(n.age)
MATCH (n) RETURN n, count(*)
MATCH (n), (m) RETURN count(*)

MATCH (n) WHERE NOT FALSE RETURN NOT TRUE
MATCH (n) WHERE NOT TRUE RETURN NOT TRUE
```