### PR TITLE
MLIR: Fix `CREATE ... RETURN`

### DIFF
--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -37,6 +37,7 @@
 #include "metadata/PropertyNull.h"
 #include "metadata/PropertyType.h"
 
+#include "reader/GraphReader.h"
 #include "versioning/CommitWriteBuffer.h"
 #include "views/GraphView.h"
 
@@ -2167,12 +2168,31 @@ void extractColumnProperties(const Column* column,
     }
 }
 
+size_t committedNodeCount(const GraphView* view) {
+    if (!view || !view->isValid()) {
+        return 0;
+    }
+
+    const GraphReader reader = view->read();
+    return reader.getTotalNodesAllocated();
+}
+
+size_t committedEdgeCount(const GraphView* view) {
+    if (!view || !view->isValid()) {
+        return 0;
+    }
+
+    const GraphReader reader = view->read();
+    return reader.getTotalEdgesAllocated();
+}
+
 CommitWriteBuffer::ExistingOrPendingNode resolveNode(const ColumnNodeIDs* column,
                                                      size_t row,
-                                                     bool isPending) {
+                                                     bool isPending,
+                                                     size_t firstPendingNodeID) {
     const NodeID nodeID = (*column)[row];
     if (isPending) {
-        return CommitWriteBuffer::PendingNodeOffset(nodeID.getValue());
+        return CommitWriteBuffer::PendingNodeOffset(nodeID.getValue() - firstPendingNodeID);
     } else {
         return nodeID;
     }
@@ -2333,8 +2353,10 @@ void NLExecutor::runCreateNode(NLExecutionContext* context, NLFunctionData* data
     bioassert(writeBuffer, "nl.create_node requires an active write transaction");
 
     const size_t rowCount = createData->getRowCount();
-    const size_t firstOffset = writeBuffer->numPendingNodes();
     const LabelSetHandle labelsetHandle = createData->getLabelSetHandle();
+
+    // Must extract this value before adding in the loop
+    const size_t numPendingNodes = writeBuffer->numPendingNodes();
 
     for (size_t row = 0; row < rowCount; row++) {
         CommitWriteBuffer::PendingNode& node = writeBuffer->newPendingNode();
@@ -2348,17 +2370,20 @@ void NLExecutor::runCreateNode(NLExecutionContext* context, NLFunctionData* data
 
         for (size_t row = 0; row < rowCount; row++) {
             CommitWriteBuffer::PendingNode& pendingNode =
-                writeBuffer->getPendingNode(firstOffset + row);
+                writeBuffer->getPendingNode(numPendingNodes + row);
             CommitWriteBuffer::UntypedProperties& properties = pendingNode.properties;
             properties.push_back(propsBuffer[row]);
         }
     }
 
+    const GraphView* view = context->getView();
+    const NodeID nextNodeID = committedNodeCount(view) + numPendingNodes;
+
     ColumnNodeIDs* result = createData->getResult();
     result->resize(rowCount);
     auto& raw = result->getRaw();
     for (size_t row = 0; row < rowCount; row++) {
-        raw[row] = NodeID(firstOffset + row);
+        raw[row] = NodeID(nextNodeID + row);
     }
 }
 
@@ -2374,29 +2399,38 @@ void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data
     const size_t rowCount = src->size();
     const EdgeTypeID edgeTypeID = createData->getEdgeTypeID();
 
+    const GraphView* view = context->getView();
+    const size_t firstPendingNodeID = committedNodeCount(view);
+
+    // Must extract this value before adding in the loop
+    const size_t numPendingEdges = writeBuffer->numPendingEdges();
+
     for (size_t row = 0; row < rowCount; row++) {
-        const CommitWriteBuffer::ExistingOrPendingNode srcNode = resolveNode(src, row, srcIsPending);
-        const CommitWriteBuffer::ExistingOrPendingNode tgtNode = resolveNode(tgt, row, tgtIsPending);
+        const CommitWriteBuffer::ExistingOrPendingNode srcNode =
+            resolveNode(src, row, srcIsPending, firstPendingNodeID);
+        const CommitWriteBuffer::ExistingOrPendingNode tgtNode =
+            resolveNode(tgt, row, tgtIsPending, firstPendingNodeID);
 
         CommitWriteBuffer::PendingEdge& edge = writeBuffer->newPendingEdge(srcNode, tgtNode);
         edge.edgeType = edgeTypeID;
     }
 
     CommitWriteBuffer::UntypedProperties propsBuffer;
-    const size_t firstEdgeOffset = writeBuffer->numPendingEdges() - rowCount;
 
     for (const NLCreateEdgeData::Property& prop : createData->properties()) {
         extractColumnProperties(prop._values, rowCount, prop._propertyTypeID, propsBuffer);
 
         for (size_t row = 0; row < rowCount; row++) {
-            writeBuffer->getPendingEdge(firstEdgeOffset + row).properties.push_back(propsBuffer[row]);
+            writeBuffer->getPendingEdge(numPendingEdges + row).properties.push_back(propsBuffer[row]);
         }
     }
+
+    const EdgeID nextEdgeID = committedEdgeCount(view) + numPendingEdges;
 
     ColumnEdgeIDs* result = createData->getResult();
     result->resize(rowCount);
     for (size_t row = 0; row < rowCount; row++) {
-        (*result)[row] = EdgeID(firstEdgeOffset + row);
+        (*result)[row] = EdgeID(nextEdgeID + row);
     }
 }
 

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -137,10 +137,15 @@ TEST_F(CreateReturnTest, returnsAPropertyOfTheNodeItCreated) {
     expectWriteRows("CREATE (n:Tag {name: 'x'}) RETURN n.name", {{"x"}});
 }
 
-// The ID a created node carries is the provisional one its change wrote, not the one the
-// graph hands it at submit, so the row count is what this pins down
 TEST_F(CreateReturnTest, returnsTheNodeItCreated) {
-    expectWriteRowCount("CREATE (n:Tag) RETURN n", 1);
+    expectWriteRows("CREATE (n:Tag) RETURN n", {{"18"}});
+}
+
+TEST_F(CreateReturnTest, multiCreate) {
+    expectWriteRows("CREATE (n:Tag) CREATE (m:Tag) RETURN n, m", {{"18", "19"}});
+    expectWriteRows("CREATE (n:Tag) CREATE (m:Tag) RETURN n, m", {{"20", "21"}});
+    expectWriteRows("CREATE (s:Src)-[e:E]->(t:Tgt) RETURN s, e, t", {{"22", "18", "23"}});
+    expectWriteRows("MATCH (n:Src), (m:Tgt) CREATE (n)<-[e:New]-(m) RETURN e", {{"19"}});
 }
 
 // The CREATE wrote no age, and a property it did not write is null rather than whatever

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -145,7 +145,11 @@ TEST_F(CreateReturnTest, multiCreate) {
     expectWriteRows("CREATE (n:Tag) CREATE (m:Tag) RETURN n, m", {{"18", "19"}});
     expectWriteRows("CREATE (n:Tag) CREATE (m:Tag) RETURN n, m", {{"20", "21"}});
     expectWriteRows("CREATE (s:Src)-[e:E]->(t:Tgt) RETURN s, e, t", {{"22", "18", "23"}});
-    expectWriteRows("MATCH (n:Src), (m:Tgt) CREATE (n)<-[e:New]-(m) RETURN e", {{"19"}});
+    expectWriteRows("CREATE (a:A) CREATE (a)-[e:E]->(b:B) RETURN a, e, b", {{"24", "19", "25"}});
+    expectWriteRows("MATCH (n:Src), (m:Tgt) CREATE (n)<-[e:New]-(m) RETURN e", {{"20"}});
+
+    expectWriteRows("commit", {});
+    expectWriteRows("MATCH (a:A)-[e:E]->(b:B) RETURN *", {{"24", "19", "25"}});
 }
 
 // The CREATE wrote no age, and a property it did not write is null rather than whatever
@@ -190,5 +194,6 @@ TEST_F(CreateReturnTest, returnsTheNodeTheChangeKept) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv);
+    return turing::test::turingTestMain(argc, argv,
+                                        [] { testing::GTEST_FLAG(repeat) = 5; });
 }


### PR DESCRIPTION
`CREATE (n:N) RETURN n` would return `0` (number of pending nodes in the `CommitWriteBuffer`) regardless of how many nodes already exist in the graph.

The correct behaviour is to return `total nodes allocated + number of nodes in CommitWriteBuffer`