### PR TITLE
Seed a traversal from an UNWIND of node IDs

### DIFF
--- a/query/AST/decl/DeclContext.cpp
+++ b/query/AST/decl/DeclContext.cpp
@@ -56,6 +56,22 @@ VarDecl* DeclContext::getOrCreateNamedVariable(CypherAST* ast, EvaluatedType typ
     return decl;
 }
 
+VarDecl* DeclContext::getOrCreateNodePatternVariable(CypherAST* ast, std::string_view name) {
+    VarDecl* declared = getDecl(name);
+
+    const bool holdsUnwoundIntegers = declared
+                                      && declared->getType() == EvaluatedType::Integer
+                                      && declared->isUnwound();
+
+    if (holdsUnwoundIntegers) {
+        declared->setType(EvaluatedType::NodePattern);
+
+        return declared;
+    }
+
+    return getOrCreateNamedVariable(ast, EvaluatedType::NodePattern, name);
+}
+
 VarDecl* DeclContext::declareProjectedVariable(CypherAST* ast, EvaluatedType type, std::string_view name) {
     VarDecl* declared = getDecl(name);
     if (declared && declared->getType() == type) {

--- a/query/AST/decl/DeclContext.h
+++ b/query/AST/decl/DeclContext.h
@@ -31,6 +31,11 @@ public:
 
     VarDecl* getOrCreateNamedVariable(CypherAST* ast, EvaluatedType type, std::string_view name);
 
+    // The name a node of a pattern binds. An integer already in scope is the node IDs an
+    // UNWIND bound, and a pattern naming it seeds itself from those nodes, so the variable
+    // becomes the pattern node it is used as rather than conflicting with it
+    VarDecl* getOrCreateNodePatternVariable(CypherAST* ast, std::string_view name);
+
     // The name a projected item publishes its column under. What follows the projection
     // reads that column, so the name binds to the item even when the query already used
     // it for a variable of another type

--- a/query/AST/decl/VarDecl.h
+++ b/query/AST/decl/VarDecl.h
@@ -19,15 +19,19 @@ public:
                            EvaluatedType type);
 
     void setIsUnnamed(bool isUnnamed) { _isUnnamed = isUnnamed; }
+    void setIsUnwound(bool isUnwound) { _isUnwound = isUnwound; }
+    void setType(EvaluatedType type) { _type = type; }
 
     EvaluatedType getType() const { return _type; }
     const std::string_view& getName() const { return _name; }
     bool isUnnamed() const { return _isUnnamed; }
+    bool isUnwound() const { return _isUnwound; }
 
 private:
     EvaluatedType _type {EvaluatedType::Invalid};
     std::string_view _name;
     bool _isUnnamed {false};
+    bool _isUnwound {false};
 
     VarDecl(EvaluatedType type, std::string_view name)
         : _type(type),

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -339,9 +339,7 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
     VarDecl* decl = nullptr;
 
     if (Symbol* symbol = nodePattern->getSymbol()) {
-        decl = _ctxt->getOrCreateNamedVariable(_ast,
-                                               EvaluatedType::NodePattern,
-                                               symbol->getName());
+        decl = _ctxt->getOrCreateNodePatternVariable(_ast, symbol->getName());
         nodePattern->setDecl(decl);
     } else {
         decl = _ctxt->createUnnamedVariable(_ast, EvaluatedType::NodePattern);
@@ -661,7 +659,9 @@ void ReadStmtAnalyzer::analyze(UnwindStmt* unwind) {
         throwError(fmt::format("Variable '{}' is already declared", symName), unwind);
     }
 
-    const VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, itemType, symName);
+    VarDecl* decl = _ctxt->getOrCreateNamedVariable(_ast, itemType, symName);
+    decl->setIsUnwound(true);
+
     unwind->setDecl(decl);
 }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -148,6 +148,22 @@ const std::unordered_map<std::string_view, BinaryFunctionEmitter> binaryFunction
     {"euclidean_distance", &emitBinaryFunction<mlir::db::EuclideanDistance>},
 };
 
+// The analyzer restricts UNWIND to a literal list, so anything else here is a statement
+// it let through and neither of the sources built from one can lower.
+const ListLiteral* unwindListOrThrow(const UnwindStmt* unwind) {
+    const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
+    if (!literalExpr) {
+        throw TuringException("Non-literal UNWIND expressions are not yet supported.");
+    }
+
+    const ListLiteral* list = dynamic_cast<const ListLiteral*>(literalExpr->getLiteral());
+    if (!list) {
+        throw TuringException("Non-list arguments to UNWIND are not yet supported.");
+    }
+
+    return list;
+}
+
 // True when a value is one of `columns` or is computed from one.
 bool readsAnyColumn(mlir::ValueRange values, llvm::ArrayRef<mlir::Value> columns) {
     llvm::DenseSet<mlir::Value> columnSet;
@@ -512,20 +528,40 @@ void DBProgramGenerator::addYieldedColumn(const VariableDependency* var, mlir::V
     std::erase_if(_part._yieldedColumns, declaresVar);
 }
 
+void DBProgramGenerator::addConstScanNodes(const VariableDependency* var, const UnwindStmt* unwind) {
+    bioassert(!_part._varMap.contains(var), "ConstScanNodes for registered variable");
+
+    const ListLiteral* list = unwindListOrThrow(unwind);
+
+    llvm::SmallVector<mlir::Attribute> elements;
+    translateListElements(list, elements);
+
+    llvm::SmallVector<int64_t> nodeIDs;
+    nodeIDs.reserve(elements.size());
+
+    for (const mlir::Attribute element : elements) {
+        const mlir::IntegerAttr nodeID = mlir::dyn_cast<mlir::IntegerAttr>(element);
+        if (!nodeID) {
+            throw TuringException("Only node IDs can be unwound into a node pattern.");
+        }
+
+        nodeIDs.push_back(nodeID.getInt());
+    }
+
+    const mlir::db::ColumnType nodeColumnType = allocColumnType(mlir::storage::NodeIDType::get(_mlirCtxt));
+
+    mlir::db::ConstScanNodes constScan = _opBuilder.create<mlir::db::ConstScanNodes>(_opBuilder.getUnknownLoc(),
+                                                                                    nodeColumnType,
+                                                                                    nodeIDs);
+
+    registerValue(var, constScan.getResult());
+    _part._seededVars.insert(var);
+}
+
 void DBProgramGenerator::addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind) {
     bioassert(!_part._varMap.contains(var), "UnwindConst for registered variable");
 
-    // The analyzer restricts UNWIND to a literal list, so anything else here is a
-    // statement it let through and this path cannot lower.
-    const LiteralExpr* literalExpr = dynamic_cast<const LiteralExpr*>(unwind->arg());
-    if (!literalExpr) {
-        throw TuringException("Non-literal UNWIND expressions are not yet supported.");
-    }
-
-    const ListLiteral* list = dynamic_cast<const ListLiteral*>(literalExpr->getLiteral());
-    if (!list) {
-        throw TuringException("Non-list arguments to UNWIND are not yet supported.");
-    }
+    const ListLiteral* list = unwindListOrThrow(unwind);
 
     llvm::SmallVector<mlir::Attribute> elements;
     translateListElements(list, elements);
@@ -840,6 +876,7 @@ void DBProgramGenerator::generatePart(std::span<Stmt* const> stmts) {
     generateLeadingYields(stmts);
     generateTraversal(stmts);
     throwOnUnboundPatternVariable();
+    throwOnDroppedUnwindSeed();
     closeBoundMerges();
     resolveEdgeIdentities();
     generatePropertyConstraints(stmts);
@@ -1253,6 +1290,22 @@ void DBProgramGenerator::throwOnUnboundPatternVariable() const {
     }
 }
 
+void DBProgramGenerator::throwOnDroppedUnwindSeed() const {
+    for (const auto& [var, unwind] : _vdg.unwindSources()) {
+        const VarDecl* const decl = var->getDecl();
+        const bool namesAPatternNode = decl && decl->getType() == EvaluatedType::NodePattern;
+
+        if (!namesAPatternNode || _part._seededVars.contains(var)) {
+            continue;
+        }
+
+        throw TuringException(fmt::format("Unwinding node IDs into the pattern variable '{}' is "
+                                          "not yet supported where the pattern reaches it from "
+                                          "elsewhere.",
+                                          var->getName()));
+    }
+}
+
 void DBProgramGenerator::extendBoundDataflow(DefinedVars& defined,
                                              std::vector<const VariableDependency*>& dataflowVars) {
     const VariableDependencyGraph::BoundVars& bound = _vdg.boundVars();
@@ -1447,7 +1500,16 @@ void DBProgramGenerator::translateComponent(const VariableDependency* root,
     if (yieldedColumn) {
         addYieldedColumn(root, yieldedColumn);
     } else if (unwindIt != unwindSources.end()) {
-        addUnwindConst(root, unwindIt->second);
+        const VarDecl* const decl = root->getDecl();
+        const bool seedsAPatternNode = decl && decl->getType() == EvaluatedType::NodePattern;
+
+        // A pattern naming the unwound variable makes its list a set of node IDs rather
+        // than a column of values, so the nodes themselves open the dataflow.
+        if (seedsAPatternNode) {
+            addConstScanNodes(root, unwindIt->second);
+        } else {
+            addUnwindConst(root, unwindIt->second);
+        }
     } else {
         addScanNodes(root);
     }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -136,6 +136,11 @@ private:
         // otherwise, which leaves every call after the traversal and every root opening
         // with a scan.
         const VariableDependency* _drivenRoot {nullptr};
+
+        // The pattern variables a const scan opened from an UNWIND's node IDs. A seeded
+        // variable the traversal reached some other way holds rows that are not the listed
+        // nodes, so what it was seeded with has to be checked against what was walked
+        std::unordered_set<const VariableDependency*> _seededVars;
     };
 
     PartScope _part;
@@ -171,6 +176,10 @@ private:
     // Rejects a pattern variable the traversal left without a column: a shape it cannot
     // walk from the variables in scope
     void throwOnUnboundPatternVariable() const;
+
+    // Rejects a variable an UNWIND seeds with node IDs that the traversal reached some
+    // other way, its list left unmatched: only the node a component opens from is seeded
+    void throwOnDroppedUnwindSeed() const;
 
     void closeBoundJoins(std::vector<const VariableDependency*>& carriedSet,
                          std::vector<const VariableDependency*>& dataflowVars);
@@ -485,6 +494,11 @@ private:
     // Opens a dataflow from an UNWIND's literal list, the way addScanNodes opens one
     // from the graph's nodes
     void addUnwindConst(const VariableDependency* var, const UnwindStmt* unwind);
+
+    // Opens a dataflow from the nodes an UNWIND's literal list names, for a variable a
+    // pattern uses as a node: the list seeds the traversal instead of feeding it values
+    void addConstScanNodes(const VariableDependency* var, const UnwindStmt* unwind);
+
     void filterAllColumns(mlir::Value predicate);
 
     // Such a scope is the single row those constants are: the predicate and the columns

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -162,6 +162,7 @@ add_call_v3_test(test_query_ir_call_writes CallWritesTest.cpp)
 add_call_v3_test(test_query_ir_call_boolean_predicates CallBooleanPredicatesTest.cpp)
 add_call_v3_test(test_query_ir_call_show_indexes CallShowIndexesTest.cpp)
 add_call_v3_test(test_query_ir_scan_by_node_ids_v3 ScanByNodeIDsV3Test.cpp)
+add_call_v3_test(test_query_ir_unwind_node_seed_v3 UnwindNodeSeedV3Test.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,
 # once with a constant argument alone and once reading the chain's tail, from the query
@@ -248,6 +249,27 @@ target_link_libraries(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE
         turing_db_ir_common_s
         turing_db_storage_s)
 target_include_directories(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# The db program an UNWIND seeding a pattern node compiles to, read against the shared
+# SimpleGraph fixture the same way.
+add_turing_test(test_query_ir_unwind_node_seed_codegen UnwindNodeSeedCodegenTest.cpp)
+target_link_libraries(test_query_ir_unwind_node_seed_codegen PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s)
+target_include_directories(test_query_ir_unwind_node_seed_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 
 # The keyless collect drain emits its one group whether or not a row arrived, against the

--- a/test/query/ir/UnwindNodeSeedCodegenTest.cpp
+++ b/test/query/ir/UnwindNodeSeedCodegenTest.cpp
@@ -1,0 +1,205 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+void nodeIDsOf(mlir::db::ConstScanNodes constScan, std::vector<int64_t>& nodeIDs) {
+    const llvm::ArrayRef<int64_t> listed = constScan.getNodeIDs();
+    nodeIDs.assign(listed.begin(), listed.end());
+}
+
+}
+
+// An UNWIND whose variable names a pattern node opens the dataflow from those nodes, so the
+// db program the query compiles to reads the same as the node-ID disjunction's - a const
+// scan feeding the hop, with no scan of the graph to cross and filter.
+class UnwindNodeSeedCodegenTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(UnwindNodeSeedCodegenTest, seededHopOpensWithAConstScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (x)-->(w) RETURN w");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScans.front(), nodeIDs);
+    const std::vector<int64_t> expected {5, 2};
+    EXPECT_EQ(nodeIDs, expected);
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 1u);
+}
+
+// The list's own order rides the op: the disjunction form sorts and dedups its IDs because
+// it stands for a set, and this one must not.
+TEST_F(UnwindNodeSeedCodegenTest, keepsTheListOrder) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (x) RETURN x");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScans.front(), nodeIDs);
+    const std::vector<int64_t> expected {5, 2};
+    EXPECT_EQ(nodeIDs, expected);
+}
+
+TEST_F(UnwindNodeSeedCodegenTest, keepsARepeatedID) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [3, 3] AS x MATCH (x) RETURN x");
+
+    llvm::SmallVector<mlir::db::ConstScanNodes> constScans = collect<mlir::db::ConstScanNodes>(*module);
+    ASSERT_EQ(constScans.size(), 1u);
+
+    std::vector<int64_t> nodeIDs;
+    nodeIDsOf(constScans.front(), nodeIDs);
+    const std::vector<int64_t> expected {3, 3};
+    EXPECT_EQ(nodeIDs, expected);
+}
+
+TEST_F(UnwindNodeSeedCodegenTest, labelledSeedKeepsALabelCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (x:Person) RETURN x");
+
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::CheckLabelConstraint>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 0u);
+}
+
+// The pattern is walked from the seed whichever end of the hop it sits on.
+TEST_F(UnwindNodeSeedCodegenTest, seedAtTheFarEndWalksTheHopBackwards) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [1] AS x MATCH (a)-->(x) RETURN a");
+
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetInEdges>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+}
+
+// Only the node a component opens from can be seeded: a second seed inside one pattern
+// would be reached by the hop, whose rows would take it over and leave its list unmatched.
+TEST_F(UnwindNodeSeedCodegenTest, rejectsASeedAHopReaches) {
+    EXPECT_THROW(generate("UNWIND [0] AS x UNWIND [1] AS y MATCH (x)-->(y) RETURN x, y"), TuringException);
+}
+
+TEST_F(UnwindNodeSeedCodegenTest, rejectsASeedTheHopReturnsTo) {
+    EXPECT_THROW(generate("UNWIND [0] AS x MATCH (x)-->(x) RETURN x"), TuringException);
+}
+
+// A barrier publishes the unwound variable as the integers it held, not as the nodes a
+// later pattern would expand.
+TEST_F(UnwindNodeSeedCodegenTest, rejectsASeedUsedAsANodeAfterAWith) {
+    EXPECT_THROW(generate("UNWIND [0] AS x WITH x MATCH (x)-->(w) RETURN w"), TuringException);
+}
+
+// An UNWIND naming no pattern node still binds a column of values, whatever the query then
+// compares it to.
+TEST_F(UnwindNodeSeedCodegenTest, valueUnwindStaysAnUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (n) WHERE n = x RETURN n");
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+}
+
+TEST_F(UnwindNodeSeedCodegenTest, unwindWithoutAMatchStaysAnUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x RETURN x");
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 0u);
+}

--- a/test/query/ir/UnwindNodeSeedV3Test.cpp
+++ b/test/query/ir/UnwindNodeSeedV3Test.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+// An UNWIND of node IDs naming a pattern node seeds the traversal from exactly those
+// nodes. Unlike the node-ID disjunction it resembles, the seed is a list and not a set:
+// the nodes come in the order written, and a repeated ID is matched again.
+class UnwindNodeSeedV3Test : public CallV3Test {
+};
+
+TEST_F(UnwindNodeSeedV3Test, seedsAHopFromTheListedNodes) {
+    StringRowSink sink;
+    runQuery("UNWIND [6, 0] AS x MATCH (x)-->(w) RETURN w", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    // Ghosts (6) knows Remy (0), whose neighbours are Adam, Computers, Eighties and Ghosts.
+    const std::vector<StringRowSink::Row> expected {{"0"}, {"1"}, {"2"}, {"3"}, {"6"}};
+    EXPECT_EQ(rows, expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, matchesTheDisjunctionFormItResembles) {
+    StringRowSink bySeed;
+    runQuery("UNWIND [6, 0] AS x MATCH (x)-->(w) RETURN w", bySeed);
+
+    StringRowSink byDisjunction;
+    runQuery("MATCH (n)-->(w) WHERE n = 6 OR n = 0 RETURN w", byDisjunction);
+
+    std::vector<StringRowSink::Row> bySeedRows;
+    bySeed.sortedRows(bySeedRows);
+    std::vector<StringRowSink::Row> byDisjunctionRows;
+    byDisjunction.sortedRows(byDisjunctionRows);
+
+    EXPECT_FALSE(bySeedRows.empty());
+    EXPECT_EQ(bySeedRows, byDisjunctionRows);
+}
+
+TEST_F(UnwindNodeSeedV3Test, yieldsTheNodesInListOrder) {
+    StringRowSink sink;
+    runQuery("UNWIND [6, 0] AS x MATCH (x) RETURN x", sink);
+
+    // The disjunction form yields the same two nodes in scan order, 0 then 6.
+    const std::vector<StringRowSink::Row> expected {{"6"}, {"0"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, repeatedIDYieldsTheNodeTwice) {
+    StringRowSink sink;
+    runQuery("UNWIND [3, 3] AS x MATCH (x) RETURN x", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"3"}, {"3"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, absentIDMatchesNothing) {
+    StringRowSink sink;
+    runQuery("UNWIND [2, 99999] AS x MATCH (x) RETURN x", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"2"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, readsAPropertyOffTheSeededNodes) {
+    StringRowSink sink;
+    runQuery("UNWIND [1, 0] AS x MATCH (x) RETURN x.name", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Adam"}, {"Remy"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, aLabelKeepsOnlyTheLabelledSeeds) {
+    StringRowSink sink;
+    runQuery("UNWIND [2, 0] AS x MATCH (x:Person) RETURN x.name", sink);
+
+    // Remy (0) is a Person; Computers (2) is an Interest.
+    const std::vector<StringRowSink::Row> expected {{"Remy"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, hopsByEdgeTypeFromASeededNode) {
+    StringRowSink sink;
+    runQuery("UNWIND [0] AS x MATCH (x)-[:KNOWS_WELL]->(w) RETURN w.name", sink);
+
+    const std::vector<StringRowSink::Row> expected {{"Adam"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, countsOverTheSeededTraversal) {
+    StringRowSink sink;
+    runQuery("UNWIND [0, 1] AS x MATCH (x)-->(w) RETURN count(w)", sink);
+
+    // Remy has four out edges, Adam three.
+    const std::vector<StringRowSink::Row> expected {{"7"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, limitBoundsTheSeededTraversal) {
+    StringRowSink sink;
+    runQuery("UNWIND [6, 0] AS x MATCH (x)-->(w) RETURN w LIMIT 1", sink);
+
+    // Ghosts (6) comes first and reaches Remy (0) alone.
+    const std::vector<StringRowSink::Row> expected {{"0"}};
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+TEST_F(UnwindNodeSeedV3Test, seedAtTheFarEndWalksTheHopBackwards) {
+    StringRowSink sink;
+    runQuery("UNWIND [2] AS x MATCH (a)-->(x) RETURN a.name", sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+
+    // Computers (2) is reached by Remy and Luc.
+    const std::vector<StringRowSink::Row> expected {{"Luc"}, {"Remy"}};
+    EXPECT_EQ(rows, expected);
+}

--- a/test/query/ir/VariableTypeConflictTest.cpp
+++ b/test/query/ir/VariableTypeConflictTest.cpp
@@ -106,6 +106,30 @@ TEST_F(VariableTypeConflictTest, rejectsANodeVariableReusedAsAnEdge) {
                                 "Variable 'n' is already declared with type 'NodePattern'");
 }
 
+// An UNWIND of node IDs may name a pattern node, which seeds the traversal from them, so
+// only a list whose items are not node IDs conflicts with the pattern.
+TEST_F(VariableTypeConflictTest, rejectsAStringUnwoundIntoANodePattern) {
+    expectTypeConflictRejection("UNWIND ['a', 'b'] AS x MATCH (x) RETURN x;",
+                                "Variable 'x' is already declared with type 'String'");
+}
+
+TEST_F(VariableTypeConflictTest, rejectsAHeterogeneousListUnwoundIntoANodePattern) {
+    expectTypeConflictRejection("UNWIND [1, 'a'] AS x MATCH (x) RETURN x;",
+                                "Variable 'x' is already declared with type 'ListItem'");
+}
+
+TEST_F(VariableTypeConflictTest, rejectsAnEmptyListUnwoundIntoANodePattern) {
+    expectTypeConflictRejection("UNWIND [] AS x MATCH (x) RETURN x;",
+                                "Variable 'x' is already declared with type 'ListItem'");
+}
+
+// The seed must be in scope before the pattern names it: an UNWIND naming a variable the
+// pattern already bound would rebind it.
+TEST_F(VariableTypeConflictTest, rejectsAnUnwindOverAPatternNode) {
+    expectTypeConflictRejection("MATCH (x)-->(w) UNWIND [1, 2] AS x RETURN w;",
+                                "Variable 'x' is already declared");
+}
+
 // The valid neighbour of those two: 'm' stays a node in both patterns and joins them on it.
 // Luc reaches Animals and Computers; Animals is entered by Luc alone, Computers by Remy and
 // Luc.


### PR DESCRIPTION
Implement seeding a pattern node from a literal UNWIND of node IDs.
And avoid a cross product.

```
UNWIND [5, 2] AS x MATCH (x)-->(w) RETURN w

UNWIND [5, 2] AS x MATCH (x) RETURN x
UNWIND [5, 2] AS x MATCH (x) RETURN x.name

UNWIND [5, 2] AS x MATCH (x:Person) RETURN x
UNWIND [0] AS x MATCH (x)-[:KNOWS_WELL]->(w) RETURN w.name

UNWIND [1] AS x MATCH (a)-->(x) RETURN a

UNWIND [0, 1] AS x MATCH (x)-->(w) RETURN count(w)
UNWIND [6, 0] AS x MATCH (x)-->(w) RETURN w LIMIT 1
```
