### PR TITLE
MLIR: Fix `CREATE ... {DELETE, SET}`

### DIFF
--- a/query/analyzer/WriteStmtAnalyzer.cpp
+++ b/query/analyzer/WriteStmtAnalyzer.cpp
@@ -79,6 +79,10 @@ void WriteStmtAnalyzer::analyze(const SetStmt* setStmt) {
 }
 
 void WriteStmtAnalyzer::analyze(const DeleteStmt* deleteStmt) {
+    if (_hasCreate) {
+        throwError("CREATE ... DELETE is not yet supported.", deleteStmt);
+    }
+
     const ExprChain* exprs = deleteStmt->getExpressions();
     for (Expr* expr : *exprs) {
         _exprAnalyzer->analyzeRootExpr(expr);

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1331,7 +1331,7 @@ void NLTranslator::translateCheckEdgeTypeConstraint(nl::CheckEdgeTypeConstraint 
 
 void NLTranslator::translateCreateNode(nl::CreateNode createNode, NLStmtContainer* body) {
     if (!_metadataBuilder) {
-        throw IRException("nl.create_node requires a MetadataBuilder (write transaction)");
+        throw IRException("Cannot perform CREATE outside of a write transaction.");
     }
 
     LabelSet labelset;
@@ -1373,7 +1373,7 @@ void NLTranslator::translateCreateNode(nl::CreateNode createNode, NLStmtContaine
 
 void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContainer* body) {
     if (!_metadataBuilder) {
-        throw IRException("nl.create_edge requires a MetadataBuilder (write transaction)");
+        throw IRException("Cannot perform CREATE outside of a write transaction.");
     }
 
     const llvm::StringRef edgeTypeName = createEdge.getEdgeType();
@@ -1417,7 +1417,7 @@ void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContaine
 
 void NLTranslator::translateSetNodeProperty(nl::SetNodeProperty setNodeProperty, NLStmtContainer* body) {
     if (!_metadataBuilder) {
-        throw IRException("nl.set_node_property requires a MetadataBuilder (write transaction)");
+        throw IRException("Cannot perform SET outside of a write transaction.");
     }
 
     const llvm::StringRef propName = setNodeProperty.getProperty();
@@ -1440,7 +1440,7 @@ void NLTranslator::translateSetNodeProperty(nl::SetNodeProperty setNodeProperty,
 
 void NLTranslator::translateSetEdgeProperty(nl::SetEdgeProperty setEdgeProperty, NLStmtContainer* body) {
     if (!_metadataBuilder) {
-        throw IRException("nl.set_edge_property requires a MetadataBuilder (write transaction)");
+        throw IRException("Cannot perform SET outside of a write transaction.");
     }
 
     const llvm::StringRef propName = setEdgeProperty.getProperty();
@@ -1462,6 +1462,10 @@ void NLTranslator::translateSetEdgeProperty(nl::SetEdgeProperty setEdgeProperty,
 }
 
 void NLTranslator::translateDeleteNode(nl::DeleteNode deleteNode, NLStmtContainer* body) {
+    if (!_metadataBuilder) {
+        throw IRException("Cannot perform DELETE outside of a write transaction.");
+    }
+
     const mlir::Value inputValue = deleteNode.getInputNodes();
     const ColumnNodeIDs* inputColumn = static_cast<const ColumnNodeIDs*>(getColumn(inputValue));
 
@@ -1473,6 +1477,10 @@ void NLTranslator::translateDeleteNode(nl::DeleteNode deleteNode, NLStmtContaine
 }
 
 void NLTranslator::translateDeleteEdge(nl::DeleteEdge deleteEdge, NLStmtContainer* body) {
+    if (!_metadataBuilder) {
+        throw IRException("Cannot perform DELETE outside of a write transaction.");
+    }
+
     const mlir::Value inputValue = deleteEdge.getInputEdges();
     const ColumnEdgeIDs* inputColumn = static_cast<const ColumnEdgeIDs*>(getColumn(inputValue));
 

--- a/test/query-test-suite/tests/fail-writes-create-delete-0.json
+++ b/test/query-test-suite/tests/fail-writes-create-delete-0.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "CREATE (n:Person) DELETE n",
   "expect": {
-    "plan": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person) DELETE n\n       |                          ^\n-------* Cannot delete pending node",
-    "result": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person) DELETE n\n       |                          ^\n-------* Cannot delete pending node",
-    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) DELETE n\\n       |                          ^\\n-------* Cannot delete pending node\"}"
+    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) DELETE n\n       |                   ^^^^^^^^\n-------* CREATE ... DELETE is not yet supported.",
+    "result": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person) DELETE n\n       |                   ^^^^^^^^\n-------* CREATE ... DELETE is not yet supported.",
+    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person) DELETE n\\n       |                   ^^^^^^^^\\n-------* CREATE ... DELETE is not yet supported.\"}"
   },
   "tags": [
     "fail",

--- a/test/query-test-suite/tests/fail-writes-create-delete-1.json
+++ b/test/query-test-suite/tests/fail-writes-create-delete-1.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e",
   "expect": {
-    "plan": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\n       |                                                  ^\n-------* Cannot delete pending edge",
-    "result": "PLAN ERROR\n-------* Query error\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\n       |                                                  ^\n-------* Cannot delete pending edge",
-    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\\n       |                                                  ^\\n-------* Cannot delete pending edge\"}"
+    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\n       |                                           ^^^^^^^^\n-------* CREATE ... DELETE is not yet supported.",
+    "result": "ANALYZE ERROR\n-------* Query error\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\n       |                                           ^^^^^^^^\n-------* CREATE ... DELETE is not yet supported.",
+    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | CREATE (n:Person)-[e:NewEdge]->(m:Person) DELETE e\\n       |                                           ^^^^^^^^\\n-------* CREATE ... DELETE is not yet supported.\"}"
   },
   "tags": [
     "fail",

--- a/test/query/ir/QueryInterpreterV3ErrorTest.cpp
+++ b/test/query/ir/QueryInterpreterV3ErrorTest.cpp
@@ -84,3 +84,28 @@ TEST_F(QueryInterpreterV3ErrorTest, reportsInternalGeneratorFailureAsUnexpected)
     EXPECT_EQ(status.getStatus(), QueryStatus::Status::PLAN_ERROR);
     EXPECT_EQ(status.getError(), "Unexpected exception: Unsupported literal kind in WHERE clause expression.");
 }
+
+TEST_F(QueryInterpreterV3ErrorTest, deleteOutsideWrite) {
+    QueryStatus status;
+    runQuery("MATCH (n) DELETE n", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::EXEC_ERROR);
+    EXPECT_EQ(status.getError(), "Cannot perform DELETE outside of a write transaction.");
+}
+
+TEST_F(QueryInterpreterV3ErrorTest, setOutsideWrite) {
+    QueryStatus status;
+    runQuery("MATCH (n) SET n.age = 0", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::EXEC_ERROR);
+    EXPECT_EQ(status.getError(), "Cannot perform SET outside of a write transaction.");
+}
+
+TEST_F(QueryInterpreterV3ErrorTest, createOutsideWrite) {
+    QueryStatus status;
+    runQuery("MATCH (n) CREATE (m:M)", status);
+
+    EXPECT_EQ(status.getStatus(), QueryStatus::Status::EXEC_ERROR);
+    EXPECT_EQ(status.getError(), "Cannot perform CREATE outside of a write transaction.");
+}
+


### PR DESCRIPTION
`CREATE ... DELETE` and `CREATE ... SET` were not supported in v2, and would require a decent overhaul of the storage/versioning/write system to implement. Throw unsupported errors in V3 for now.