### PR TITLE
Fix: Write to what the same query created

### DIFF
--- a/query/analyzer/WriteStmtAnalyzer.cpp
+++ b/query/analyzer/WriteStmtAnalyzer.cpp
@@ -63,16 +63,12 @@ void WriteStmtAnalyzer::analyze(const Stmt* stmt) {
 }
 
 void WriteStmtAnalyzer::analyze(const CreateStmt* createStmt) {
-    _hasCreate = true;
     if (createStmt->getPattern()) {
         analyze(createStmt->getPattern());
     }
 }
 
 void WriteStmtAnalyzer::analyze(const SetStmt* setStmt) {
-    if (_hasCreate) {
-        throwError("CREATE ... SET is not yet supported. Please use brace initialisation.", setStmt);
-    }
     for (SetItem* item : setStmt->getItems()) {
         analyze(item);
     }

--- a/query/analyzer/WriteStmtAnalyzer.h
+++ b/query/analyzer/WriteStmtAnalyzer.h
@@ -50,7 +50,6 @@ private:
     ExprAnalyzer* _exprAnalyzer {nullptr};
     std::unordered_set<const VarDecl*> _toBeCreated;
     const GraphMetadata& _graphMetadata;
-    bool _hasCreate {false};
 
     void analyze(const CreateStmt* createStmt);
     void analyze(const SetStmt* setStmt);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2178,6 +2178,16 @@ CommitWriteBuffer::ExistingOrPendingNode resolveNode(const ColumnNodeIDs* column
     }
 }
 
+// The IDs a create wrote into its result column are offsets into the change's write
+// buffer, so a delete of what the same query created reads them back as such
+template <typename IDT>
+void collectPendingOffsets(const ColumnVector<IDT>* column, std::vector<size_t>& offsets) {
+    const std::vector<IDT>& raw = column->getRaw();
+
+    offsets.resize(raw.size());
+    std::transform(raw.begin(), raw.end(), offsets.begin(), [](IDT id) { return id.getValue(); });
+}
+
 void throwIfNodesHaveEdges(const GraphView& view, const ColumnNodeIDs* nodes) {
     const Tombstones& tombstones = view.tombstones();
 
@@ -2444,9 +2454,28 @@ void NLExecutor::runDeleteNode(NLExecutionContext* context, NLFunctionData* data
     bioassert(writeBuffer, "nl.delete_node requires an active write transaction");
 
     const ColumnNodeIDs* nodes = deleteData->getInput();
+    const bool detaching = deleteData->isDetaching();
+
+    if (deleteData->isInputPending()) {
+        std::vector<size_t> offsets;
+        collectPendingOffsets(nodes, offsets);
+
+        if (!detaching && writeBuffer->pendingNodesHaveEdges(offsets)) {
+            throw IRException("Cannot delete a node with relationships; use DETACH DELETE");
+        }
+
+        writeBuffer->addDeletedPendingNodes(offsets);
+
+        if (detaching) {
+            writeBuffer->addHangingPendingEdges();
+        }
+
+        return;
+    }
+
     const GraphView* view = context->getView();
 
-    if (deleteData->isDetaching()) {
+    if (detaching) {
         writeBuffer->addDeletedNodes(nodes->getRaw());
         writeBuffer->addHangingEdges(*view);
     } else {
@@ -2461,6 +2490,16 @@ void NLExecutor::runDeleteEdge(NLExecutionContext* context, NLFunctionData* data
     bioassert(writeBuffer, "nl.delete_edge requires an active write transaction");
 
     const ColumnEdgeIDs* edges = deleteData->getInput();
+
+    if (deleteData->isInputPending()) {
+        std::vector<size_t> offsets;
+        collectPendingOffsets(edges, offsets);
+
+        writeBuffer->addDeletedPendingEdges(offsets);
+
+        return;
+    }
+
     writeBuffer->addDeletedEdges(edges->getRaw());
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2423,7 +2423,16 @@ void NLExecutor::runSetNodeProperty(NLExecutionContext* context, NLFunctionData*
     const Column* nodeCol = setData->getValue();
     extractColumnProperties(nodeCol, rowCount, propID, propsBuffer);
 
-    const auto& raw = nodes->getRaw();
+    const std::vector<NodeID>& raw = nodes->getRaw();
+
+    if (setData->isInputPending()) {
+        for (size_t row = 0; row < rowCount; row++) {
+            writeBuffer->setPendingNodeProperty(raw[row].getValue(), propsBuffer[row]);
+        }
+
+        return;
+    }
+
     for (size_t row = 0; row < rowCount; row++) {
         writeBuffer->addNodeUpdate(raw[row], propsBuffer[row]);
     }
@@ -2442,7 +2451,16 @@ void NLExecutor::runSetEdgeProperty(NLExecutionContext* context, NLFunctionData*
     CommitWriteBuffer::UntypedProperties propsBuffer;
     extractColumnProperties(edgeCol, rowCount, propID, propsBuffer);
 
-    const auto& raw = edges->getRaw();
+    const std::vector<EdgeID>& raw = edges->getRaw();
+
+    if (setData->isInputPending()) {
+        for (size_t row = 0; row < rowCount; row++) {
+            writeBuffer->setPendingEdgeProperty(raw[row].getValue(), propsBuffer[row]);
+        }
+
+        return;
+    }
+
     for (size_t row = 0; row < rowCount; row++) {
         writeBuffer->addEdgeUpdate(raw[row], propsBuffer[row]);
     }

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -2120,42 +2120,50 @@ class NLSetNodePropertyData : public NLFunctionData {
 public:
     NLSetNodePropertyData(PropertyTypeID propertyTypeID,
                           const ColumnNodeIDs* input,
+                          bool inputIsPending,
                           const Column* value)
         : _input(input),
         _value(value),
-        _propertyTypeID(propertyTypeID)
+        _propertyTypeID(propertyTypeID),
+        _inputIsPending(inputIsPending)
     {
     }
 
     PropertyTypeID getPropertyTypeID() const { return _propertyTypeID; }
     const ColumnNodeIDs* getInput() const { return _input; }
+    bool isInputPending() const { return _inputIsPending; }
     const Column* getValue() const { return _value; }
 
 private:
     const ColumnNodeIDs* _input {nullptr};
     const Column* _value {nullptr};
     PropertyTypeID _propertyTypeID;
+    bool _inputIsPending {false};
 };
 
 class NLSetEdgePropertyData : public NLFunctionData {
 public:
     NLSetEdgePropertyData(PropertyTypeID propertyTypeID,
                           const ColumnEdgeIDs* input,
+                          bool inputIsPending,
                           const Column* value)
         : _input(input),
         _value(value),
-        _propertyTypeID(propertyTypeID)
+        _propertyTypeID(propertyTypeID),
+        _inputIsPending(inputIsPending)
     {
     }
 
     PropertyTypeID getPropertyTypeID() const { return _propertyTypeID; }
     const ColumnEdgeIDs* getInput() const { return _input; }
+    bool isInputPending() const { return _inputIsPending; }
     const Column* getValue() const { return _value; }
 
 private:
     const ColumnEdgeIDs* _input {nullptr};
     const Column* _value {nullptr};
     PropertyTypeID _propertyTypeID;
+    bool _inputIsPending {false};
 };
 
 class NLDeleteNodeData : public NLFunctionData {

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -2160,31 +2160,37 @@ private:
 
 class NLDeleteNodeData : public NLFunctionData {
 public:
-    NLDeleteNodeData(const ColumnNodeIDs* input, bool detaching)
+    NLDeleteNodeData(const ColumnNodeIDs* input, bool inputIsPending, bool detaching)
         : _input(input),
+        _inputIsPending(inputIsPending),
         _detaching(detaching)
     {
     }
 
     const ColumnNodeIDs* getInput() const { return _input; }
+    bool isInputPending() const { return _inputIsPending; }
     bool isDetaching() const { return _detaching; }
 
 private:
     const ColumnNodeIDs* _input {nullptr};
+    bool _inputIsPending {false};
     bool _detaching {false};
 };
 
 class NLDeleteEdgeData : public NLFunctionData {
 public:
-    NLDeleteEdgeData(const ColumnEdgeIDs* input)
-        : _input(input)
+    NLDeleteEdgeData(const ColumnEdgeIDs* input, bool inputIsPending)
+        : _input(input),
+        _inputIsPending(inputIsPending)
     {
     }
 
     const ColumnEdgeIDs* getInput() const { return _input; }
+    bool isInputPending() const { return _inputIsPending; }
 
 private:
     const ColumnEdgeIDs* _input {nullptr};
+    bool _inputIsPending {false};
 };
 
 // nl.output data

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1111,6 +1111,7 @@ void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContaine
 
     ColumnEdgeIDs* result = _memory->alloc<ColumnEdgeIDs>();
     _valueSlots[createEdge.getResult()] = result;
+    _pendingEdgeValues.insert(createEdge.getResult());
 
     NLCreateEdgeData* data = _program->allocFunctionData<NLCreateEdgeData>(
         edgeTypeID,
@@ -1185,10 +1186,12 @@ void NLTranslator::translateSetEdgeProperty(nl::SetEdgeProperty setEdgeProperty,
 
 void NLTranslator::translateDeleteNode(nl::DeleteNode deleteNode, NLStmtContainer* body) {
     const mlir::Value inputValue = deleteNode.getInputNodes();
+    const bool inputIsPending = _pendingNodeValues.contains(inputValue);
     const ColumnNodeIDs* inputColumn = static_cast<const ColumnNodeIDs*>(getColumn(inputValue));
 
     NLDeleteNodeData* data = _program->allocFunctionData<NLDeleteNodeData>(
         inputColumn,
+        inputIsPending,
         deleteNode.getDetach());
 
     body->emplaceStmt(&NLExecutor::runDeleteNode, data);
@@ -1196,9 +1199,11 @@ void NLTranslator::translateDeleteNode(nl::DeleteNode deleteNode, NLStmtContaine
 
 void NLTranslator::translateDeleteEdge(nl::DeleteEdge deleteEdge, NLStmtContainer* body) {
     const mlir::Value inputValue = deleteEdge.getInputEdges();
+    const bool inputIsPending = _pendingEdgeValues.contains(inputValue);
     const ColumnEdgeIDs* inputColumn = static_cast<const ColumnEdgeIDs*>(getColumn(inputValue));
 
-    NLDeleteEdgeData* data = _program->allocFunctionData<NLDeleteEdgeData>(inputColumn);
+    NLDeleteEdgeData* data = _program->allocFunctionData<NLDeleteEdgeData>(inputColumn,
+                                                                          inputIsPending);
 
     body->emplaceStmt(&NLExecutor::runDeleteEdge, data);
 }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1150,12 +1150,14 @@ void NLTranslator::translateSetNodeProperty(nl::SetNodeProperty setNodeProperty,
     const ValueType valueType = valueTypeFromChunkType(propValue.getType());
     const PropertyType propType = _metadataBuilder->getOrCreatePropertyType(propName, valueType);
 
+    const bool inputIsPending = _pendingNodeValues.contains(inputValue);
     const ColumnNodeIDs* inputColumn = static_cast<const ColumnNodeIDs*>(getColumn(inputValue));
     const Column* valueColumn = getColumn(propValue);
 
     NLSetNodePropertyData* data = _program->allocFunctionData<NLSetNodePropertyData>(
         propType._id,
         inputColumn,
+        inputIsPending,
         valueColumn);
 
     body->emplaceStmt(&NLExecutor::runSetNodeProperty, data);
@@ -1173,12 +1175,14 @@ void NLTranslator::translateSetEdgeProperty(nl::SetEdgeProperty setEdgeProperty,
     const ValueType valueType = valueTypeFromChunkType(propValue.getType());
     const PropertyType propType = _metadataBuilder->getOrCreatePropertyType(propName, valueType);
 
+    const bool inputIsPending = _pendingEdgeValues.contains(inputValue);
     const ColumnEdgeIDs* inputColumn = static_cast<const ColumnEdgeIDs*>(getColumn(inputValue));
     const Column* valueColumn = getColumn(propValue);
 
     NLSetEdgePropertyData* data = _program->allocFunctionData<NLSetEdgePropertyData>(
         propType._id,
         inputColumn,
+        inputIsPending,
         valueColumn);
 
     body->emplaceStmt(&NLExecutor::runSetEdgeProperty, data);

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -132,6 +132,9 @@ private:
     // Set of nl.create_node result SSA values
     llvm::DenseSet<mlir::Value> _pendingNodeValues;
 
+    // Set of nl.create_edge result SSA values
+    llvm::DenseSet<mlir::Value> _pendingEdgeValues;
+
     // nl.limit handle SSA value -> the runtime counter it produces, so the loops,
     // nl.limit_update and nl.output that name the handle find the same counter
     llvm::DenseMap<mlir::Value, NLLimitState*> _limitStates;

--- a/storage/versioning/CommitBuilder.cpp
+++ b/storage/versioning/CommitBuilder.cpp
@@ -160,7 +160,7 @@ void CommitBuilder::flushWriteBuffer([[maybe_unused]] JobSystem& jobsystem) {
         // We create a single datapart when flushing the buffer,
         // to ensure it is synced with the metadata provided when rebasing main
         DataPartBuilder& dpBuilder = newBuilder();
-        wb.buildPending(dpBuilder);
+        wb.buildPending(dpBuilder, tombstones);
     }
 
     if (wb.containsUpdates()) {

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -1,5 +1,6 @@
 #include "CommitWriteBuffer.h"
 
+#include <algorithm>
 #include <variant>
 #include <vector>
 
@@ -146,6 +147,33 @@ bool CommitWriteBuffer::pendingNodesHaveEdges(std::span<const PendingNodeOffset>
     }
 
     return false;
+}
+
+void CommitWriteBuffer::setPendingProperty(UntypedProperties& properties,
+                                           const UntypedProperty& property) {
+    // A pending entity's properties are read first-wins when it is built, so an update
+    // has to take the place of the value the create wrote rather than follow it.
+    const auto samePropertyType = [&property](const UntypedProperty& existing) {
+        return existing.propertyID == property.propertyID;
+    };
+
+    const auto existing = std::ranges::find_if(properties, samePropertyType);
+    if (existing != properties.end()) {
+        *existing = property;
+        return;
+    }
+
+    properties.push_back(property);
+}
+
+void CommitWriteBuffer::setPendingNodeProperty(PendingNodeOffset nodeOffset,
+                                               const UntypedProperty& property) {
+    setPendingProperty(getPendingNode(nodeOffset).properties, property);
+}
+
+void CommitWriteBuffer::setPendingEdgeProperty(size_t edgeOffset,
+                                               const UntypedProperty& property) {
+    setPendingProperty(getPendingEdge(edgeOffset).properties, property);
 }
 
 void CommitWriteBuffer::addHangingEdges(const GraphView& view) {

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -96,6 +96,58 @@ void CommitWriteBuffer::addEdgeUpdate(EdgeID id, UntypedProperty& updatedPropert
     _updatedEdges.emplace_back(id, updatedProperty);
 }
 
+bool CommitWriteBuffer::isPendingNodeOffset(const ExistingOrPendingNode& node,
+                                           PendingNodeOffset offset) {
+    const PendingNodeOffset* pendingOffset = std::get_if<PendingNodeOffset>(&node);
+    if (!pendingOffset) {
+        return false;
+    }
+
+    return *pendingOffset == offset;
+}
+
+bool CommitWriteBuffer::isPendingEdgeIncidentTo(const PendingEdge& edge,
+                                                std::span<const PendingNodeOffset> nodeOffsets) {
+    for (const PendingNodeOffset offset : nodeOffsets) {
+        if (isPendingNodeOffset(edge.src, offset) || isPendingNodeOffset(edge.tgt, offset)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void CommitWriteBuffer::addDeletedPendingNodes(std::span<const PendingNodeOffset> nodeOffsets) {
+    _deletedPendingNodes.insert(nodeOffsets.begin(), nodeOffsets.end());
+}
+
+void CommitWriteBuffer::addDeletedPendingEdges(std::span<const size_t> edgeOffsets) {
+    _deletedPendingEdges.insert(edgeOffsets.begin(), edgeOffsets.end());
+}
+
+void CommitWriteBuffer::addHangingPendingEdges() {
+    const std::vector<PendingNodeOffset> deletedNodeOffsets(_deletedPendingNodes.begin(),
+                                                            _deletedPendingNodes.end());
+
+    for (size_t edgeOffset = 0; edgeOffset < _pendingEdges.size(); edgeOffset++) {
+        if (isPendingEdgeIncidentTo(_pendingEdges[edgeOffset], deletedNodeOffsets)) {
+            _deletedPendingEdges.insert(edgeOffset);
+        }
+    }
+}
+
+bool CommitWriteBuffer::pendingNodesHaveEdges(std::span<const PendingNodeOffset> nodeOffsets) const {
+    for (size_t edgeOffset = 0; edgeOffset < _pendingEdges.size(); edgeOffset++) {
+        const bool alreadyDeleted = _deletedPendingEdges.contains(edgeOffset);
+
+        if (!alreadyDeleted && isPendingEdgeIncidentTo(_pendingEdges[edgeOffset], nodeOffsets)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void CommitWriteBuffer::addHangingEdges(const GraphView& view) {
     // TODO: With the new @ref WriteProcessor, we already have the column. Update this
     // function to take the ColumnVector<NodeID> explicitly so we do not need to construct
@@ -129,8 +181,8 @@ void CommitWriteBuffer::addHangingEdges(const GraphView& view) {
     }
 }
 
-void CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
-                                         const PendingNode& node) {
+NodeID CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
+                                           const PendingNode& node) {
     const NodeID nodeID = builder.addNode(node.labelsetHandle);
 
     // Adding node properties
@@ -150,26 +202,40 @@ void CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
     }
 
     _journal.addWrittenNode(nodeID);
+
+    return nodeID;
 }
 
-void CommitWriteBuffer::buildPendingNodes(DataPartBuilder& builder) {
-    for (const auto& node : pendingNodes()) {
-        buildPendingNode(builder, node);
+void CommitWriteBuffer::buildPendingNodes(DataPartBuilder& builder, Tombstones& tombstones) {
+    // A cancelled create is still built, so that the offset a pending edge holds for a
+    // node keeps naming the same row of the datapart, and tombstoned once it has an ID.
+    std::vector<NodeID> cancelled;
+    cancelled.reserve(_deletedPendingNodes.size());
+
+    const PendingNodes& nodes = pendingNodes();
+    for (size_t offset = 0; offset < nodes.size(); offset++) {
+        const NodeID nodeID = buildPendingNode(builder, nodes[offset]);
+
+        if (_deletedPendingNodes.contains(offset)) {
+            cancelled.push_back(nodeID);
+        }
     }
+
+    tombstones.addNodeTombstones(cancelled);
 }
 
-void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
-                                         const PendingEdge& edge) {
+EdgeID CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
+                                           const PendingEdge& edge) {
     // If this edge has source or target which is a node in a previous datapart, check
     // if it has been deleted.
     if (const NodeID* srcID = std::get_if<NodeID>(&edge.src)) {
         if (deletedNodes().contains(*srcID)) {
-            return;
+            return EdgeID {};
         }
     }
     if (const NodeID* tgtID = std::get_if<NodeID>(&edge.tgt)) {
         if (deletedNodes().contains(*tgtID)) {
-            return;
+            return EdgeID {};
         }
     }
 
@@ -212,17 +278,29 @@ void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
     }
 
     _journal.addWrittenEdge(newEdgeID);
+
+    return newEdgeID;
 }
 
-void CommitWriteBuffer::buildPendingEdges(DataPartBuilder& builder) {
-    for (const PendingEdge& edge : pendingEdges()) {
-        buildPendingEdge(builder, edge);
+void CommitWriteBuffer::buildPendingEdges(DataPartBuilder& builder, Tombstones& tombstones) {
+    std::vector<EdgeID> cancelled;
+    cancelled.reserve(_deletedPendingEdges.size());
+
+    const PendingEdges& edges = pendingEdges();
+    for (size_t offset = 0; offset < edges.size(); offset++) {
+        const EdgeID edgeID = buildPendingEdge(builder, edges[offset]);
+
+        if (edgeID.isValid() && _deletedPendingEdges.contains(offset)) {
+            cancelled.push_back(edgeID);
+        }
     }
+
+    tombstones.addEdgeTombstones(cancelled);
 }
 
-void CommitWriteBuffer::buildPending(DataPartBuilder& builder) {
-    buildPendingNodes(builder);
-    buildPendingEdges(builder);
+void CommitWriteBuffer::buildPending(DataPartBuilder& builder, Tombstones& tombstones) {
+    buildPendingNodes(builder, tombstones);
+    buildPendingEdges(builder, tombstones);
 }
 
 void CommitWriteBuffer::applyNodeUpdates(DataPartBuilder& builder) {

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include <unordered_set>
 #include <variant>
 #include <vector>
@@ -53,6 +54,10 @@ public:
      using PendingEdges = std::vector<PendingEdge>;
      using DeletedNodes = std::unordered_set<NodeID>;
      using DeletedEdges = std::unordered_set<EdgeID>;
+     /// Offsets into @ref _pendingNodes / @ref _pendingEdges, not IDs: the creates
+     /// this commit cancels because a query deleted what it had just created
+     using DeletedPendingNodes = std::unordered_set<PendingNodeOffset>;
+     using DeletedPendingEdges = std::unordered_set<size_t>;
      using UpdatedNodes = std::vector<NodeUpdate>;
      using UpdatedEdges = std::vector<EdgeUpdate>;
      using PendingIndexes = std::vector<WeakArc<Index>>;
@@ -104,7 +109,7 @@ public:
       * as registering all newly created nodes/edges in the associated @ref WriteSet of
       * @ref _journal
       */
-     void buildPending(DataPartBuilder& builder);
+     void buildPending(DataPartBuilder& builder, Tombstones& tombstones);
 
      void applyUpdates(DataPartBuilder& builder);
 
@@ -172,6 +177,18 @@ public:
 
     void addHangingEdges(const GraphView& view);
 
+    void addDeletedPendingNodes(std::span<const PendingNodeOffset> nodeOffsets);
+    void addDeletedPendingEdges(std::span<const size_t> edgeOffsets);
+
+    /**
+     * @brief The counterpart of @ref addHangingEdges over the pending edges, which no
+     * graph view holds yet: cancels every one of them incident to a cancelled pending
+     * node.
+     */
+    void addHangingPendingEdges();
+
+    bool pendingNodesHaveEdges(std::span<const PendingNodeOffset> nodeOffsets) const;
+
     void addPendingIndex(const WeakArc<Index>& index);
     void addDroppedIndex(const WeakArc<Index>& index);
 
@@ -209,6 +226,10 @@ private:
     // Edges to be deleted when this commit commits
     DeletedEdges _deletedEdges;
 
+    // Pending nodes and edges this commit creates and then deletes
+    DeletedPendingNodes _deletedPendingNodes;
+    DeletedPendingEdges _deletedPendingEdges;
+
     UpdatedNodes _updatedNodes;
     UpdatedEdges _updatedEdges;
 
@@ -218,14 +239,21 @@ private:
     PendingNodes& pendingNodes() { return _pendingNodes; }
     PendingEdges& pendingEdges() { return _pendingEdges; }
 
-    // Collection of methods to write the buffer to the provided datapart builder
-    void buildPendingNodes(DataPartBuilder& builder);
-    void buildPendingEdges(DataPartBuilder& builder);
+    static bool isPendingNodeOffset(const ExistingOrPendingNode& node, PendingNodeOffset offset);
 
-    void buildPendingNode(DataPartBuilder& builder, const PendingNode& node);
+    static bool isPendingEdgeIncidentTo(const PendingEdge& edge,
+                                        std::span<const PendingNodeOffset> nodeOffsets);
+
+    // Collection of methods to write the buffer to the provided datapart builder
+    void buildPendingNodes(DataPartBuilder& builder, Tombstones& tombstones);
+    void buildPendingEdges(DataPartBuilder& builder, Tombstones& tombstones);
+
+    NodeID buildPendingNode(DataPartBuilder& builder, const PendingNode& node);
     void addPendingNodeProperties(DataPartBuilder& builder, const PendingNode& node);
 
-    void buildPendingEdge(DataPartBuilder& builder, const PendingEdge& edge);
+    /// The ID the edge was built with, or an invalid one when it was skipped because an
+    /// endpoint of it is gone
+    EdgeID buildPendingEdge(DataPartBuilder& builder, const PendingEdge& edge);
 
     void applyNodeUpdates(DataPartBuilder& builder);
     void applyEdgeUpdates(DataPartBuilder& builder);

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -170,6 +170,15 @@ public:
     void addEdgeUpdate(EdgeID id, UntypedProperty& updatedProperty);
 
     /**
+     * @brief Writes @param property onto a node this commit has yet to create, replacing
+     * the value its create wrote for the same property: the update sets an entity that
+     * has no ID for @ref addNodeUpdate to name yet.
+     */
+    void setPendingNodeProperty(PendingNodeOffset nodeOffset, const UntypedProperty& property);
+
+    void setPendingEdgeProperty(size_t edgeOffset, const UntypedProperty& property);
+
+    /**
      * @brief Adds a single EdgeID contained in @param newDeletedEdge to the member @ref
      * _deletedEdges
      */
@@ -238,6 +247,8 @@ private:
 
     PendingNodes& pendingNodes() { return _pendingNodes; }
     PendingEdges& pendingEdges() { return _pendingEdges; }
+
+    static void setPendingProperty(UntypedProperties& properties, const UntypedProperty& property);
 
     static bool isPendingNodeOffset(const ExistingOrPendingNode& node, PendingNodeOffset offset);
 

--- a/test/query-test-suite/tests/create-then-set.json
+++ b/test/query-test-suite/tests/create-then-set.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "CREATE (n:Person) SET n.age = 32 RETURN n, n.age",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\n       |                   ^^^^^^^^^^^^^^\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\n       |                   ^^^^^^^^^^^^^^\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\\n       |                   ^^^^^^^^^^^^^^\\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.\"}"
+    "plan": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\n       |                                            ^^^^^\n-------* Could not return properties from variable with ambiguous source.",
+    "result": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\n       |                                            ^^^^^\n-------* Could not return properties from variable with ambiguous source.",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) SET n.age = 32 RETURN n, n.age\\n       |                                            ^^^^^\\n-------* Could not return properties from variable with ambiguous source.\"}"
   },
   "tags": [
     "create",

--- a/test/query-test-suite/tests/success-writes-create-set-0.json
+++ b/test/query-test-suite/tests/success-writes-create-set-0.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "CREATE (n:Person) SET n.age = \"Node\"",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = \"Node\"\n       |                   ^^^^^^^^^^^^^^^^^^\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = \"Node\"\n       |                   ^^^^^^^^^^^^^^^^^^\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) SET n.age = \\\"Node\\\"\\n       |                   ^^^^^^^^^^^^^^^^^^\\n-------* CREATE ... SET is not yet supported. Please use brace initialisation.\"}"
+    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = \"Node\"\n       |                       ^^^^^^^^^^^^^^\n-------* Cannot evaluate property: types 'Int64' and 'String' are incompatible",
+    "result": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) SET n.age = \"Node\"\n       |                       ^^^^^^^^^^^^^^\n-------* Cannot evaluate property: types 'Int64' and 'String' are incompatible",
+    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) SET n.age = \\\"Node\\\"\\n       |                       ^^^^^^^^^^^^^^\\n-------* Cannot evaluate property: types 'Int64' and 'String' are incompatible\"}"
   },
   "tags": [
     "success",

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1109,6 +1109,17 @@ target_link_libraries(test_query_ir_create_return PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_create_return PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_create_delete CreateDeleteTest.cpp)
+target_link_libraries(test_query_ir_create_delete PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_create_delete PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with_write WithWriteTest.cpp)
 target_link_libraries(test_query_ir_with_write PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1120,6 +1120,17 @@ target_link_libraries(test_query_ir_create_delete PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_create_delete PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_create_set CreateSetTest.cpp)
+target_link_libraries(test_query_ir_create_set PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_create_set PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with_write WithWriteTest.cpp)
 target_link_libraries(test_query_ir_with_write PRIVATE
         turing_db_s

--- a/test/query/ir/CreateDeleteTest.cpp
+++ b/test/query/ir/CreateDeleteTest.cpp
@@ -1,0 +1,225 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The eighteen nodes of simpledb, which MATCH (n) matches once a create and its delete
+// have netted out
+constexpr uint64_t nodeCount = 18;
+
+}
+
+// A DELETE reading what a CREATE bound in the same query: the node the pattern wrote is
+// the node the delete removes, rather than one a MATCH found.
+class CreateDeleteTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    void submit(const ChangeID& changeID) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // Runs a writing query in its own change, filling outStatus so a caller can assert on
+    // a deliberate failure. The change is left unsubmitted.
+    void runWrite(std::string_view query, QueryStatus& outStatus) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        _interpreter->execute(outStatus,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+    }
+
+    void applyWrite(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        submit(changeID);
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CreateDeleteTest, deletesTheNodeItJustCreated) {
+    QueryStatus status;
+    runWrite("CREATE (n:Tag {name: 'ephemeral'}) DELETE n", status);
+
+    EXPECT_TRUE(status.isOk()) << "error: " << status.getError();
+}
+
+TEST_F(CreateDeleteTest, createFollowedByItsDeleteAddsNoNode) {
+    applyWrite("CREATE (n:Tag {name: 'ephemeral'}) DELETE n");
+
+    expectCounts("MATCH (n) RETURN count(n)", {nodeCount});
+}
+
+TEST_F(CreateDeleteTest, deletesOnlyTheNodeTheDeleteNames) {
+    applyWrite("CREATE (a:Tag {name: 'kept'}), (b:Tag {name: 'dropped'}) DELETE b");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"kept"}});
+}
+
+TEST_F(CreateDeleteTest, deletesTheEdgeItJustCreatedAndKeepsItsEnds) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) DELETE e");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"a"}, {"b"}});
+    expectRows("MATCH (a:Tag)-[:LINK]->(b:Tag) RETURN a.name, b.name", {});
+}
+
+TEST_F(CreateDeleteTest, detachDeletesTheNodeItJustCreatedWithItsEdge) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[:LINK]->(b:Tag {name: 'b'}) DETACH DELETE a");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"b"}});
+}
+
+// Deleting the edge first leaves the node isolated, so the plain delete of it that follows
+// has nothing to reject
+TEST_F(CreateDeleteTest, deletesACreatedEdgeAndItsCreatedEndTogether) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) DELETE e, a");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"b"}});
+}
+
+TEST_F(CreateDeleteTest, rejectsAPlainDeleteOfACreatedNodeItsQueryGaveAnEdge) {
+    QueryStatus status;
+    runWrite("CREATE (a:Tag {name: 'a'})-[:LINK]->(b:Tag {name: 'b'}) DELETE a", status);
+
+    EXPECT_FALSE(status.isOk()) << "a plain DELETE of a connected node should fail";
+}
+
+// A created node's ID is its offset in the change's write buffer, which collides with the
+// ID of a committed node the delete must leave in place: simpledb's node 0, Remy, and
+// every edge incident to him.
+TEST_F(CreateDeleteTest, detachDeleteOfACreatedNodeLeavesTheCommittedNodesAlone) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[:LINK]->(b:Tag {name: 'b'}) DETACH DELETE a");
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.name", {{"Remy"}});
+    expectRows("MATCH (p:Person)-[e:KNOWS_WELL]->(q:Person) RETURN e.name",
+               {{"Adam -> Remy"}, {"Remy -> Adam"}});
+    expectRows("MATCH (i:Interest)-[e:KNOWS_WELL]->(p:Person) RETURN e.name", {{"Ghosts -> Remy"}});
+}
+
+// The same collision on the edge side, against simpledb's committed edge 0, Remy -> Adam.
+TEST_F(CreateDeleteTest, deleteOfACreatedEdgeLeavesTheCommittedEdgesAlone) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) DELETE e");
+
+    expectRows("MATCH (p:Person)-[e:KNOWS_WELL]->(q:Person) RETURN e.name",
+               {{"Adam -> Remy"}, {"Remy -> Adam"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/CreateSetTest.cpp
+++ b/test/query/ir/CreateSetTest.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A SET writing to what a CREATE bound in the same query: the property lands on the entity
+// the pattern wrote, rather than on one a MATCH found.
+class CreateSetTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    void submit(const ChangeID& changeID) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    void applyWrite(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        submit(changeID);
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+TEST_F(CreateSetTest, setsAPropertyOnTheNodeItJustCreated) {
+    applyWrite("CREATE (n:Tag {name: 'x'}) SET n.age = 1");
+
+    expectRows("MATCH (t:Tag) RETURN t.name, t.age", {{"x", "1"}});
+}
+
+TEST_F(CreateSetTest, overwritesAPropertyTheCreateWrote) {
+    applyWrite("CREATE (n:Tag {name: 'x'}) SET n.name = 'y'");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"y"}});
+}
+
+TEST_F(CreateSetTest, setsTwoPropertiesOnTheNodeItJustCreated) {
+    applyWrite("CREATE (n:Tag {name: 'x'}) SET n.name = 'y', n.age = 2");
+
+    expectRows("MATCH (t:Tag) RETURN t.name, t.age", {{"y", "2"}});
+}
+
+// A created node's ID is its offset in the change's write buffer, which collides with the
+// ID of a committed node the SET must leave alone: simpledb's node 0, Remy.
+TEST_F(CreateSetTest, setOnACreatedNodeLeavesTheCommittedNodesAlone) {
+    applyWrite("CREATE (n:Tag {name: 'x'}) SET n.name = 'y'");
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.name, p.age", {{"Remy", "32"}});
+}
+
+TEST_F(CreateSetTest, setsAPropertyOnTheEdgeItJustCreated) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) SET e.name = 'a -> b'");
+
+    expectRows("MATCH (a:Tag)-[e:LINK]->(b:Tag) RETURN e.name", {{"a -> b"}});
+}
+
+// The same collision on the edge side, against simpledb's committed edge 0, Remy -> Adam.
+TEST_F(CreateSetTest, setOnACreatedEdgeLeavesTheCommittedEdgesAlone) {
+    applyWrite("CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) SET e.name = 'a -> b'");
+
+    expectRows("MATCH (p:Person)-[e:KNOWS_WELL]->(q:Person) RETURN e.name",
+               {{"Adam -> Remy"}, {"Remy -> Adam"}});
+}
+
+// The SET names a matched node, not a created one, so the CREATE beside it is no reason to
+// turn the query away
+TEST_F(CreateSetTest, setsAPropertyOnAMatchedNodeBesideACreate) {
+    applyWrite("MATCH (p:Person {name: 'Remy'}) CREATE (t:Tag {name: 'x'}) SET p.age = 99");
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.age", {{"99"}});
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"x"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
DELETE and SET mistook the write-buffer offset a CREATE returns in its result column for a committed ID, thus hitting an unrelated committed entity instead.

```
CREATE (n:Tag {name: 'ephemeral'}) DELETE n
CREATE (a:Tag {name: 'kept'}), (b:Tag {name: 'dropped'}) DELETE b
CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) DELETE e
CREATE (a:Tag {name: 'a'})-[:LINK]->(b:Tag {name: 'b'}) DETACH DELETE a
CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) DELETE e, a

CREATE (n:Tag {name: 'x'}) SET n.age = 1
CREATE (n:Tag {name: 'x'}) SET n.name = 'y'
CREATE (n:Tag {name: 'x'}) SET n.name = 'y', n.age = 2
CREATE (a:Tag {name: 'a'})-[e:LINK]->(b:Tag {name: 'b'}) SET e.name = 'a -> b'
MATCH (p:Person {name: 'Remy'}) CREATE (t:Tag {name: 'x'}) SET p.age = 99
```
