### PR TITLE
Test the v3 standalone CALL shapes and header an empty v3 result

### DIFF
--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -162,6 +162,7 @@ add_call_v3_test(test_query_ir_call_writes CallWritesTest.cpp)
 add_call_v3_test(test_query_ir_call_boolean_predicates CallBooleanPredicatesTest.cpp)
 add_call_v3_test(test_query_ir_call_show_indexes CallShowIndexesTest.cpp)
 add_call_v3_test(test_query_ir_standalone_call StandaloneCallTest.cpp)
+add_call_v3_test(test_query_ir_empty_result_column_names EmptyResultColumnNamesTest.cpp)
 add_call_v3_test(test_query_ir_scan_by_node_ids_v3 ScanByNodeIDsV3Test.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -161,6 +161,7 @@ add_call_v3_test(test_query_ir_call_carried_scalar CallCarriedScalarTest.cpp)
 add_call_v3_test(test_query_ir_call_writes CallWritesTest.cpp)
 add_call_v3_test(test_query_ir_call_boolean_predicates CallBooleanPredicatesTest.cpp)
 add_call_v3_test(test_query_ir_call_show_indexes CallShowIndexesTest.cpp)
+add_call_v3_test(test_query_ir_standalone_call StandaloneCallTest.cpp)
 add_call_v3_test(test_query_ir_scan_by_node_ids_v3 ScanByNodeIDsV3Test.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,

--- a/test/query/ir/EmptyResultColumnNamesTest.cpp
+++ b/test/query/ir/EmptyResultColumnNamesTest.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+class EmptyResultColumnNamesTest : public CallV3Test {
+};
+
+TEST_F(EmptyResultColumnNamesTest, namesTheColumnsOfAnEmptyGetNodes) {
+    StringRowSink sink;
+    runQuery("CALL db.getNodes([]) YIELD id, labels, inEdgeCount, outEdgeCount, properties RETURN id", sink);
+
+    const std::vector<std::string> expectedNames {"id"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+    EXPECT_TRUE(sink.getRows().empty());
+}
+
+TEST_F(EmptyResultColumnNamesTest, namesTheColumnsOfAnEmptyGetEdges) {
+    StringRowSink sink;
+    runQuery("CALL db.getEdges([]) YIELD id, src, tgt, edgeTypeID, properties RETURN id", sink);
+
+    const std::vector<std::string> expectedNames {"id"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+    EXPECT_TRUE(sink.getRows().empty());
+}
+
+TEST_F(EmptyResultColumnNamesTest, namesTheColumnsOfAListNodesMatchingNothing) {
+    StringRowSink sink;
+    runQuery("CALL db.listNodes([], ['name'], ['zzznope'], 0, 1000) YIELD id, labels, properties RETURN id, labels, properties", sink);
+
+    const std::vector<std::string> expectedNames {"id", "labels", "properties"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+    EXPECT_TRUE(sink.getRows().empty());
+}
+
+TEST_F(EmptyResultColumnNamesTest, namesTheColumnsOfAStandaloneCallMatchingNothing) {
+    StringRowSink sink;
+    runQuery("CALL db.getNodes([])", sink);
+
+    const std::vector<std::string> expectedNames {"id", "labels", "inEdgeCount", "outEdgeCount", "properties"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+    EXPECT_TRUE(sink.getRows().empty());
+}

--- a/test/query/ir/StandaloneCallTest.cpp
+++ b/test/query/ir/StandaloneCallTest.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+class StandaloneCallTest : public CallV3Test {
+};
+
+TEST_F(StandaloneCallTest, namesAndAnswersEveryReturnValueWithoutAYield) {
+    StringRowSink sink;
+    runQuery("CALL db.labels()", sink);
+
+    const std::vector<std::string> expectedNames {"id", "label"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+
+    const std::vector<StringRowSink::Row> expected {{"0", "Person"},
+                                                   {"1", "SoftwareEngineering"},
+                                                   {"2", "Founder"},
+                                                   {"3", "Bioinformatics"},
+                                                   {"4", "Interest"},
+                                                   {"5", "Exotic"},
+                                                   {"6", "Supernatural"},
+                                                   {"7", "SleepDisturber"},
+                                                   {"8", "Sales"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(StandaloneCallTest, yieldStarAnswersEveryReturnValueWithoutAReturn) {
+    StringRowSink sink;
+    runQuery("CALL db.propertyTypes() YIELD *", sink);
+
+    const std::vector<std::string> expectedNames {"id", "propertyType", "valueType"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+
+    const std::vector<StringRowSink::Row> expected {{"0", "name", "String"},
+                                                    {"1", "dob", "String"},
+                                                    {"2", "age", "Int64"},
+                                                    {"3", "isFrench", "Bool"},
+                                                    {"4", "hasPhD", "Bool"},
+                                                    {"5", "isReal", "Bool"},
+                                                    {"6", "duration", "Int64"},
+                                                    {"7", "proficiency", "String"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(StandaloneCallTest, readsALiteralArgument) {
+    StringRowSink sink;
+    runQuery("call db.describeCommit(\"not-a-commit\")", sink);
+
+    const std::vector<std::string> expectedNames {"nodeCount", "edgeCount", "partCount"};
+    EXPECT_EQ(sink.getNames(), expectedNames);
+
+    const std::vector<StringRowSink::Row> expected {{"0", "0", "0"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}

--- a/test/query/ir/StringRowSink.cpp
+++ b/test/query/ir/StringRowSink.cpp
@@ -12,6 +12,7 @@
 #include "list/ListBufferTypeTag.h"
 #include "list/ListElementView.h"
 #include "list/ListView.h"
+#include "metadata/PropertyType.h"
 
 using namespace db;
 using namespace turing::test;
@@ -37,6 +38,16 @@ bool textOfPlain(const Column* chunk, size_t rowIndex, std::string& text) {
     }
 
     text = fmt::format("{}", column->getRaw()[rowIndex]);
+    return true;
+}
+
+bool textOfValueType(const Column* chunk, size_t rowIndex, std::string& text) {
+    const auto* column = dynamic_cast<const ColumnVector<ValueType>*>(chunk);
+    if (!column) {
+        return false;
+    }
+
+    text = ValueTypeName::value(column->getRaw()[rowIndex]);
     return true;
 }
 
@@ -165,6 +176,8 @@ std::string StringRowSink::cellText(const Column* chunk, size_t rowIndex) {
     } else if (textOfID<PropertyTypeID>(chunk, rowIndex, text)) {
         return text;
     } else if (textOfID<EdgeTypeID>(chunk, rowIndex, text)) {
+        return text;
+    } else if (textOfValueType(chunk, rowIndex, text)) {
         return text;
     } else if (textOfPlain<uint64_t>(chunk, rowIndex, text)) {
         return text;

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -664,6 +664,20 @@ public:
 
     void setColumnNames(std::span<const std::string_view> names) override {
         _columnNames.assign(names.begin(), names.end());
+
+        if (_quiet) {
+            return;
+        }
+
+        tabulate::RowStream headerRow;
+        std::string header;
+        for (size_t columnIndex = 0; columnIndex < _columnNames.size(); columnIndex++) {
+            columnHeader(header, columnIndex);
+            headerRow << header;
+        }
+
+        _table.add_row(std::move(headerRow));
+        _headerWritten = true;
     }
 
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
@@ -672,17 +686,16 @@ public:
             return;
         }
 
-        if (_execCount == 0) {
+        if (!_headerWritten) {
             tabulate::RowStream headerRow;
+            std::string header;
             for (size_t columnIndex = 0; columnIndex < chunks.size(); columnIndex++) {
-                const bool isNamed = columnIndex < _columnNames.size() && !_columnNames[columnIndex].empty();
-                if (isNamed) {
-                    headerRow << _columnNames[columnIndex];
-                } else {
-                    headerRow << ("$" + std::to_string(columnIndex));
-                }
+                columnHeader(header, columnIndex);
+                headerRow << header;
             }
+
             _table.add_row(std::move(headerRow));
+            _headerWritten = true;
         }
 
         for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
@@ -694,8 +707,6 @@ public:
             _table.add_row(std::move(rs));
             _rowCount++;
         }
-
-        _execCount++;
     }
 
     tabulate::Table& getTable() { return _table; }
@@ -704,9 +715,18 @@ public:
 private:
     tabulate::Table _table;
     std::vector<std::string> _columnNames;
-    size_t _execCount {0};
     size_t _rowCount {0};
+    bool _headerWritten {false};
     bool _quiet {false};
+
+    void columnHeader(std::string& header, size_t columnIndex) const {
+        const bool isNamed = columnIndex < _columnNames.size() && !_columnNames[columnIndex].empty();
+        if (isNamed) {
+            header = _columnNames[columnIndex];
+        } else {
+            header = "$" + std::to_string(columnIndex);
+        }
+    }
 };
 
 }


### PR DESCRIPTION
Test the v3 standalone CALL shapes and give an empty v3 result its header.

```
CALL db.labels()
CALL db.propertyTypes() YIELD *
call db.describeCommit("not-a-commit")

CALL db.getNodes([])
CALL db.getNodes([]) YIELD id, labels, inEdgeCount, outEdgeCount, properties RETURN id
CALL db.getEdges([]) YIELD id, src, tgt, edgeTypeID, properties RETURN id
CALL db.listNodes([], ['name'], ['zzznope'], 0, 1000) YIELD id, labels, properties RETURN id, labels, properties
```
