### PR TITLE
MLIR: implement MERGE

### DIFF
--- a/query/AST/CMakeLists.txt
+++ b/query/AST/CMakeLists.txt
@@ -34,6 +34,7 @@ set(ast_sources
     stmt/SetItem.cpp
     stmt/CallStmt.cpp
     stmt/CreateStmt.cpp
+    stmt/MergeStmt.cpp
     stmt/DeleteStmt.cpp
     stmt/ReturnStmt.cpp
     stmt/ShortestPathStmt.cpp

--- a/query/AST/CypherAST.h
+++ b/query/AST/CypherAST.h
@@ -57,6 +57,7 @@ class MatchStmt;
 class ShortestPathStmt;
 class CallStmt;
 class CreateStmt;
+class MergeStmt;
 class SetStmt;
 class DeleteStmt;
 class QueryCommand;
@@ -150,6 +151,7 @@ public:
     friend ShortestPathStmt;
     friend CallStmt;
     friend CreateStmt;
+    friend MergeStmt;
     friend SetStmt;
     friend DeleteStmt;
     friend ReturnStmt;

--- a/query/AST/CypherASTDumper.cpp
+++ b/query/AST/CypherASTDumper.cpp
@@ -16,6 +16,7 @@
 #include "stmt/Limit.h"
 #include "stmt/Skip.h"
 #include "stmt/CreateStmt.h"
+#include "stmt/MergeStmt.h"
 #include "stmt/ShortestPathStmt.h"
 #include "Projection.h"
 #include "Pattern.h"
@@ -215,6 +216,13 @@ void CypherASTDumper::dump(std::ostream& out, const SinglePartQuery* query) {
                     const CreateStmt* createStmt = static_cast<const CreateStmt*>(stmt);
                     out << "    _" << std::hex << query << " ||--o{ _" << std::hex << createStmt << " : \"\"\n";
                     dump(out, createStmt);
+                }
+                break;
+
+                case Stmt::Kind::MERGE: {
+                    const MergeStmt* mergeStmt = static_cast<const MergeStmt*>(stmt);
+                    out << "    _" << std::hex << query << " ||--o{ _" << std::hex << mergeStmt << " : \"\"\n";
+                    dump(out, mergeStmt);
                 }
                 break;
 
@@ -453,6 +461,27 @@ void CypherASTDumper::dump(std::ostream& out, const MatchStmt* match) {
         const Skip* skip = match->getSkip();
         out << "    _" << std::hex << match << " ||--o{ _" << std::hex << skip << " : \"\"\n";
         dump(out, skip);
+    }
+}
+
+void CypherASTDumper::dump(std::ostream& out, const MergeStmt* merge) {
+    out << "    _" << std::hex << merge << " {\n";
+    out << "        ASTType MERGE\n";
+    out << "    }\n";
+
+    const Pattern* pattern = merge->getPattern();
+    out << "    _" << std::hex << merge << " ||--o{ _" << std::hex << pattern << " : \"\"\n";
+
+    dump(out, pattern);
+
+    if (const SetStmt* onCreate = merge->getOnCreate()) {
+        out << "    _" << std::hex << merge << " ||--o{ _" << std::hex << onCreate << " : \"ON CREATE\"\n";
+        dump(out, onCreate);
+    }
+
+    if (const SetStmt* onMatch = merge->getOnMatch()) {
+        out << "    _" << std::hex << merge << " ||--o{ _" << std::hex << onMatch << " : \"ON MATCH\"\n";
+        dump(out, onMatch);
     }
 }
 

--- a/query/AST/CypherASTDumper.h
+++ b/query/AST/CypherASTDumper.h
@@ -42,6 +42,7 @@ class LoadGraphQuery;
 class ListGraphQuery;
 class ListAvailableGraphsQuery;
 class MergeDataPartsQuery;
+class MergeStmt;
 class CreateGraphQuery;
 class LoadGMLQuery;
 class LoadParquetQuery;
@@ -88,6 +89,7 @@ private:
     void dump(std::ostream& out, const S3TransferQuery* query);
     void dump(std::ostream& out, const MatchStmt* match);
     void dump(std::ostream& out, const CreateStmt* create);
+    void dump(std::ostream& out, const MergeStmt* merge);
     void dump(std::ostream& out, const CallStmt* call);
     void dump(std::ostream& out, const YieldClause* yield);
     void dump(std::ostream& out, const DeleteStmt* deleteStmt);

--- a/query/AST/stmt/MergeStmt.cpp
+++ b/query/AST/stmt/MergeStmt.cpp
@@ -1,0 +1,14 @@
+#include "MergeStmt.h"
+
+#include "CypherAST.h"
+
+using namespace db;
+
+MergeStmt::~MergeStmt() {
+}
+
+MergeStmt* MergeStmt::create(CypherAST* ast, Pattern* pattern) {
+    MergeStmt* stmt = new MergeStmt(pattern);
+    ast->addStmt(stmt);
+    return stmt;
+}

--- a/query/AST/stmt/MergeStmt.h
+++ b/query/AST/stmt/MergeStmt.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Stmt.h"
+
+namespace db {
+
+class Pattern;
+class SetStmt;
+class CypherAST;
+
+// MERGE's one path pattern, plus the two SET clauses its outcome selects between:
+// ON CREATE ... runs over the rows the pattern was written for, ON MATCH ... over the
+// rows it was found for.
+class MergeStmt : public Stmt {
+public:
+    static MergeStmt* create(CypherAST* ast, Pattern* pattern);
+
+    Kind getKind() const override { return Kind::MERGE; }
+
+    const Pattern* getPattern() const { return _pattern; }
+
+    const SetStmt* getOnCreate() const { return _onCreate; }
+    const SetStmt* getOnMatch() const { return _onMatch; }
+
+    void setOnCreate(SetStmt* onCreate) { _onCreate = onCreate; }
+    void setOnMatch(SetStmt* onMatch) { _onMatch = onMatch; }
+
+private:
+    Pattern* _pattern {nullptr};
+    SetStmt* _onCreate {nullptr};
+    SetStmt* _onMatch {nullptr};
+
+    MergeStmt(Pattern* pattern)
+        : _pattern(pattern)
+    {
+    }
+
+    ~MergeStmt() override;
+};
+
+}

--- a/query/AST/stmt/Stmt.h
+++ b/query/AST/stmt/Stmt.h
@@ -12,6 +12,7 @@ public:
         MATCH = 0,
         CALL,
         CREATE,
+        MERGE,
         SET,
         DELETE,
         RETURN,

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -533,6 +533,7 @@ void CypherAnalyzer::setV3() {
     _isV3 = true;
     _exprAnalyzer->setV3();
     _readAnalyzer->setV3();
+    _writeAnalyzer->setV3();
 }
 
 void CypherAnalyzer::analyzeDistinct(const Projection* projection, const Stmt* clause) const {

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -113,6 +113,7 @@ void ReadStmtAnalyzer::analyze(Stmt* stmt) {
         break;
 
         case Stmt::Kind::CREATE:
+        case Stmt::Kind::MERGE:
         case Stmt::Kind::SET:
         case Stmt::Kind::DELETE:
         case Stmt::Kind::RETURN:

--- a/query/analyzer/WriteStmtAnalyzer.cpp
+++ b/query/analyzer/WriteStmtAnalyzer.cpp
@@ -26,6 +26,7 @@
 #include "stmt/SetItem.h"
 #include "stmt/Stmt.h"
 #include "stmt/CreateStmt.h"
+#include "stmt/MergeStmt.h"
 #include "stmt/SetStmt.h"
 
 using namespace db;
@@ -44,6 +45,10 @@ void WriteStmtAnalyzer::analyze(const Stmt* stmt) {
     switch (stmt->getKind()) {
         case Stmt::Kind::CREATE:
             analyze(static_cast<const CreateStmt*>(stmt));
+            break;
+
+        case Stmt::Kind::MERGE:
+            analyze(static_cast<const MergeStmt*>(stmt));
             break;
 
         case Stmt::Kind::SET:
@@ -66,6 +71,24 @@ void WriteStmtAnalyzer::analyze(const CreateStmt* createStmt) {
     _hasCreate = true;
     if (createStmt->getPattern()) {
         analyze(createStmt->getPattern());
+    }
+}
+
+void WriteStmtAnalyzer::analyze(const MergeStmt* mergeStmt) {
+    if (!_isV3) {
+        throwError("MERGE is only supported by the MLIR query engine.", mergeStmt);
+    }
+
+    analyze(mergeStmt->getPattern());
+
+    for (const SetStmt* actions : {mergeStmt->getOnCreate(), mergeStmt->getOnMatch()}) {
+        if (!actions) {
+            continue;
+        }
+
+        for (SetItem* item : actions->getItems()) {
+            analyze(item);
+        }
     }
 }
 

--- a/query/analyzer/WriteStmtAnalyzer.cpp
+++ b/query/analyzer/WriteStmtAnalyzer.cpp
@@ -234,6 +234,10 @@ void WriteStmtAnalyzer::analyze(EdgePattern* edgePattern) {
     edgePattern->setDecl(decl);
     edgePattern->setData(data);
 
+    if (edgePattern->getQuantifiedPath()) {
+        throwError("Variable length relationships cannot be used in a write pattern", edgePattern);
+    }
+
     if (edgePattern->types() == nullptr) {
         throwError("Edge pattern must have at least one edge type", edgePattern);
     }

--- a/query/analyzer/WriteStmtAnalyzer.cpp
+++ b/query/analyzer/WriteStmtAnalyzer.cpp
@@ -102,7 +102,7 @@ void WriteStmtAnalyzer::analyze(const SetStmt* setStmt) {
 }
 
 void WriteStmtAnalyzer::analyze(const DeleteStmt* deleteStmt) {
-    if (_hasCreate) {
+    if (_hasCreate && !_isV3) {
         throwError("CREATE ... DELETE is not yet supported.", deleteStmt);
     }
 

--- a/query/analyzer/WriteStmtAnalyzer.h
+++ b/query/analyzer/WriteStmtAnalyzer.h
@@ -14,6 +14,7 @@ class DeclContext;
 class ExprAnalyzer;
 class Stmt;
 class CreateStmt;
+class MergeStmt;
 class SetStmt;
 class SetItem;
 class DeleteStmt;
@@ -40,6 +41,8 @@ public:
         _exprAnalyzer = exprAnalyzer;
     }
 
+    void setV3() { _isV3 = true; }
+
     // Statements
     void analyze(const Stmt* stmt);
 
@@ -51,8 +54,10 @@ private:
     std::unordered_set<const VarDecl*> _toBeCreated;
     const GraphMetadata& _graphMetadata;
     bool _hasCreate {false};
+    bool _isV3 {false};
 
     void analyze(const CreateStmt* createStmt);
+    void analyze(const MergeStmt* mergeStmt);
     void analyze(const SetStmt* setStmt);
     void analyze(const DeleteStmt* deleteStmt);
     void analyze(const Pattern* pattern);

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -85,6 +85,7 @@
 #include "expr/SymbolExpr.h"
 #include "expr/UnaryExpr.h"
 #include "stmt/CreateStmt.h"
+#include "stmt/MergeStmt.h"
 #include "stmt/DeleteStmt.h"
 #include "expr/ExprChain.h"
 #include "stmt/Limit.h"
@@ -932,6 +933,10 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
 
     const ReturnStmt* returnStmt = query->getReturnStmt();
     const Projection* projection = returnStmt ? returnStmt->getProjection() : nullptr;
+
+    // The merge runs ahead of the grouping: it is what the rows the projection groups
+    // come from, since a merge fans a row out over every match it binds
+    generateMerge(query);
 
     if (projection) {
         generateGroupAggregate(projection);
@@ -2833,6 +2838,306 @@ void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
     }
 }
 
+void DBProgramGenerator::publishMergedEntity(const VarDecl* decl,
+                                             mlir::Value column,
+                                             mlir::Value pending,
+                                             llvm::ArrayRef<llvm::StringRef> propNames,
+                                             llvm::ArrayRef<mlir::Value> propValues) {
+    publishCreatedEntity(decl, column, {}, {}, propNames, propValues);
+    _part._createdEntities[decl]._pending = pending;
+}
+
+mlir::Value DBProgramGenerator::findPendingMask(const VarDecl* decl) const {
+    const auto findIt = _part._createdEntities.find(decl);
+    if (findIt == end(_part._createdEntities)) {
+        return mlir::Value {};
+    }
+
+    return findIt->second._pending;
+}
+
+void DBProgramGenerator::generateMerge(const SinglePartQuery* query) {
+    const StmtContainer* updateStmts = query->getUpdateStmts();
+    if (!updateStmts) {
+        return;
+    }
+
+    for (const Stmt* stmt : updateStmts->stmts()) {
+        if (stmt->getKind() != Stmt::Kind::MERGE) {
+            continue;
+        }
+
+        generateMergeStmt(static_cast<const MergeStmt*>(stmt));
+    }
+}
+
+void DBProgramGenerator::generateMergeStmt(const MergeStmt* mergeStmt) {
+    MergePattern pattern;
+    collectMergePattern(mergeStmt, pattern);
+
+    MergeCarrySet carrySet;
+    collectMergeCarrySet(carrySet);
+
+    llvm::SmallVector<mlir::Type> resultTypes;
+    const mlir::db::ColumnType nodeIDType = allocColumnType(mlir::storage::NodeIDType::get(_mlirCtxt));
+    const mlir::db::ColumnType edgeIDType = allocColumnType(mlir::storage::EdgeIDType::get(_mlirCtxt));
+    const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+
+    for (size_t nodeIndex = 0; nodeIndex < pattern._nodes.size(); nodeIndex++) {
+        resultTypes.push_back(nodeIDType);
+        resultTypes.push_back(boolType);
+    }
+
+    for (size_t hopIndex = 0; hopIndex < pattern._hops.size(); hopIndex++) {
+        resultTypes.push_back(edgeIDType);
+        resultTypes.push_back(boolType);
+    }
+
+    resultTypes.push_back(boolType);
+
+    for (const mlir::Value column : carrySet._columns) {
+        resultTypes.push_back(column.getType());
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    mlir::db::Merge merge = _opBuilder.create<mlir::db::Merge>(loc,
+                                                               resultTypes,
+                                                               _opBuilder.getArrayAttr(pattern._nodeLabels),
+                                                               _opBuilder.getArrayAttr(pattern._nodePropNames),
+                                                               _opBuilder.getArrayAttr(pattern._edgeTypes),
+                                                               _opBuilder.getArrayAttr(pattern._edgePropNames),
+                                                               _opBuilder.getDenseI64ArrayAttr(pattern._directions),
+                                                               _opBuilder.getDenseI64ArrayAttr(pattern._pendingNodes),
+                                                               pattern._boundNodes,
+                                                               pattern._boundPending,
+                                                               pattern._nodePropValues,
+                                                               pattern._edgePropValues,
+                                                               carrySet._columns);
+
+    const mlir::Operation::result_range results = merge.getResults();
+    const mlir::Value created = results[2 * (pattern._nodes.size() + pattern._hops.size())];
+
+    // A bound node keeps the binding it came in under, which the carry set hands back
+    // re-indexed onto the rows the merge emitted; every other entity of the pattern is
+    // published under the column and mask the merge produced for it.
+    for (size_t nodeIndex = 0; nodeIndex < pattern._nodes.size(); nodeIndex++) {
+        const MergeEntity& node = pattern._nodes[nodeIndex];
+        if (node._bound) {
+            continue;
+        }
+
+        publishMergedEntity(node._decl,
+                            results[2 * nodeIndex],
+                            results[2 * nodeIndex + 1],
+                            node._propNames,
+                            node._propValues);
+    }
+
+    const size_t firstHopResult = 2 * pattern._nodes.size();
+    for (size_t hopIndex = 0; hopIndex < pattern._hops.size(); hopIndex++) {
+        const MergeEntity& hop = pattern._hops[hopIndex];
+        if (!hop._decl) {
+            continue;
+        }
+
+        publishMergedEntity(hop._decl,
+                            results[firstHopResult + 2 * hopIndex],
+                            results[firstHopResult + 2 * hopIndex + 1],
+                            hop._propNames,
+                            hop._propValues);
+    }
+
+    rebindMergeCarrySet(results, carrySet);
+
+    generateMergeActions(mergeStmt, created);
+}
+
+void DBProgramGenerator::collectMergePattern(const MergeStmt* mergeStmt, MergePattern& pattern) {
+    const Pattern* patternAst = mergeStmt->getPattern();
+    bioassert(patternAst->elements().size() == 1, "MERGE carries a single path pattern");
+
+    const PatternElement* element = patternAst->elements().front();
+    const std::vector<EntityPattern*>& entities = element->getEntities();
+
+    for (size_t index = 0; index < entities.size(); index++) {
+        const bool isNode = index % 2 == 0;
+
+        if (isNode) {
+            collectMergeNode(static_cast<const NodePattern*>(entities[index]), pattern);
+        } else {
+            collectMergeHop(static_cast<const EdgePattern*>(entities[index]), pattern);
+        }
+    }
+}
+
+void DBProgramGenerator::collectMergeNode(const NodePattern* nodePattern, MergePattern& pattern) {
+    MergeEntity node;
+    node._decl = nodePattern->getDecl();
+
+    const NodePatternData* data = nodePattern->getData();
+
+    // The analyzer leaves a node the query already bound without pattern data: its rows
+    // come in through a column rather than from labels and property values
+    node._bound = data == nullptr;
+
+    if (node._bound) {
+        // Every merge of a part is generated ahead of its creates, so a bound node with
+        // no column is one a CREATE of the same part writes. Its entities are
+        // provisional and in no graph a merge reads, so binding one would leave the
+        // merge matching against whichever committed node the provisional ID collides
+        // with.
+        const mlir::Value column = resolveEntityColumn(node._decl);
+        if (!column) {
+            throw TuringException(fmt::format("MERGE cannot bind '{}': a CREATE in the same query "
+                                              "writes it, and what a CREATE writes is not visible "
+                                              "to a MERGE",
+                                              node._decl->getName()));
+        }
+
+        const mlir::Value pending = findPendingMask(node._decl);
+        if (pending) {
+            pattern._pendingNodes.push_back(static_cast<int64_t>(pattern._nodes.size()));
+            pattern._boundPending.push_back(pending);
+        }
+
+        pattern._boundNodes.push_back(column);
+        pattern._nodeLabels.push_back(_opBuilder.getStrArrayAttr({}));
+        pattern._nodePropNames.push_back(_opBuilder.getStrArrayAttr({}));
+        pattern._nodes.push_back(node);
+        return;
+    }
+
+    llvm::SmallVector<llvm::StringRef> labelNames;
+    for (const std::string_view label : data->labelConstraints()) {
+        labelNames.push_back(llvm::StringRef(label.data(), label.size()));
+    }
+
+    collectMergeProperties(data, node);
+
+    pattern._nodeLabels.push_back(_opBuilder.getStrArrayAttr(labelNames));
+    pattern._nodePropNames.push_back(_opBuilder.getStrArrayAttr(node._propNames));
+    pattern._nodePropValues.append(node._propValues.begin(), node._propValues.end());
+    pattern._nodes.push_back(node);
+}
+
+void DBProgramGenerator::collectMergeHop(const EdgePattern* edgePattern, MergePattern& pattern) {
+    const EdgePatternData* data = edgePattern->getData();
+    bioassert(data && !data->edgeTypeConstraints().empty(), "MERGE hop must have an edge type");
+
+    MergeEntity hop;
+    const VarDecl* decl = edgePattern->getDecl();
+    if (decl && !decl->isUnnamed()) {
+        hop._decl = decl;
+    }
+
+    collectMergeProperties(data, hop);
+
+    const std::string_view edgeType = data->edgeTypeConstraints().front();
+
+    pattern._edgeTypes.push_back(_opBuilder.getStringAttr(llvm::StringRef(edgeType.data(), edgeType.size())));
+    pattern._edgePropNames.push_back(_opBuilder.getStrArrayAttr(hop._propNames));
+    pattern._edgePropValues.append(hop._propValues.begin(), hop._propValues.end());
+    pattern._directions.push_back(static_cast<int64_t>(mergeDirectionOf(edgePattern)));
+    pattern._hops.push_back(hop);
+}
+
+void DBProgramGenerator::collectMergeProperties(const PatternData* data, MergeEntity& entity) {
+    for (const EntityPropertyConstraint& constraint : data->exprConstraints()) {
+        translateExpr(constraint._expr);
+
+        const std::string_view propName = constraint._propTypeName;
+        entity._propNames.push_back(llvm::StringRef(propName.data(), propName.size()));
+        entity._propValues.push_back(_part._exprMap.at(constraint._expr));
+    }
+}
+
+mlir::storage::EdgeDirection DBProgramGenerator::mergeDirectionOf(const EdgePattern* edgePattern) {
+    switch (edgePattern->getDirection()) {
+        case EdgePattern::Direction::Undirected:
+            return mlir::storage::EdgeDirection::Undirected;
+        break;
+
+        case EdgePattern::Direction::Backward:
+            return mlir::storage::EdgeDirection::Backward;
+        break;
+
+        case EdgePattern::Direction::Forward:
+            return mlir::storage::EdgeDirection::Forward;
+        break;
+    }
+
+    bioassert(false, "Unhandled edge pattern direction");
+    return mlir::storage::EdgeDirection::Forward;
+}
+
+void DBProgramGenerator::collectMergeCarrySet(MergeCarrySet& carrySet) {
+    collectInFlightColumns(carrySet._inFlight);
+    carrySet._columns.append(carrySet._inFlight._columns.begin(), carrySet._inFlight._columns.end());
+
+    // What an earlier CREATE or MERGE wrote is in flight too, and no VDG variable, so
+    // collectInFlightColumns knows nothing of it: a merge that fans the rows out has to
+    // take those columns along or they would stop matching the rows beside them.
+    for (const auto& [decl, written] : _part._createdEntities) {
+        if (isRowAlignedHere(written._column)) {
+            carrySet._writtenDecls.push_back(decl);
+        }
+    }
+
+    // Ordered by the name the query gave each entity, so the carry set a program carries
+    // is the query's choice and not the addresses'
+    std::ranges::sort(carrySet._writtenDecls, [](const VarDecl* lhs, const VarDecl* rhs) {
+        return lhs->getName() < rhs->getName();
+    });
+
+    for (const VarDecl* decl : carrySet._writtenDecls) {
+        const PartScope::CreatedEntity& written = _part._createdEntities.at(decl);
+
+        carrySet._columns.push_back(written._column);
+
+        if (written._pending) {
+            carrySet._columns.push_back(written._pending);
+        }
+    }
+}
+
+void DBProgramGenerator::rebindMergeCarrySet(mlir::Operation::result_range results,
+                                             const MergeCarrySet& carrySet) {
+    const size_t firstCarried = results.size() - carrySet._columns.size();
+
+    rebindInFlightColumns(results, firstCarried, carrySet._inFlight);
+
+    size_t resultIndex = firstCarried + carrySet._inFlight._columns.size();
+    for (const VarDecl* decl : carrySet._writtenDecls) {
+        PartScope::CreatedEntity& written = _part._createdEntities.at(decl);
+
+        written._column = results[resultIndex];
+        resultIndex++;
+
+        if (written._pending) {
+            written._pending = results[resultIndex];
+            resultIndex++;
+        }
+    }
+}
+
+void DBProgramGenerator::generateMergeActions(const MergeStmt* mergeStmt, mlir::Value created) {
+    const SetStmt* onCreate = mergeStmt->getOnCreate();
+    if (onCreate) {
+        generateSetItems(onCreate, created);
+    }
+
+    const SetStmt* onMatch = mergeStmt->getOnMatch();
+    if (!onMatch) {
+        return;
+    }
+
+    const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+    const mlir::Value matched =
+        _opBuilder.create<mlir::db::NotOp>(_opBuilder.getUnknownLoc(), boolType, created).getResult();
+
+    generateSetItems(onMatch, matched);
+}
+
 void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
     const StmtContainer* updateStmts = query->getUpdateStmts();
     if (!updateStmts) {
@@ -2853,6 +3158,10 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
         if (yieldedColumn._decl && isRowAlignedHere(yieldedColumn._column)) {
             knownVars[yieldedColumn._decl] = yieldedColumn._column;
         }
+    }
+
+    for (const auto& [writtenDecl, written] : _part._createdEntities) {
+        knownVars[writtenDecl] = written._column;
     }
 
     // The pattern's own order picks the column, since reading an arbitrary bucket of
@@ -2953,10 +3262,11 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
                           "CREATE edge must have an edge type");
                 const std::string_view edgeType = edgeData->edgeTypeConstraints().front();
 
-                const mlir::Value srcValue =
-                    edge->getDirection() == EdgePattern::Direction::Backward ? rhsValue : lhsValue;
-                const mlir::Value tgtValue =
-                    edge->getDirection() == EdgePattern::Direction::Backward ? lhsValue : rhsValue;
+                const bool backward = edge->getDirection() == EdgePattern::Direction::Backward;
+                const NodePattern* srcNode = backward ? targetNode : nodePtn;
+                const NodePattern* tgtNode = backward ? nodePtn : targetNode;
+                const mlir::Value srcValue = backward ? rhsValue : lhsValue;
+                const mlir::Value tgtValue = backward ? lhsValue : rhsValue;
 
                 mlir::db::CreateEdge createEdge = _opBuilder.create<mlir::db::CreateEdge>(
                     loc,
@@ -2965,7 +3275,9 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
                     tgtValue,
                     _opBuilder.getStringAttr(edgeType),
                     _opBuilder.getStrArrayAttr(propNames),
-                    mlir::ValueRange{propValues});
+                    mlir::ValueRange{propValues},
+                    findPendingMask(srcNode->getDecl()),
+                    findPendingMask(tgtNode->getDecl()));
 
                 const VarDecl* edgeDecl = edge->getDecl();
                 if (edgeDecl && !edgeDecl->isUnnamed()) {
@@ -3147,42 +3459,48 @@ void DBProgramGenerator::generateSet(const SinglePartQuery* query) {
         return;
     }
 
-    const mlir::Location loc = _opBuilder.getUnknownLoc();
-
     for (const Stmt* stmt : updateStmts->stmts()) {
         if (stmt->getKind() != Stmt::Kind::SET) {
             continue;
         }
 
-        const SetStmt* setStmt = static_cast<const SetStmt*>(stmt);
+        generateSetItems(static_cast<const SetStmt*>(stmt), mlir::Value {});
+    }
+}
 
-        for (const SetItem* item : setStmt->getItems()) {
-            const SetItem::PropertyExprAssign* assign =
-                std::get_if<SetItem::PropertyExprAssign>(&item->item());
-            bioassert(assign, "Only property-assignment SET items are supported");
+void DBProgramGenerator::generateSetItems(const SetStmt* setStmt, mlir::Value rows) {
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
 
-            const PropertyExpr* propertyExpr = assign->_propTypeExpr;
-            const VarDecl* entityDecl = propertyExpr->getEntityVarDecl();
-            const std::string_view varName = entityDecl->getName();
-            const std::string_view propName = propertyExpr->getPropName();
+    for (const SetItem* item : setStmt->getItems()) {
+        const SetItem::PropertyExprAssign* assign =
+            std::get_if<SetItem::PropertyExprAssign>(&item->item());
+        bioassert(assign, "Only property-assignment SET items are supported");
 
-            const mlir::Value entityColumn = resolveEntityColumn(entityDecl);
-            bioassert(entityColumn, "SET on unknown variable: {}", varName);
+        const PropertyExpr* propertyExpr = assign->_propTypeExpr;
+        const VarDecl* entityDecl = propertyExpr->getEntityVarDecl();
+        const std::string_view varName = entityDecl->getName();
+        const std::string_view propName = propertyExpr->getPropName();
 
-            translateExpr(assign->_propValueExpr);
-            const mlir::Value valueColumn = _part._exprMap.at(assign->_propValueExpr);
+        const mlir::Value entityColumn = resolveEntityColumn(entityDecl);
+        bioassert(entityColumn, "SET on unknown variable: {}", varName);
 
-            const mlir::StringAttr propAttr = _opBuilder.getStringAttr(propName);
-            const EvaluatedType entityType = entityDecl->getType();
-            const bool isNode = entityType == EvaluatedType::NodePattern;
-            const bool isEdge = entityType == EvaluatedType::EdgePattern;
-            bioassert(isNode || isEdge, "SET on non-entity variable: {}", varName);
+        translateExpr(assign->_propValueExpr);
+        const mlir::Value valueColumn = _part._exprMap.at(assign->_propValueExpr);
 
-            if (isNode) {
-                _opBuilder.create<mlir::db::SetNodeProperty>(loc, entityColumn, propAttr, valueColumn);
-            } else /* (isEdge) */ {
-                _opBuilder.create<mlir::db::SetEdgeProperty>(loc, entityColumn, propAttr, valueColumn);
-            }
+        // A merge's rows mix entities it wrote with entities it bound, and the two are
+        // written to differently: the mask says which is which
+        const mlir::Value pending = findPendingMask(entityDecl);
+
+        const mlir::StringAttr propAttr = _opBuilder.getStringAttr(propName);
+        const EvaluatedType entityType = entityDecl->getType();
+        const bool isNode = entityType == EvaluatedType::NodePattern;
+        const bool isEdge = entityType == EvaluatedType::EdgePattern;
+        bioassert(isNode || isEdge, "SET on non-entity variable: {}", varName);
+
+        if (isNode) {
+            _opBuilder.create<mlir::db::SetNodeProperty>(loc, entityColumn, propAttr, valueColumn, pending, rows);
+        } else /* (isEdge) */ {
+            _opBuilder.create<mlir::db::SetEdgeProperty>(loc, entityColumn, propAttr, valueColumn, pending, rows);
         }
     }
 }
@@ -3216,6 +3534,16 @@ void DBProgramGenerator::generateDelete(const SinglePartQuery* query) {
             const mlir::Value entityColumn = resolveEntityColumn(decl);
             if (!entityColumn) {
                 throwError("Cannot delete unbound variable: " + std::string(varName), expr);
+            }
+
+            // A merge's rows mix entities the graph holds with entities this change
+            // wrote, and a tombstone names a committed ID: deleting the mixture would
+            // tombstone whichever committed entity a provisional ID collides with
+            if (findPendingMask(decl)) {
+                throw TuringException(fmt::format("DELETE cannot take '{}': a MERGE in the same "
+                                                  "query binds it, and what a MERGE writes is not "
+                                                  "committed yet",
+                                                  varName));
             }
 
             const EvaluatedType entityType = decl->getType();
@@ -4272,11 +4600,18 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
         const auto& properties = createdIt->second._properties;
         const auto propertyIt = properties.find(propName);
 
+        // A property the write set is that value in every row: a MERGE's bound rows
+        // matched on it as much as its written rows carry it
         if (propertyIt != end(properties)) {
             return propertyIt->second;
         }
 
-        return nullConstantColumn();
+        // Every row a CREATE wrote is provisional, so a property it did not write is
+        // null. A MERGE's rows are read off the graph instead, its provisional ones
+        // reading null there.
+        if (!createdIt->second._pending) {
+            return nullConstantColumn();
+        }
     }
 
     const mlir::Value entityColumn = resolveEntityColumn(entityDecl);
@@ -4293,11 +4628,13 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
     const bool isEdge = entityType == EvaluatedType::EdgePattern;
     bioassert(isNode || isEdge, "Property access on non-entity variable: {}", varName);
 
+    const mlir::Value pending = findPendingMask(entityDecl);
+
     if (isNode) {
-        auto op = _opBuilder.create<mlir::db::GetNodeProperties>(loc, resultType, entityColumn, propAttr);
+        auto op = _opBuilder.create<mlir::db::GetNodeProperties>(loc, resultType, entityColumn, propAttr, pending);
         return op.getResult();
     } else {
-        auto op = _opBuilder.create<mlir::db::GetEdgeProperties>(loc, resultType, entityColumn, propAttr);
+        auto op = _opBuilder.create<mlir::db::GetEdgeProperties>(loc, resultType, entityColumn, propAttr, pending);
         return op.getResult();
     }
 }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -934,19 +934,10 @@ void DBProgramGenerator::generate(const CypherAST* ast) {
     const ReturnStmt* returnStmt = query->getReturnStmt();
     const Projection* projection = returnStmt ? returnStmt->getProjection() : nullptr;
 
-    // The merge runs ahead of the grouping: it is what the rows the projection groups
-    // come from, since a merge fans a row out over every match it binds
-    generateMerge(query);
+    generateUpdates(query);
 
     if (projection) {
         generateGroupAggregate(projection);
-    }
-
-    generateCreate(query);
-    generateSet(query);
-    generateDelete(query);
-
-    if (projection) {
         generateOutput(projection);
     } else {
         generateYieldedOutput(query);
@@ -2856,18 +2847,35 @@ mlir::Value DBProgramGenerator::findPendingMask(const VarDecl* decl) const {
     return findIt->second._pending;
 }
 
-void DBProgramGenerator::generateMerge(const SinglePartQuery* query) {
+void DBProgramGenerator::generateUpdates(const SinglePartQuery* query) {
     const StmtContainer* updateStmts = query->getUpdateStmts();
     if (!updateStmts) {
         return;
     }
 
     for (const Stmt* stmt : updateStmts->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::MERGE) {
-            continue;
-        }
+        switch (stmt->getKind()) {
+            case Stmt::Kind::MERGE:
+                generateMergeStmt(static_cast<const MergeStmt*>(stmt));
+            break;
 
-        generateMergeStmt(static_cast<const MergeStmt*>(stmt));
+            case Stmt::Kind::CREATE:
+                generateCreateStmt(static_cast<const CreateStmt*>(stmt));
+            break;
+
+            case Stmt::Kind::SET:
+                generateSetItems(static_cast<const SetStmt*>(stmt), mlir::Value {});
+            break;
+
+            case Stmt::Kind::DELETE:
+                generateDeleteStmt(static_cast<const DeleteStmt*>(stmt));
+            break;
+
+            default:
+                throw TuringException(fmt::format("Unsupported update statement of kind {}",
+                                                  static_cast<int>(stmt->getKind())));
+            break;
+        }
     }
 }
 
@@ -2883,7 +2891,13 @@ void DBProgramGenerator::generateMergeStmt(const MergeStmt* mergeStmt) {
     const mlir::db::ColumnType edgeIDType = allocColumnType(mlir::storage::EdgeIDType::get(_mlirCtxt));
     const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
 
-    for (size_t nodeIndex = 0; nodeIndex < pattern._nodes.size(); nodeIndex++) {
+    // A bound node's rows come back through the carry set, so the op produces a column
+    // and a mask only for the chain nodes it looks up or writes
+    for (const MergeEntity& node : pattern._nodes) {
+        if (node._bound) {
+            continue;
+        }
+
         resultTypes.push_back(nodeIDType);
         resultTypes.push_back(boolType);
     }
@@ -2915,37 +2929,37 @@ void DBProgramGenerator::generateMergeStmt(const MergeStmt* mergeStmt) {
                                                                carrySet._columns);
 
     const mlir::Operation::result_range results = merge.getResults();
-    const mlir::Value created = results[2 * (pattern._nodes.size() + pattern._hops.size())];
 
     // A bound node keeps the binding it came in under, which the carry set hands back
     // re-indexed onto the rows the merge emitted; every other entity of the pattern is
     // published under the column and mask the merge produced for it.
-    for (size_t nodeIndex = 0; nodeIndex < pattern._nodes.size(); nodeIndex++) {
-        const MergeEntity& node = pattern._nodes[nodeIndex];
+    size_t resultIndex = 0;
+    for (const MergeEntity& node : pattern._nodes) {
         if (node._bound) {
             continue;
         }
 
         publishMergedEntity(node._decl,
-                            results[2 * nodeIndex],
-                            results[2 * nodeIndex + 1],
+                            results[resultIndex],
+                            results[resultIndex + 1],
                             node._propNames,
                             node._propValues);
+        resultIndex += 2;
     }
 
-    const size_t firstHopResult = 2 * pattern._nodes.size();
-    for (size_t hopIndex = 0; hopIndex < pattern._hops.size(); hopIndex++) {
-        const MergeEntity& hop = pattern._hops[hopIndex];
-        if (!hop._decl) {
-            continue;
+    for (const MergeEntity& hop : pattern._hops) {
+        if (hop._decl) {
+            publishMergedEntity(hop._decl,
+                                results[resultIndex],
+                                results[resultIndex + 1],
+                                hop._propNames,
+                                hop._propValues);
         }
 
-        publishMergedEntity(hop._decl,
-                            results[firstHopResult + 2 * hopIndex],
-                            results[firstHopResult + 2 * hopIndex + 1],
-                            hop._propNames,
-                            hop._propValues);
+        resultIndex += 2;
     }
+
+    const mlir::Value created = results[resultIndex];
 
     rebindMergeCarrySet(results, carrySet);
 
@@ -2981,20 +2995,26 @@ void DBProgramGenerator::collectMergeNode(const NodePattern* nodePattern, MergeP
     node._bound = data == nullptr;
 
     if (node._bound) {
-        // Every merge of a part is generated ahead of its creates, so a bound node with
-        // no column is one a CREATE of the same part writes. Its entities are
-        // provisional and in no graph a merge reads, so binding one would leave the
-        // merge matching against whichever committed node the provisional ID collides
-        // with.
         const mlir::Value column = resolveEntityColumn(node._decl);
         if (!column) {
+            throw TuringException(fmt::format("MERGE cannot bind '{}': nothing ahead of it in the "
+                                              "query binds it",
+                                              node._decl->getName()));
+        }
+
+        const mlir::Value pending = findPendingMask(node._decl);
+
+        // A CREATE's entities are provisional and in no graph a merge reads, so binding
+        // one would leave the merge matching against whichever committed node the
+        // provisional ID collides with
+        const bool writtenByACreate = !pending && _part._createdEntities.contains(node._decl);
+        if (writtenByACreate) {
             throw TuringException(fmt::format("MERGE cannot bind '{}': a CREATE in the same query "
                                               "writes it, and what a CREATE writes is not visible "
                                               "to a MERGE",
                                               node._decl->getName()));
         }
 
-        const mlir::Value pending = findPendingMask(node._decl);
         if (pending) {
             pattern._pendingNodes.push_back(static_cast<int64_t>(pattern._nodes.size()));
             pattern._boundPending.push_back(pending);
@@ -3076,26 +3096,48 @@ void DBProgramGenerator::collectMergeCarrySet(MergeCarrySet& carrySet) {
 
     // What an earlier CREATE or MERGE wrote is in flight too, and no VDG variable, so
     // collectInFlightColumns knows nothing of it: a merge that fans the rows out has to
-    // take those columns along or they would stop matching the rows beside them.
+    // take those columns along or they would stop matching the rows beside them. The
+    // value columns of the properties it recorded go along for the same reason - a
+    // projection reads a written property off them rather than off the graph.
     for (const auto& [decl, written] : _part._createdEntities) {
-        if (isRowAlignedHere(written._column)) {
-            carrySet._writtenDecls.push_back(decl);
+        if (!isRowAlignedHere(written._column)) {
+            continue;
         }
+
+        CarriedEntity carried;
+        carried._decl = decl;
+
+        for (const auto& [propName, propColumn] : written._properties) {
+            // A constant holds one value standing for every row rather than rows of its
+            // own, so the fan-out leaves it as it is
+            const bool carriesRows = isRowAlignedHere(propColumn) && !yieldsConstantColumn(propColumn);
+            if (carriesRows) {
+                carried._propNames.push_back(propName);
+            }
+        }
+
+        std::ranges::sort(carried._propNames);
+
+        carrySet._writtenEntities.push_back(carried);
     }
 
     // Ordered by the name the query gave each entity, so the carry set a program carries
     // is the query's choice and not the addresses'
-    std::ranges::sort(carrySet._writtenDecls, [](const VarDecl* lhs, const VarDecl* rhs) {
-        return lhs->getName() < rhs->getName();
+    std::ranges::sort(carrySet._writtenEntities, [](const CarriedEntity& lhs, const CarriedEntity& rhs) {
+        return lhs._decl->getName() < rhs._decl->getName();
     });
 
-    for (const VarDecl* decl : carrySet._writtenDecls) {
-        const PartScope::CreatedEntity& written = _part._createdEntities.at(decl);
+    for (const CarriedEntity& carried : carrySet._writtenEntities) {
+        const PartScope::CreatedEntity& written = _part._createdEntities.at(carried._decl);
 
         carrySet._columns.push_back(written._column);
 
         if (written._pending) {
             carrySet._columns.push_back(written._pending);
+        }
+
+        for (const std::string_view propName : carried._propNames) {
+            carrySet._columns.push_back(written._properties.at(propName));
         }
     }
 }
@@ -3107,14 +3149,19 @@ void DBProgramGenerator::rebindMergeCarrySet(mlir::Operation::result_range resul
     rebindInFlightColumns(results, firstCarried, carrySet._inFlight);
 
     size_t resultIndex = firstCarried + carrySet._inFlight._columns.size();
-    for (const VarDecl* decl : carrySet._writtenDecls) {
-        PartScope::CreatedEntity& written = _part._createdEntities.at(decl);
+    for (const CarriedEntity& carried : carrySet._writtenEntities) {
+        PartScope::CreatedEntity& written = _part._createdEntities.at(carried._decl);
 
         written._column = results[resultIndex];
         resultIndex++;
 
         if (written._pending) {
             written._pending = results[resultIndex];
+            resultIndex++;
+        }
+
+        for (const std::string_view propName : carried._propNames) {
+            written._properties.at(propName) = results[resultIndex];
             resultIndex++;
         }
     }
@@ -3138,12 +3185,7 @@ void DBProgramGenerator::generateMergeActions(const MergeStmt* mergeStmt, mlir::
     generateSetItems(onMatch, matched);
 }
 
-void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
-    const StmtContainer* updateStmts = query->getUpdateStmts();
-    if (!updateStmts) {
-        return;
-    }
-
+void DBProgramGenerator::generateCreateStmt(const CreateStmt* createStmt) {
     // Collect the columns a MATCH bound or a CALL yielded, by variable, so CREATE
     // patterns can reference them.
     std::unordered_map<const VarDecl*, mlir::Value> knownVars;
@@ -3229,68 +3271,62 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
     llvm::SmallVector<llvm::StringRef> propNames;
     llvm::SmallVector<mlir::Value> propValues;
 
-    for (const Stmt* stmt : updateStmts->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::CREATE) {
-            continue;
-        }
-        const CreateStmt* createStmt = static_cast<const CreateStmt*>(stmt);
-        const Pattern* pattern = createStmt->getPattern();
+    const Pattern* pattern = createStmt->getPattern();
 
-        for (const PatternElement* element : pattern->elements()) {
-            const EntityPattern* entPtn = element->getRootEntity();
-            const auto* nodePtn = dynamic_cast<const NodePattern*>(entPtn);
-            bioassert(nodePtn, "Unknown root entity");
+    for (const PatternElement* element : pattern->elements()) {
+        const EntityPattern* entPtn = element->getRootEntity();
+        const auto* nodePtn = dynamic_cast<const NodePattern*>(entPtn);
+        bioassert(nodePtn, "Unknown root entity");
 
-            mlir::Value lhsValue = resolveOrCreateNode(nodePtn);
+        mlir::Value lhsValue = resolveOrCreateNode(nodePtn);
 
-            for (auto [edge, targetNode] : element->getElementChain()) {
-                const mlir::Value rhsValue = resolveOrCreateNode(targetNode);
+        for (auto [edge, targetNode] : element->getElementChain()) {
+            const mlir::Value rhsValue = resolveOrCreateNode(targetNode);
 
-                propNames.clear();
-                propValues.clear();
-                const EdgePatternData* edgeData = edge->getData();
-                if (edgeData) {
-                    for (const EntityPropertyConstraint& constraint : edgeData->exprConstraints()) {
-                        translateExpr(constraint._expr);
-                        const std::string_view propName = constraint._propTypeName;
-                        propNames.push_back(llvm::StringRef(propName.data(), propName.size()));
-                        propValues.push_back(_part._exprMap.at(constraint._expr));
-                    }
+            propNames.clear();
+            propValues.clear();
+            const EdgePatternData* edgeData = edge->getData();
+            if (edgeData) {
+                for (const EntityPropertyConstraint& constraint : edgeData->exprConstraints()) {
+                    translateExpr(constraint._expr);
+                    const std::string_view propName = constraint._propTypeName;
+                    propNames.push_back(llvm::StringRef(propName.data(), propName.size()));
+                    propValues.push_back(_part._exprMap.at(constraint._expr));
                 }
-
-                bioassert(edgeData && !edgeData->edgeTypeConstraints().empty(),
-                          "CREATE edge must have an edge type");
-                const std::string_view edgeType = edgeData->edgeTypeConstraints().front();
-
-                const bool backward = edge->getDirection() == EdgePattern::Direction::Backward;
-                const NodePattern* srcNode = backward ? targetNode : nodePtn;
-                const NodePattern* tgtNode = backward ? nodePtn : targetNode;
-                const mlir::Value srcValue = backward ? rhsValue : lhsValue;
-                const mlir::Value tgtValue = backward ? lhsValue : rhsValue;
-
-                mlir::db::CreateEdge createEdge = _opBuilder.create<mlir::db::CreateEdge>(
-                    loc,
-                    edgeIDType,
-                    srcValue,
-                    tgtValue,
-                    _opBuilder.getStringAttr(edgeType),
-                    _opBuilder.getStrArrayAttr(propNames),
-                    mlir::ValueRange{propValues},
-                    findPendingMask(srcNode->getDecl()),
-                    findPendingMask(tgtNode->getDecl()));
-
-                const VarDecl* edgeDecl = edge->getDecl();
-                if (edgeDecl && !edgeDecl->isUnnamed()) {
-                    publishCreatedEntity(edgeDecl,
-                                         createEdge.getResult(),
-                                         {},
-                                         llvm::StringRef {edgeType.data(), edgeType.size()},
-                                         propNames,
-                                         propValues);
-                }
-
-                lhsValue = rhsValue;
             }
+
+            bioassert(edgeData && !edgeData->edgeTypeConstraints().empty(),
+                      "CREATE edge must have an edge type");
+            const std::string_view edgeType = edgeData->edgeTypeConstraints().front();
+
+            const bool backward = edge->getDirection() == EdgePattern::Direction::Backward;
+            const NodePattern* srcNode = backward ? targetNode : nodePtn;
+            const NodePattern* tgtNode = backward ? nodePtn : targetNode;
+            const mlir::Value srcValue = backward ? rhsValue : lhsValue;
+            const mlir::Value tgtValue = backward ? lhsValue : rhsValue;
+
+            mlir::db::CreateEdge createEdge = _opBuilder.create<mlir::db::CreateEdge>(
+                loc,
+                edgeIDType,
+                srcValue,
+                tgtValue,
+                _opBuilder.getStringAttr(edgeType),
+                _opBuilder.getStrArrayAttr(propNames),
+                mlir::ValueRange{propValues},
+                findPendingMask(srcNode->getDecl()),
+                findPendingMask(tgtNode->getDecl()));
+
+            const VarDecl* edgeDecl = edge->getDecl();
+            if (edgeDecl && !edgeDecl->isUnnamed()) {
+                publishCreatedEntity(edgeDecl,
+                                     createEdge.getResult(),
+                                     {},
+                                     llvm::StringRef {edgeType.data(), edgeType.size()},
+                                     propNames,
+                                     propValues);
+            }
+
+            lhsValue = rhsValue;
         }
     }
 }
@@ -3453,21 +3489,6 @@ mlir::Value DBProgramGenerator::resolveWildcardColumn() const {
     return resolveColumnInScope([](mlir::Value) { return true; });
 }
 
-void DBProgramGenerator::generateSet(const SinglePartQuery* query) {
-    const StmtContainer* updateStmts = query->getUpdateStmts();
-    if (!updateStmts) {
-        return;
-    }
-
-    for (const Stmt* stmt : updateStmts->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::SET) {
-            continue;
-        }
-
-        generateSetItems(static_cast<const SetStmt*>(stmt), mlir::Value {});
-    }
-}
-
 void DBProgramGenerator::generateSetItems(const SetStmt* setStmt, mlir::Value rows) {
     const mlir::Location loc = _opBuilder.getUnknownLoc();
 
@@ -3505,58 +3526,50 @@ void DBProgramGenerator::generateSetItems(const SetStmt* setStmt, mlir::Value ro
     }
 }
 
-void DBProgramGenerator::generateDelete(const SinglePartQuery* query) {
-    const StmtContainer* updateStmts = query->getUpdateStmts();
-    if (!updateStmts) {
-        return;
-    }
-
+void DBProgramGenerator::generateDeleteStmt(const DeleteStmt* deleteStmt) {
     const mlir::Location loc = _opBuilder.getUnknownLoc();
+    const bool detach = deleteStmt->isDetaching();
 
-    for (const Stmt* stmt : updateStmts->stmts()) {
-        if (stmt->getKind() != Stmt::Kind::DELETE) {
-            continue;
+    for (const Expr* expr : *deleteStmt->getExpressions()) {
+        if (expr->getKind() != Expr::Kind::SYMBOL) {
+            throwError("Expressions in DELETE statements can only be symbols", expr);
         }
 
-        const DeleteStmt* deleteStmt = static_cast<const DeleteStmt*>(stmt);
-        const bool detach = deleteStmt->isDetaching();
+        const SymbolExpr* symbolExpr = static_cast<const SymbolExpr*>(expr);
+        const VarDecl* decl = symbolExpr->getDecl();
+        bioassert(decl, "DELETE target symbol has no declaration");
+        const std::string_view varName = decl->getName();
 
-        for (const Expr* expr : *deleteStmt->getExpressions()) {
-            if (expr->getKind() != Expr::Kind::SYMBOL) {
-                throwError("Expressions in DELETE statements can only be symbols", expr);
-            }
+        const mlir::Value entityColumn = resolveEntityColumn(decl);
+        if (!entityColumn) {
+            throwError("Cannot delete unbound variable: " + std::string(varName), expr);
+        }
 
-            const SymbolExpr* symbolExpr = static_cast<const SymbolExpr*>(expr);
-            const VarDecl* decl = symbolExpr->getDecl();
-            bioassert(decl, "DELETE target symbol has no declaration");
-            const std::string_view varName = decl->getName();
+        // A write's rows hold provisional IDs this change has not committed and a
+        // tombstone names a committed ID: deleting them would tombstone whichever
+        // committed entity a provisional ID collides with
+        if (findPendingMask(decl)) {
+            throw TuringException(fmt::format("DELETE cannot take '{}': a MERGE in the same "
+                                              "query binds it, and what a MERGE writes is not "
+                                              "committed yet",
+                                              varName));
+        } else if (_part._createdEntities.contains(decl)) {
+            throw TuringException(fmt::format("DELETE cannot take '{}': a CREATE in the same "
+                                              "query writes it, and what a CREATE writes is not "
+                                              "committed yet",
+                                              varName));
+        }
 
-            const mlir::Value entityColumn = resolveEntityColumn(decl);
-            if (!entityColumn) {
-                throwError("Cannot delete unbound variable: " + std::string(varName), expr);
-            }
+        const EvaluatedType entityType = decl->getType();
+        const bool isNode = entityType == EvaluatedType::NodePattern;
+        const bool isEdge = entityType == EvaluatedType::EdgePattern;
 
-            // A merge's rows mix entities the graph holds with entities this change
-            // wrote, and a tombstone names a committed ID: deleting the mixture would
-            // tombstone whichever committed entity a provisional ID collides with
-            if (findPendingMask(decl)) {
-                throw TuringException(fmt::format("DELETE cannot take '{}': a MERGE in the same "
-                                                  "query binds it, and what a MERGE writes is not "
-                                                  "committed yet",
-                                                  varName));
-            }
-
-            const EvaluatedType entityType = decl->getType();
-            const bool isNode = entityType == EvaluatedType::NodePattern;
-            const bool isEdge = entityType == EvaluatedType::EdgePattern;
-
-            if (isNode) {
-                _opBuilder.create<mlir::db::DeleteNode>(loc, entityColumn, detach);
-            } else if (isEdge) {
-                _opBuilder.create<mlir::db::DeleteEdge>(loc, entityColumn);
-            } else {
-                throwError("Can only delete nodes or edges", expr);
-            }
+        if (isNode) {
+            _opBuilder.create<mlir::db::DeleteNode>(loc, entityColumn, detach);
+        } else if (isEdge) {
+            _opBuilder.create<mlir::db::DeleteEdge>(loc, entityColumn);
+        } else {
+            throwError("Can only delete nodes or edges", expr);
         }
     }
 }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -3545,29 +3545,20 @@ void DBProgramGenerator::generateDeleteStmt(const DeleteStmt* deleteStmt) {
             throwError("Cannot delete unbound variable: " + std::string(varName), expr);
         }
 
-        // A write's rows hold provisional IDs this change has not committed and a
-        // tombstone names a committed ID: deleting them would tombstone whichever
-        // committed entity a provisional ID collides with
-        if (findPendingMask(decl)) {
-            throw TuringException(fmt::format("DELETE cannot take '{}': a MERGE in the same "
-                                              "query binds it, and what a MERGE writes is not "
-                                              "committed yet",
-                                              varName));
-        } else if (_part._createdEntities.contains(decl)) {
-            throw TuringException(fmt::format("DELETE cannot take '{}': a CREATE in the same "
-                                              "query writes it, and what a CREATE writes is not "
-                                              "committed yet",
-                                              varName));
-        }
+        // A merge's rows mix entities the graph holds with entities this change wrote,
+        // and the two are deleted differently: the mask says which is which. A CREATE's
+        // rows are provisional throughout and carry no mask, which the write buffer
+        // reads off the column the create produced.
+        const mlir::Value pending = findPendingMask(decl);
 
         const EvaluatedType entityType = decl->getType();
         const bool isNode = entityType == EvaluatedType::NodePattern;
         const bool isEdge = entityType == EvaluatedType::EdgePattern;
 
         if (isNode) {
-            _opBuilder.create<mlir::db::DeleteNode>(loc, entityColumn, detach);
+            _opBuilder.create<mlir::db::DeleteNode>(loc, entityColumn, detach, pending);
         } else if (isEdge) {
-            _opBuilder.create<mlir::db::DeleteEdge>(loc, entityColumn);
+            _opBuilder.create<mlir::db::DeleteEdge>(loc, entityColumn, pending);
         } else {
             throwError("Can only delete nodes or edges", expr);
         }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -4737,6 +4737,12 @@ mlir::Value DBProgramGenerator::translateCreatedMetadata(std::string_view funcNa
 
     const PartScope::CreatedEntity& created = createdIt->second;
 
+    // A MERGE's rows mix the entities it wrote with the ones it bound, so no one label
+    // set or type stands for the column: those rows read theirs where each entity lives
+    if (created._pending) {
+        return {};
+    }
+
     if (funcName == "labels") {
         return constantLabelString(created._labels);
     } else if (funcName == "edgeType") {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2831,11 +2831,11 @@ void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
 
 void DBProgramGenerator::publishMergedEntity(const VarDecl* decl,
                                              mlir::Value column,
-                                             mlir::Value pending,
-                                             llvm::ArrayRef<llvm::StringRef> propNames,
-                                             llvm::ArrayRef<mlir::Value> propValues) {
-    publishCreatedEntity(decl, column, {}, {}, propNames, propValues);
-    _part._createdEntities[decl]._pending = pending;
+                                             mlir::Value pending) {
+    PartScope::CreatedEntity& merged = _part._createdEntities[decl];
+
+    merged._column = column;
+    merged._pending = pending;
 }
 
 mlir::Value DBProgramGenerator::findPendingMask(const VarDecl* decl) const {
@@ -2939,21 +2939,13 @@ void DBProgramGenerator::generateMergeStmt(const MergeStmt* mergeStmt) {
             continue;
         }
 
-        publishMergedEntity(node._decl,
-                            results[resultIndex],
-                            results[resultIndex + 1],
-                            node._propNames,
-                            node._propValues);
+        publishMergedEntity(node._decl, results[resultIndex], results[resultIndex + 1]);
         resultIndex += 2;
     }
 
     for (const MergeEntity& hop : pattern._hops) {
         if (hop._decl) {
-            publishMergedEntity(hop._decl,
-                                results[resultIndex],
-                                results[resultIndex + 1],
-                                hop._propNames,
-                                hop._propValues);
+            publishMergedEntity(hop._decl, results[resultIndex], results[resultIndex + 1]);
         }
 
         resultIndex += 2;
@@ -3097,12 +3089,12 @@ void DBProgramGenerator::collectMergeCarrySet(MergeCarrySet& carrySet) {
     // What an earlier CREATE or MERGE wrote is in flight too, and no VDG variable, so
     // collectInFlightColumns knows nothing of it: a merge that fans the rows out has to
     // take those columns along or they would stop matching the rows beside them. The
-    // value columns of the properties it recorded go along for the same reason - a
-    // projection reads a written property off them rather than off the graph.
+    // value columns of the properties a CREATE recorded go along for the same reason - a
+    // projection reads a created property off them rather than off the graph.
     for (const auto& [decl, written] : _part._createdEntities) {
-        if (!isRowAlignedHere(written._column)) {
-            continue;
-        }
+        bioassert(isRowAlignedHere(written._column),
+                  "MERGE cannot carry '{}' along: what wrote it holds another row set here",
+                  decl->getName());
 
         CarriedEntity carried;
         carried._decl = decl;
@@ -3110,10 +3102,16 @@ void DBProgramGenerator::collectMergeCarrySet(MergeCarrySet& carrySet) {
         for (const auto& [propName, propColumn] : written._properties) {
             // A constant holds one value standing for every row rather than rows of its
             // own, so the fan-out leaves it as it is
-            const bool carriesRows = isRowAlignedHere(propColumn) && !yieldsConstantColumn(propColumn);
-            if (carriesRows) {
-                carried._propNames.push_back(propName);
+            if (yieldsConstantColumn(propColumn)) {
+                continue;
             }
+
+            bioassert(isRowAlignedHere(propColumn),
+                      "MERGE cannot carry '{}.{}' along: what wrote it holds another row set here",
+                      decl->getName(),
+                      propName);
+
+            carried._propNames.push_back(propName);
         }
 
         std::ranges::sort(carried._propNames);
@@ -3278,6 +3276,7 @@ void DBProgramGenerator::generateCreateStmt(const CreateStmt* createStmt) {
         const auto* nodePtn = dynamic_cast<const NodePattern*>(entPtn);
         bioassert(nodePtn, "Unknown root entity");
 
+        const NodePattern* lhsNode = nodePtn;
         mlir::Value lhsValue = resolveOrCreateNode(nodePtn);
 
         for (auto [edge, targetNode] : element->getElementChain()) {
@@ -3300,8 +3299,8 @@ void DBProgramGenerator::generateCreateStmt(const CreateStmt* createStmt) {
             const std::string_view edgeType = edgeData->edgeTypeConstraints().front();
 
             const bool backward = edge->getDirection() == EdgePattern::Direction::Backward;
-            const NodePattern* srcNode = backward ? targetNode : nodePtn;
-            const NodePattern* tgtNode = backward ? nodePtn : targetNode;
+            const NodePattern* srcNode = backward ? targetNode : lhsNode;
+            const NodePattern* tgtNode = backward ? lhsNode : targetNode;
             const mlir::Value srcValue = backward ? rhsValue : lhsValue;
             const mlir::Value tgtValue = backward ? lhsValue : rhsValue;
 
@@ -3326,6 +3325,7 @@ void DBProgramGenerator::generateCreateStmt(const CreateStmt* createStmt) {
                                      propValues);
             }
 
+            lhsNode = targetNode;
             lhsValue = rhsValue;
         }
     }
@@ -4605,26 +4605,21 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
         return fieldColumn;
     }
 
-    // A created entity holds a provisional ID, which the graph a fetch reads knows nothing
-    // about: the value of one of its properties is the one the CREATE wrote there, and
-    // every property it did not write is null
+    // Every row a CREATE wrote holds a provisional ID, which the graph a fetch reads knows
+    // nothing about: the value of one of its properties is the one the CREATE wrote there,
+    // and a property it did not write is null. A MERGE's rows are a mixture, so they go
+    // through the fetch below, which reads each row where its own entity lives.
     const auto createdIt = _part._createdEntities.find(entityDecl);
-    if (createdIt != end(_part._createdEntities)) {
+    const bool writtenByACreate = createdIt != end(_part._createdEntities) && !createdIt->second._pending;
+    if (writtenByACreate) {
         const auto& properties = createdIt->second._properties;
         const auto propertyIt = properties.find(propName);
 
-        // A property the write set is that value in every row: a MERGE's bound rows
-        // matched on it as much as its written rows carry it
         if (propertyIt != end(properties)) {
             return propertyIt->second;
         }
 
-        // Every row a CREATE wrote is provisional, so a property it did not write is
-        // null. A MERGE's rows are read off the graph instead, its provisional ones
-        // reading null there.
-        if (!createdIt->second._pending) {
-            return nullConstantColumn();
-        }
+        return nullConstantColumn();
     }
 
     const mlir::Value entityColumn = resolveEntityColumn(entityDecl);

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -36,7 +36,9 @@ class FunctionInvocationExpr;
 class FunctionInvocation;
 class UnaryExpr;
 class CallStmt;
+class CreateStmt;
 class CypherAST;
+class DeleteStmt;
 class EdgePattern;
 class EmbeddingLiteral;
 class EntityTypeExpr;
@@ -353,17 +355,27 @@ private:
         llvm::SmallVector<mlir::Value> _edgePropValues;
     };
 
-    // What a merge takes along past its fan-out: the columns in flight, then the column
-    // and mask of every entity an earlier write bound, which are in no VDG variable and
-    // so in no in-flight set
+    // One entity an earlier write bound that a merge takes along past its fan-out: its
+    // ID column, its pending mask when it has one, then the value column of each
+    // property the write recorded, under the names sorted here
+    struct CarriedEntity {
+        const VarDecl* _decl {nullptr};
+        llvm::SmallVector<std::string_view> _propNames;
+    };
+
+    // What a merge takes along past its fan-out: the columns in flight, then the columns
+    // of every entity an earlier write bound, which are in no VDG variable and so in no
+    // in-flight set
     struct MergeCarrySet {
         InFlightColumns _inFlight;
         llvm::SmallVector<mlir::Value> _columns;
-        llvm::SmallVector<const VarDecl*> _writtenDecls;
+        llvm::SmallVector<CarriedEntity> _writtenEntities;
     };
 
-    void generateCreate(const SinglePartQuery* query);
-    void generateMerge(const SinglePartQuery* query);
+    // Emits each update statement of a part in the order the query writes them, so a
+    // statement reading what an earlier one wrote is generated behind it
+    void generateUpdates(const SinglePartQuery* query);
+    void generateCreateStmt(const CreateStmt* createStmt);
     void generateMergeStmt(const MergeStmt* mergeStmt);
 
     void collectMergePattern(const MergeStmt* mergeStmt, MergePattern& pattern);
@@ -393,12 +405,10 @@ private:
     // for a variable no write bound and for one a CREATE bound - whose every row does
     mlir::Value findPendingMask(const VarDecl* decl) const;
 
-    void generateSet(const SinglePartQuery* query);
-
     // The property writes of one SET clause, over the rows @param rows selects - every
     // row for a plain SET, which passes a null mask
     void generateSetItems(const SetStmt* setStmt, mlir::Value rows);
-    void generateDelete(const SinglePartQuery* query);
+    void generateDeleteStmt(const DeleteStmt* deleteStmt);
     void generateOutput(const Projection* projection);
 
     // A standalone CALL ends no projection: what it yielded is the result

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -393,13 +393,11 @@ private:
 
     static mlir::storage::EdgeDirection mergeDirectionOf(const EdgePattern* edgePattern);
 
-    // Records what a MERGE bound for one named entity of its pattern: the same as a
-    // CREATE, plus the mask telling the rows it wrote from the rows it bound
-    void publishMergedEntity(const VarDecl* decl,
-                             mlir::Value column,
-                             mlir::Value pending,
-                             llvm::ArrayRef<llvm::StringRef> propNames,
-                             llvm::ArrayRef<mlir::Value> propValues);
+    // Records what a MERGE bound for one named entity of its pattern: its column and the
+    // mask telling the rows it wrote from the rows it bound. Its properties are not
+    // recorded the way a CREATE's are - a merge row reads them where its own entity
+    // lives, off the graph or out of the write buffer.
+    void publishMergedEntity(const VarDecl* decl, mlir::Value column, mlir::Value pending);
 
     // The mask saying which of a variable's rows hold a provisional ID, or a null Value
     // for a variable no write bound and for one a CREATE bound - whose every row does

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -37,6 +37,7 @@ class FunctionInvocation;
 class UnaryExpr;
 class CallStmt;
 class CypherAST;
+class EdgePattern;
 class EmbeddingLiteral;
 class EntityTypeExpr;
 class Expr;
@@ -45,6 +46,9 @@ class Literal;
 class ListLiteral;
 class LoadCSVStmt;
 class MatchStmt;
+class MergeStmt;
+class NodePattern;
+class PatternData;
 class Projection;
 class PropertyExpr;
 class ReturnStmt;
@@ -54,6 +58,7 @@ class VarDecl;
 class VectorSearchStmt;
 class VariableDependency;
 class DependencyEdge;
+class SetStmt;
 class SinglePartQuery;
 class Stmt;
 class WhereClause;
@@ -149,6 +154,13 @@ private:
         // come from here instead
         struct CreatedEntity {
             mlir::Value _column;
+
+            // Which rows of the column hold a provisional ID: null when every one does,
+            // which is what a CREATE writes. A MERGE mixes the entities it wrote with
+            // the ones it bound, so its rows are told apart by a mask - and a property
+            // it did not write is read off the graph rather than being null.
+            mlir::Value _pending;
+
             std::unordered_map<std::string_view, mlir::Value> _properties;
             std::vector<std::string> _labels;
             std::string _edgeType;
@@ -312,8 +324,80 @@ private:
                               llvm::ArrayRef<llvm::StringRef> propNames,
                               llvm::ArrayRef<mlir::Value> propValues);
 
+    // The chain of one MERGE pattern, as db.merge carries it: one entry per node and
+    // one per hop, with the attribute lists and operand groups they fill
+    struct MergeEntity {
+        const VarDecl* _decl {nullptr};
+        llvm::SmallVector<llvm::StringRef> _propNames;
+        llvm::SmallVector<mlir::Value> _propValues;
+
+        // A node the query already bound, whose rows come in through a column rather
+        // than from labels and property values. Never true of a hop.
+        bool _bound {false};
+    };
+
+    struct MergePattern {
+        llvm::SmallVector<MergeEntity> _nodes;
+        llvm::SmallVector<MergeEntity> _hops;
+
+        llvm::SmallVector<mlir::Attribute> _nodeLabels;
+        llvm::SmallVector<mlir::Attribute> _nodePropNames;
+        llvm::SmallVector<mlir::Attribute> _edgeTypes;
+        llvm::SmallVector<mlir::Attribute> _edgePropNames;
+        llvm::SmallVector<int64_t> _directions;
+        llvm::SmallVector<int64_t> _pendingNodes;
+
+        llvm::SmallVector<mlir::Value> _boundNodes;
+        llvm::SmallVector<mlir::Value> _boundPending;
+        llvm::SmallVector<mlir::Value> _nodePropValues;
+        llvm::SmallVector<mlir::Value> _edgePropValues;
+    };
+
+    // What a merge takes along past its fan-out: the columns in flight, then the column
+    // and mask of every entity an earlier write bound, which are in no VDG variable and
+    // so in no in-flight set
+    struct MergeCarrySet {
+        InFlightColumns _inFlight;
+        llvm::SmallVector<mlir::Value> _columns;
+        llvm::SmallVector<const VarDecl*> _writtenDecls;
+    };
+
     void generateCreate(const SinglePartQuery* query);
+    void generateMerge(const SinglePartQuery* query);
+    void generateMergeStmt(const MergeStmt* mergeStmt);
+
+    void collectMergePattern(const MergeStmt* mergeStmt, MergePattern& pattern);
+    void collectMergeNode(const NodePattern* nodePattern, MergePattern& pattern);
+    void collectMergeHop(const EdgePattern* edgePattern, MergePattern& pattern);
+    void collectMergeProperties(const PatternData* data, MergeEntity& entity);
+
+    void collectMergeCarrySet(MergeCarrySet& carrySet);
+    void rebindMergeCarrySet(mlir::Operation::result_range results, const MergeCarrySet& carrySet);
+
+    // Emits the ON CREATE and ON MATCH clauses of a merge, each over the rows @param
+    // created selects: the rows the merge wrote, and - through its negation - the rows
+    // it bound
+    void generateMergeActions(const MergeStmt* mergeStmt, mlir::Value created);
+
+    static mlir::storage::EdgeDirection mergeDirectionOf(const EdgePattern* edgePattern);
+
+    // Records what a MERGE bound for one named entity of its pattern: the same as a
+    // CREATE, plus the mask telling the rows it wrote from the rows it bound
+    void publishMergedEntity(const VarDecl* decl,
+                             mlir::Value column,
+                             mlir::Value pending,
+                             llvm::ArrayRef<llvm::StringRef> propNames,
+                             llvm::ArrayRef<mlir::Value> propValues);
+
+    // The mask saying which of a variable's rows hold a provisional ID, or a null Value
+    // for a variable no write bound and for one a CREATE bound - whose every row does
+    mlir::Value findPendingMask(const VarDecl* decl) const;
+
     void generateSet(const SinglePartQuery* query);
+
+    // The property writes of one SET clause, over the rows @param rows selects - every
+    // row for a plain SET, which passes a null mask
+    void generateSetItems(const SetStmt* setStmt, mlir::Value rows);
     void generateDelete(const SinglePartQuery* query);
     void generateOutput(const Projection* projection);
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -8,6 +8,8 @@
 #include "IRLiteralList.h"
 #include "StorageEnums.h"
 #include "ColumnIndicesFormat.h"
+#include "EdgeDirectionsFormat.h"
+#include "MergePatternShape.h"
 #include "GroupAggregateKindsFormat.h"
 #include "PropertyScanLiteral.h"
 
@@ -293,6 +295,32 @@ LogicalResult CreateEdge::verify() {
     if (getPropNames().size() != getPropValues().size()) {
         return emitOpError("prop_names and prop_values must have the same count, but has ")
                << getPropNames().size() << " names and " << getPropValues().size() << " values";
+    }
+
+    return success();
+}
+
+LogicalResult Merge::verify() {
+    const LogicalResult pattern = verifyMergePattern(getOperation(),
+                                                     getNodeLabels(),
+                                                     getNodePropNames(),
+                                                     getEdgeTypes(),
+                                                     getEdgePropNames(),
+                                                     getEdgeDirectionsAttr(),
+                                                     getPendingNodesAttr(),
+                                                     getBoundNodes().size(),
+                                                     getBoundPending().size(),
+                                                     getNodePropValues().size(),
+                                                     getEdgePropValues().size());
+    if (failed(pattern)) {
+        return pattern;
+    }
+
+    const size_t expectedResults = mergeResultCount(getNodeLabels(), getCarriedColumns().size());
+    if (getResults().size() != expectedResults) {
+        return emitOpError("must produce one column per chain entity, the created mask and one "
+                           "per carried column - ")
+               << expectedResults << " in all, but produces " << getResults().size();
     }
 
     return success();

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1651,12 +1651,16 @@ def DeleteNode : TuringOp<"delete_node"> {
     `detach` carries the DETACH keyword
 
       db.delete_node(%n) detach : (!db.column<!storage.node_id>) -> ()
+
+    `pending` is the mask a db.merge produced beside its node column: those rows
+    hold an offset into the change's write buffer rather than an ID the graph
+    knows, so the change drops the write instead of tombstoning an ID.
   }];
 
-  let arguments = (ins Column:$input_nodes, UnitAttr:$detach);
+  let arguments = (ins Column:$input_nodes, UnitAttr:$detach, Optional<Column>:$pending);
 
   let assemblyFormat = [{
-    `(` $input_nodes `)` (`detach` $detach^)? attr-dict `:`
+    `(` $input_nodes `)` (`detach` $detach^)? (`pending` $pending^)? attr-dict `:`
     functional-type(operands, results)
   }];
 }
@@ -1666,12 +1670,14 @@ def DeleteEdge : TuringOp<"delete_edge"> {
 
   let description = [{
       db.delete_edge(%e) : (!db.column<!storage.edge_id>) -> ()
+
+    `pending` is delete_node's mask, over edges.
   }];
 
-  let arguments = (ins Column:$input_edges);
+  let arguments = (ins Column:$input_edges, Optional<Column>:$pending);
 
   let assemblyFormat = [{
-    `(` $input_edges `)` attr-dict `:` functional-type(operands, results)
+    `(` $input_edges `)` (`pending` $pending^)? attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -631,8 +631,9 @@ def GetNodeProperties : TuringOp<"get_node_properties", [Pure]> {
 
     `pending`, when present, is the mask a db.merge produced beside its node
     column: those rows hold an offset into the change's write buffer rather than
-    an ID the graph knows, so their value reads null instead of whatever node the
-    offset would collide with.
+    an ID the graph knows, so their value is read out of that buffer instead of off
+    whatever node the offset would collide with - null there when the write set the
+    property on none of them.
 
       %v = db.get_node_properties(%n, "age") pending %mask
              : (!db.column<!storage.node_id>, !db.column<!storage.bool>) -> !db.column<none>
@@ -673,7 +674,7 @@ def GetEdgeProperties : TuringOp<"get_edge_properties", [Pure]> {
     property's value type is only resolved against the schema during lowering.
 
     `pending` is get_node_properties' mask, over edges: a row a db.merge wrote
-    holds a write-buffer offset, and its value reads null.
+    holds a write-buffer offset, and its value is read out of the write buffer.
   }];
 
   let arguments = (ins Column:$input_edges, StrAttr:$property, Optional<Column>:$pending);

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -628,20 +628,27 @@ def GetNodeProperties : TuringOp<"get_node_properties", [Pure]> {
     node is dropped - the lowering uses the with-null property fetch. One op
     reads one property; `RETURN a.name, a.age` is two ops sharing %a. Reading a
     property is a deterministic read of the graph, so the op is Pure.
+
+    `pending`, when present, is the mask a db.merge produced beside its node
+    column: those rows hold an offset into the change's write buffer rather than
+    an ID the graph knows, so their value reads null instead of whatever node the
+    offset would collide with.
+
+      %v = db.get_node_properties(%n, "age") pending %mask
+             : (!db.column<!storage.node_id>, !db.column<!storage.bool>) -> !db.column<none>
   }];
 
   // `property` is the symbolic property name, the same `name`/`age` spelled in
   // the query. Being an attribute and not an SSA value, it is absent from
   // `operands` below; lowering resolves it to a storage PropertyTypeID.
-  let arguments = (ins Column:$input_nodes, StrAttr:$property);
+  let arguments = (ins Column:$input_nodes, StrAttr:$property, Optional<Column>:$pending);
   let results   = (outs Column:$result);
 
-  // One operand and one result, so functional-type(operands, results) prints the
-  // `(!db.column<...>) -> !db.column<...>` form, as get_out_edges does; the
-  // string attribute prints inside the parens, ahead of the colon, and MLIR
-  // elides it from attr-dict because the format already names it.
+  // The string attribute prints inside the parens, ahead of the colon, and MLIR
+  // elides it from attr-dict because the format already names it. The optional
+  // mask prints after a `pending` keyword, which anchors its group.
   let assemblyFormat = [{
-    `(` $input_nodes `,` $property `)` attr-dict `:`
+    `(` $input_nodes `,` $property `)` (`pending` $pending^)? attr-dict `:`
     functional-type(operands, results)
   }];
 }
@@ -664,13 +671,16 @@ def GetEdgeProperties : TuringOp<"get_edge_properties", [Pure]> {
     op chosen (get_node_properties vs get_edge_properties) selects which side of
     the graph the property is read from. The value column is left typed none: the
     property's value type is only resolved against the schema during lowering.
+
+    `pending` is get_node_properties' mask, over edges: a row a db.merge wrote
+    holds a write-buffer offset, and its value reads null.
   }];
 
-  let arguments = (ins Column:$input_edges, StrAttr:$property);
+  let arguments = (ins Column:$input_edges, StrAttr:$property, Optional<Column>:$pending);
   let results   = (outs Column:$result);
 
   let assemblyFormat = [{
-    `(` $input_edges `,` $property `)` attr-dict `:`
+    `(` $input_edges `,` $property `)` (`pending` $pending^)? attr-dict `:`
     functional-type(operands, results)
   }];
 }
@@ -1458,7 +1468,7 @@ def CreateNode : TuringOp<"create_node", [AttrSizedOperandSegments]> {
   }];
 }
 
-def CreateEdge : TuringOp<"create_edge"> {
+def CreateEdge : TuringOp<"create_edge", [AttrSizedOperandSegments]> {
   let summary = "Create one edge per input row between corresponding source and target nodes";
 
   let description = [{
@@ -1481,17 +1491,104 @@ def CreateEdge : TuringOp<"create_edge"> {
                        Column:$tgt_ids,
                        StrAttr:$edge_type,
                        StrArrayAttr:$prop_names,
-                       Variadic<Column>:$prop_values);
+                       Variadic<Column>:$prop_values,
+                       Optional<Column>:$src_pending,
+                       Optional<Column>:$tgt_pending);
   let results   = (outs ColumnEdgeIDs:$result);
   let hasVerifier = 1;
 
+  // The two optional masks say, row by row, which endpoints are entities this change
+  // wrote and has not committed - what a db.merge's node column mixes. A column a
+  // db.create_node produced is pending in every row and carries no mask; one a scan or a
+  // traversal bound is pending in none and carries none either.
   let assemblyFormat = [{
-    `(` $src_ids `,` $tgt_ids `,` $edge_type `,` $prop_names `,` `{` $prop_values `}` `)` attr-dict `:`
+    `(` $src_ids `,` $tgt_ids `,` $edge_type `,` $prop_names `,` `{` $prop_values `}` `)`
+    (`src_pending` $src_pending^)? (`tgt_pending` $tgt_pending^)? attr-dict `:`
     functional-type(operands, results)
   }];
 }
 
-def SetNodeProperty : TuringOp<"set_node_property"> {
+def Merge : TuringOp<"merge", [AttrSizedOperandSegments]> {
+  let summary = "Bind one MERGE path pattern per input row, writing it when the graph does not hold it";
+
+  let description = [{
+    The declarative counterpart of Cypher's MERGE. The pattern is one path - a chain
+    of nodes joined by hops - and it is matched and written as a unit: for each input
+    row the op looks the whole chain up, emits one row per match it finds, and only
+    when it finds none writes the entities the pattern does not already have bound
+    and emits that one row. That whole-pattern rule is what keeps MERGE from being a
+    sequence of per-entity merges: `MERGE (a:P {n: 1})-[:K]->(b:P {n: 2})` writes a
+    fresh `a` and `b` when no such hop exists, even when nodes matching each end do.
+
+    The chain is spelled out by the attributes, one entry per entity in pattern order:
+
+      %n, %n_pending, %created = db.merge nodes [["Person"]] props [["name"]]
+                                         edges [] props [] dirs []
+                                         bound {} pending {} values {%name} {} carrying {}
+        : (!db.column<!storage.string>)
+          -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+
+    `node_labels` carries each chain node's label set. An empty one marks a node the
+    query already bound - `MATCH (a) MERGE (a)-[:K]->(b:Bot)` - whose column comes in
+    through `bound_nodes` instead, in chain order; every other node is matched by its
+    labels (a superset match, as db.scan_nodes_by_label) and its `node_prop_names`
+    values, and written with exactly those when the pattern is missing. A node the
+    op writes needs a label, so a node with neither labels nor a bound column is
+    rejected.
+
+    `bound_pending` is empty, or holds one boolean column per bound node saying which
+    of its rows are entities this change has written but not committed - what an
+    earlier db.merge or db.create_node produced. Such a row is in no graph the match
+    reads, so the pattern under it can never be found and is written instead.
+
+    `edge_types`, `edge_prop_names` and `edge_directions` carry one entry per hop,
+    each hop joining the chain node ahead of it to the one behind. A hop's direction
+    is read from the query; `undirected` matches a hop either way round and writes a
+    forward one.
+
+    The results pair each chain entity with a boolean mask, nodes in chain order then
+    hops: the entity's ID column, then the rows of it that are pending - written by this
+    change and not committed, so an offset into the write buffer rather than an ID the
+    graph holds. A bound node's mask is the one it came in under, re-indexed; every
+    other entity's says whether this row wrote it or bound one an earlier merge wrote.
+    After those pairs comes the boolean column saying which rows the op wrote the whole
+    pattern for - what ON CREATE and ON MATCH select on - then the carry set.
+    `carried_columns` mirrors db.get_out_edges': the columns in flight, handed back
+    re-indexed onto the rows the merge emitted, so a row the op emitted twice repeats
+    them and one it emitted nothing for drops them.
+  }];
+
+  let arguments = (ins StrArrayArrayAttr:$node_labels,
+                       StrArrayArrayAttr:$node_prop_names,
+                       StrArrayAttr:$edge_types,
+                       StrArrayArrayAttr:$edge_prop_names,
+                       DenseI64ArrayAttr:$edge_directions,
+                       DenseI64ArrayAttr:$pending_nodes,
+                       Variadic<Column>:$bound_nodes,
+                       Variadic<Column>:$bound_pending,
+                       Variadic<Column>:$node_prop_values,
+                       Variadic<Column>:$edge_prop_values,
+                       Variadic<Column>:$carried_columns);
+
+  let results = (outs Variadic<Column>:$results);
+
+  let hasVerifier = 1;
+
+  // The five attribute lists print ahead of the operands, each under the keyword
+  // naming what it describes, so a chain reads left to right. The directions go
+  // through the shared custom directive so they print as keywords rather than as
+  // the raw integers the DenseI64ArrayAttr stores.
+  let assemblyFormat = [{
+    `nodes` $node_labels `props` $node_prop_names
+    `edges` $edge_types `props` $edge_prop_names `dirs` custom<EdgeDirections>($edge_directions)
+    `bound` `{` $bound_nodes `}` `pending` custom<ColumnIndices>($pending_nodes) `{` $bound_pending `}`
+    `values` `{` $node_prop_values `}` `{` $edge_prop_values `}`
+    `carrying` `{` $carried_columns `}`
+    attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def SetNodeProperty : TuringOp<"set_node_property", [AttrSizedOperandSegments]> {
   let summary = "Set one named property on each input node to a row-aligned value";
 
   let description = [{
@@ -1503,17 +1600,25 @@ def SetNodeProperty : TuringOp<"set_node_property"> {
     Node variable keeps its existing column.
   }];
 
-  let arguments = (ins Column:$input_nodes, StrAttr:$property, Column:$value);
+  let arguments = (ins Column:$input_nodes,
+                       StrAttr:$property,
+                       Column:$value,
+                       Optional<Column>:$pending,
+                       Optional<Column>:$rows);
 
+  // `pending` says, row by row, which entities this change wrote and has not committed -
+  // those are written in the write buffer rather than recorded as an update to a
+  // committed entity. `rows` narrows which rows are written at all: Cypher's ON CREATE
+  // passes the merge's created mask, ON MATCH its negation, and a plain SET passes none.
   let assemblyFormat = [{
-    `(` $input_nodes `,` $property `,` $value `)` attr-dict `:`
-    functional-type(operands, results)
+    `(` $input_nodes `,` $property `,` $value `)` (`pending` $pending^)? (`rows` $rows^)?
+    attr-dict `:` functional-type(operands, results)
   }];
 
   let hasVerifier = 1;
 }
 
-def SetEdgeProperty : TuringOp<"set_edge_property"> {
+def SetEdgeProperty : TuringOp<"set_edge_property", [AttrSizedOperandSegments]> {
   let summary = "Set one named property on each input edge to a row-aligned value";
 
   let description = [{
@@ -1523,11 +1628,15 @@ def SetEdgeProperty : TuringOp<"set_edge_property"> {
     Edge variable keeps its existing column.
   }];
 
-  let arguments = (ins Column:$input_edges, StrAttr:$property, Column:$value);
+  let arguments = (ins Column:$input_edges,
+                       StrAttr:$property,
+                       Column:$value,
+                       Optional<Column>:$pending,
+                       Optional<Column>:$rows);
 
   let assemblyFormat = [{
-    `(` $input_edges `,` $property `,` $value `)` attr-dict `:`
-    functional-type(operands, results)
+    `(` $input_edges `,` $property `,` $value `)` (`pending` $pending^)? (`rows` $rows^)?
+    attr-dict `:` functional-type(operands, results)
   }];
 
   let hasVerifier = 1;

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1546,13 +1546,14 @@ def Merge : TuringOp<"merge", [AttrSizedOperandSegments]> {
     is read from the query; `undirected` matches a hop either way round and writes a
     forward one.
 
-    The results pair each chain entity with a boolean mask, nodes in chain order then
-    hops: the entity's ID column, then the rows of it that are pending - written by this
-    change and not committed, so an offset into the write buffer rather than an ID the
-    graph holds. A bound node's mask is the one it came in under, re-indexed; every
-    other entity's says whether this row wrote it or bound one an earlier merge wrote.
-    After those pairs comes the boolean column saying which rows the op wrote the whole
-    pattern for - what ON CREATE and ON MATCH select on - then the carry set.
+    The results pair each entity the op looks up with a boolean mask, nodes in chain
+    order then hops: the entity's ID column, then the rows of it that are pending -
+    written by this change and not committed, so an offset into the write buffer rather
+    than an ID the graph holds. A bound node has no pair of its own: its rows came in
+    through `bound_nodes` and come back through the carry set, re-indexed like every
+    other column in flight. After those pairs comes the boolean column saying which rows
+    the op wrote the whole pattern for - what ON CREATE and ON MATCH select on - then the
+    carry set.
     `carried_columns` mirrors db.get_out_edges': the columns in flight, handed back
     re-indexed onto the rows the merge emitted, so a row the op emitted twice repeats
     them and one it emitted nothing for drops them.

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1651,6 +1651,20 @@ bool matchPropertyRead(Operation* op, StringAttr& property, bool& nodeProperty) 
     return false;
 }
 
+bool matchPropertyWrite(Operation* op, StringAttr& property, bool& nodeProperty) {
+    if (SetNodeProperty write = dyn_cast<SetNodeProperty>(op)) {
+        property = write.getPropertyAttr();
+        nodeProperty = true;
+        return true;
+    } else if (SetEdgeProperty write = dyn_cast<SetEdgeProperty>(op)) {
+        property = write.getPropertyAttr();
+        nodeProperty = false;
+        return true;
+    }
+
+    return false;
+}
+
 // Widens an op's carry set by one column and hands back the result it comes out as. A carry
 // set is the trailing operands and the trailing results of the op holding it, so the column
 // appends to both; an op's arity is fixed once built, hence the rebuild.
@@ -1732,9 +1746,20 @@ struct ReusePropertyReads : public impl::ReusePropertyReadsBase<ReusePropertyRea
         Operation* const root = getOperation();
 
         llvm::SmallVector<Operation*> reads;
+        llvm::DenseSet<Attribute> writtenNodeProperties;
+        llvm::DenseSet<Attribute> writtenEdgeProperties;
         root->walk([&](Operation* op) {
+            StringAttr writtenProperty;
+            bool writesNodes = false;
+
             if (isa<GetNodeProperties, GetEdgeProperties>(op)) {
                 reads.push_back(op);
+            } else if (matchPropertyWrite(op, writtenProperty, writesNodes)) {
+                if (writesNodes) {
+                    writtenNodeProperties.insert(writtenProperty);
+                } else {
+                    writtenEdgeProperties.insert(writtenProperty);
+                }
             }
         });
 
@@ -1744,6 +1769,13 @@ struct ReusePropertyReads : public impl::ReusePropertyReadsBase<ReusePropertyRea
             bool nodeProperty = false;
             const bool isPropertyRead = matchPropertyRead(read, property, nodeProperty);
             bioassert(isPropertyRead, "A collected op is a property read");
+
+            // A read standing before this one saw what the property held before the write,
+            // and a projection behind a SET reads what the statement wrote
+            const llvm::DenseSet<Attribute>& written = nodeProperty ? writtenNodeProperties : writtenEdgeProperties;
+            if (written.contains(property)) {
+                continue;
+            }
 
             const Value reused = propertyColumnOf(read->getOperand(0), property, nodeProperty, read, builder);
             if (!reused) {

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -9,6 +9,8 @@
 #include "IRLiteralList.h"
 #include "StorageEnums.h"
 #include "ColumnIndicesFormat.h"
+#include "EdgeDirectionsFormat.h"
+#include "MergePatternShape.h"
 #include "GroupAggregateKindsFormat.h"
 #include "PropertyScanLiteral.h"
 
@@ -678,6 +680,32 @@ LogicalResult CreateEdge::verify() {
     if (getPropNames().size() != getPropValues().size()) {
         return emitOpError("prop_names and prop_values must have the same count, but has ")
                << getPropNames().size() << " names and " << getPropValues().size() << " values";
+    }
+
+    return success();
+}
+
+LogicalResult Merge::verify() {
+    const LogicalResult pattern = verifyMergePattern(getOperation(),
+                                                     getNodeLabels(),
+                                                     getNodePropNames(),
+                                                     getEdgeTypes(),
+                                                     getEdgePropNames(),
+                                                     getEdgeDirectionsAttr(),
+                                                     getPendingNodesAttr(),
+                                                     getBoundNodes().size(),
+                                                     getBoundPending().size(),
+                                                     getNodePropValues().size(),
+                                                     getEdgePropValues().size());
+    if (failed(pattern)) {
+        return pattern;
+    }
+
+    const size_t expectedResults = mergeResultCount(getNodeLabels(), getCarriedColumns().size());
+    if (getResults().size() != expectedResults) {
+        return emitOpError("must produce one chunk per chain entity, the created mask and one "
+                           "per carried chunk - ")
+               << expectedResults << " in all, but produces " << getResults().size();
     }
 
     return success();

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -2157,10 +2157,13 @@ def DeleteNode : NLOp<"delete_node"> {
       }
   }];
 
-  let arguments = (ins NLNodeIDChunk:$input_nodes, UnitAttr:$detach);
+  // `pending` is the mask an nl.merge produced beside its node chunk: such a row names
+  // a node this change wrote and has not committed, which is dropped from the write
+  // buffer rather than tombstoned by an ID the graph does not hold.
+  let arguments = (ins NLNodeIDChunk:$input_nodes, UnitAttr:$detach, Optional<NLBoolChunk>:$pending);
 
   let assemblyFormat = [{
-    $input_nodes (`detach` $detach^)? attr-dict
+    $input_nodes (`detach` $detach^)? (`pending` $pending^)? attr-dict
   }];
 }
 
@@ -2172,10 +2175,10 @@ def DeleteEdge : NLOp<"delete_edge"> {
       }
   }];
 
-  let arguments = (ins NLEdgeIDChunk:$input_edges);
+  let arguments = (ins NLEdgeIDChunk:$input_edges, Optional<NLBoolChunk>:$pending);
 
   let assemblyFormat = [{
-    $input_edges attr-dict
+    $input_edges (`pending` $pending^)? attr-dict
   }];
 }
 

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -507,13 +507,19 @@ def GetNodeProperties : NLOp<"get_node_properties", [Pure, RowAlignedThroughOper
       }
   }];
 
-  // The node chunk and the property handle are both buildable, so their types
-  // are omitted; only the nullable value chunk type is spelled, after the colon.
-  let arguments = (ins NLNodeIDChunk:$input_nodes, NLPropertyTypeHandle:$property_type);
+  // The node chunk, the property handle and the optional pending mask are all
+  // buildable, so their types are omitted; only the nullable value chunk type is
+  // spelled, after the colon. `pending` is the mask an nl.merge produced beside its
+  // node chunk: such a row holds a write-buffer offset rather than an ID the graph
+  // knows, so its value reads null instead of the node the offset collides with.
+  let arguments = (ins NLNodeIDChunk:$input_nodes,
+                       NLPropertyTypeHandle:$property_type,
+                       Optional<NLBoolChunk>:$pending);
   let results   = (outs NLChunk:$values);
 
   let assemblyFormat = [{
-    `(` $input_nodes `,` $property_type `)` attr-dict `:` qualified(type($values))
+    `(` $input_nodes `,` $property_type `)` (`pending` $pending^)? attr-dict `:`
+    qualified(type($values))
   }];
 }
 
@@ -528,11 +534,14 @@ def GetEdgeProperties : NLOp<"get_edge_properties", [Pure, RowAlignedThroughOper
     It opens no loop and yields a nullable value chunk, one value per input edge.
   }];
 
-  let arguments = (ins NLEdgeIDChunk:$input_edges, NLPropertyTypeHandle:$property_type);
+  let arguments = (ins NLEdgeIDChunk:$input_edges,
+                       NLPropertyTypeHandle:$property_type,
+                       Optional<NLBoolChunk>:$pending);
   let results   = (outs NLChunk:$values);
 
   let assemblyFormat = [{
-    `(` $input_edges `,` $property_type `)` attr-dict `:` qualified(type($values))
+    `(` $input_edges `,` $property_type `)` (`pending` $pending^)? attr-dict `:`
+    qualified(type($values))
   }];
 }
 
@@ -2003,7 +2012,7 @@ def CreateNode : NLOp<"create_node", [AttrSizedOperandSegments]> {
   }];
 }
 
-def CreateEdge : NLOp<"create_edge"> {
+def CreateEdge : NLOp<"create_edge", [AttrSizedOperandSegments]> {
   let summary = "Write one edge per input row into the open transaction's write buffer";
   let description = [{
     Adds one pending edge per row to the transaction's CommitWriteBuffer.
@@ -2019,17 +2028,81 @@ def CreateEdge : NLOp<"create_edge"> {
                        NLNodeIDChunk:$tgt_ids,
                        StrAttr:$edge_type,
                        StrArrayAttr:$prop_names,
-                       Variadic<NLChunk>:$prop_values);
+                       Variadic<NLChunk>:$prop_values,
+                       Optional<NLBoolChunk>:$src_pending,
+                       Optional<NLBoolChunk>:$tgt_pending);
   let results   = (outs NLEdgeIDChunk:$result);
   let hasVerifier = 1;
 
+  // The two optional masks say, row by row, which endpoints are nodes this change wrote
+  // and has not committed - what an nl.merge's node chunk mixes. A chunk an
+  // nl.create_node produced is pending in every row and carries no mask.
   let assemblyFormat = [{
-    $src_ids `,` $tgt_ids `,` $edge_type `,` $prop_names `,` `{` $prop_values `}` attr-dict
+    $src_ids `,` $tgt_ids `,` $edge_type `,` $prop_names `,` `{` $prop_values `}`
+    (`src_pending` $src_pending^)? (`tgt_pending` $tgt_pending^)? attr-dict
     ( `:` qualified(type($prop_values))^ )?
   }];
 }
 
-def SetNodeProperty : NLOp<"set_node_property"> {
+def Merge : NLOp<"merge", [AttrSizedOperandSegments]> {
+  let summary = "Look one MERGE path pattern up per row of the input chunks, writing it when the graph does not hold it";
+
+  let description = [{
+    Imperative counterpart of db.merge, and the one op of the family that both reads
+    the graph and writes the transaction's CommitWriteBuffer. For each row of its
+    input chunks it looks the whole chain up - candidate nodes by label and property
+    value, then each hop by type and property value - and fills its result chunks
+    with one row per match. A row that matches nothing has the entities the pattern
+    does not already bind written as pending nodes and edges, and contributes the one
+    row those make.
+
+      nl.for %names in %unwind {
+        %n, %n_pending, %created = nl.merge nodes [["Person"]] props [["name"]]
+                                           edges [] props [] dirs []
+                                           bound {} pending {} values {%names} {} carrying {}
+          : (!nl.chunk<!storage.string>)
+            -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>, !nl.chunk<!storage.bool>)
+      }
+
+    The results grow or shrink the row count, the way nl.cross_product does: a row
+    matched twice is emitted twice and the carry set is gathered onto the emitted
+    rows, so every result chunk of one step holds the same rows.
+
+    A node chunk the op produces mixes node IDs the graph holds with offsets into the
+    write buffer, and the mask beside it says which rows are which - the same mask a
+    following nl.set_node_property or nl.merge reads to know how to resolve a row.
+    The graph the match reads is the commit the change sits on, so a pattern this
+    query wrote is invisible to it; what the op wrote itself it does remember, so
+    merging the same node twice in one query writes it once.
+  }];
+
+  let arguments = (ins StrArrayArrayAttr:$node_labels,
+                       StrArrayArrayAttr:$node_prop_names,
+                       StrArrayAttr:$edge_types,
+                       StrArrayArrayAttr:$edge_prop_names,
+                       DenseI64ArrayAttr:$edge_directions,
+                       DenseI64ArrayAttr:$pending_nodes,
+                       Variadic<NLChunk>:$bound_nodes,
+                       Variadic<NLChunk>:$bound_pending,
+                       Variadic<NLChunk>:$node_prop_values,
+                       Variadic<NLChunk>:$edge_prop_values,
+                       Variadic<NLChunk>:$carried_columns);
+
+  let results = (outs Variadic<NLChunk>:$results);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `nodes` $node_labels `props` $node_prop_names
+    `edges` $edge_types `props` $edge_prop_names `dirs` custom<EdgeDirections>($edge_directions)
+    `bound` `{` $bound_nodes `}` `pending` custom<ColumnIndices>($pending_nodes) `{` $bound_pending `}`
+    `values` `{` $node_prop_values `}` `{` $edge_prop_values `}`
+    `carrying` `{` $carried_columns `}`
+    attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def SetNodeProperty : NLOp<"set_node_property", [AttrSizedOperandSegments]> {
   let summary = "Update one named property per input node in the open transaction's write buffer";
   let description = [{
       nl.for %nodes in %scan {
@@ -2037,16 +2110,21 @@ def SetNodeProperty : NLOp<"set_node_property"> {
       }
   }];
 
-  let arguments = (ins NLNodeIDChunk:$input_nodes, StrAttr:$property, NLChunk:$value);
+  let arguments = (ins NLNodeIDChunk:$input_nodes,
+                       StrAttr:$property,
+                       NLChunk:$value,
+                       Optional<NLBoolChunk>:$pending,
+                       Optional<NLBoolChunk>:$rows);
 
   let assemblyFormat = [{
-    $input_nodes `,` $property `,` $value attr-dict `:` qualified(type($value))
+    $input_nodes `,` $property `,` $value (`pending` $pending^)? (`rows` $rows^)?
+    attr-dict `:` qualified(type($value))
   }];
 
   let hasVerifier = 1;
 }
 
-def SetEdgeProperty : NLOp<"set_edge_property"> {
+def SetEdgeProperty : NLOp<"set_edge_property", [AttrSizedOperandSegments]> {
   let summary = "Update one named property per input edge in the open transaction's write buffer";
   let description = [{
       nl.for %s, %e, %t in %edges {
@@ -2054,10 +2132,15 @@ def SetEdgeProperty : NLOp<"set_edge_property"> {
       }
   }];
 
-  let arguments = (ins NLEdgeIDChunk:$input_edges, StrAttr:$property, NLChunk:$value);
+  let arguments = (ins NLEdgeIDChunk:$input_edges,
+                       StrAttr:$property,
+                       NLChunk:$value,
+                       Optional<NLBoolChunk>:$pending,
+                       Optional<NLBoolChunk>:$rows);
 
   let assemblyFormat = [{
-    $input_edges `,` $property `,` $value attr-dict `:` qualified(type($value))
+    $input_edges `,` $property `,` $value (`pending` $pending^)? (`rows` $rows^)?
+    attr-dict `:` qualified(type($value))
   }];
 
   let hasVerifier = 1;

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -511,7 +511,8 @@ def GetNodeProperties : NLOp<"get_node_properties", [Pure, RowAlignedThroughOper
   // buildable, so their types are omitted; only the nullable value chunk type is
   // spelled, after the colon. `pending` is the mask an nl.merge produced beside its
   // node chunk: such a row holds a write-buffer offset rather than an ID the graph
-  // knows, so its value reads null instead of the node the offset collides with.
+  // knows, so its value is read out of the write buffer rather than off the node the
+  // offset collides with - null there when the write set the property on none.
   let arguments = (ins NLNodeIDChunk:$input_nodes,
                        NLPropertyTypeHandle:$property_type,
                        Optional<NLBoolChunk>:$pending);

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -2070,7 +2070,9 @@ def Merge : NLOp<"merge", [AttrSizedOperandSegments]> {
 
     A node chunk the op produces mixes node IDs the graph holds with offsets into the
     write buffer, and the mask beside it says which rows are which - the same mask a
-    following nl.set_node_property or nl.merge reads to know how to resolve a row.
+    following nl.set_node_property or nl.merge reads to know how to resolve a row. A
+    bound node has no chunk of its own: it came in through `bound_nodes` and comes back
+    through the carry set, gathered onto the emitted rows like every other chunk.
     The graph the match reads is the commit the change sits on, so a pattern this
     query wrote is invisible to it; what the op wrote itself it does remember, so
     merging the same node twice in one query writes it once.

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -222,6 +222,16 @@ def NLEdgeIDChunk : Type<
     BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
                   "::mlir::storage::EdgeIDType::get($_builder.getContext()))">;
 
+// The mask sibling of NLNodeIDChunk: constrains an operand to
+// !nl.chunk<!storage.bool> - a row-by-row flag beside another chunk, as nl.merge's
+// pending masks are - and carries the recipe that lets a format omit its type.
+def NLBoolChunk : Type<
+        CPred<"::llvm::isa<::mlir::nl::ChunkType>($_self) && "
+              "::llvm::isa<::mlir::storage::BoolType>(::llvm::cast<::mlir::nl::ChunkType>($_self).getElementType())">,
+        "chunk of booleans", "::mlir::nl::ChunkType">,
+    BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
+                  "::mlir::storage::BoolType::get($_builder.getContext()))">;
+
 def NLLabelSetIDChunk : Type<
         CPred<"::llvm::isa<::mlir::nl::ChunkType>($_self) && "
               "::llvm::isa<::mlir::storage::LabelSetIDType>(::llvm::cast<::mlir::nl::ChunkType>($_self).getElementType())">,

--- a/query/ir/dialect/storage/CMakeLists.txt
+++ b/query/ir/dialect/storage/CMakeLists.txt
@@ -23,6 +23,8 @@ add_mlir_library(turing_db_ir_storagedialect_s
   StorageDialect.cpp
   StorageTypes.cpp
   GroupAggregateKindsFormat.cpp
+  EdgeDirectionsFormat.cpp
+  MergePatternShape.cpp
   ColumnIndicesFormat.cpp
   PropertyScanLiteral.cpp
 

--- a/query/ir/dialect/storage/EdgeDirectionsFormat.cpp
+++ b/query/ir/dialect/storage/EdgeDirectionsFormat.cpp
@@ -1,0 +1,60 @@
+#include "EdgeDirectionsFormat.h"
+
+#include <optional>
+#include <stdint.h>
+
+#include "mlir/IR/Builders.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "StorageEnums.h"
+
+using namespace mlir;
+
+namespace storage = mlir::storage;
+
+ParseResult mlir::parseEdgeDirections(OpAsmParser& parser, DenseI64ArrayAttr& directions) {
+    llvm::SmallVector<int64_t> values;
+
+    const auto parseDirection = [&]() -> ParseResult {
+        llvm::StringRef keyword;
+        if (parser.parseKeyword(&keyword)) {
+            return failure();
+        }
+
+        const std::optional<storage::EdgeDirection> direction = storage::symbolizeEdgeDirection(keyword);
+        if (!direction) {
+            return parser.emitError(parser.getCurrentLocation()) << "unknown edge direction '" << keyword << "'";
+        }
+
+        values.push_back(static_cast<int64_t>(*direction));
+        return success();
+    };
+
+    if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Square, parseDirection)) {
+        return failure();
+    }
+
+    directions = parser.getBuilder().getDenseI64ArrayAttr(values);
+    return success();
+}
+
+void mlir::printEdgeDirections(OpAsmPrinter& printer, Operation* op, DenseI64ArrayAttr directions) {
+    printer << "[";
+
+    llvm::interleaveComma(directions.asArrayRef(), printer, [&](int64_t raw) {
+        const std::optional<storage::EdgeDirection> direction = storage::symbolizeEdgeDirection(static_cast<uint64_t>(raw));
+
+        // A verified op only ever carries valid directions, but the printer can run on
+        // in-flight IR, so fall back to the raw integer rather than dereferencing a
+        // null optional.
+        if (direction) {
+            printer << storage::stringifyEdgeDirection(*direction);
+        } else {
+            printer << raw;
+        }
+    });
+
+    printer << "]";
+}

--- a/query/ir/dialect/storage/EdgeDirectionsFormat.h
+++ b/query/ir/dialect/storage/EdgeDirectionsFormat.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace mlir {
+
+// Custom assembly-format directive shared by db.merge and nl.merge for the per-hop
+// direction list of a MERGE pattern. It prints and parses the list as EdgeDirection
+// keywords - `[forward, undirected]` rather than the raw `[2, 0]` - while the ops
+// store it as a compact DenseI64ArrayAttr, the way the aggregate kinds are stored.
+ParseResult parseEdgeDirections(OpAsmParser& parser, DenseI64ArrayAttr& directions);
+
+void printEdgeDirections(OpAsmPrinter& printer, Operation* op, DenseI64ArrayAttr directions);
+
+}

--- a/query/ir/dialect/storage/MergePatternShape.cpp
+++ b/query/ir/dialect/storage/MergePatternShape.cpp
@@ -1,0 +1,134 @@
+#include "MergePatternShape.h"
+
+#include <optional>
+#include <stdint.h>
+
+#include "mlir/IR/Operation.h"
+
+#include "StorageEnums.h"
+
+using namespace mlir;
+
+namespace storage = mlir::storage;
+
+LogicalResult mlir::verifyMergePattern(Operation* op,
+                                       ArrayAttr nodeLabels,
+                                       ArrayAttr nodePropNames,
+                                       ArrayAttr edgeTypes,
+                                       ArrayAttr edgePropNames,
+                                       DenseI64ArrayAttr edgeDirections,
+                                       DenseI64ArrayAttr pendingNodes,
+                                       size_t boundNodes,
+                                       size_t boundPending,
+                                       size_t nodePropValues,
+                                       size_t edgePropValues) {
+    const size_t nodeCount = nodeLabels.size();
+    if (nodeCount == 0) {
+        return op->emitOpError("requires at least one chain node");
+    }
+
+    if (nodePropNames.size() != nodeCount) {
+        return op->emitOpError("props must give one name list per chain node, but has ")
+               << nodePropNames.size() << " lists for " << nodeCount << " nodes";
+    }
+
+    const size_t hopCount = nodeCount - 1;
+    if (edgeTypes.size() != hopCount) {
+        return op->emitOpError("edges must give one type per hop, but has ")
+               << edgeTypes.size() << " types for " << hopCount << " hops";
+    }
+
+    if (edgePropNames.size() != hopCount) {
+        return op->emitOpError("props must give one name list per hop, but has ")
+               << edgePropNames.size() << " lists for " << hopCount << " hops";
+    }
+
+    if (edgeDirections.size() != static_cast<int64_t>(hopCount)) {
+        return op->emitOpError("dirs must give one direction per hop, but has ")
+               << edgeDirections.size() << " directions for " << hopCount << " hops";
+    }
+
+    for (const int64_t raw : edgeDirections.asArrayRef()) {
+        if (!storage::symbolizeEdgeDirection(static_cast<uint64_t>(raw))) {
+            return op->emitOpError("carries an unknown edge direction ") << raw;
+        }
+    }
+
+    size_t expectedBound = 0;
+    size_t expectedNodeValues = 0;
+    for (size_t node = 0; node < nodeCount; node++) {
+        const size_t labels = cast<ArrayAttr>(nodeLabels[node]).size();
+        const size_t props = cast<ArrayAttr>(nodePropNames[node]).size();
+
+        if (labels == 0) {
+            expectedBound++;
+
+            if (props != 0) {
+                return op->emitOpError("chain node ") << node << " is bound, so it cannot carry "
+                       << props << " property names";
+            }
+        }
+
+        expectedNodeValues += props;
+    }
+
+    if (boundNodes != expectedBound) {
+        return op->emitOpError("bound must give one column per bound chain node, but has ")
+               << boundNodes << " columns for " << expectedBound << " bound nodes";
+    }
+
+    if (pendingNodes.size() != static_cast<int64_t>(boundPending)) {
+        return op->emitOpError("pending must name the chain node of each of its masks, but has ")
+               << pendingNodes.size() << " names for " << boundPending << " masks";
+    }
+
+    int64_t previousPendingNode = -1;
+    for (const int64_t pendingNode : pendingNodes.asArrayRef()) {
+        if (pendingNode <= previousPendingNode) {
+            return op->emitOpError("pending must name its chain nodes in increasing order, but "
+                                   "names ")
+                   << pendingNode << " after " << previousPendingNode;
+        }
+
+        if (pendingNode >= static_cast<int64_t>(nodeCount)) {
+            return op->emitOpError("pending names chain node ") << pendingNode
+                   << ", past the " << nodeCount << " the pattern has";
+        }
+
+        if (!cast<ArrayAttr>(nodeLabels[pendingNode]).empty()) {
+            return op->emitOpError("pending names chain node ") << pendingNode
+                   << ", which is not bound and so has no rows to be pending";
+        }
+
+        previousPendingNode = pendingNode;
+    }
+
+    if (nodePropValues != expectedNodeValues) {
+        return op->emitOpError("values must give one node column per property name, but has ")
+               << nodePropValues << " columns for " << expectedNodeValues << " names";
+    }
+
+    size_t expectedEdgeValues = 0;
+    for (size_t hop = 0; hop < hopCount; hop++) {
+        if (cast<StringAttr>(edgeTypes[hop]).getValue().empty()) {
+            return op->emitOpError("hop ") << hop << " requires a non-empty edge type";
+        }
+
+        expectedEdgeValues += cast<ArrayAttr>(edgePropNames[hop]).size();
+    }
+
+    if (edgePropValues != expectedEdgeValues) {
+        return op->emitOpError("values must give one hop column per property name, but has ")
+               << edgePropValues << " columns for " << expectedEdgeValues << " names";
+    }
+
+    return success();
+}
+
+size_t mlir::mergeResultCount(ArrayAttr nodeLabels, size_t carriedColumns) {
+    const size_t nodeCount = nodeLabels.size();
+    const size_t hopCount = nodeCount > 0 ? nodeCount - 1 : 0;
+
+    // An ID column and a pending mask per chain entity, then the created mask
+    return 2 * (nodeCount + hopCount) + 1 + carriedColumns;
+}

--- a/query/ir/dialect/storage/MergePatternShape.cpp
+++ b/query/ir/dialect/storage/MergePatternShape.cpp
@@ -125,10 +125,22 @@ LogicalResult mlir::verifyMergePattern(Operation* op,
     return success();
 }
 
+size_t mlir::mergeMatchedNodeCount(ArrayAttr nodeLabels) {
+    size_t matched = 0;
+    for (const Attribute labels : nodeLabels) {
+        if (!cast<ArrayAttr>(labels).empty()) {
+            matched++;
+        }
+    }
+
+    return matched;
+}
+
 size_t mlir::mergeResultCount(ArrayAttr nodeLabels, size_t carriedColumns) {
     const size_t nodeCount = nodeLabels.size();
     const size_t hopCount = nodeCount > 0 ? nodeCount - 1 : 0;
 
-    // An ID column and a pending mask per chain entity, then the created mask
-    return 2 * (nodeCount + hopCount) + 1 + carriedColumns;
+    // An ID column and a pending mask per hop and per node the merge looks up, then the
+    // created mask
+    return 2 * (mergeMatchedNodeCount(nodeLabels) + hopCount) + 1 + carriedColumns;
 }

--- a/query/ir/dialect/storage/MergePatternShape.h
+++ b/query/ir/dialect/storage/MergePatternShape.h
@@ -25,9 +25,13 @@ LogicalResult verifyMergePattern(Operation* op,
                                  size_t nodePropValues,
                                  size_t edgePropValues);
 
+// How many of @param nodeLabels' chain nodes the merge looks up rather than takes a
+// bound column for: the ones carrying a label set.
+size_t mergeMatchedNodeCount(ArrayAttr nodeLabels);
+
 // The result count a merge of @param nodeLabels' chain produces: an ID column and a
-// pending mask per chain node and per hop, the created mask, then one per carried
-// column.
+// pending mask per looked-up chain node and per hop, the created mask, then one per
+// carried column.
 size_t mergeResultCount(ArrayAttr nodeLabels, size_t carriedColumns);
 
 }

--- a/query/ir/dialect/storage/MergePatternShape.h
+++ b/query/ir/dialect/storage/MergePatternShape.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+
+class Operation;
+
+// Verifies the shape of a MERGE path pattern, shared by db.merge and nl.merge: one
+// entry per chain node in the two node lists, one per hop in the three hop lists, and
+// an operand group whose size each of those lists accounts for. The two ops carry the
+// same chain over different column types, so only the counts are checked here.
+LogicalResult verifyMergePattern(Operation* op,
+                                 ArrayAttr nodeLabels,
+                                 ArrayAttr nodePropNames,
+                                 ArrayAttr edgeTypes,
+                                 ArrayAttr edgePropNames,
+                                 DenseI64ArrayAttr edgeDirections,
+                                 DenseI64ArrayAttr pendingNodes,
+                                 size_t boundNodes,
+                                 size_t boundPending,
+                                 size_t nodePropValues,
+                                 size_t edgePropValues);
+
+// The result count a merge of @param nodeLabels' chain produces: an ID column and a
+// pending mask per chain node and per hop, the created mask, then one per carried
+// column.
+size_t mergeResultCount(ArrayAttr nodeLabels, size_t carriedColumns);
+
+}

--- a/query/ir/dialect/storage/StorageEnums.td
+++ b/query/ir/dialect/storage/StorageEnums.td
@@ -117,6 +117,17 @@ def VectorIndexKind : I64EnumAttr<"VectorIndexKind", "The implementation of a ve
     let cppNamespace = "::mlir::storage";
 }
 
+// Which way a MERGE pattern's hop points, from the chain node ahead of it to the one
+// behind. `undirected` is Cypher's `-[r:T]-`: it matches a hop either way round and
+// writes a forward one when the pattern has to be created.
+def EdgeDirection : I64EnumAttr<"EdgeDirection", "The direction of a pattern hop", [
+    I64EnumAttrCase<"Undirected", 0, "undirected">,
+    I64EnumAttrCase<"Backward", 1, "backward">,
+    I64EnumAttrCase<"Forward", 2, "forward">,
+]> {
+    let cppNamespace = "::mlir::storage";
+}
+
 // Whether a property index covers nodes or edges.
 def IndexedEntity : I64EnumAttr<"IndexedEntity", "The entity a property index covers", [
     I64EnumAttrCase<"Node", 0, "node">,

--- a/query/ir/dialect/storage/StorageTypes.td
+++ b/query/ir/dialect/storage/StorageTypes.td
@@ -155,4 +155,9 @@ def List : StorageType<"List", "list"> {
     let assemblyFormat = "`<` $elementType `>`";
 }
 
+// One string array per entity of a MERGE pattern: the label set of each chain node,
+// or the property names of each node and each hop. Both db.merge and nl.merge carry
+// these lists, so the constraint lives beside the types the two dialects share.
+def StrArrayArrayAttr : TypedArrayAttrBase<StrArrayAttr, "array of string arrays">;
+
 #endif // STORAGE_TYPES

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -2,6 +2,7 @@ set(ir_interpreter_sources
     NLProgram.cpp
     NLOutputSink.cpp
     NLExecutor.cpp
+    NLMergeWorkingSet.cpp
     NLTranslator.cpp
     NLInterpreter.cpp
     NLSystemContext.cpp

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -3,6 +3,7 @@ set(ir_interpreter_sources
     NLOutputSink.cpp
     NLExecutionContext.cpp
     NLWriteProperties.cpp
+    NLWrittenValues.cpp
     NLExecutor.cpp
     NLMergeExecutor.cpp
     NLMergeWorkingSet.cpp

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(ir_interpreter_sources
     NLProgram.cpp
     NLOutputSink.cpp
+    NLExecutionContext.cpp
+    NLWriteProperties.cpp
     NLExecutor.cpp
+    NLMergeExecutor.cpp
     NLMergeWorkingSet.cpp
     NLTranslator.cpp
     NLInterpreter.cpp

--- a/query/ir/interpreter/NLExecutionContext.cpp
+++ b/query/ir/interpreter/NLExecutionContext.cpp
@@ -6,6 +6,7 @@
 #include "VectorDatabase.h"
 
 #include "NLSystemContext.h"
+#include "NLWrittenValues.h"
 
 using namespace db;
 
@@ -18,7 +19,8 @@ NLExecutionContext::NLExecutionContext(const GraphView* view,
     _sink(sink),
     _chunkSize(chunkSize),
     _writeBuffer(writeBuffer),
-    _system(system)
+    _system(system),
+    _writtenValues(std::make_unique<NLWrittenValues>())
 {
 }
 

--- a/query/ir/interpreter/NLExecutionContext.cpp
+++ b/query/ir/interpreter/NLExecutionContext.cpp
@@ -1,0 +1,41 @@
+#include "NLExecutionContext.h"
+
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringConfig.h"
+#include "VectorDatabase.h"
+
+#include "NLSystemContext.h"
+
+using namespace db;
+
+NLExecutionContext::NLExecutionContext(const GraphView* view,
+                                       NLOutputSink* sink,
+                                       size_t chunkSize,
+                                       CommitWriteBuffer* writeBuffer,
+                                       const NLSystemContext* system)
+    : _view(view),
+    _sink(sink),
+    _chunkSize(chunkSize),
+    _writeBuffer(writeBuffer),
+    _system(system)
+{
+}
+
+NLExecutionContext::~NLExecutionContext() {
+}
+
+vec::VectorDatabase* NLExecutionContext::getVectorDatabase() const {
+    SystemAccessor* const accessor = _system ? _system->getAccessor() : nullptr;
+
+    return accessor ? accessor->getVectorDatabase() : nullptr;
+}
+
+const fs::Path* NLExecutionContext::getDataDir() const {
+    const SystemManager* const manager = _system ? _system->getSystemManager() : nullptr;
+    if (!manager) {
+        return nullptr;
+    }
+
+    return &manager->getConfig()->getDataDir();
+}

--- a/query/ir/interpreter/NLExecutionContext.h
+++ b/query/ir/interpreter/NLExecutionContext.h
@@ -2,6 +2,8 @@
 
 #include <stddef.h>
 
+#include <memory>
+
 namespace fs {
 class Path;
 }
@@ -16,6 +18,7 @@ class CommitWriteBuffer;
 class GraphView;
 class NLOutputSink;
 class NLSystemContext;
+class NLWrittenValues;
 
 // What every handler of a running NLProgram reads the world through: the graph it runs
 // against, where its rows go, and the change it writes into.
@@ -49,12 +52,16 @@ public:
     // manager, which the load reports as a user-facing error.
     const fs::Path* getDataDir() const;
 
+    // What the change has written so far, as a read later in the same program sees it
+    NLWrittenValues& getWrittenValues() const { return *_writtenValues; }
+
 private:
     const GraphView* _view {nullptr};
     NLOutputSink* _sink {nullptr};
     size_t _chunkSize {0};
     CommitWriteBuffer* _writeBuffer {nullptr};
     const NLSystemContext* _system {nullptr};
+    std::unique_ptr<NLWrittenValues> _writtenValues;
 };
 
 }

--- a/query/ir/interpreter/NLExecutionContext.h
+++ b/query/ir/interpreter/NLExecutionContext.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <stddef.h>
+
+namespace fs {
+class Path;
+}
+
+namespace vec {
+class VectorDatabase;
+}
+
+namespace db {
+
+class CommitWriteBuffer;
+class GraphView;
+class NLOutputSink;
+class NLSystemContext;
+
+// What every handler of a running NLProgram reads the world through: the graph it runs
+// against, where its rows go, and the change it writes into.
+class NLExecutionContext {
+public:
+    NLExecutionContext(const GraphView* view,
+                       NLOutputSink* sink,
+                       size_t chunkSize,
+                       CommitWriteBuffer* writeBuffer = nullptr,
+                       const NLSystemContext* system = nullptr);
+    ~NLExecutionContext();
+
+    const GraphView* getView() const { return _view; }
+    NLOutputSink* getSink() const { return _sink; }
+    size_t getChunkSize() const { return _chunkSize; }
+    CommitWriteBuffer* getWriteBuffer() const { return _writeBuffer; }
+
+    // The server-level facilities the system commands reach for. Every query the server
+    // runs carries one, ordinary reads included; it is null only for a caller that hands
+    // the interpreter none, as the IR tests do.
+    const NLSystemContext* getSystem() const { return _system; }
+
+    // The vector indexes a search reads, borrowed from the session's accessor. They are
+    // the one store outside the graph an ordinary query reaches, so - unlike the rest of
+    // the system context - a dataflow loop reads them; null when the session opened no
+    // accessor, which the search reports as a user-facing error.
+    vec::VectorDatabase* getVectorDatabase() const;
+
+    // The directory a file the query names is resolved against - the one place outside
+    // the graph a dataflow loop reads from. Null for a session that opened no system
+    // manager, which the load reports as a user-facing error.
+    const fs::Path* getDataDir() const;
+
+private:
+    const GraphView* _view {nullptr};
+    NLOutputSink* _sink {nullptr};
+    size_t _chunkSize {0};
+    CommitWriteBuffer* _writeBuffer {nullptr};
+    const NLSystemContext* _system {nullptr};
+};
+
+}

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -62,6 +62,7 @@
 #include "NLSystemContext.h"
 
 #include "NLProgram.h"
+#include "NLMergeWorkingSet.h"
 #include "NLOutputSink.h"
 
 #include "LocalMemory.h"
@@ -2608,10 +2609,93 @@ void mergeKeyAppendConstColumn(const Column* column, size_t row, std::string& ke
     distinctAppendValueBytes(key, (*static_cast<const ColumnConst<ElementType>*>(column))[row]);
 }
 
+// The numeric siblings of the three above, keying the row's value in KeyType - the type
+// the schema holds the property as - rather than in the one its column holds. The
+// analyzer lets an integer constrain a double-typed property, and the graph side keys
+// the double it reads back, so the two only compare equal once the row's value is
+// converted to it.
+template <typename ElementType, typename KeyType>
+void mergeKeyAppendNumericPlainColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
+
+    key.push_back('\1');
+    distinctAppendValueBytes(key, static_cast<KeyType>(raw[row]));
+}
+
+template <typename ElementType, typename KeyType>
+void mergeKeyAppendNumericConstColumn(const Column* column, size_t row, std::string& key) {
+    key.push_back('\1');
+    distinctAppendValueBytes(key, static_cast<KeyType>((*static_cast<const ColumnConst<ElementType>*>(column))[row]));
+}
+
+template <typename ElementType, typename KeyType>
+void mergeKeyAppendNumericOptColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<ElementType>>*>(column)->getRaw();
+    const std::optional<ElementType>& value = raw[row];
+
+    if (!value.has_value()) {
+        key.push_back('\0');
+        return;
+    }
+
+    key.push_back('\1');
+    distinctAppendValueBytes(key, static_cast<KeyType>(*value));
+}
+
 // Keys the way a nullable column's null row does, so a merge on a null value binds the
 // nodes that lack the property
 void mergeKeyAppendConstNull(const Column* column, size_t row, std::string& key) {
     key.push_back('\0');
+}
+
+// Which of the three shapes a merge property value column comes in, so one selector
+// serves all of them
+enum class MergeColumnShape {
+    Plain,
+    Const,
+    Opt,
+};
+
+template <typename ElementType, typename KeyType, MergeColumnShape Shape>
+NLKeyAppendFunction mergeKeyAppendFor() {
+    if constexpr (Shape == MergeColumnShape::Plain) {
+        return &mergeKeyAppendNumericPlainColumn<ElementType, KeyType>;
+    } else if constexpr (Shape == MergeColumnShape::Const) {
+        return &mergeKeyAppendNumericConstColumn<ElementType, KeyType>;
+    } else {
+        return &mergeKeyAppendNumericOptColumn<ElementType, KeyType>;
+    }
+}
+
+// The appender for a numeric value column, keying its rows in the type the schema holds
+// the property as. Identical types convert for free, so one path covers both.
+template <typename ElementType, MergeColumnShape Shape>
+NLKeyAppendFunction selectNumericMergeKeyAppend(ValueType keyType) {
+    switch (keyType) {
+        case ValueType::Int64:
+            return mergeKeyAppendFor<ElementType, types::Int64::Primitive, Shape>();
+        break;
+
+        case ValueType::UInt64:
+            return mergeKeyAppendFor<ElementType, types::UInt64::Primitive, Shape>();
+        break;
+
+        case ValueType::Double:
+            return mergeKeyAppendFor<ElementType, types::Double::Primitive, Shape>();
+        break;
+
+        default:
+            throw IRException("a MERGE pattern cannot constrain a non-numeric property to a number");
+        break;
+    }
+}
+
+// A non-numeric value converts to no other type the schema might hold the property as,
+// so it can only key against a property of its own type
+void throwUnlessKeyedAsItsOwnType(ValueType valueType, ValueType keyType) {
+    if (valueType != keyType) {
+        throw IRException("a MERGE pattern cannot constrain a property to a value of another type");
+    }
 }
 
 template <typename Property>
@@ -2700,6 +2784,7 @@ public:
     MergeStep(NLExecutionContext* context, NLMergeData* data)
         : _context(context),
         _data(data),
+        _work(data->getWorkingSet()),
         _writeBuffer(context->getWriteBuffer()),
         _view(context->getView()),
         _firstPendingNodeID(committedNodeCount(_view)),
@@ -2710,20 +2795,9 @@ public:
     void run();
 
 private:
-    // A chain matched as far as one node, and the entities it bound getting there
-    struct PartialMatch {
-        std::vector<NLMergeRef> _nodes;
-        std::vector<NLMergeRef> _edges;
-    };
-
-    struct Extension {
-        NLMergeRef _source;
-        NLMergeRef _edge;
-        NLMergeRef _target;
-    };
-
     NLExecutionContext* _context {nullptr};
     NLMergeData* _data {nullptr};
+    NLMergeWorkingSet* _work {nullptr};
     CommitWriteBuffer* _writeBuffer {nullptr};
     const GraphView* _view {nullptr};
 
@@ -2733,32 +2807,12 @@ private:
     size_t _firstPendingNodeID {0};
     size_t _firstPendingEdgeID {0};
 
-    // Per chain node, the current row's candidates, and their refs as a set for the
-    // membership test each hop's far end has to pass
-    std::vector<std::vector<NLMergeRef>> _candidates;
-    std::vector<std::unordered_set<uint64_t>> _candidateKeys;
-
-    // Extracted once for the whole chunk, so a written row picks its values by row index
-    std::vector<std::vector<CommitWriteBuffer::UntypedProperties>> _nodeProperties;
-    std::vector<std::vector<CommitWriteBuffer::UntypedProperties>> _hopProperties;
-
-    // The frontier of the chain walk and the one the current hop extends it into
-    std::vector<PartialMatch> _matches;
-    std::vector<PartialMatch> _extended;
-
-    // The current hop's candidate graph edges, and where each source node's run of them
-    // starts and ends once they are grouped
-    std::vector<Extension> _extensions;
-    std::unordered_map<uint64_t, std::pair<size_t, size_t>> _extensionRuns;
-
-    std::string _key;
-    std::string _hopKey;
-
     void extractProperties(size_t rowCount);
     void clearResults();
 
     void collectCandidates(size_t row);
     void matchRow(size_t row);
+    void buildHopKeys(const NLMergeData::Hop& hop, size_t row);
     void extendHop(size_t hopIndex);
 
     void collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex);
@@ -2766,7 +2820,7 @@ private:
     void dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop);
     void groupExtensionsBySource();
 
-    void emitRow(const PartialMatch& match, size_t row, bool created);
+    void emitRow(const NLMergePartialMatch& match, size_t row, bool created);
     void writeRow(size_t row);
 
     NLMergeRef writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row);
@@ -2793,8 +2847,8 @@ void MergeStep::run() {
     clearResults();
     extractProperties(rowCount);
 
-    _candidates.assign(_data->nodes().size(), {});
-    _candidateKeys.assign(_data->nodes().size(), {});
+    _work->_candidates.resize(_data->nodes().size());
+    _work->_candidateKeys.resize(_data->nodes().size());
 
     for (size_t row = 0; row < rowCount; row++) {
         matchRow(row);
@@ -2804,9 +2858,12 @@ void MergeStep::run() {
 }
 
 void MergeStep::clearResults() {
+    // A bound node has no output of its own: its rows come back through the carry set
     for (const NLMergeData::Node& node : _data->nodes()) {
-        node._output->clear();
-        node._outputPending->clear();
+        if (node._output) {
+            node._output->clear();
+            node._outputPending->clear();
+        }
     }
 
     for (const NLMergeData::Hop& hop : _data->hops()) {
@@ -2822,29 +2879,33 @@ void MergeStep::extractProperties(size_t rowCount) {
     const std::vector<NLMergeData::Node>& nodes = _data->nodes();
     const std::vector<NLMergeData::Hop>& hops = _data->hops();
 
-    _nodeProperties.assign(nodes.size(), {});
+    _work->_nodeProperties.resize(nodes.size());
     for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
         const std::vector<NLMergeProperty>& properties = nodes[nodeIndex]._properties;
-        _nodeProperties[nodeIndex].resize(properties.size());
+        // The extractor clears each buffer it fills, so a step reuses what the last one
+        // allocated
+        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_nodeProperties[nodeIndex];
+        extracted.resize(properties.size());
 
         for (size_t index = 0; index < properties.size(); index++) {
             extractColumnProperties(properties[index]._values,
                                     rowCount,
                                     properties[index]._propertyType._id,
-                                    _nodeProperties[nodeIndex][index]);
+                                    extracted[index]);
         }
     }
 
-    _hopProperties.assign(hops.size(), {});
+    _work->_hopProperties.resize(hops.size());
     for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
         const std::vector<NLMergeProperty>& properties = hops[hopIndex]._properties;
-        _hopProperties[hopIndex].resize(properties.size());
+        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_hopProperties[hopIndex];
+        extracted.resize(properties.size());
 
         for (size_t index = 0; index < properties.size(); index++) {
             extractColumnProperties(properties[index]._values,
                                     rowCount,
                                     properties[index]._propertyType._id,
-                                    _hopProperties[hopIndex][index]);
+                                    extracted[index]);
         }
     }
 }
@@ -2854,7 +2915,7 @@ void MergeStep::collectCandidates(size_t row) {
 
     for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
         const NLMergeData::Node& node = nodes[nodeIndex];
-        std::vector<NLMergeRef>& candidates = _candidates[nodeIndex];
+        std::vector<NLMergeRef>& candidates = _work->_candidates[nodeIndex];
         candidates.clear();
 
         if (node._boundColumn) {
@@ -2869,18 +2930,19 @@ void MergeStep::collectCandidates(size_t row) {
                 buildMergeNodeIndex(_context, index);
             }
 
-            _key.clear();
-            appendMergeKey(node._properties, row, _key);
+            std::string& key = _work->_key;
+            key.clear();
+            appendMergeKey(node._properties, row, key);
 
-            const std::span<const NLMergeRef> committed = index->find(_key);
+            const std::span<const NLMergeRef> committed = index->find(key);
             candidates.insert(candidates.end(), committed.begin(), committed.end());
 
-            _key.insert(0, node._signature);
-            const std::span<const NLMergeRef> pending = _data->getPendingNodes()->find(_key);
+            key.insert(0, node._signature);
+            const std::span<const NLMergeRef> pending = _data->getPendingNodes()->find(key);
             candidates.insert(candidates.end(), pending.begin(), pending.end());
         }
 
-        std::unordered_set<uint64_t>& keys = _candidateKeys[nodeIndex];
+        std::unordered_set<uint64_t>& keys = _work->_candidateKeys[nodeIndex];
         keys.clear();
         for (const NLMergeRef& candidate : candidates) {
             keys.insert(candidate.asKey());
@@ -2891,34 +2953,51 @@ void MergeStep::collectCandidates(size_t row) {
 void MergeStep::matchRow(size_t row) {
     collectCandidates(row);
 
-    _matches.clear();
-    for (const NLMergeRef& candidate : _candidates.front()) {
-        PartialMatch match;
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+    const size_t nodeCount = _data->nodes().size();
+
+    std::vector<NLMergePartialMatch>& matches = _work->_matches;
+    matches.clear();
+    for (const NLMergeRef& candidate : _work->_candidates.front()) {
+        NLMergePartialMatch& match = matches.emplace_back();
+
+        // The walk appends one node and one edge per hop, so the whole chain fits the
+        // allocation the first node forces
+        match._nodes.reserve(nodeCount);
+        match._edges.reserve(hops.size());
         match._nodes.push_back(candidate);
-        _matches.push_back(match);
     }
 
-    const std::vector<NLMergeData::Hop>& hops = _data->hops();
-    for (size_t hopIndex = 0; hopIndex < hops.size() && !_matches.empty(); hopIndex++) {
-        _hopKey.clear();
-        appendMergeKey(hops[hopIndex]._properties, row, _hopKey);
+    for (size_t hopIndex = 0; hopIndex < hops.size() && !matches.empty(); hopIndex++) {
+        buildHopKeys(hops[hopIndex], row);
 
         extendHop(hopIndex);
     }
 
-    if (_matches.empty()) {
+    if (matches.empty()) {
         writeRow(row);
         return;
     }
 
-    for (const PartialMatch& match : _matches) {
+    for (const NLMergePartialMatch& match : matches) {
         emitRow(match, row, /*created=*/false);
     }
 }
 
+void MergeStep::buildHopKeys(const NLMergeData::Hop& hop, size_t row) {
+    // The values the hop asks for, which a candidate edge's own values are compared
+    // against, and those same values behind the hop's signature - what the pending log
+    // is keyed by, since it holds every hop this query wrote under one pair of endpoints
+    _work->_hopKey.clear();
+    appendMergeKey(hop._properties, row, _work->_hopKey);
+
+    _work->_pendingHopKey.assign(hop._signature);
+    _work->_pendingHopKey.append(_work->_hopKey);
+}
+
 void MergeStep::extendHop(size_t hopIndex) {
     const NLMergeData::Hop& hop = _data->hops()[hopIndex];
-    const std::unordered_set<uint64_t>& targets = _candidateKeys[hopIndex + 1];
+    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
     const NLMergePendingEdges* pendingEdges = _data->getPendingEdges();
 
     collectGraphExtensions(hop, hopIndex);
@@ -2926,29 +3005,39 @@ void MergeStep::extendHop(size_t hopIndex) {
     const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
     const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
 
-    _extended.clear();
-    for (const PartialMatch& match : _matches) {
+    std::vector<NLMergePartialMatch>& matches = _work->_matches;
+    std::vector<NLMergePartialMatch>& extended = _work->_extended;
+
+    extended.clear();
+    for (const NLMergePartialMatch& match : matches) {
         const NLMergeRef source = match._nodes.back();
 
         const auto extendWith = [&](const NLMergeRef& edge, const NLMergeRef& target) {
-            PartialMatch extended = match;
-            extended._edges.push_back(edge);
-            extended._nodes.push_back(target);
-            _extended.push_back(extended);
+            NLMergePartialMatch& grown = extended.emplace_back(match);
+            grown._edges.push_back(edge);
+            grown._nodes.push_back(target);
         };
 
-        const auto runIt = _extensionRuns.find(source.asKey());
-        if (runIt != end(_extensionRuns)) {
+        const auto runIt = _work->_extensionRuns.find(source.asKey());
+        if (runIt != end(_work->_extensionRuns)) {
             const auto [first, last] = runIt->second;
             for (size_t index = first; index < last; index++) {
-                extendWith(_extensions[index]._edge, _extensions[index]._target);
+                const NLMergeExtension& extension = _work->_extensions[index];
+                extendWith(extension._edge, extension._target);
             }
         }
 
-        const auto extendWithPending = [&](std::span<const NLMergePendingEdges::Entry> entries) {
+        // An undirected hop follows both ways round, and a self-loop is on both sides of
+        // its own node: the outgoing pass has it, so the incoming one leaves it alone
+        const auto extendWithPending = [&](std::span<const NLMergePendingEdges::Entry> entries,
+                                           bool skipSelfLoops) {
             for (const NLMergePendingEdges::Entry& entry : entries) {
+                if (skipSelfLoops && entry._other == source) {
+                    continue;
+                }
+
                 const bool sameType = entry._edgeType == hop._writeEdgeType;
-                const bool sameProperties = entry._propertyKey == _hopKey;
+                const bool sameProperties = entry._propertyKey == _work->_pendingHopKey;
                 const bool onACandidate = targets.contains(entry._other.asKey());
 
                 if (sameType && sameProperties && onACandidate) {
@@ -2958,20 +3047,20 @@ void MergeStep::extendHop(size_t hopIndex) {
         };
 
         if (followsOutgoing) {
-            extendWithPending(pendingEdges->outOf(source));
+            extendWithPending(pendingEdges->outOf(source), /*skipSelfLoops=*/false);
         }
 
         if (followsIncoming) {
-            extendWithPending(pendingEdges->into(source));
+            extendWithPending(pendingEdges->into(source), /*skipSelfLoops=*/followsOutgoing);
         }
     }
 
-    _matches.swap(_extended);
+    matches.swap(extended);
 }
 
 void MergeStep::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex) {
-    _extensions.clear();
-    _extensionRuns.clear();
+    _work->_extensions.clear();
+    _work->_extensionRuns.clear();
 
     // A type the schema does not have is on no committed edge, so only a pending one can
     // extend the match
@@ -2982,9 +3071,19 @@ void MergeStep::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIn
     ColumnNodeIDs* sources = hop._scanSources;
     sources->clear();
 
-    for (const PartialMatch& match : _matches) {
+    // Two partial matches reaching the same node scan its edges once: the runs below are
+    // keyed by source node, so a second copy of one would fold into its run and extend
+    // every match that reached it a second time.
+    std::unordered_set<uint64_t>& sourceKeys = _work->_scanSourceKeys;
+    sourceKeys.clear();
+
+    for (const NLMergePartialMatch& match : _work->_matches) {
         const NLMergeRef source = match._nodes.back();
-        if (!source._pending) {
+        if (source._pending) {
+            continue;
+        }
+
+        if (sourceKeys.insert(source.asKey()).second) {
             sources->push_back(NodeID(source._id));
         }
     }
@@ -3009,12 +3108,21 @@ void MergeStep::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIn
 }
 
 void MergeStep::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing) {
-    const std::unordered_set<uint64_t>& targets = _candidateKeys[hopIndex + 1];
+    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
     const Tombstones& tombstones = _view->tombstones();
     const ColumnNodeIDs* sources = hop._scanSources;
 
+    // An undirected hop scans both ways round, and a self-loop is an out-edge and an
+    // in-edge of the one node: the outgoing pass has it already
+    const bool undirected = hop._direction == NLMergeDirection::Undirected;
+    const bool skipSelfLoops = undirected && !outgoing;
+
     const auto collect = [&](const EdgeRecord& record) {
         if (record._edgeTypeID != hop._matchEdgeType || tombstones.containsEdge(record._edgeID)) {
+            return;
+        }
+
+        if (skipSelfLoops && record._otherID == record._nodeID) {
             return;
         }
 
@@ -3023,9 +3131,9 @@ void MergeStep::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t ho
             return;
         }
 
-        _extensions.push_back({._source={._id=record._nodeID.getValue(), ._pending=false},
-                               ._edge={._id=record._edgeID.getValue(), ._pending=false},
-                               ._target=target});
+        _work->_extensions.push_back({._source={._id=record._nodeID.getValue(), ._pending=false},
+                                      ._edge={._id=record._edgeID.getValue(), ._pending=false},
+                                      ._target=target});
     };
 
     if (outgoing) {
@@ -3043,13 +3151,14 @@ void MergeStep::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t ho
 
 void MergeStep::dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop) {
     const std::vector<NLMergeScanProperty>& scanProperties = hop._scanProperties;
-    if (scanProperties.empty() || _extensions.empty()) {
+    std::vector<NLMergeExtension>& extensions = _work->_extensions;
+    if (scanProperties.empty() || extensions.empty()) {
         return;
     }
 
     ColumnEdgeIDs* edges = hop._scanEdges;
     edges->clear();
-    for (const Extension& extension : _extensions) {
+    for (const NLMergeExtension& extension : extensions) {
         edges->push_back(EdgeID(extension._edge._id));
     }
 
@@ -3057,49 +3166,58 @@ void MergeStep::dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop) {
         fetchMergeEdgeProperty(*_view, property, edges);
     }
 
-    std::vector<Extension> kept;
-    std::string key;
-    for (size_t index = 0; index < _extensions.size(); index++) {
+    std::vector<NLMergeExtension>& kept = _work->_keptExtensions;
+    std::string& key = _work->_scanKey;
+
+    kept.clear();
+    for (size_t index = 0; index < extensions.size(); index++) {
         key.clear();
         appendMergeKey(scanProperties, index, key);
 
-        if (key == _hopKey) {
-            kept.push_back(_extensions[index]);
+        if (key == _work->_hopKey) {
+            kept.push_back(extensions[index]);
         }
     }
 
-    _extensions.swap(kept);
+    extensions.swap(kept);
 }
 
 void MergeStep::groupExtensionsBySource() {
-    std::ranges::stable_sort(_extensions, [](const Extension& lhs, const Extension& rhs) {
+    std::vector<NLMergeExtension>& extensions = _work->_extensions;
+
+    std::ranges::stable_sort(extensions, [](const NLMergeExtension& lhs, const NLMergeExtension& rhs) {
         return lhs._source.asKey() < rhs._source.asKey();
     });
 
     size_t first = 0;
-    while (first < _extensions.size()) {
-        const uint64_t sourceKey = _extensions[first]._source.asKey();
+    while (first < extensions.size()) {
+        const uint64_t sourceKey = extensions[first]._source.asKey();
 
         size_t last = first + 1;
-        while (last < _extensions.size() && _extensions[last]._source.asKey() == sourceKey) {
+        while (last < extensions.size() && extensions[last]._source.asKey() == sourceKey) {
             last++;
         }
 
-        _extensionRuns[sourceKey] = {first, last};
+        _work->_extensionRuns[sourceKey] = {first, last};
         first = last;
     }
 }
 
-void MergeStep::emitRow(const PartialMatch& match, size_t row, bool created) {
+void MergeStep::emitRow(const NLMergePartialMatch& match, size_t row, bool created) {
     const std::vector<NLMergeData::Node>& nodes = _data->nodes();
     const std::vector<NLMergeData::Hop>& hops = _data->hops();
 
     for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
-        const NLMergeRef& node = match._nodes[nodeIndex];
-        const uint64_t nodeID = node._pending ? node._id + _firstPendingNodeID : node._id;
+        const NLMergeData::Node& node = nodes[nodeIndex];
+        if (!node._output) {
+            continue;
+        }
 
-        nodes[nodeIndex]._output->push_back(NodeID(nodeID));
-        nodes[nodeIndex]._outputPending->push_back(node._pending);
+        const NLMergeRef& entity = match._nodes[nodeIndex];
+        const uint64_t nodeID = entity._pending ? entity._id + _firstPendingNodeID : entity._id;
+
+        node._output->push_back(NodeID(nodeID));
+        node._outputPending->push_back(entity._pending);
     }
 
     for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
@@ -3118,12 +3236,15 @@ void MergeStep::writeRow(size_t row) {
     const std::vector<NLMergeData::Node>& nodes = _data->nodes();
     const std::vector<NLMergeData::Hop>& hops = _data->hops();
 
-    PartialMatch written;
+    NLMergePartialMatch written;
+    written._nodes.reserve(nodes.size());
+    written._edges.reserve(hops.size());
+
     for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
         const NLMergeData::Node& node = nodes[nodeIndex];
 
         if (node._boundColumn) {
-            written._nodes.push_back(_candidates[nodeIndex].front());
+            written._nodes.push_back(_work->_candidates[nodeIndex].front());
         } else {
             written._nodes.push_back(writeNode(node, nodeIndex, row));
         }
@@ -3149,7 +3270,7 @@ NLMergeRef MergeStep::writeNode(const NLMergeData::Node& node, size_t nodeIndex,
     CommitWriteBuffer::PendingNode& pending = _writeBuffer->newPendingNode();
     pending.labelsetHandle = node._labelSetHandle;
 
-    for (const CommitWriteBuffer::UntypedProperties& values : _nodeProperties[nodeIndex]) {
+    for (const CommitWriteBuffer::UntypedProperties& values : _work->_nodeProperties[nodeIndex]) {
         pending.properties.push_back(values[row]);
     }
 
@@ -3157,9 +3278,10 @@ NLMergeRef MergeStep::writeNode(const NLMergeData::Node& node, size_t nodeIndex,
 
     // A later row asking for the same values binds this node rather than writing a
     // second one, which is what makes a merge over many rows idempotent
-    _key.assign(node._signature);
-    appendMergeKey(node._properties, row, _key);
-    _data->getPendingNodes()->add(_key, ref);
+    std::string& key = _work->_key;
+    key.assign(node._signature);
+    appendMergeKey(node._properties, row, key);
+    _data->getPendingNodes()->add(key, ref);
 
     return ref;
 }
@@ -3175,16 +3297,15 @@ NLMergeRef MergeStep::writeEdge(const NLMergeData::Hop& hop,
                                                                            asWriteBufferNode(target));
     pending.edgeType = hop._writeEdgeType;
 
-    for (const CommitWriteBuffer::UntypedProperties& values : _hopProperties[hopIndex]) {
+    for (const CommitWriteBuffer::UntypedProperties& values : _work->_hopProperties[hopIndex]) {
         pending.properties.push_back(values[row]);
     }
 
     // Keyed by its own hop's values, not by whichever hop the match reached before it
     // gave up: a later row looks each hop of the chain up under its own key
-    _hopKey.clear();
-    appendMergeKey(hop._properties, row, _hopKey);
+    buildHopKeys(hop, row);
 
-    _data->getPendingEdges()->add(source, target, hop._writeEdgeType, offset, _hopKey);
+    _data->getPendingEdges()->add(source, target, hop._writeEdgeType, offset, _work->_pendingHopKey);
 
     return {._id=offset, ._pending=true};
 }
@@ -6197,29 +6318,32 @@ NLCopyFunction NLExecutor::selectPlainCopyFunction(ValueType valueType) {
     }
 }
 
-NLKeyAppendFunction NLExecutor::selectPlainMergeKeyAppendFunction(NLChunkKind kind) {
+NLKeyAppendFunction NLExecutor::selectPlainMergeKeyAppendFunction(NLChunkKind kind, ValueType keyType) {
     switch (kind) {
         case NLChunkKind::UInt64:
-            return &mergeKeyAppendPlainColumn<types::UInt64::Primitive>;
+            return selectNumericMergeKeyAppend<types::UInt64::Primitive, MergeColumnShape::Plain>(keyType);
         break;
 
         case NLChunkKind::Int64:
-            return &mergeKeyAppendPlainColumn<types::Int64::Primitive>;
+            return selectNumericMergeKeyAppend<types::Int64::Primitive, MergeColumnShape::Plain>(keyType);
         break;
 
         case NLChunkKind::Double:
-            return &mergeKeyAppendPlainColumn<types::Double::Primitive>;
+            return selectNumericMergeKeyAppend<types::Double::Primitive, MergeColumnShape::Plain>(keyType);
         break;
 
         case NLChunkKind::Bool:
+            throwUnlessKeyedAsItsOwnType(ValueType::Bool, keyType);
             return &mergeKeyAppendPlainColumn<types::Bool::Primitive>;
         break;
 
         case NLChunkKind::String:
+            throwUnlessKeyedAsItsOwnType(ValueType::String, keyType);
             return &mergeKeyAppendPlainColumn<types::String::Primitive>;
         break;
 
         case NLChunkKind::OwnedString:
+            throwUnlessKeyedAsItsOwnType(ValueType::String, keyType);
             return &mergeKeyAppendPlainColumn<std::string>;
         break;
 
@@ -6239,25 +6363,27 @@ NLKeyAppendFunction NLExecutor::selectPlainMergeKeyAppendFunction(NLChunkKind ki
     return nullptr;
 }
 
-NLKeyAppendFunction NLExecutor::selectConstMergeKeyAppendFunction(ValueType valueType) {
+NLKeyAppendFunction NLExecutor::selectConstMergeKeyAppendFunction(ValueType valueType, ValueType keyType) {
     switch (valueType) {
         case ValueType::Int64:
-            return &mergeKeyAppendConstColumn<types::Int64::Primitive>;
+            return selectNumericMergeKeyAppend<types::Int64::Primitive, MergeColumnShape::Const>(keyType);
         break;
 
         case ValueType::UInt64:
-            return &mergeKeyAppendConstColumn<types::UInt64::Primitive>;
+            return selectNumericMergeKeyAppend<types::UInt64::Primitive, MergeColumnShape::Const>(keyType);
         break;
 
         case ValueType::Double:
-            return &mergeKeyAppendConstColumn<types::Double::Primitive>;
+            return selectNumericMergeKeyAppend<types::Double::Primitive, MergeColumnShape::Const>(keyType);
         break;
 
         case ValueType::Bool:
+            throwUnlessKeyedAsItsOwnType(ValueType::Bool, keyType);
             return &mergeKeyAppendConstColumn<types::Bool::Primitive>;
         break;
 
         case ValueType::String:
+            throwUnlessKeyedAsItsOwnType(ValueType::String, keyType);
             return &mergeKeyAppendConstColumn<types::String::Primitive>;
         break;
 
@@ -6273,6 +6399,27 @@ NLKeyAppendFunction NLExecutor::selectConstMergeKeyAppendFunction(ValueType valu
 
     bioassert(false, "Unhandled value type");
     return nullptr;
+}
+
+NLKeyAppendFunction NLExecutor::selectOptMergeKeyAppendFunction(ValueType valueType, ValueType keyType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return selectNumericMergeKeyAppend<types::Int64::Primitive, MergeColumnShape::Opt>(keyType);
+        break;
+
+        case ValueType::UInt64:
+            return selectNumericMergeKeyAppend<types::UInt64::Primitive, MergeColumnShape::Opt>(keyType);
+        break;
+
+        case ValueType::Double:
+            return selectNumericMergeKeyAppend<types::Double::Primitive, MergeColumnShape::Opt>(keyType);
+        break;
+
+        default:
+            throwUnlessKeyedAsItsOwnType(valueType, keyType);
+            return selectOptKeyAppendFunction(valueType);
+        break;
+    }
 }
 
 NLKeyAppendFunction NLExecutor::selectNullMergeKeyAppendFunction() {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -62,6 +62,8 @@
 #include "NLSystemContext.h"
 
 #include "NLProgram.h"
+#include "NLMergeExecutor.h"
+#include "NLWriteProperties.h"
 #include "NLMergeWorkingSet.h"
 #include "NLOutputSink.h"
 
@@ -2378,161 +2380,6 @@ void runEdgeLoopSteps(NLExecutionContext* context,
     }
 }
 
-class ConstPropertyExtractor {
-public:
-    ConstPropertyExtractor(CommitWriteBuffer::UntypedProperties& buf,
-                           PropertyTypeID propID,
-                           size_t rowCount)
-        : _buf(buf),
-        _propID(propID),
-        _rowCount(rowCount)
-    {
-    }
-
-    template <typename T>
-    void operator()(const ColumnConst<T>* typed) {
-        _buf.clear();
-        _buf.reserve(_rowCount);
-        for (size_t i = 0; i < _rowCount; i++) {
-            _buf.emplace_back(_propID, typed->getRaw());
-        }
-    }
-
-    void operator()(const ColumnConst<types::String::Primitive>* typed) {
-        _buf.clear();
-        _buf.reserve(_rowCount);
-        for (size_t i = 0; i < _rowCount; i++) {
-            _buf.emplace_back(_propID, std::string(typed->getRaw()));
-        }
-    }
-
-    void operator()(const ColumnConst<types::Embedding::Primitive>* typed) {
-        _buf.clear();
-        _buf.reserve(_rowCount);
-        const types::Embedding::Primitive span = typed->getRaw();
-        for (size_t i = 0; i < _rowCount; i++) {
-            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(span.begin(), span.end()));
-        }
-    }
-
-private:
-    CommitWriteBuffer::UntypedProperties& _buf;
-    PropertyTypeID _propID;
-    size_t _rowCount;
-};
-
-class VectorPropertyExtractor {
-public:
-    VectorPropertyExtractor(CommitWriteBuffer::UntypedProperties& buf,
-                            PropertyTypeID propID)
-        : _buf(buf),
-        _propID(propID)
-    {
-    }
-
-    template <typename T>
-    void operator()(const ColumnVector<T>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const T& val : *typed) {
-            _buf.emplace_back(_propID, val);
-        }
-    }
-
-    void operator()(const ColumnVector<types::String::Primitive>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const types::String::Primitive val : *typed) {
-            _buf.emplace_back(_propID, std::string(val));
-        }
-    }
-
-    void operator()(const ColumnVector<types::Embedding::Primitive>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const types::Embedding::Primitive val : *typed) {
-            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(val.begin(), val.end()));
-        }
-    }
-
-    template <typename T>
-    void operator()(const ColumnVector<std::optional<T>>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const std::optional<T>& val : *typed) {
-            if (!val) {
-                throw IRException("Cannot set a property to NULL in CREATE.");
-            }
-            _buf.emplace_back(_propID, *val);
-        }
-    }
-
-    void operator()(const ColumnVector<std::optional<types::String::Primitive>>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const std::optional<types::String::Primitive>& val : *typed) {
-            if (!val) {
-                throw IRException("Cannot set a property to NULL in CREATE.");
-            }
-            _buf.emplace_back(_propID, std::string(*val));
-        }
-    }
-
-    void operator()(const ColumnVector<std::optional<types::Embedding::Primitive>>* typed) {
-        _buf.clear();
-        _buf.reserve(typed->size());
-        for (const std::optional<types::Embedding::Primitive>& val : *typed) {
-            if (!val) {
-                throw IRException("Cannot set a property to NULL in CREATE.");
-            }
-            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(val->begin(), val->end()));
-        }
-    }
-
-private:
-    CommitWriteBuffer::UntypedProperties& _buf;
-    PropertyTypeID _propID;
-};
-
-void extractColumnProperties(const Column* column,
-                             size_t rowCount,
-                             PropertyTypeID propID,
-                             CommitWriteBuffer::UntypedProperties& buf) {
-    using Types = WriteProcessorPropertyTypes;
-
-    const ContainerKind::Code containerKind = ColumnKind::extractContainerKind(column->getKind());
-
-    if (containerKind == ContainerKind::code<ColumnConst>()) {
-        ConstPropertyExtractor extractor(buf, propID, rowCount);
-        ColumnSingleDispatcher<Types::AllowedConst,
-                               ConstPropertyExtractor,
-                               Types::ExcludedConst>::dispatch(column, extractor);
-    } else {
-        VectorPropertyExtractor extractor(buf, propID);
-        ColumnSingleDispatcher<Types::AllowedVector,
-                               VectorPropertyExtractor,
-                               Types::ExcludedVector>::dispatch(column, extractor);
-    }
-}
-
-size_t committedNodeCount(const GraphView* view) {
-    if (!view || !view->isValid()) {
-        return 0;
-    }
-
-    const GraphReader reader = view->read();
-    return reader.getTotalNodesAllocated();
-}
-
-size_t committedEdgeCount(const GraphView* view) {
-    if (!view || !view->isValid()) {
-        return 0;
-    }
-
-    const GraphReader reader = view->read();
-    return reader.getTotalEdgesAllocated();
-}
-
 CommitWriteBuffer::ExistingOrPendingNode resolveNode(const ColumnNodeIDs* column,
                                                      size_t row,
                                                      bool isPending,
@@ -2572,6 +2419,50 @@ void setPendingProperty(CommitWriteBuffer::UntypedProperties& properties,
 
 bool writeTouchesRow(const ColumnMask* rows, size_t row) {
     return !rows || (*rows)[row];
+}
+
+// One property of an entity this change wrote and has not committed, read back out of
+// the write buffer. The value the pattern wrote is held as whatever type the row's own
+// column carried, so it is converted to the type the schema holds the property as -
+// which is the type of the column the fetch is filling.
+template <typename T>
+std::optional<typename T::Primitive> readPendingProperty(const CommitWriteBuffer::UntypedProperties& properties,
+                                                         PropertyTypeID propertyTypeID) {
+    using Primitive = typename T::Primitive;
+
+    const auto convert = [](const auto& held) -> std::optional<Primitive> {
+        using Held = std::decay_t<decltype(held)>;
+
+        if constexpr (std::is_convertible_v<const Held&, Primitive>) {
+            return Primitive(held);
+        } else {
+            return std::nullopt;
+        }
+    };
+
+    for (const CommitWriteBuffer::UntypedProperty& property : properties) {
+        if (property.propertyID == propertyTypeID) {
+            return std::visit(convert, property.value);
+        }
+    }
+
+    return std::nullopt;
+}
+
+// A pending row names its entity by the ID it will commit as, so the write buffer is
+// indexed by what is left once the committed space is taken off
+template <typename ID, typename T>
+std::optional<typename T::Primitive> readPendingEntityProperty(CommitWriteBuffer* writeBuffer,
+                                                               const GraphView* view,
+                                                               uint64_t id,
+                                                               PropertyTypeID propertyTypeID) {
+    if constexpr (std::is_same_v<ID, NodeID>) {
+        const size_t offset = id - committedNodeCount(view);
+        return readPendingProperty<T>(writeBuffer->getPendingNode(offset).properties, propertyTypeID);
+    } else {
+        const size_t offset = id - committedEdgeCount(view);
+        return readPendingProperty<T>(writeBuffer->getPendingEdge(offset).properties, propertyTypeID);
+    }
 }
 
 void throwIfNodesHaveEdges(const GraphView& view, const ColumnNodeIDs* nodes) {
@@ -2695,635 +2586,6 @@ NLKeyAppendFunction selectNumericMergeKeyAppend(ValueType keyType) {
 void throwUnlessKeyedAsItsOwnType(ValueType valueType, ValueType keyType) {
     if (valueType != keyType) {
         throw IRException("a MERGE pattern cannot constrain a property to a value of another type");
-    }
-}
-
-template <typename Property>
-void appendMergeKey(const std::vector<Property>& properties, size_t row, std::string& key) {
-    for (const Property& property : properties) {
-        property._keyAppend(property._values, row, key);
-    }
-}
-
-template <typename ID, typename T>
-void fetchMergeProperty(const GraphView& view,
-                        PropertyTypeID propertyTypeID,
-                        const ColumnVector<ID>* ids,
-                        Column* output) {
-    auto* typed = static_cast<ColumnOptVector<typename T::Primitive>*>(output);
-
-    GetPropertiesWithNullChunkWriter<ID, T> writer(view, propertyTypeID, ids);
-    writer.setOutput(typed);
-    writer.fill(ids->size());
-}
-
-void fetchMergeNodeProperty(const GraphView& view,
-                            const NLMergeScanProperty& property,
-                            const ColumnNodeIDs* nodes) {
-    const auto fetch = [&]<SupportedType T>() {
-        fetchMergeProperty<NodeID, T>(view, property._propertyType._id, nodes, property._values);
-    };
-
-    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
-}
-
-void fetchMergeEdgeProperty(const GraphView& view,
-                            const NLMergeScanProperty& property,
-                            const ColumnEdgeIDs* edges) {
-    const auto fetch = [&]<SupportedType T>() {
-        fetchMergeProperty<EdgeID, T>(view, property._propertyType._id, edges, property._values);
-    };
-
-    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
-}
-
-// One scan of the spec's label set with one property fetch per key property per chunk,
-// rather than a lookup per row of the merge
-void buildMergeNodeIndex(NLExecutionContext* context, NLMergeNodeIndex* index) {
-    index->markBuilt();
-
-    if (!index->isMatchable()) {
-        return;
-    }
-
-    const GraphView& view = *context->getView();
-    const LabelSetHandle labelset(index->getLabels());
-    const std::vector<NLMergeScanProperty>& scanProperties = index->scanProperties();
-    ColumnNodeIDs* nodes = index->getScanNodes();
-
-    ScanNodesByLabelChunkWriter scan(view, labelset);
-    scan.setNodeIDs(nodes);
-
-    std::string key;
-    while (scan.isValid()) {
-        scan.fill(context->getChunkSize());
-
-        const size_t rowCount = nodes->size();
-        if (rowCount == 0) {
-            continue;
-        }
-
-        for (const NLMergeScanProperty& property : scanProperties) {
-            fetchMergeNodeProperty(view, property, nodes);
-        }
-
-        for (size_t row = 0; row < rowCount; row++) {
-            key.clear();
-            appendMergeKey(scanProperties, row, key);
-
-            index->add(key, {._id=(*nodes)[row].getValue(), ._pending=false});
-        }
-    }
-}
-
-// One step of an nl.merge: the rows its input chunks hold, each looked up against the
-// graph and against the entities this query already wrote, then written where the
-// pattern is missing.
-class MergeStep {
-public:
-    MergeStep(NLExecutionContext* context, NLMergeData* data)
-        : _context(context),
-        _data(data),
-        _work(data->getWorkingSet()),
-        _writeBuffer(context->getWriteBuffer()),
-        _view(context->getView()),
-        _firstPendingNodeID(committedNodeCount(_view)),
-        _firstPendingEdgeID(committedEdgeCount(_view))
-    {
-    }
-
-    void run();
-
-private:
-    NLExecutionContext* _context {nullptr};
-    NLMergeData* _data {nullptr};
-    NLMergeWorkingSet* _work {nullptr};
-    CommitWriteBuffer* _writeBuffer {nullptr};
-    const GraphView* _view {nullptr};
-
-    // A ref this step holds names a pending entity by its write-buffer offset, while the
-    // columns it reads and fills name one by the ID it will commit as: one past the last
-    // the graph holds, plus that offset
-    size_t _firstPendingNodeID {0};
-    size_t _firstPendingEdgeID {0};
-
-    void extractProperties(size_t rowCount);
-    void clearResults();
-
-    void collectCandidates(size_t row);
-    void matchRow(size_t row);
-    void buildHopKeys(const NLMergeData::Hop& hop, size_t row);
-    void extendHop(size_t hopIndex);
-
-    void collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex);
-    void collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing);
-    void dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop);
-    void groupExtensionsBySource();
-
-    void emitRow(const NLMergePartialMatch& match, size_t row, bool created);
-    void writeRow(size_t row);
-
-    NLMergeRef writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row);
-    NLMergeRef writeEdge(const NLMergeData::Hop& hop,
-                         size_t hopIndex,
-                         size_t row,
-                         const NLMergeRef& source,
-                         const NLMergeRef& target);
-
-    static CommitWriteBuffer::ExistingOrPendingNode asWriteBufferNode(const NLMergeRef& ref);
-
-    void gatherCarriedColumns();
-};
-
-void MergeStep::run() {
-    bioassert(_writeBuffer, "nl.merge requires an active write transaction");
-
-    const Column* rowCarrier = _data->getRowCarrier();
-
-    // A pattern reading no column at all stands on its own, and runs over the single
-    // row its literals are - the row db.create_node writes without a cardinality
-    const size_t rowCount = rowCarrier ? rowCarrier->size() : 1;
-
-    clearResults();
-    extractProperties(rowCount);
-
-    _work->_candidates.resize(_data->nodes().size());
-    _work->_candidateKeys.resize(_data->nodes().size());
-
-    for (size_t row = 0; row < rowCount; row++) {
-        matchRow(row);
-    }
-
-    gatherCarriedColumns();
-}
-
-void MergeStep::clearResults() {
-    // A bound node has no output of its own: its rows come back through the carry set
-    for (const NLMergeData::Node& node : _data->nodes()) {
-        if (node._output) {
-            node._output->clear();
-            node._outputPending->clear();
-        }
-    }
-
-    for (const NLMergeData::Hop& hop : _data->hops()) {
-        hop._output->clear();
-        hop._outputPending->clear();
-    }
-
-    _data->getCreated()->clear();
-    _data->getIndices()->clear();
-}
-
-void MergeStep::extractProperties(size_t rowCount) {
-    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
-    const std::vector<NLMergeData::Hop>& hops = _data->hops();
-
-    _work->_nodeProperties.resize(nodes.size());
-    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
-        const std::vector<NLMergeProperty>& properties = nodes[nodeIndex]._properties;
-        // The extractor clears each buffer it fills, so a step reuses what the last one
-        // allocated
-        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_nodeProperties[nodeIndex];
-        extracted.resize(properties.size());
-
-        for (size_t index = 0; index < properties.size(); index++) {
-            extractColumnProperties(properties[index]._values,
-                                    rowCount,
-                                    properties[index]._propertyType._id,
-                                    extracted[index]);
-        }
-    }
-
-    _work->_hopProperties.resize(hops.size());
-    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
-        const std::vector<NLMergeProperty>& properties = hops[hopIndex]._properties;
-        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_hopProperties[hopIndex];
-        extracted.resize(properties.size());
-
-        for (size_t index = 0; index < properties.size(); index++) {
-            extractColumnProperties(properties[index]._values,
-                                    rowCount,
-                                    properties[index]._propertyType._id,
-                                    extracted[index]);
-        }
-    }
-}
-
-void MergeStep::collectCandidates(size_t row) {
-    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
-
-    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
-        const NLMergeData::Node& node = nodes[nodeIndex];
-        std::vector<NLMergeRef>& candidates = _work->_candidates[nodeIndex];
-        candidates.clear();
-
-        if (node._boundColumn) {
-            const bool pending = node._boundPending && (*node._boundPending)[row];
-            const uint64_t boundID = (*node._boundColumn)[row].getValue();
-            const uint64_t id = pending ? boundID - _firstPendingNodeID : boundID;
-
-            candidates.push_back({._id=id, ._pending=pending});
-        } else {
-            NLMergeNodeIndex* index = node._index;
-            if (!index->isBuilt()) {
-                buildMergeNodeIndex(_context, index);
-            }
-
-            std::string& key = _work->_key;
-            key.clear();
-            appendMergeKey(node._properties, row, key);
-
-            const std::span<const NLMergeRef> committed = index->find(key);
-            candidates.insert(candidates.end(), committed.begin(), committed.end());
-
-            key.insert(0, node._signature);
-            const std::span<const NLMergeRef> pending = _data->getPendingNodes()->find(key);
-            candidates.insert(candidates.end(), pending.begin(), pending.end());
-        }
-
-        std::unordered_set<uint64_t>& keys = _work->_candidateKeys[nodeIndex];
-        keys.clear();
-        for (const NLMergeRef& candidate : candidates) {
-            keys.insert(candidate.asKey());
-        }
-    }
-}
-
-void MergeStep::matchRow(size_t row) {
-    collectCandidates(row);
-
-    const std::vector<NLMergeData::Hop>& hops = _data->hops();
-    const size_t nodeCount = _data->nodes().size();
-
-    std::vector<NLMergePartialMatch>& matches = _work->_matches;
-    matches.clear();
-    for (const NLMergeRef& candidate : _work->_candidates.front()) {
-        NLMergePartialMatch& match = matches.emplace_back();
-
-        // The walk appends one node and one edge per hop, so the whole chain fits the
-        // allocation the first node forces
-        match._nodes.reserve(nodeCount);
-        match._edges.reserve(hops.size());
-        match._nodes.push_back(candidate);
-    }
-
-    for (size_t hopIndex = 0; hopIndex < hops.size() && !matches.empty(); hopIndex++) {
-        buildHopKeys(hops[hopIndex], row);
-
-        extendHop(hopIndex);
-    }
-
-    if (matches.empty()) {
-        writeRow(row);
-        return;
-    }
-
-    for (const NLMergePartialMatch& match : matches) {
-        emitRow(match, row, /*created=*/false);
-    }
-}
-
-void MergeStep::buildHopKeys(const NLMergeData::Hop& hop, size_t row) {
-    // The values the hop asks for, which a candidate edge's own values are compared
-    // against, and those same values behind the hop's signature - what the pending log
-    // is keyed by, since it holds every hop this query wrote under one pair of endpoints
-    _work->_hopKey.clear();
-    appendMergeKey(hop._properties, row, _work->_hopKey);
-
-    _work->_pendingHopKey.assign(hop._signature);
-    _work->_pendingHopKey.append(_work->_hopKey);
-}
-
-void MergeStep::extendHop(size_t hopIndex) {
-    const NLMergeData::Hop& hop = _data->hops()[hopIndex];
-    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
-    const NLMergePendingEdges* pendingEdges = _data->getPendingEdges();
-
-    collectGraphExtensions(hop, hopIndex);
-
-    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
-    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
-
-    std::vector<NLMergePartialMatch>& matches = _work->_matches;
-    std::vector<NLMergePartialMatch>& extended = _work->_extended;
-
-    extended.clear();
-    for (const NLMergePartialMatch& match : matches) {
-        const NLMergeRef source = match._nodes.back();
-
-        const auto extendWith = [&](const NLMergeRef& edge, const NLMergeRef& target) {
-            NLMergePartialMatch& grown = extended.emplace_back(match);
-            grown._edges.push_back(edge);
-            grown._nodes.push_back(target);
-        };
-
-        const auto runIt = _work->_extensionRuns.find(source.asKey());
-        if (runIt != end(_work->_extensionRuns)) {
-            const auto [first, last] = runIt->second;
-            for (size_t index = first; index < last; index++) {
-                const NLMergeExtension& extension = _work->_extensions[index];
-                extendWith(extension._edge, extension._target);
-            }
-        }
-
-        // An undirected hop follows both ways round, and a self-loop is on both sides of
-        // its own node: the outgoing pass has it, so the incoming one leaves it alone
-        const auto extendWithPending = [&](std::span<const NLMergePendingEdges::Entry> entries,
-                                           bool skipSelfLoops) {
-            for (const NLMergePendingEdges::Entry& entry : entries) {
-                if (skipSelfLoops && entry._other == source) {
-                    continue;
-                }
-
-                const bool sameType = entry._edgeType == hop._writeEdgeType;
-                const bool sameProperties = entry._propertyKey == _work->_pendingHopKey;
-                const bool onACandidate = targets.contains(entry._other.asKey());
-
-                if (sameType && sameProperties && onACandidate) {
-                    extendWith({._id=entry._offset, ._pending=true}, entry._other);
-                }
-            }
-        };
-
-        if (followsOutgoing) {
-            extendWithPending(pendingEdges->outOf(source), /*skipSelfLoops=*/false);
-        }
-
-        if (followsIncoming) {
-            extendWithPending(pendingEdges->into(source), /*skipSelfLoops=*/followsOutgoing);
-        }
-    }
-
-    matches.swap(extended);
-}
-
-void MergeStep::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex) {
-    _work->_extensions.clear();
-    _work->_extensionRuns.clear();
-
-    // A type the schema does not have is on no committed edge, so only a pending one can
-    // extend the match
-    if (!hop._matchEdgeType.isValid()) {
-        return;
-    }
-
-    ColumnNodeIDs* sources = hop._scanSources;
-    sources->clear();
-
-    // Two partial matches reaching the same node scan its edges once: the runs below are
-    // keyed by source node, so a second copy of one would fold into its run and extend
-    // every match that reached it a second time.
-    std::unordered_set<uint64_t>& sourceKeys = _work->_scanSourceKeys;
-    sourceKeys.clear();
-
-    for (const NLMergePartialMatch& match : _work->_matches) {
-        const NLMergeRef source = match._nodes.back();
-        if (source._pending) {
-            continue;
-        }
-
-        if (sourceKeys.insert(source.asKey()).second) {
-            sources->push_back(NodeID(source._id));
-        }
-    }
-
-    if (sources->empty()) {
-        return;
-    }
-
-    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
-    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
-
-    if (followsOutgoing) {
-        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/true);
-    }
-
-    if (followsIncoming) {
-        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/false);
-    }
-
-    dropExtensionsWithOtherProperties(hop);
-    groupExtensionsBySource();
-}
-
-void MergeStep::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing) {
-    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
-    const Tombstones& tombstones = _view->tombstones();
-    const ColumnNodeIDs* sources = hop._scanSources;
-
-    // An undirected hop scans both ways round, and a self-loop is an out-edge and an
-    // in-edge of the one node: the outgoing pass has it already
-    const bool undirected = hop._direction == NLMergeDirection::Undirected;
-    const bool skipSelfLoops = undirected && !outgoing;
-
-    const auto collect = [&](const EdgeRecord& record) {
-        if (record._edgeTypeID != hop._matchEdgeType || tombstones.containsEdge(record._edgeID)) {
-            return;
-        }
-
-        if (skipSelfLoops && record._otherID == record._nodeID) {
-            return;
-        }
-
-        const NLMergeRef target {._id=record._otherID.getValue(), ._pending=false};
-        if (!targets.contains(target.asKey())) {
-            return;
-        }
-
-        _work->_extensions.push_back({._source={._id=record._nodeID.getValue(), ._pending=false},
-                                      ._edge={._id=record._edgeID.getValue(), ._pending=false},
-                                      ._target=target});
-    };
-
-    if (outgoing) {
-        const GetOutEdgesRange outEdges(*_view, sources);
-        for (const EdgeRecord& record : outEdges) {
-            collect(record);
-        }
-    } else {
-        const GetInEdgesRange inEdges(*_view, sources);
-        for (const EdgeRecord& record : inEdges) {
-            collect(record);
-        }
-    }
-}
-
-void MergeStep::dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop) {
-    const std::vector<NLMergeScanProperty>& scanProperties = hop._scanProperties;
-    std::vector<NLMergeExtension>& extensions = _work->_extensions;
-    if (scanProperties.empty() || extensions.empty()) {
-        return;
-    }
-
-    ColumnEdgeIDs* edges = hop._scanEdges;
-    edges->clear();
-    for (const NLMergeExtension& extension : extensions) {
-        edges->push_back(EdgeID(extension._edge._id));
-    }
-
-    for (const NLMergeScanProperty& property : scanProperties) {
-        fetchMergeEdgeProperty(*_view, property, edges);
-    }
-
-    std::vector<NLMergeExtension>& kept = _work->_keptExtensions;
-    std::string& key = _work->_scanKey;
-
-    kept.clear();
-    for (size_t index = 0; index < extensions.size(); index++) {
-        key.clear();
-        appendMergeKey(scanProperties, index, key);
-
-        if (key == _work->_hopKey) {
-            kept.push_back(extensions[index]);
-        }
-    }
-
-    extensions.swap(kept);
-}
-
-void MergeStep::groupExtensionsBySource() {
-    std::vector<NLMergeExtension>& extensions = _work->_extensions;
-
-    std::ranges::stable_sort(extensions, [](const NLMergeExtension& lhs, const NLMergeExtension& rhs) {
-        return lhs._source.asKey() < rhs._source.asKey();
-    });
-
-    size_t first = 0;
-    while (first < extensions.size()) {
-        const uint64_t sourceKey = extensions[first]._source.asKey();
-
-        size_t last = first + 1;
-        while (last < extensions.size() && extensions[last]._source.asKey() == sourceKey) {
-            last++;
-        }
-
-        _work->_extensionRuns[sourceKey] = {first, last};
-        first = last;
-    }
-}
-
-void MergeStep::emitRow(const NLMergePartialMatch& match, size_t row, bool created) {
-    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
-    const std::vector<NLMergeData::Hop>& hops = _data->hops();
-
-    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
-        const NLMergeData::Node& node = nodes[nodeIndex];
-        if (!node._output) {
-            continue;
-        }
-
-        const NLMergeRef& entity = match._nodes[nodeIndex];
-        const uint64_t nodeID = entity._pending ? entity._id + _firstPendingNodeID : entity._id;
-
-        node._output->push_back(NodeID(nodeID));
-        node._outputPending->push_back(entity._pending);
-    }
-
-    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
-        const NLMergeRef& edge = match._edges[hopIndex];
-        const uint64_t edgeID = edge._pending ? edge._id + _firstPendingEdgeID : edge._id;
-
-        hops[hopIndex]._output->push_back(EdgeID(edgeID));
-        hops[hopIndex]._outputPending->push_back(edge._pending);
-    }
-
-    _data->getCreated()->push_back(created);
-    _data->getIndices()->push_back(row);
-}
-
-void MergeStep::writeRow(size_t row) {
-    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
-    const std::vector<NLMergeData::Hop>& hops = _data->hops();
-
-    NLMergePartialMatch written;
-    written._nodes.reserve(nodes.size());
-    written._edges.reserve(hops.size());
-
-    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
-        const NLMergeData::Node& node = nodes[nodeIndex];
-
-        if (node._boundColumn) {
-            written._nodes.push_back(_work->_candidates[nodeIndex].front());
-        } else {
-            written._nodes.push_back(writeNode(node, nodeIndex, row));
-        }
-    }
-
-    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
-        const NLMergeData::Hop& hop = hops[hopIndex];
-
-        // An undirected hop is written pointing forward, the way Cypher writes it
-        const bool backward = hop._direction == NLMergeDirection::Backward;
-        const NLMergeRef& source = backward ? written._nodes[hopIndex + 1] : written._nodes[hopIndex];
-        const NLMergeRef& target = backward ? written._nodes[hopIndex] : written._nodes[hopIndex + 1];
-
-        written._edges.push_back(writeEdge(hop, hopIndex, row, source, target));
-    }
-
-    emitRow(written, row, /*created=*/true);
-}
-
-NLMergeRef MergeStep::writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row) {
-    const uint64_t offset = _writeBuffer->numPendingNodes();
-
-    CommitWriteBuffer::PendingNode& pending = _writeBuffer->newPendingNode();
-    pending.labelsetHandle = node._labelSetHandle;
-
-    for (const CommitWriteBuffer::UntypedProperties& values : _work->_nodeProperties[nodeIndex]) {
-        pending.properties.push_back(values[row]);
-    }
-
-    const NLMergeRef ref {._id=offset, ._pending=true};
-
-    // A later row asking for the same values binds this node rather than writing a
-    // second one, which is what makes a merge over many rows idempotent
-    std::string& key = _work->_key;
-    key.assign(node._signature);
-    appendMergeKey(node._properties, row, key);
-    _data->getPendingNodes()->add(key, ref);
-
-    return ref;
-}
-
-NLMergeRef MergeStep::writeEdge(const NLMergeData::Hop& hop,
-                                size_t hopIndex,
-                                size_t row,
-                                const NLMergeRef& source,
-                                const NLMergeRef& target) {
-    const uint64_t offset = _writeBuffer->numPendingEdges();
-
-    CommitWriteBuffer::PendingEdge& pending = _writeBuffer->newPendingEdge(asWriteBufferNode(source),
-                                                                           asWriteBufferNode(target));
-    pending.edgeType = hop._writeEdgeType;
-
-    for (const CommitWriteBuffer::UntypedProperties& values : _work->_hopProperties[hopIndex]) {
-        pending.properties.push_back(values[row]);
-    }
-
-    // Keyed by its own hop's values, not by whichever hop the match reached before it
-    // gave up: a later row looks each hop of the chain up under its own key
-    buildHopKeys(hop, row);
-
-    _data->getPendingEdges()->add(source, target, hop._writeEdgeType, offset, _work->_pendingHopKey);
-
-    return {._id=offset, ._pending=true};
-}
-
-CommitWriteBuffer::ExistingOrPendingNode MergeStep::asWriteBufferNode(const NLMergeRef& ref) {
-    if (ref._pending) {
-        return CommitWriteBuffer::PendingNodeOffset(ref._id);
-    }
-
-    return NodeID(ref._id);
-}
-
-void MergeStep::gatherCarriedColumns() {
-    const ColumnVector<size_t>* indices = _data->getIndices();
-
-    for (const NLCarriedColumn& carried : _data->carriedColumns()) {
-        const NLGatherFunction gather = carried.getGatherFunc();
-        gather(carried.getInput(), indices, carried.getOutput());
     }
 }
 
@@ -3566,21 +2828,6 @@ void shortestPathSearch(NLExecutionContext* context, NLShortestPathLoopData* loo
 
 }
 
-vec::VectorDatabase* NLExecutionContext::getVectorDatabase() const {
-    SystemAccessor* const accessor = _system ? _system->getAccessor() : nullptr;
-
-    return accessor ? accessor->getVectorDatabase() : nullptr;
-}
-
-const fs::Path* NLExecutionContext::getDataDir() const {
-    const SystemManager* const manager = _system ? _system->getSystemManager() : nullptr;
-    if (!manager) {
-        return nullptr;
-    }
-
-    return &manager->getConfig()->getDataDir();
-}
-
 NLExecutor::NLExecutor(const GraphView* view,
                        const NLProgram* prog,
                        NLOutputSink* sink,
@@ -3647,8 +2894,8 @@ void NLExecutor::runCreateNode(NLExecutionContext* context, NLFunctionData* data
 }
 
 void NLExecutor::runMerge(NLExecutionContext* context, NLFunctionData* data) {
-    MergeStep step(context, static_cast<NLMergeData*>(data));
-    step.run();
+    NLMergeExecutor merge(context, static_cast<NLMergeData*>(data));
+    merge.run();
 }
 
 void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data) {
@@ -6628,16 +5875,23 @@ void NLExecutor::runPropertyFetch(NLExecutionContext* context, NLFunctionData* d
 
     // A pending row's ID is an offset into the write buffer, which the fetch above read
     // as an ID of the graph: whatever it found belongs to another entity, so the value
-    // the query sees is the absent one a written entity's unwritten property has.
+    // is read out of the write buffer instead - null there when the write set none.
     const ColumnMask* pending = fetchData->getPending();
     if (!pending) {
         return;
     }
 
+    CommitWriteBuffer* writeBuffer = context->getWriteBuffer();
+    bioassert(writeBuffer, "a property fetch over written entities requires an active write transaction");
+
     auto& raw = output->getRaw();
+    const auto& inputRaw = inputIDs->getRaw();
     for (size_t row = 0; row < raw.size(); row++) {
         if ((*pending)[row]) {
-            raw[row] = std::nullopt;
+            raw[row] = readPendingEntityProperty<ID, T>(writeBuffer,
+                                                        &view,
+                                                        inputRaw[row].getValue(),
+                                                        propertyTypeID);
         }
     }
 }

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2544,6 +2544,35 @@ CommitWriteBuffer::ExistingOrPendingNode resolveNode(const ColumnNodeIDs* column
     }
 }
 
+// A column a merge produced mixes the two ID spaces, so its mask answers row by row;
+// one with no mask is pending in every row or in none.
+bool isPendingRow(const ColumnMask* pending, bool isPendingColumn, size_t row) {
+    if (pending) {
+        return (*pending)[row];
+    }
+
+    return isPendingColumn;
+}
+
+// The write buffer builds one column per property of a pending entity, so a second entry
+// for the same property would be a second value for the same cell: ON CREATE writes over
+// the value the pattern wrote a moment earlier rather than beside it.
+void setPendingProperty(CommitWriteBuffer::UntypedProperties& properties,
+                        const CommitWriteBuffer::UntypedProperty& property) {
+    for (CommitWriteBuffer::UntypedProperty& held : properties) {
+        if (held.propertyID == property.propertyID) {
+            held.value = property.value;
+            return;
+        }
+    }
+
+    properties.push_back(property);
+}
+
+bool writeTouchesRow(const ColumnMask* rows, size_t row) {
+    return !rows || (*rows)[row];
+}
+
 void throwIfNodesHaveEdges(const GraphView& view, const ColumnNodeIDs* nodes) {
     const Tombstones& tombstones = view.tombstones();
 
@@ -2559,6 +2588,621 @@ void throwIfNodesHaveEdges(const GraphView& view, const ColumnNodeIDs* nodes) {
         if (!tombstones.containsEdge(record._edgeID)) {
             throw IRException("Cannot delete a node with relationships; use DETACH DELETE");
         }
+    }
+}
+
+// A merge keys the value a row asks for against the value the graph holds, and those
+// arrive in a plain and a nullable column respectively: the two have to serialize alike,
+// which is why a plain row writes the tag byte the nullable one writes for a value.
+template <typename ElementType>
+void mergeKeyAppendPlainColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
+
+    key.push_back('\1');
+    distinctAppendValueBytes(key, raw[row]);
+}
+
+template <typename ElementType>
+void mergeKeyAppendConstColumn(const Column* column, size_t row, std::string& key) {
+    key.push_back('\1');
+    distinctAppendValueBytes(key, (*static_cast<const ColumnConst<ElementType>*>(column))[row]);
+}
+
+// Keys the way a nullable column's null row does, so a merge on a null value binds the
+// nodes that lack the property
+void mergeKeyAppendConstNull(const Column* column, size_t row, std::string& key) {
+    key.push_back('\0');
+}
+
+template <typename Property>
+void appendMergeKey(const std::vector<Property>& properties, size_t row, std::string& key) {
+    for (const Property& property : properties) {
+        property._keyAppend(property._values, row, key);
+    }
+}
+
+template <typename ID, typename T>
+void fetchMergeProperty(const GraphView& view,
+                        PropertyTypeID propertyTypeID,
+                        const ColumnVector<ID>* ids,
+                        Column* output) {
+    auto* typed = static_cast<ColumnOptVector<typename T::Primitive>*>(output);
+
+    GetPropertiesWithNullChunkWriter<ID, T> writer(view, propertyTypeID, ids);
+    writer.setOutput(typed);
+    writer.fill(ids->size());
+}
+
+void fetchMergeNodeProperty(const GraphView& view,
+                            const NLMergeScanProperty& property,
+                            const ColumnNodeIDs* nodes) {
+    const auto fetch = [&]<SupportedType T>() {
+        fetchMergeProperty<NodeID, T>(view, property._propertyType._id, nodes, property._values);
+    };
+
+    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
+}
+
+void fetchMergeEdgeProperty(const GraphView& view,
+                            const NLMergeScanProperty& property,
+                            const ColumnEdgeIDs* edges) {
+    const auto fetch = [&]<SupportedType T>() {
+        fetchMergeProperty<EdgeID, T>(view, property._propertyType._id, edges, property._values);
+    };
+
+    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
+}
+
+// One scan of the spec's label set with one property fetch per key property per chunk,
+// rather than a lookup per row of the merge
+void buildMergeNodeIndex(NLExecutionContext* context, NLMergeNodeIndex* index) {
+    index->markBuilt();
+
+    if (!index->isMatchable()) {
+        return;
+    }
+
+    const GraphView& view = *context->getView();
+    const LabelSetHandle labelset(index->getLabels());
+    const std::vector<NLMergeScanProperty>& scanProperties = index->scanProperties();
+    ColumnNodeIDs* nodes = index->getScanNodes();
+
+    ScanNodesByLabelChunkWriter scan(view, labelset);
+    scan.setNodeIDs(nodes);
+
+    std::string key;
+    while (scan.isValid()) {
+        scan.fill(context->getChunkSize());
+
+        const size_t rowCount = nodes->size();
+        if (rowCount == 0) {
+            continue;
+        }
+
+        for (const NLMergeScanProperty& property : scanProperties) {
+            fetchMergeNodeProperty(view, property, nodes);
+        }
+
+        for (size_t row = 0; row < rowCount; row++) {
+            key.clear();
+            appendMergeKey(scanProperties, row, key);
+
+            index->add(key, {._id=(*nodes)[row].getValue(), ._pending=false});
+        }
+    }
+}
+
+// One step of an nl.merge: the rows its input chunks hold, each looked up against the
+// graph and against the entities this query already wrote, then written where the
+// pattern is missing.
+class MergeStep {
+public:
+    MergeStep(NLExecutionContext* context, NLMergeData* data)
+        : _context(context),
+        _data(data),
+        _writeBuffer(context->getWriteBuffer()),
+        _view(context->getView()),
+        _firstPendingNodeID(committedNodeCount(_view)),
+        _firstPendingEdgeID(committedEdgeCount(_view))
+    {
+    }
+
+    void run();
+
+private:
+    // A chain matched as far as one node, and the entities it bound getting there
+    struct PartialMatch {
+        std::vector<NLMergeRef> _nodes;
+        std::vector<NLMergeRef> _edges;
+    };
+
+    struct Extension {
+        NLMergeRef _source;
+        NLMergeRef _edge;
+        NLMergeRef _target;
+    };
+
+    NLExecutionContext* _context {nullptr};
+    NLMergeData* _data {nullptr};
+    CommitWriteBuffer* _writeBuffer {nullptr};
+    const GraphView* _view {nullptr};
+
+    // A ref this step holds names a pending entity by its write-buffer offset, while the
+    // columns it reads and fills name one by the ID it will commit as: one past the last
+    // the graph holds, plus that offset
+    size_t _firstPendingNodeID {0};
+    size_t _firstPendingEdgeID {0};
+
+    // Per chain node, the current row's candidates, and their refs as a set for the
+    // membership test each hop's far end has to pass
+    std::vector<std::vector<NLMergeRef>> _candidates;
+    std::vector<std::unordered_set<uint64_t>> _candidateKeys;
+
+    // Extracted once for the whole chunk, so a written row picks its values by row index
+    std::vector<std::vector<CommitWriteBuffer::UntypedProperties>> _nodeProperties;
+    std::vector<std::vector<CommitWriteBuffer::UntypedProperties>> _hopProperties;
+
+    // The frontier of the chain walk and the one the current hop extends it into
+    std::vector<PartialMatch> _matches;
+    std::vector<PartialMatch> _extended;
+
+    // The current hop's candidate graph edges, and where each source node's run of them
+    // starts and ends once they are grouped
+    std::vector<Extension> _extensions;
+    std::unordered_map<uint64_t, std::pair<size_t, size_t>> _extensionRuns;
+
+    std::string _key;
+    std::string _hopKey;
+
+    void extractProperties(size_t rowCount);
+    void clearResults();
+
+    void collectCandidates(size_t row);
+    void matchRow(size_t row);
+    void extendHop(size_t hopIndex);
+
+    void collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex);
+    void collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing);
+    void dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop);
+    void groupExtensionsBySource();
+
+    void emitRow(const PartialMatch& match, size_t row, bool created);
+    void writeRow(size_t row);
+
+    NLMergeRef writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row);
+    NLMergeRef writeEdge(const NLMergeData::Hop& hop,
+                         size_t hopIndex,
+                         size_t row,
+                         const NLMergeRef& source,
+                         const NLMergeRef& target);
+
+    static CommitWriteBuffer::ExistingOrPendingNode asWriteBufferNode(const NLMergeRef& ref);
+
+    void gatherCarriedColumns();
+};
+
+void MergeStep::run() {
+    bioassert(_writeBuffer, "nl.merge requires an active write transaction");
+
+    const Column* rowCarrier = _data->getRowCarrier();
+
+    // A pattern reading no column at all stands on its own, and runs over the single
+    // row its literals are - the row db.create_node writes without a cardinality
+    const size_t rowCount = rowCarrier ? rowCarrier->size() : 1;
+
+    clearResults();
+    extractProperties(rowCount);
+
+    _candidates.assign(_data->nodes().size(), {});
+    _candidateKeys.assign(_data->nodes().size(), {});
+
+    for (size_t row = 0; row < rowCount; row++) {
+        matchRow(row);
+    }
+
+    gatherCarriedColumns();
+}
+
+void MergeStep::clearResults() {
+    for (const NLMergeData::Node& node : _data->nodes()) {
+        node._output->clear();
+        node._outputPending->clear();
+    }
+
+    for (const NLMergeData::Hop& hop : _data->hops()) {
+        hop._output->clear();
+        hop._outputPending->clear();
+    }
+
+    _data->getCreated()->clear();
+    _data->getIndices()->clear();
+}
+
+void MergeStep::extractProperties(size_t rowCount) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    _nodeProperties.assign(nodes.size(), {});
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const std::vector<NLMergeProperty>& properties = nodes[nodeIndex]._properties;
+        _nodeProperties[nodeIndex].resize(properties.size());
+
+        for (size_t index = 0; index < properties.size(); index++) {
+            extractColumnProperties(properties[index]._values,
+                                    rowCount,
+                                    properties[index]._propertyType._id,
+                                    _nodeProperties[nodeIndex][index]);
+        }
+    }
+
+    _hopProperties.assign(hops.size(), {});
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const std::vector<NLMergeProperty>& properties = hops[hopIndex]._properties;
+        _hopProperties[hopIndex].resize(properties.size());
+
+        for (size_t index = 0; index < properties.size(); index++) {
+            extractColumnProperties(properties[index]._values,
+                                    rowCount,
+                                    properties[index]._propertyType._id,
+                                    _hopProperties[hopIndex][index]);
+        }
+    }
+}
+
+void MergeStep::collectCandidates(size_t row) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeData::Node& node = nodes[nodeIndex];
+        std::vector<NLMergeRef>& candidates = _candidates[nodeIndex];
+        candidates.clear();
+
+        if (node._boundColumn) {
+            const bool pending = node._boundPending && (*node._boundPending)[row];
+            const uint64_t boundID = (*node._boundColumn)[row].getValue();
+            const uint64_t id = pending ? boundID - _firstPendingNodeID : boundID;
+
+            candidates.push_back({._id=id, ._pending=pending});
+        } else {
+            NLMergeNodeIndex* index = node._index;
+            if (!index->isBuilt()) {
+                buildMergeNodeIndex(_context, index);
+            }
+
+            _key.clear();
+            appendMergeKey(node._properties, row, _key);
+
+            const std::span<const NLMergeRef> committed = index->find(_key);
+            candidates.insert(candidates.end(), committed.begin(), committed.end());
+
+            _key.insert(0, node._signature);
+            const std::span<const NLMergeRef> pending = _data->getPendingNodes()->find(_key);
+            candidates.insert(candidates.end(), pending.begin(), pending.end());
+        }
+
+        std::unordered_set<uint64_t>& keys = _candidateKeys[nodeIndex];
+        keys.clear();
+        for (const NLMergeRef& candidate : candidates) {
+            keys.insert(candidate.asKey());
+        }
+    }
+}
+
+void MergeStep::matchRow(size_t row) {
+    collectCandidates(row);
+
+    _matches.clear();
+    for (const NLMergeRef& candidate : _candidates.front()) {
+        PartialMatch match;
+        match._nodes.push_back(candidate);
+        _matches.push_back(match);
+    }
+
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+    for (size_t hopIndex = 0; hopIndex < hops.size() && !_matches.empty(); hopIndex++) {
+        _hopKey.clear();
+        appendMergeKey(hops[hopIndex]._properties, row, _hopKey);
+
+        extendHop(hopIndex);
+    }
+
+    if (_matches.empty()) {
+        writeRow(row);
+        return;
+    }
+
+    for (const PartialMatch& match : _matches) {
+        emitRow(match, row, /*created=*/false);
+    }
+}
+
+void MergeStep::extendHop(size_t hopIndex) {
+    const NLMergeData::Hop& hop = _data->hops()[hopIndex];
+    const std::unordered_set<uint64_t>& targets = _candidateKeys[hopIndex + 1];
+    const NLMergePendingEdges* pendingEdges = _data->getPendingEdges();
+
+    collectGraphExtensions(hop, hopIndex);
+
+    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
+    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
+
+    _extended.clear();
+    for (const PartialMatch& match : _matches) {
+        const NLMergeRef source = match._nodes.back();
+
+        const auto extendWith = [&](const NLMergeRef& edge, const NLMergeRef& target) {
+            PartialMatch extended = match;
+            extended._edges.push_back(edge);
+            extended._nodes.push_back(target);
+            _extended.push_back(extended);
+        };
+
+        const auto runIt = _extensionRuns.find(source.asKey());
+        if (runIt != end(_extensionRuns)) {
+            const auto [first, last] = runIt->second;
+            for (size_t index = first; index < last; index++) {
+                extendWith(_extensions[index]._edge, _extensions[index]._target);
+            }
+        }
+
+        const auto extendWithPending = [&](std::span<const NLMergePendingEdges::Entry> entries) {
+            for (const NLMergePendingEdges::Entry& entry : entries) {
+                const bool sameType = entry._edgeType == hop._writeEdgeType;
+                const bool sameProperties = entry._propertyKey == _hopKey;
+                const bool onACandidate = targets.contains(entry._other.asKey());
+
+                if (sameType && sameProperties && onACandidate) {
+                    extendWith({._id=entry._offset, ._pending=true}, entry._other);
+                }
+            }
+        };
+
+        if (followsOutgoing) {
+            extendWithPending(pendingEdges->outOf(source));
+        }
+
+        if (followsIncoming) {
+            extendWithPending(pendingEdges->into(source));
+        }
+    }
+
+    _matches.swap(_extended);
+}
+
+void MergeStep::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex) {
+    _extensions.clear();
+    _extensionRuns.clear();
+
+    // A type the schema does not have is on no committed edge, so only a pending one can
+    // extend the match
+    if (!hop._matchEdgeType.isValid()) {
+        return;
+    }
+
+    ColumnNodeIDs* sources = hop._scanSources;
+    sources->clear();
+
+    for (const PartialMatch& match : _matches) {
+        const NLMergeRef source = match._nodes.back();
+        if (!source._pending) {
+            sources->push_back(NodeID(source._id));
+        }
+    }
+
+    if (sources->empty()) {
+        return;
+    }
+
+    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
+    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
+
+    if (followsOutgoing) {
+        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/true);
+    }
+
+    if (followsIncoming) {
+        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/false);
+    }
+
+    dropExtensionsWithOtherProperties(hop);
+    groupExtensionsBySource();
+}
+
+void MergeStep::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing) {
+    const std::unordered_set<uint64_t>& targets = _candidateKeys[hopIndex + 1];
+    const Tombstones& tombstones = _view->tombstones();
+    const ColumnNodeIDs* sources = hop._scanSources;
+
+    const auto collect = [&](const EdgeRecord& record) {
+        if (record._edgeTypeID != hop._matchEdgeType || tombstones.containsEdge(record._edgeID)) {
+            return;
+        }
+
+        const NLMergeRef target {._id=record._otherID.getValue(), ._pending=false};
+        if (!targets.contains(target.asKey())) {
+            return;
+        }
+
+        _extensions.push_back({._source={._id=record._nodeID.getValue(), ._pending=false},
+                               ._edge={._id=record._edgeID.getValue(), ._pending=false},
+                               ._target=target});
+    };
+
+    if (outgoing) {
+        const GetOutEdgesRange outEdges(*_view, sources);
+        for (const EdgeRecord& record : outEdges) {
+            collect(record);
+        }
+    } else {
+        const GetInEdgesRange inEdges(*_view, sources);
+        for (const EdgeRecord& record : inEdges) {
+            collect(record);
+        }
+    }
+}
+
+void MergeStep::dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop) {
+    const std::vector<NLMergeScanProperty>& scanProperties = hop._scanProperties;
+    if (scanProperties.empty() || _extensions.empty()) {
+        return;
+    }
+
+    ColumnEdgeIDs* edges = hop._scanEdges;
+    edges->clear();
+    for (const Extension& extension : _extensions) {
+        edges->push_back(EdgeID(extension._edge._id));
+    }
+
+    for (const NLMergeScanProperty& property : scanProperties) {
+        fetchMergeEdgeProperty(*_view, property, edges);
+    }
+
+    std::vector<Extension> kept;
+    std::string key;
+    for (size_t index = 0; index < _extensions.size(); index++) {
+        key.clear();
+        appendMergeKey(scanProperties, index, key);
+
+        if (key == _hopKey) {
+            kept.push_back(_extensions[index]);
+        }
+    }
+
+    _extensions.swap(kept);
+}
+
+void MergeStep::groupExtensionsBySource() {
+    std::ranges::stable_sort(_extensions, [](const Extension& lhs, const Extension& rhs) {
+        return lhs._source.asKey() < rhs._source.asKey();
+    });
+
+    size_t first = 0;
+    while (first < _extensions.size()) {
+        const uint64_t sourceKey = _extensions[first]._source.asKey();
+
+        size_t last = first + 1;
+        while (last < _extensions.size() && _extensions[last]._source.asKey() == sourceKey) {
+            last++;
+        }
+
+        _extensionRuns[sourceKey] = {first, last};
+        first = last;
+    }
+}
+
+void MergeStep::emitRow(const PartialMatch& match, size_t row, bool created) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeRef& node = match._nodes[nodeIndex];
+        const uint64_t nodeID = node._pending ? node._id + _firstPendingNodeID : node._id;
+
+        nodes[nodeIndex]._output->push_back(NodeID(nodeID));
+        nodes[nodeIndex]._outputPending->push_back(node._pending);
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const NLMergeRef& edge = match._edges[hopIndex];
+        const uint64_t edgeID = edge._pending ? edge._id + _firstPendingEdgeID : edge._id;
+
+        hops[hopIndex]._output->push_back(EdgeID(edgeID));
+        hops[hopIndex]._outputPending->push_back(edge._pending);
+    }
+
+    _data->getCreated()->push_back(created);
+    _data->getIndices()->push_back(row);
+}
+
+void MergeStep::writeRow(size_t row) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    PartialMatch written;
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeData::Node& node = nodes[nodeIndex];
+
+        if (node._boundColumn) {
+            written._nodes.push_back(_candidates[nodeIndex].front());
+        } else {
+            written._nodes.push_back(writeNode(node, nodeIndex, row));
+        }
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const NLMergeData::Hop& hop = hops[hopIndex];
+
+        // An undirected hop is written pointing forward, the way Cypher writes it
+        const bool backward = hop._direction == NLMergeDirection::Backward;
+        const NLMergeRef& source = backward ? written._nodes[hopIndex + 1] : written._nodes[hopIndex];
+        const NLMergeRef& target = backward ? written._nodes[hopIndex] : written._nodes[hopIndex + 1];
+
+        written._edges.push_back(writeEdge(hop, hopIndex, row, source, target));
+    }
+
+    emitRow(written, row, /*created=*/true);
+}
+
+NLMergeRef MergeStep::writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row) {
+    const uint64_t offset = _writeBuffer->numPendingNodes();
+
+    CommitWriteBuffer::PendingNode& pending = _writeBuffer->newPendingNode();
+    pending.labelsetHandle = node._labelSetHandle;
+
+    for (const CommitWriteBuffer::UntypedProperties& values : _nodeProperties[nodeIndex]) {
+        pending.properties.push_back(values[row]);
+    }
+
+    const NLMergeRef ref {._id=offset, ._pending=true};
+
+    // A later row asking for the same values binds this node rather than writing a
+    // second one, which is what makes a merge over many rows idempotent
+    _key.assign(node._signature);
+    appendMergeKey(node._properties, row, _key);
+    _data->getPendingNodes()->add(_key, ref);
+
+    return ref;
+}
+
+NLMergeRef MergeStep::writeEdge(const NLMergeData::Hop& hop,
+                                size_t hopIndex,
+                                size_t row,
+                                const NLMergeRef& source,
+                                const NLMergeRef& target) {
+    const uint64_t offset = _writeBuffer->numPendingEdges();
+
+    CommitWriteBuffer::PendingEdge& pending = _writeBuffer->newPendingEdge(asWriteBufferNode(source),
+                                                                           asWriteBufferNode(target));
+    pending.edgeType = hop._writeEdgeType;
+
+    for (const CommitWriteBuffer::UntypedProperties& values : _hopProperties[hopIndex]) {
+        pending.properties.push_back(values[row]);
+    }
+
+    // Keyed by its own hop's values, not by whichever hop the match reached before it
+    // gave up: a later row looks each hop of the chain up under its own key
+    _hopKey.clear();
+    appendMergeKey(hop._properties, row, _hopKey);
+
+    _data->getPendingEdges()->add(source, target, hop._writeEdgeType, offset, _hopKey);
+
+    return {._id=offset, ._pending=true};
+}
+
+CommitWriteBuffer::ExistingOrPendingNode MergeStep::asWriteBufferNode(const NLMergeRef& ref) {
+    if (ref._pending) {
+        return CommitWriteBuffer::PendingNodeOffset(ref._id);
+    }
+
+    return NodeID(ref._id);
+}
+
+void MergeStep::gatherCarriedColumns() {
+    const ColumnVector<size_t>* indices = _data->getIndices();
+
+    for (const NLCarriedColumn& carried : _data->carriedColumns()) {
+        const NLGatherFunction gather = carried.getGatherFunc();
+        gather(carried.getInput(), indices, carried.getOutput());
     }
 }
 
@@ -2881,6 +3525,11 @@ void NLExecutor::runCreateNode(NLExecutionContext* context, NLFunctionData* data
     }
 }
 
+void NLExecutor::runMerge(NLExecutionContext* context, NLFunctionData* data) {
+    MergeStep step(context, static_cast<NLMergeData*>(data));
+    step.run();
+}
+
 void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data) {
     NLCreateEdgeData* createData = static_cast<NLCreateEdgeData*>(data);
     CommitWriteBuffer* writeBuffer = context->getWriteBuffer();
@@ -2893,6 +3542,9 @@ void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data
     const size_t rowCount = src->size();
     const EdgeTypeID edgeTypeID = createData->getEdgeTypeID();
 
+    const ColumnMask* srcPending = createData->getSrcPendingMask();
+    const ColumnMask* tgtPending = createData->getTgtPendingMask();
+
     const GraphView* view = context->getView();
     const size_t firstPendingNodeID = committedNodeCount(view);
 
@@ -2901,9 +3553,9 @@ void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data
 
     for (size_t row = 0; row < rowCount; row++) {
         const CommitWriteBuffer::ExistingOrPendingNode srcNode =
-            resolveNode(src, row, srcIsPending, firstPendingNodeID);
+            resolveNode(src, row, isPendingRow(srcPending, srcIsPending, row), firstPendingNodeID);
         const CommitWriteBuffer::ExistingOrPendingNode tgtNode =
-            resolveNode(tgt, row, tgtIsPending, firstPendingNodeID);
+            resolveNode(tgt, row, isPendingRow(tgtPending, tgtIsPending, row), firstPendingNodeID);
 
         CommitWriteBuffer::PendingEdge& edge = writeBuffer->newPendingEdge(srcNode, tgtNode);
         edge.edgeType = edgeTypeID;
@@ -2941,9 +3593,24 @@ void NLExecutor::runSetNodeProperty(NLExecutionContext* context, NLFunctionData*
     const Column* nodeCol = setData->getValue();
     extractColumnProperties(nodeCol, rowCount, propID, propsBuffer);
 
+    const ColumnMask* pending = setData->getPending();
+    const ColumnMask* rows = setData->getRows();
+
+    const size_t firstPendingNodeID = committedNodeCount(context->getView());
+
     const auto& raw = nodes->getRaw();
     for (size_t row = 0; row < rowCount; row++) {
-        writeBuffer->addNodeUpdate(raw[row], propsBuffer[row]);
+        if (!writeTouchesRow(rows, row)) {
+            continue;
+        }
+
+        if (pending && (*pending)[row]) {
+            CommitWriteBuffer::PendingNode& node =
+                writeBuffer->getPendingNode(raw[row].getValue() - firstPendingNodeID);
+            setPendingProperty(node.properties, propsBuffer[row]);
+        } else {
+            writeBuffer->addNodeUpdate(raw[row], propsBuffer[row]);
+        }
     }
 }
 
@@ -2960,9 +3627,24 @@ void NLExecutor::runSetEdgeProperty(NLExecutionContext* context, NLFunctionData*
     CommitWriteBuffer::UntypedProperties propsBuffer;
     extractColumnProperties(edgeCol, rowCount, propID, propsBuffer);
 
+    const ColumnMask* pending = setData->getPending();
+    const ColumnMask* rows = setData->getRows();
+
+    const size_t firstPendingEdgeID = committedEdgeCount(context->getView());
+
     const auto& raw = edges->getRaw();
     for (size_t row = 0; row < rowCount; row++) {
-        writeBuffer->addEdgeUpdate(raw[row], propsBuffer[row]);
+        if (!writeTouchesRow(rows, row)) {
+            continue;
+        }
+
+        if (pending && (*pending)[row]) {
+            CommitWriteBuffer::PendingEdge& edge =
+                writeBuffer->getPendingEdge(raw[row].getValue() - firstPendingEdgeID);
+            setPendingProperty(edge.properties, propsBuffer[row]);
+        } else {
+            writeBuffer->addEdgeUpdate(raw[row], propsBuffer[row]);
+        }
     }
 }
 
@@ -5515,6 +6197,88 @@ NLCopyFunction NLExecutor::selectPlainCopyFunction(ValueType valueType) {
     }
 }
 
+NLKeyAppendFunction NLExecutor::selectPlainMergeKeyAppendFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::UInt64:
+            return &mergeKeyAppendPlainColumn<types::UInt64::Primitive>;
+        break;
+
+        case NLChunkKind::Int64:
+            return &mergeKeyAppendPlainColumn<types::Int64::Primitive>;
+        break;
+
+        case NLChunkKind::Double:
+            return &mergeKeyAppendPlainColumn<types::Double::Primitive>;
+        break;
+
+        case NLChunkKind::Bool:
+            return &mergeKeyAppendPlainColumn<types::Bool::Primitive>;
+        break;
+
+        case NLChunkKind::String:
+            return &mergeKeyAppendPlainColumn<types::String::Primitive>;
+        break;
+
+        case NLChunkKind::OwnedString:
+            return &mergeKeyAppendPlainColumn<std::string>;
+        break;
+
+        case NLChunkKind::NodeID:
+        case NLChunkKind::EdgeID:
+        case NLChunkKind::EdgeTypeID:
+        case NLChunkKind::LabelID:
+        case NLChunkKind::PropertyTypeID:
+        case NLChunkKind::ValueTypeCode:
+        case NLChunkKind::List:
+        case NLChunkKind::Path:
+            throw IRException("a MERGE pattern cannot constrain a property to this value");
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return nullptr;
+}
+
+NLKeyAppendFunction NLExecutor::selectConstMergeKeyAppendFunction(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return &mergeKeyAppendConstColumn<types::Int64::Primitive>;
+        break;
+
+        case ValueType::UInt64:
+            return &mergeKeyAppendConstColumn<types::UInt64::Primitive>;
+        break;
+
+        case ValueType::Double:
+            return &mergeKeyAppendConstColumn<types::Double::Primitive>;
+        break;
+
+        case ValueType::Bool:
+            return &mergeKeyAppendConstColumn<types::Bool::Primitive>;
+        break;
+
+        case ValueType::String:
+            return &mergeKeyAppendConstColumn<types::String::Primitive>;
+        break;
+
+        case ValueType::Embedding:
+            throw IRException("a MERGE pattern cannot constrain a property to an embedding");
+        break;
+
+        case ValueType::Invalid:
+        case ValueType::_SIZE:
+            throw IRException("invalid MERGE property value type");
+        break;
+    }
+
+    bioassert(false, "Unhandled value type");
+    return nullptr;
+}
+
+NLKeyAppendFunction NLExecutor::selectNullMergeKeyAppendFunction() {
+    return &mergeKeyAppendConstNull;
+}
+
 NLKeyAppendFunction NLExecutor::selectPlainKeyAppendFunction(ValueType valueType) {
     switch (valueType) {
         case ValueType::Int64:
@@ -5714,6 +6478,21 @@ void NLExecutor::runPropertyFetch(NLExecutionContext* context, NLFunctionData* d
     GetPropertiesWithNullChunkWriter<ID, T> writer(view, propertyTypeID, inputIDs);
     writer.setOutput(output);
     writer.fill(inputIDs->size());
+
+    // A pending row's ID is an offset into the write buffer, which the fetch above read
+    // as an ID of the graph: whatever it found belongs to another entity, so the value
+    // the query sees is the absent one a written entity's unwritten property has.
+    const ColumnMask* pending = fetchData->getPending();
+    if (!pending) {
+        return;
+    }
+
+    auto& raw = output->getRaw();
+    for (size_t row = 0; row < raw.size(); row++) {
+        if ((*pending)[row]) {
+            raw[row] = std::nullopt;
+        }
+    }
 }
 
 // The translator selects among these by the value type the property resolves

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -246,7 +246,9 @@ void unwindTaggedElementEmit(const Column* source,
 
 template <typename Functor>
 Functor makeFunctor(NLExecutionContext* context) {
-    if constexpr (std::is_constructible_v<Functor, GraphView>) {
+    if constexpr (std::is_constructible_v<Functor, GraphView, const CommitWriteBuffer*>) {
+        return Functor(*context->getView(), context->getWriteBuffer());
+    } else if constexpr (std::is_constructible_v<Functor, GraphView>) {
         return Functor(*context->getView());
     } else {
         return Functor {};

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -3064,22 +3064,23 @@ void NLExecutor::runDeleteNode(NLExecutionContext* context, NLFunctionData* data
     const size_t firstPendingNodeID = committedNodeCount(view);
 
     const auto& raw = nodes->getRaw();
-    bool droppedAPendingNode = false;
 
     for (size_t row = 0; row < raw.size(); row++) {
-        if (!isPendingRow(pending, allPending, row)) {
-            committed->push_back(raw[row]);
-            continue;
-        }
+        const bool isPending = isPendingRow(pending, allPending, row);
+        const CommitWriteBuffer::ExistingOrPendingNode node =
+            resolveNode(nodes, row, isPending, firstPendingNodeID);
 
-        const CommitWriteBuffer::PendingNodeOffset offset = raw[row].getValue() - firstPendingNodeID;
-
-        if (!detaching && writeBuffer->pendingNodeHasEdges(offset)) {
+        // A relationship this query wrote counts as much as one the graph holds, whether
+        // it hangs off a node the query wrote or off one already committed
+        if (!detaching && writeBuffer->hasPendingEdgesOn(node)) {
             throw IRException("Cannot delete a node with relationships; use DETACH DELETE");
         }
 
-        writeBuffer->addDeletedPendingNode(offset);
-        droppedAPendingNode = true;
+        if (isPending) {
+            writeBuffer->addDeletedPendingNode(std::get<CommitWriteBuffer::PendingNodeOffset>(node));
+        } else {
+            committed->push_back(raw[row]);
+        }
     }
 
     if (!detaching) {
@@ -3093,10 +3094,7 @@ void NLExecutor::runDeleteNode(NLExecutionContext* context, NLFunctionData* data
     }
 
     writeBuffer->addHangingEdges(*view);
-
-    if (droppedAPendingNode) {
-        writeBuffer->addHangingPendingEdges();
-    }
+    writeBuffer->addHangingPendingEdges();
 }
 
 void NLExecutor::runDeleteEdge(NLExecutionContext* context, NLFunctionData* data) {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -64,6 +64,7 @@
 #include "NLProgram.h"
 #include "NLMergeExecutor.h"
 #include "NLWriteProperties.h"
+#include "NLWrittenValues.h"
 #include "NLMergeWorkingSet.h"
 #include "NLOutputSink.h"
 
@@ -2421,13 +2422,24 @@ bool writeTouchesRow(const ColumnMask* rows, size_t row) {
     return !rows || (*rows)[row];
 }
 
-// One property of an entity this change wrote and has not committed, read back out of
-// the write buffer. The value the pattern wrote is held as whatever type the row's own
-// column carried, so it is converted to the type the schema holds the property as -
-// which is the type of the column the fetch is filling.
+// A column of strings or embeddings borrows what it holds, and the change rewrites its
+// own values as the query runs, so those are copied where the column can outlive them
 template <typename T>
-std::optional<typename T::Primitive> readPendingProperty(const CommitWriteBuffer::UntypedProperties& properties,
-                                                         PropertyTypeID propertyTypeID) {
+const CommitWriteBuffer::SupportedTypeVariant& retainIfBorrowed(NLWrittenValues& written,
+                                                                const CommitWriteBuffer::SupportedTypeVariant& value) {
+    if constexpr (std::is_same_v<T, types::String> || std::is_same_v<T, types::Embedding>) {
+        return written.retain(value);
+    } else {
+        return value;
+    }
+}
+
+// One value this change wrote, as the column the fetch is filling holds it. The value is
+// held as whatever type the row's own column carried, so it is converted to the type the
+// schema holds the property as - which is the column's element type.
+template <typename T>
+std::optional<typename T::Primitive> readWrittenValue(NLWrittenValues& written,
+                                                      const CommitWriteBuffer::SupportedTypeVariant& value) {
     using Primitive = typename T::Primitive;
 
     const auto convert = [](const auto& held) -> std::optional<Primitive> {
@@ -2440,9 +2452,16 @@ std::optional<typename T::Primitive> readPendingProperty(const CommitWriteBuffer
         }
     };
 
+    return std::visit(convert, retainIfBorrowed<T>(written, value));
+}
+
+template <typename T>
+std::optional<typename T::Primitive> readPendingProperty(NLWrittenValues& written,
+                                                         const CommitWriteBuffer::UntypedProperties& properties,
+                                                         PropertyTypeID propertyTypeID) {
     for (const CommitWriteBuffer::UntypedProperty& property : properties) {
         if (property.propertyID == propertyTypeID) {
-            return std::visit(convert, property.value);
+            return readWrittenValue<T>(written, property.value);
         }
     }
 
@@ -2453,15 +2472,27 @@ std::optional<typename T::Primitive> readPendingProperty(const CommitWriteBuffer
 // indexed by what is left once the committed space is taken off
 template <typename ID, typename T>
 std::optional<typename T::Primitive> readPendingEntityProperty(CommitWriteBuffer* writeBuffer,
+                                                               NLWrittenValues& written,
                                                                const GraphView* view,
                                                                uint64_t id,
                                                                PropertyTypeID propertyTypeID) {
     if constexpr (std::is_same_v<ID, NodeID>) {
         const size_t offset = id - committedNodeCount(view);
-        return readPendingProperty<T>(writeBuffer->getPendingNode(offset).properties, propertyTypeID);
+        return readPendingProperty<T>(written, writeBuffer->getPendingNode(offset).properties, propertyTypeID);
     } else {
         const size_t offset = id - committedEdgeCount(view);
-        return readPendingProperty<T>(writeBuffer->getPendingEdge(offset).properties, propertyTypeID);
+        return readPendingProperty<T>(written, writeBuffer->getPendingEdge(offset).properties, propertyTypeID);
+    }
+}
+
+template <typename ID>
+const CommitWriteBuffer::SupportedTypeVariant* findEntityUpdate(const NLWrittenValues& written,
+                                                                ID id,
+                                                                PropertyTypeID propertyTypeID) {
+    if constexpr (std::is_same_v<ID, NodeID>) {
+        return written.findNodeUpdate(id, propertyTypeID);
+    } else {
+        return written.findEdgeUpdate(id, propertyTypeID);
     }
 }
 
@@ -3023,13 +3054,48 @@ void NLExecutor::runDeleteNode(NLExecutionContext* context, NLFunctionData* data
 
     const ColumnNodeIDs* nodes = deleteData->getInput();
     const GraphView* view = context->getView();
+    const ColumnMask* pending = deleteData->getPending();
+    const bool allPending = deleteData->isAllPending();
+    const bool detaching = deleteData->isDetaching();
 
-    if (deleteData->isDetaching()) {
-        writeBuffer->addDeletedNodes(nodes->getRaw());
-        writeBuffer->addHangingEdges(*view);
-    } else {
-        throwIfNodesHaveEdges(*view, nodes);
-        writeBuffer->addDeletedNodes(nodes->getRaw());
+    ColumnNodeIDs* committed = deleteData->getCommitted();
+    committed->clear();
+
+    const size_t firstPendingNodeID = committedNodeCount(view);
+
+    const auto& raw = nodes->getRaw();
+    bool droppedAPendingNode = false;
+
+    for (size_t row = 0; row < raw.size(); row++) {
+        if (!isPendingRow(pending, allPending, row)) {
+            committed->push_back(raw[row]);
+            continue;
+        }
+
+        const CommitWriteBuffer::PendingNodeOffset offset = raw[row].getValue() - firstPendingNodeID;
+
+        if (!detaching && writeBuffer->pendingNodeHasEdges(offset)) {
+            throw IRException("Cannot delete a node with relationships; use DETACH DELETE");
+        }
+
+        writeBuffer->addDeletedPendingNode(offset);
+        droppedAPendingNode = true;
+    }
+
+    if (!detaching) {
+        throwIfNodesHaveEdges(*view, committed);
+    }
+
+    writeBuffer->addDeletedNodes(committed->getRaw());
+
+    if (!detaching) {
+        return;
+    }
+
+    writeBuffer->addHangingEdges(*view);
+
+    if (droppedAPendingNode) {
+        writeBuffer->addHangingPendingEdges();
     }
 }
 
@@ -3039,7 +3105,24 @@ void NLExecutor::runDeleteEdge(NLExecutionContext* context, NLFunctionData* data
     bioassert(writeBuffer, "nl.delete_edge requires an active write transaction");
 
     const ColumnEdgeIDs* edges = deleteData->getInput();
-    writeBuffer->addDeletedEdges(edges->getRaw());
+    const ColumnMask* pending = deleteData->getPending();
+    const bool allPending = deleteData->isAllPending();
+
+    ColumnEdgeIDs* committed = deleteData->getCommitted();
+    committed->clear();
+
+    const size_t firstPendingEdgeID = committedEdgeCount(context->getView());
+
+    const auto& raw = edges->getRaw();
+    for (size_t row = 0; row < raw.size(); row++) {
+        if (isPendingRow(pending, allPending, row)) {
+            writeBuffer->addDeletedPendingEdge(raw[row].getValue() - firstPendingEdgeID);
+        } else {
+            committed->push_back(raw[row]);
+        }
+    }
+
+    writeBuffer->addDeletedEdges(committed->getRaw());
 }
 
 void NLExecutor::runScanNodesLoop(NLExecutionContext* context, NLFunctionData* data) {
@@ -5873,25 +5956,40 @@ void NLExecutor::runPropertyFetch(NLExecutionContext* context, NLFunctionData* d
     writer.setOutput(output);
     writer.fill(inputIDs->size());
 
-    // A pending row's ID is an offset into the write buffer, which the fetch above read
-    // as an ID of the graph: whatever it found belongs to another entity, so the value
-    // is read out of the write buffer instead - null there when the write set none.
+    // The fetch above read the graph, which holds this change's writes nowhere: a row
+    // whose entity the change wrote holds a write-buffer offset rather than an ID the
+    // graph knows, and a row it merely updated still reads the value from before.
     const ColumnMask* pending = fetchData->getPending();
-    if (!pending) {
+    CommitWriteBuffer* writeBuffer = context->getWriteBuffer();
+
+    if (!writeBuffer) {
+        bioassert(!pending, "a property fetch over written entities requires an active write transaction");
         return;
     }
 
-    CommitWriteBuffer* writeBuffer = context->getWriteBuffer();
-    bioassert(writeBuffer, "a property fetch over written entities requires an active write transaction");
+    NLWrittenValues& written = context->getWrittenValues();
+    written.indexUpdates(writeBuffer);
+
+    if (!pending && !written.hasUpdates()) {
+        return;
+    }
 
     auto& raw = output->getRaw();
     const auto& inputRaw = inputIDs->getRaw();
     for (size_t row = 0; row < raw.size(); row++) {
-        if ((*pending)[row]) {
+        if (pending && (*pending)[row]) {
             raw[row] = readPendingEntityProperty<ID, T>(writeBuffer,
+                                                        written,
                                                         &view,
                                                         inputRaw[row].getValue(),
                                                         propertyTypeID);
+            continue;
+        }
+
+        const CommitWriteBuffer::SupportedTypeVariant* update =
+            findEntityUpdate<ID>(written, inputRaw[row], propertyTypeID);
+        if (update) {
+            raw[row] = readWrittenValue<T>(written, *update);
         }
     }
 }

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -5,68 +5,16 @@
 #include "columns/ColumnOperator.h"
 #include "metadata/PropertyType.h"
 
+#include "NLExecutionContext.h"
 #include "NLProgram.h"
-
-namespace fs {
-class Path;
-}
-
-namespace vec {
-class VectorDatabase;
-}
 
 namespace db {
 
 class GraphView;
 class NLOutputSink;
 class LocalMemory;
-class CommitWriteBuffer;
 class NLSystemContext;
 class NLVectorSearchLoopData;
-
-class NLExecutionContext {
-public:
-    NLExecutionContext(const GraphView* view,
-                       NLOutputSink* sink,
-                       size_t chunkSize,
-                       CommitWriteBuffer* writeBuffer = nullptr,
-                       const NLSystemContext* system = nullptr)
-        : _view(view),
-        _sink(sink),
-        _chunkSize(chunkSize),
-        _writeBuffer(writeBuffer),
-        _system(system)
-    {
-    }
-
-    const GraphView* getView() const { return _view; }
-    NLOutputSink* getSink() const { return _sink; }
-    size_t getChunkSize() const { return _chunkSize; }
-    CommitWriteBuffer* getWriteBuffer() const { return _writeBuffer; }
-
-    // The server-level facilities the system commands reach for. Every query the server
-    // runs carries one, ordinary reads included; it is null only for a caller that hands
-    // the interpreter none, as the IR tests do.
-    const NLSystemContext* getSystem() const { return _system; }
-
-    // The vector indexes a search reads, borrowed from the session's accessor. They are
-    // the one store outside the graph an ordinary query reaches, so - unlike the rest of
-    // the system context - a dataflow loop reads them; null when the session opened no
-    // accessor, which the search reports as a user-facing error.
-    vec::VectorDatabase* getVectorDatabase() const;
-
-    // The directory a file the query names is resolved against - the one place outside
-    // the graph a dataflow loop reads from. Null for a session that opened no system
-    // manager, which the load reports as a user-facing error.
-    const fs::Path* getDataDir() const;
-
-private:
-    const GraphView* _view {nullptr};
-    NLOutputSink* _sink {nullptr};
-    size_t _chunkSize {0};
-    CommitWriteBuffer* _writeBuffer {nullptr};
-    const NLSystemContext* _system {nullptr};
-};
 
 // Executes a translated NLProgram against a graph view
 class NLExecutor {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -253,6 +253,10 @@ public:
 
     static void runCreateEdge(NLExecutionContext* context, NLFunctionData* data);
 
+    // Bind one MERGE pattern per row of the op's input chunks, writing the pattern for
+    // the rows the graph and this query's earlier writes do not already hold it for.
+    static void runMerge(NLExecutionContext* context, NLFunctionData* data);
+
     static void runSetNodeProperty(NLExecutionContext* context, NLFunctionData* data);
 
     static void runSetEdgeProperty(NLExecutionContext* context, NLFunctionData* data);
@@ -342,6 +346,15 @@ public:
     static NLBroadcastFunction selectPlainBlockRepeatFunction(ValueType valueType);
     static NLBroadcastFunction selectPlainTileFunction(ValueType valueType);
     static NLKeyAppendFunction selectPlainKeyAppendFunction(ValueType valueType);
+
+    // The appenders that key one row of a merge's property value column. A merge keys
+    // the value a row asks for against the value the graph holds, and those arrive in a
+    // plain (or constant) column and a nullable one respectively, so these write the
+    // present-value tag byte selectOptKeyAppendFunction' appenders write - which is the
+    // nullable shape's selector, reused as is.
+    static NLKeyAppendFunction selectPlainMergeKeyAppendFunction(NLChunkKind kind);
+    static NLKeyAppendFunction selectConstMergeKeyAppendFunction(ValueType valueType);
+    static NLKeyAppendFunction selectNullMergeKeyAppendFunction();
     static NLGroupKeyGatherFunction selectPlainGroupKeyGather(ValueType valueType);
 
     // Block-repeat for an ID chunk of this kind (outer column).

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -350,10 +350,14 @@ public:
     // The appenders that key one row of a merge's property value column. A merge keys
     // the value a row asks for against the value the graph holds, and those arrive in a
     // plain (or constant) column and a nullable one respectively, so these write the
-    // present-value tag byte selectOptKeyAppendFunction' appenders write - which is the
-    // nullable shape's selector, reused as is.
-    static NLKeyAppendFunction selectPlainMergeKeyAppendFunction(NLChunkKind kind);
-    static NLKeyAppendFunction selectConstMergeKeyAppendFunction(ValueType valueType);
+    // present-value tag byte selectOptKeyAppendFunction' appenders write.
+    //
+    // @param keyType is the type the schema holds the property as, which the row's own
+    // value is keyed in: the analyzer lets an integer constrain a double-typed property,
+    // and the graph side keys the double it reads back.
+    static NLKeyAppendFunction selectPlainMergeKeyAppendFunction(NLChunkKind kind, ValueType keyType);
+    static NLKeyAppendFunction selectConstMergeKeyAppendFunction(ValueType valueType, ValueType keyType);
+    static NLKeyAppendFunction selectOptMergeKeyAppendFunction(ValueType valueType, ValueType keyType);
     static NLKeyAppendFunction selectNullMergeKeyAppendFunction();
     static NLGroupKeyGatherFunction selectPlainGroupKeyGather(ValueType valueType);
 

--- a/query/ir/interpreter/NLMergeExecutor.cpp
+++ b/query/ir/interpreter/NLMergeExecutor.cpp
@@ -1,0 +1,619 @@
+#include "NLMergeExecutor.h"
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <span>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "iterators/GetInEdgesIterator.h"
+#include "iterators/GetOutEdgesIterator.h"
+#include "iterators/GetPropertiesWithNullIterator.h"
+#include "iterators/ScanNodesByLabelIterator.h"
+#include "columns/ColumnOptVector.h"
+#include "metadata/PropertyType.h"
+
+#include "versioning/CommitWriteBuffer.h"
+#include "views/GraphView.h"
+
+#include "NLExecutionContext.h"
+#include "NLWriteProperties.h"
+
+#include "BioAssert.h"
+
+using namespace db;
+
+namespace {
+
+template <typename Property>
+void appendMergeKey(const std::vector<Property>& properties, size_t row, std::string& key) {
+    for (const Property& property : properties) {
+        property._keyAppend(property._values, row, key);
+    }
+}
+
+template <typename ID, typename T>
+void fetchMergeProperty(const GraphView& view,
+                        PropertyTypeID propertyTypeID,
+                        const ColumnVector<ID>* ids,
+                        Column* output) {
+    auto* typed = static_cast<ColumnOptVector<typename T::Primitive>*>(output);
+
+    GetPropertiesWithNullChunkWriter<ID, T> writer(view, propertyTypeID, ids);
+    writer.setOutput(typed);
+    writer.fill(ids->size());
+}
+
+void fetchMergeNodeProperty(const GraphView& view,
+                            const NLMergeScanProperty& property,
+                            const ColumnNodeIDs* nodes) {
+    const auto fetch = [&]<SupportedType T>() {
+        fetchMergeProperty<NodeID, T>(view, property._propertyType._id, nodes, property._values);
+    };
+
+    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
+}
+
+void fetchMergeEdgeProperty(const GraphView& view,
+                            const NLMergeScanProperty& property,
+                            const ColumnEdgeIDs* edges) {
+    const auto fetch = [&]<SupportedType T>() {
+        fetchMergeProperty<EdgeID, T>(view, property._propertyType._id, edges, property._values);
+    };
+
+    ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
+}
+
+}
+
+NLMergeExecutor::NLMergeExecutor(NLExecutionContext* context, NLMergeData* data)
+    : _context(context),
+    _data(data),
+    _work(data->getWorkingSet()),
+    _writeBuffer(context->getWriteBuffer()),
+    _view(context->getView()),
+    _firstPendingNodeID(committedNodeCount(_view)),
+    _firstPendingEdgeID(committedEdgeCount(_view))
+{
+}
+
+NLMergeExecutor::~NLMergeExecutor() {
+}
+
+void NLMergeExecutor::run() {
+    bioassert(_writeBuffer, "nl.merge requires an active write transaction");
+
+    const Column* rowCarrier = _data->getRowCarrier();
+
+    // A pattern reading no column at all stands on its own, and runs over the single
+    // row its literals are - the row db.create_node writes without a cardinality
+    const size_t rowCount = rowCarrier ? rowCarrier->size() : 1;
+
+    clearResults();
+    extractProperties(rowCount);
+
+    _work->_candidates.resize(_data->nodes().size());
+    _work->_candidateKeys.resize(_data->nodes().size());
+
+    for (size_t row = 0; row < rowCount; row++) {
+        matchRow(row);
+    }
+
+    gatherCarriedColumns();
+}
+
+void NLMergeExecutor::clearResults() {
+    // A bound node has no output of its own: its rows come back through the carry set
+    for (const NLMergeData::Node& node : _data->nodes()) {
+        if (node._output) {
+            node._output->clear();
+            node._outputPending->clear();
+        }
+    }
+
+    for (const NLMergeData::Hop& hop : _data->hops()) {
+        hop._output->clear();
+        hop._outputPending->clear();
+    }
+
+    _data->getCreated()->clear();
+    _data->getIndices()->clear();
+}
+
+void NLMergeExecutor::extractProperties(size_t rowCount) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    _work->_nodeProperties.resize(nodes.size());
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const std::vector<NLMergeProperty>& properties = nodes[nodeIndex]._properties;
+        // The extractor clears each buffer it fills, so a step reuses what the last one
+        // allocated
+        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_nodeProperties[nodeIndex];
+        extracted.resize(properties.size());
+
+        for (size_t index = 0; index < properties.size(); index++) {
+            extractColumnProperties(properties[index]._values,
+                                                rowCount,
+                                                properties[index]._propertyType._id,
+                                                extracted[index]);
+        }
+    }
+
+    _work->_hopProperties.resize(hops.size());
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const std::vector<NLMergeProperty>& properties = hops[hopIndex]._properties;
+        NLMergeWorkingSet::PropertiesPerRow& extracted = _work->_hopProperties[hopIndex];
+        extracted.resize(properties.size());
+
+        for (size_t index = 0; index < properties.size(); index++) {
+            extractColumnProperties(properties[index]._values,
+                                                rowCount,
+                                                properties[index]._propertyType._id,
+                                                extracted[index]);
+        }
+    }
+}
+
+// One scan of the spec's label set with one property fetch per key property per chunk,
+// rather than a lookup per row of the merge
+void NLMergeExecutor::buildNodeIndex(NLMergeNodeIndex* index) {
+    index->markBuilt();
+
+    if (!index->isMatchable()) {
+        return;
+    }
+
+    const LabelSetHandle labelset(index->getLabels());
+    const std::vector<NLMergeScanProperty>& scanProperties = index->scanProperties();
+    ColumnNodeIDs* nodes = index->getScanNodes();
+
+    ScanNodesByLabelChunkWriter scan(*_view, labelset);
+    scan.setNodeIDs(nodes);
+
+    std::string key;
+    while (scan.isValid()) {
+        scan.fill(_context->getChunkSize());
+
+        const size_t rowCount = nodes->size();
+        if (rowCount == 0) {
+            continue;
+        }
+
+        for (const NLMergeScanProperty& property : scanProperties) {
+            fetchMergeNodeProperty(*_view, property, nodes);
+        }
+
+        for (size_t row = 0; row < rowCount; row++) {
+            key.clear();
+            appendMergeKey(scanProperties, row, key);
+
+            index->add(key, {._id=(*nodes)[row].getValue(), ._pending=false});
+        }
+    }
+}
+
+void NLMergeExecutor::collectCandidates(size_t row) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeData::Node& node = nodes[nodeIndex];
+        std::vector<NLMergeRef>& candidates = _work->_candidates[nodeIndex];
+        candidates.clear();
+
+        if (node._boundColumn) {
+            const bool pending = node._boundPending && (*node._boundPending)[row];
+            const uint64_t boundID = (*node._boundColumn)[row].getValue();
+            const uint64_t id = pending ? boundID - _firstPendingNodeID : boundID;
+
+            candidates.push_back({._id=id, ._pending=pending});
+        } else {
+            NLMergeNodeIndex* index = node._index;
+            if (!index->isBuilt()) {
+                buildNodeIndex(index);
+            }
+
+            std::string& key = _work->_key;
+            key.clear();
+            appendMergeKey(node._properties, row, key);
+
+            const std::span<const NLMergeRef> committed = index->find(key);
+            candidates.insert(candidates.end(), committed.begin(), committed.end());
+
+            key.insert(0, node._signature);
+            const std::span<const NLMergeRef> pending = _data->getPendingNodes()->find(key);
+            candidates.insert(candidates.end(), pending.begin(), pending.end());
+        }
+
+        std::unordered_set<uint64_t>& keys = _work->_candidateKeys[nodeIndex];
+        keys.clear();
+        for (const NLMergeRef& candidate : candidates) {
+            keys.insert(candidate.asKey());
+        }
+    }
+}
+
+void NLMergeExecutor::matchRow(size_t row) {
+    collectCandidates(row);
+
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+    const size_t nodeCount = _data->nodes().size();
+
+    std::vector<NLMergePartialMatch>& matches = _work->_matches;
+    matches.clear();
+    for (const NLMergeRef& candidate : _work->_candidates.front()) {
+        NLMergePartialMatch& match = matches.emplace_back();
+
+        // The walk appends one node and one edge per hop, so the whole chain fits the
+        // allocation the first node forces
+        match._nodes.reserve(nodeCount);
+        match._edges.reserve(hops.size());
+        match._nodes.push_back(candidate);
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hops.size() && !matches.empty(); hopIndex++) {
+        buildHopKeys(hops[hopIndex], row);
+
+        extendHop(hopIndex);
+    }
+
+    if (matches.empty()) {
+        writeRow(row);
+        return;
+    }
+
+    for (const NLMergePartialMatch& match : matches) {
+        emitRow(match, row, /*created=*/false);
+    }
+}
+
+void NLMergeExecutor::buildHopKeys(const NLMergeData::Hop& hop, size_t row) {
+    // The values the hop asks for, which a candidate edge's own values are compared
+    // against, and those same values behind the hop's signature - what the pending log
+    // is keyed by, since it holds every hop this query wrote under one pair of endpoints
+    _work->_hopKey.clear();
+    appendMergeKey(hop._properties, row, _work->_hopKey);
+
+    _work->_pendingHopKey.assign(hop._signature);
+    _work->_pendingHopKey.append(_work->_hopKey);
+}
+
+void NLMergeExecutor::extendHop(size_t hopIndex) {
+    const NLMergeData::Hop& hop = _data->hops()[hopIndex];
+    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
+    const NLMergePendingEdges* pendingEdges = _data->getPendingEdges();
+
+    collectGraphExtensions(hop, hopIndex);
+
+    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
+    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
+
+    std::vector<NLMergePartialMatch>& matches = _work->_matches;
+    std::vector<NLMergePartialMatch>& extended = _work->_extended;
+
+    extended.clear();
+    for (const NLMergePartialMatch& match : matches) {
+        const NLMergeRef source = match._nodes.back();
+
+        // Cypher binds each relationship of a pattern to an edge of its own, so a hop
+        // cannot walk back along one the match already holds
+        const auto extendWith = [&](const NLMergeRef& edge, const NLMergeRef& target) {
+            if (std::ranges::find(match._edges, edge) != end(match._edges)) {
+                return;
+            }
+
+            NLMergePartialMatch& grown = extended.emplace_back(match);
+            grown._edges.push_back(edge);
+            grown._nodes.push_back(target);
+        };
+
+        const auto runIt = _work->_extensionRuns.find(source.asKey());
+        if (runIt != end(_work->_extensionRuns)) {
+            const auto [first, last] = runIt->second;
+            for (size_t index = first; index < last; index++) {
+                const NLMergeExtension& extension = _work->_extensions[index];
+                extendWith(extension._edge, extension._target);
+            }
+        }
+
+        // An undirected hop follows both ways round, and a self-loop is on both sides of
+        // its own node: the outgoing pass has it, so the incoming one leaves it alone
+        const auto extendWithPending = [&](std::span<const NLMergePendingEdges::Entry> entries,
+                                           bool skipSelfLoops) {
+            for (const NLMergePendingEdges::Entry& entry : entries) {
+                if (skipSelfLoops && entry._other == source) {
+                    continue;
+                }
+
+                const bool sameType = entry._edgeType == hop._writeEdgeType;
+                const bool sameProperties = entry._propertyKey == _work->_pendingHopKey;
+                const bool onACandidate = targets.contains(entry._other.asKey());
+
+                if (sameType && sameProperties && onACandidate) {
+                    extendWith({._id=entry._offset, ._pending=true}, entry._other);
+                }
+            }
+        };
+
+        if (followsOutgoing) {
+            extendWithPending(pendingEdges->outOf(source), /*skipSelfLoops=*/false);
+        }
+
+        if (followsIncoming) {
+            extendWithPending(pendingEdges->into(source), /*skipSelfLoops=*/followsOutgoing);
+        }
+    }
+
+    matches.swap(extended);
+}
+
+void NLMergeExecutor::collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex) {
+    _work->_extensions.clear();
+    _work->_extensionRuns.clear();
+
+    // A type the schema does not have is on no committed edge, so only a pending one can
+    // extend the match
+    if (!hop._matchEdgeType.isValid()) {
+        return;
+    }
+
+    ColumnNodeIDs* sources = hop._scanSources;
+    sources->clear();
+
+    // Two partial matches reaching the same node scan its edges once: the runs below are
+    // keyed by source node, so a second copy of one would fold into its run and extend
+    // every match that reached it a second time.
+    std::unordered_set<uint64_t>& sourceKeys = _work->_scanSourceKeys;
+    sourceKeys.clear();
+
+    for (const NLMergePartialMatch& match : _work->_matches) {
+        const NLMergeRef source = match._nodes.back();
+        if (source._pending) {
+            continue;
+        }
+
+        if (sourceKeys.insert(source.asKey()).second) {
+            sources->push_back(NodeID(source._id));
+        }
+    }
+
+    if (sources->empty()) {
+        return;
+    }
+
+    const bool followsOutgoing = hop._direction != NLMergeDirection::Backward;
+    const bool followsIncoming = hop._direction != NLMergeDirection::Forward;
+
+    if (followsOutgoing) {
+        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/true);
+    }
+
+    if (followsIncoming) {
+        collectDirectedExtensions(hop, hopIndex, /*outgoing=*/false);
+    }
+
+    dropExtensionsWithOtherProperties(hop);
+    groupExtensionsBySource();
+}
+
+void NLMergeExecutor::collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing) {
+    const std::unordered_set<uint64_t>& targets = _work->_candidateKeys[hopIndex + 1];
+    const Tombstones& tombstones = _view->tombstones();
+    const ColumnNodeIDs* sources = hop._scanSources;
+
+    // An undirected hop scans both ways round, and a self-loop is an out-edge and an
+    // in-edge of the one node: the outgoing pass has it already
+    const bool undirected = hop._direction == NLMergeDirection::Undirected;
+    const bool skipSelfLoops = undirected && !outgoing;
+
+    const auto collect = [&](const EdgeRecord& record) {
+        if (record._edgeTypeID != hop._matchEdgeType || tombstones.containsEdge(record._edgeID)) {
+            return;
+        }
+
+        if (skipSelfLoops && record._otherID == record._nodeID) {
+            return;
+        }
+
+        const NLMergeRef target {._id=record._otherID.getValue(), ._pending=false};
+        if (!targets.contains(target.asKey())) {
+            return;
+        }
+
+        _work->_extensions.push_back({._source={._id=record._nodeID.getValue(), ._pending=false},
+                                      ._edge={._id=record._edgeID.getValue(), ._pending=false},
+                                      ._target=target});
+    };
+
+    if (outgoing) {
+        const GetOutEdgesRange outEdges(*_view, sources);
+        for (const EdgeRecord& record : outEdges) {
+            collect(record);
+        }
+    } else {
+        const GetInEdgesRange inEdges(*_view, sources);
+        for (const EdgeRecord& record : inEdges) {
+            collect(record);
+        }
+    }
+}
+
+void NLMergeExecutor::dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop) {
+    const std::vector<NLMergeScanProperty>& scanProperties = hop._scanProperties;
+    std::vector<NLMergeExtension>& extensions = _work->_extensions;
+    if (scanProperties.empty() || extensions.empty()) {
+        return;
+    }
+
+    ColumnEdgeIDs* edges = hop._scanEdges;
+    edges->clear();
+    for (const NLMergeExtension& extension : extensions) {
+        edges->push_back(EdgeID(extension._edge._id));
+    }
+
+    for (const NLMergeScanProperty& property : scanProperties) {
+        fetchMergeEdgeProperty(*_view, property, edges);
+    }
+
+    std::vector<NLMergeExtension>& kept = _work->_keptExtensions;
+    std::string& key = _work->_scanKey;
+
+    kept.clear();
+    for (size_t index = 0; index < extensions.size(); index++) {
+        key.clear();
+        appendMergeKey(scanProperties, index, key);
+
+        if (key == _work->_hopKey) {
+            kept.push_back(extensions[index]);
+        }
+    }
+
+    extensions.swap(kept);
+}
+
+void NLMergeExecutor::groupExtensionsBySource() {
+    std::vector<NLMergeExtension>& extensions = _work->_extensions;
+
+    std::ranges::stable_sort(extensions, [](const NLMergeExtension& lhs, const NLMergeExtension& rhs) {
+        return lhs._source.asKey() < rhs._source.asKey();
+    });
+
+    size_t first = 0;
+    while (first < extensions.size()) {
+        const uint64_t sourceKey = extensions[first]._source.asKey();
+
+        size_t last = first + 1;
+        while (last < extensions.size() && extensions[last]._source.asKey() == sourceKey) {
+            last++;
+        }
+
+        _work->_extensionRuns[sourceKey] = {first, last};
+        first = last;
+    }
+}
+
+void NLMergeExecutor::emitRow(const NLMergePartialMatch& match, size_t row, bool created) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeData::Node& node = nodes[nodeIndex];
+        if (!node._output) {
+            continue;
+        }
+
+        const NLMergeRef& entity = match._nodes[nodeIndex];
+        const uint64_t nodeID = entity._pending ? entity._id + _firstPendingNodeID : entity._id;
+
+        node._output->push_back(NodeID(nodeID));
+        node._outputPending->push_back(entity._pending);
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const NLMergeRef& edge = match._edges[hopIndex];
+        const uint64_t edgeID = edge._pending ? edge._id + _firstPendingEdgeID : edge._id;
+
+        hops[hopIndex]._output->push_back(EdgeID(edgeID));
+        hops[hopIndex]._outputPending->push_back(edge._pending);
+    }
+
+    _data->getCreated()->push_back(created);
+    _data->getIndices()->push_back(row);
+}
+
+void NLMergeExecutor::writeRow(size_t row) {
+    const std::vector<NLMergeData::Node>& nodes = _data->nodes();
+    const std::vector<NLMergeData::Hop>& hops = _data->hops();
+
+    NLMergePartialMatch written;
+    written._nodes.reserve(nodes.size());
+    written._edges.reserve(hops.size());
+
+    for (size_t nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++) {
+        const NLMergeData::Node& node = nodes[nodeIndex];
+
+        if (node._boundColumn) {
+            written._nodes.push_back(_work->_candidates[nodeIndex].front());
+        } else {
+            written._nodes.push_back(writeNode(node, nodeIndex, row));
+        }
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hops.size(); hopIndex++) {
+        const NLMergeData::Hop& hop = hops[hopIndex];
+
+        // An undirected hop is written pointing forward, the way Cypher writes it
+        const bool backward = hop._direction == NLMergeDirection::Backward;
+        const NLMergeRef& source = backward ? written._nodes[hopIndex + 1] : written._nodes[hopIndex];
+        const NLMergeRef& target = backward ? written._nodes[hopIndex] : written._nodes[hopIndex + 1];
+
+        written._edges.push_back(writeEdge(hop, hopIndex, row, source, target));
+    }
+
+    emitRow(written, row, /*created=*/true);
+}
+
+NLMergeRef NLMergeExecutor::writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row) {
+    const uint64_t offset = _writeBuffer->numPendingNodes();
+
+    CommitWriteBuffer::PendingNode& pending = _writeBuffer->newPendingNode();
+    pending.labelsetHandle = node._labelSetHandle;
+
+    for (const CommitWriteBuffer::UntypedProperties& values : _work->_nodeProperties[nodeIndex]) {
+        pending.properties.push_back(values[row]);
+    }
+
+    const NLMergeRef ref {._id=offset, ._pending=true};
+
+    // A later row asking for the same values binds this node rather than writing a
+    // second one, which is what makes a merge over many rows idempotent
+    std::string& key = _work->_key;
+    key.assign(node._signature);
+    appendMergeKey(node._properties, row, key);
+    _data->getPendingNodes()->add(key, ref);
+
+    return ref;
+}
+
+NLMergeRef NLMergeExecutor::writeEdge(const NLMergeData::Hop& hop,
+                                  size_t hopIndex,
+                                  size_t row,
+                                  const NLMergeRef& source,
+                                  const NLMergeRef& target) {
+    const uint64_t offset = _writeBuffer->numPendingEdges();
+
+    CommitWriteBuffer::PendingEdge& pending = _writeBuffer->newPendingEdge(asWriteBufferNode(source),
+                                                                          asWriteBufferNode(target));
+    pending.edgeType = hop._writeEdgeType;
+
+    for (const CommitWriteBuffer::UntypedProperties& values : _work->_hopProperties[hopIndex]) {
+        pending.properties.push_back(values[row]);
+    }
+
+    // Keyed by its own hop's values, not by whichever hop the match reached before it
+    // gave up: a later row looks each hop of the chain up under its own key
+    buildHopKeys(hop, row);
+
+    _data->getPendingEdges()->add(source, target, hop._writeEdgeType, offset, _work->_pendingHopKey);
+
+    return {._id=offset, ._pending=true};
+}
+
+CommitWriteBuffer::ExistingOrPendingNode NLMergeExecutor::asWriteBufferNode(const NLMergeRef& ref) {
+    if (ref._pending) {
+        return CommitWriteBuffer::PendingNodeOffset(ref._id);
+    }
+
+    return NodeID(ref._id);
+}
+
+void NLMergeExecutor::gatherCarriedColumns() {
+    const ColumnVector<size_t>* indices = _data->getIndices();
+
+    for (const NLCarriedColumn& carried : _data->carriedColumns()) {
+        const NLGatherFunction gather = carried.getGatherFunc();
+        gather(carried.getInput(), indices, carried.getOutput());
+    }
+}

--- a/query/ir/interpreter/NLMergeExecutor.h
+++ b/query/ir/interpreter/NLMergeExecutor.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "versioning/CommitWriteBuffer.h"
+
+#include "NLMergeWorkingSet.h"
+#include "NLProgram.h"
+
+namespace db {
+
+class GraphView;
+class NLExecutionContext;
+
+// Runs one nl.merge over the rows its input chunks hold: each looked up against the
+// graph and against the entities this query already wrote, then written where the
+// pattern is missing.
+class NLMergeExecutor {
+public:
+    NLMergeExecutor(NLExecutionContext* context, NLMergeData* data);
+    ~NLMergeExecutor();
+
+    void run();
+
+private:
+    NLExecutionContext* _context {nullptr};
+    NLMergeData* _data {nullptr};
+    NLMergeWorkingSet* _work {nullptr};
+    CommitWriteBuffer* _writeBuffer {nullptr};
+    const GraphView* _view {nullptr};
+
+    // A ref this step holds names a pending entity by its write-buffer offset, while the
+    // columns it reads and fills name one by the ID it will commit as: one past the last
+    // the graph holds, plus that offset
+    size_t _firstPendingNodeID {0};
+    size_t _firstPendingEdgeID {0};
+
+    void extractProperties(size_t rowCount);
+    void clearResults();
+
+    void buildNodeIndex(NLMergeNodeIndex* index);
+    void collectCandidates(size_t row);
+    void matchRow(size_t row);
+    void buildHopKeys(const NLMergeData::Hop& hop, size_t row);
+    void extendHop(size_t hopIndex);
+
+    void collectGraphExtensions(const NLMergeData::Hop& hop, size_t hopIndex);
+    void collectDirectedExtensions(const NLMergeData::Hop& hop, size_t hopIndex, bool outgoing);
+    void dropExtensionsWithOtherProperties(const NLMergeData::Hop& hop);
+    void groupExtensionsBySource();
+
+    void emitRow(const NLMergePartialMatch& match, size_t row, bool created);
+    void writeRow(size_t row);
+
+    NLMergeRef writeNode(const NLMergeData::Node& node, size_t nodeIndex, size_t row);
+    NLMergeRef writeEdge(const NLMergeData::Hop& hop,
+                         size_t hopIndex,
+                         size_t row,
+                         const NLMergeRef& source,
+                         const NLMergeRef& target);
+
+    static CommitWriteBuffer::ExistingOrPendingNode asWriteBufferNode(const NLMergeRef& ref);
+
+    void gatherCarriedColumns();
+};
+
+}

--- a/query/ir/interpreter/NLMergeWorkingSet.cpp
+++ b/query/ir/interpreter/NLMergeWorkingSet.cpp
@@ -1,0 +1,9 @@
+#include "NLMergeWorkingSet.h"
+
+using namespace db;
+
+NLMergeWorkingSet::NLMergeWorkingSet() {
+}
+
+NLMergeWorkingSet::~NLMergeWorkingSet() {
+}

--- a/query/ir/interpreter/NLMergeWorkingSet.h
+++ b/query/ir/interpreter/NLMergeWorkingSet.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "versioning/CommitWriteBuffer.h"
+
+#include "NLProgram.h"
+
+namespace db {
+
+// A merge chain matched as far as one node, and the entities it bound getting there
+struct NLMergePartialMatch {
+    std::vector<NLMergeRef> _nodes;
+    std::vector<NLMergeRef> _edges;
+};
+
+// One hop a partial match's far node can be extended along: the edge and the node it
+// lands on
+struct NLMergeExtension {
+    NLMergeRef _source;
+    NLMergeRef _edge;
+    NLMergeRef _target;
+};
+
+// The scratch one step of an nl.merge works in: the candidates of each chain node, the
+// frontier of the chain walk, the edges a hop can extend it along and the keys it looks
+// entities up under. Owned by the op's data, so a merge driven by many chunks allocates
+// it once rather than once per chunk.
+struct NLMergeWorkingSet {
+    // The values one entity spec asks for, extracted once for the whole chunk so a
+    // written row picks its own by row index
+    using PropertiesPerRow = std::vector<CommitWriteBuffer::UntypedProperties>;
+
+    NLMergeWorkingSet();
+    ~NLMergeWorkingSet();
+
+    // Per chain node, the current row's candidates, and their refs as a set for the
+    // membership test each hop's far end has to pass
+    std::vector<std::vector<NLMergeRef>> _candidates;
+    std::vector<std::unordered_set<uint64_t>> _candidateKeys;
+
+    std::vector<PropertiesPerRow> _nodeProperties;
+    std::vector<PropertiesPerRow> _hopProperties;
+
+    // The frontier of the chain walk and the one the current hop extends it into
+    std::vector<NLMergePartialMatch> _matches;
+    std::vector<NLMergePartialMatch> _extended;
+
+    // The current hop's candidate graph edges, the ones of them carrying the property
+    // values the hop asks for, and where each source node's run of them starts and ends
+    // once they are grouped
+    std::vector<NLMergeExtension> _extensions;
+    std::vector<NLMergeExtension> _keptExtensions;
+    std::unordered_map<uint64_t, std::pair<size_t, size_t>> _extensionRuns;
+
+    // The nodes a hop scans out of, deduplicated: two partial matches reaching the same
+    // node scan its edges once
+    std::unordered_set<uint64_t> _scanSourceKeys;
+
+    // A chain node's lookup key, a hop's, that same key behind the hop's signature -
+    // which is what the pending log is keyed by - and the key a candidate edge's own
+    // values serialize into
+    std::string _key;
+    std::string _hopKey;
+    std::string _pendingHopKey;
+    std::string _scanKey;
+};
+
+}

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <numeric>
 
+#include "NLMergeWorkingSet.h"
 #include "Procedure.h"
 #include "ProcedureData.h"
 
@@ -19,6 +20,26 @@ NLProgram::~NLProgram() {
 
 void NLProgram::setColumnNames(std::span<const std::string_view> names) {
     _columnNames.assign(names.begin(), names.end());
+}
+
+NLMergeNodeIndex* NLProgram::findMergeNodeIndex(const std::string& signature) const {
+    const auto findIt = _mergeNodeIndexes.find(signature);
+    if (findIt == end(_mergeNodeIndexes)) {
+        return nullptr;
+    }
+
+    return findIt->second.get();
+}
+
+NLMergeNodeIndex* NLProgram::addMergeNodeIndex(const std::string& signature,
+                                               const LabelSet& labels,
+                                               bool matchable,
+                                               ColumnNodeIDs* scanNodes) {
+    auto index = std::make_unique<NLMergeNodeIndex>(labels, matchable, scanNodes);
+    NLMergeNodeIndex* indexPtr = index.get();
+    _mergeNodeIndexes.emplace(signature, std::move(index));
+
+    return indexPtr;
 }
 
 NLProcedureState::NLProcedureState(const Procedure* procedure,
@@ -390,7 +411,8 @@ NLMergeData::NLMergeData(NLMergePendingNodes* pendingNodes,
                          ColumnMask* created)
     : _pendingNodes(pendingNodes),
     _pendingEdges(pendingEdges),
-    _created(created)
+    _created(created),
+    _workingSet(std::make_unique<NLMergeWorkingSet>())
 {
 }
 

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -309,3 +309,90 @@ void NLSortState::sort() {
 
     _sorted = true;
 }
+
+NLMergeNodeIndex::NLMergeNodeIndex(const LabelSet& labels, bool matchable, ColumnNodeIDs* scanNodes)
+    : _labels(labels),
+    _scanNodes(scanNodes),
+    _matchable(matchable)
+{
+}
+
+NLMergeNodeIndex::~NLMergeNodeIndex() {
+}
+
+std::span<const NLMergeRef> NLMergeNodeIndex::find(const std::string& key) const {
+    const auto findIt = _byKey.find(key);
+    if (findIt == end(_byKey)) {
+        return {};
+    }
+
+    return findIt->second;
+}
+
+NLMergePendingNodes::NLMergePendingNodes() {
+}
+
+NLMergePendingNodes::~NLMergePendingNodes() {
+}
+
+std::span<const NLMergeRef> NLMergePendingNodes::find(const std::string& key) const {
+    const auto findIt = _byKey.find(key);
+    if (findIt == end(_byKey)) {
+        return {};
+    }
+
+    return findIt->second;
+}
+
+NLMergePendingEdges::NLMergePendingEdges() {
+}
+
+NLMergePendingEdges::~NLMergePendingEdges() {
+}
+
+void NLMergePendingEdges::add(const NLMergeRef& source,
+                              const NLMergeRef& target,
+                              EdgeTypeID edgeType,
+                              uint64_t offset,
+                              const std::string& propertyKey) {
+    _outgoing[source.asKey()].push_back({._other=target,
+                                         ._edgeType=edgeType,
+                                         ._offset=offset,
+                                         ._propertyKey=propertyKey});
+
+    _incoming[target.asKey()].push_back({._other=source,
+                                        ._edgeType=edgeType,
+                                        ._offset=offset,
+                                        ._propertyKey=propertyKey});
+}
+
+std::span<const NLMergePendingEdges::Entry> NLMergePendingEdges::outOf(const NLMergeRef& node) const {
+    return lookup(_outgoing, node);
+}
+
+std::span<const NLMergePendingEdges::Entry> NLMergePendingEdges::into(const NLMergeRef& node) const {
+    return lookup(_incoming, node);
+}
+
+std::span<const NLMergePendingEdges::Entry> NLMergePendingEdges::lookup(
+        const std::unordered_map<uint64_t, std::vector<Entry>>& edges,
+        const NLMergeRef& node) {
+    const auto findIt = edges.find(node.asKey());
+    if (findIt == end(edges)) {
+        return {};
+    }
+
+    return findIt->second;
+}
+
+NLMergeData::NLMergeData(NLMergePendingNodes* pendingNodes,
+                         NLMergePendingEdges* pendingEdges,
+                         ColumnMask* created)
+    : _pendingNodes(pendingNodes),
+    _pendingEdges(pendingEdges),
+    _created(created)
+{
+}
+
+NLMergeData::~NLMergeData() {
+}

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -33,6 +33,7 @@ namespace db {
 
 class NLExecutionContext;
 class NLFunctionData;
+struct NLMergeWorkingSet;
 class NLShortestPathLoopData;
 class Procedure;
 class ProcedureContext;
@@ -2621,7 +2622,10 @@ private:
 
 // Every edge this query's merges wrote, under each of the two nodes it joins: a pending
 // edge is in no graph the match reads, so this is where a later row's hop finds it. One
-// log per program, shared by every merge op in it.
+// log per program, shared by every merge op in it. The entries under one pair of
+// endpoints come from every hop spec the query has, so each carries its hop's signature
+// ahead of its property values - two hops constraining different properties to values
+// with the same bytes would otherwise bind each other's edge.
 class NLMergePendingEdges {
 public:
     struct Entry {
@@ -2657,7 +2661,8 @@ class NLMergeData : public NLFunctionData {
 public:
     // One node of the chain. A bound node reads its rows from _boundColumn and is never
     // written; every other one is looked up through _index and, when the pattern is
-    // missing, written under _labelSetHandle with _properties' values.
+    // missing, written under _labelSetHandle with _properties' values. Only a looked-up
+    // node holds output chunks: a bound one's rows come back through the carry set.
     struct Node {
         std::vector<NLMergeProperty> _properties;
 
@@ -2681,6 +2686,12 @@ public:
     struct Hop {
         std::vector<NLMergeProperty> _properties;
         std::vector<NLMergeScanProperty> _scanProperties;
+
+        // What the pending log's keys for this spec start with, the sibling of Node's:
+        // the edge log is keyed by the endpoints alone, so without it two hops
+        // constraining different properties to values with the same bytes would collide
+        std::string _signature;
+
         EdgeTypeID _matchEdgeType;
         EdgeTypeID _writeEdgeType;
         NLMergeDirection _direction {NLMergeDirection::Forward};
@@ -2718,6 +2729,10 @@ public:
 
     ColumnVector<size_t>* getIndices() { return &_indices; }
 
+    // The scratch every step of the op works in, allocated once with the op rather than
+    // once per chunk
+    NLMergeWorkingSet* getWorkingSet() const { return _workingSet.get(); }
+
 private:
     std::vector<Node> _nodes;
     std::vector<Hop> _hops;
@@ -2726,6 +2741,7 @@ private:
     NLMergePendingEdges* _pendingEdges {nullptr};
     ColumnMask* _created {nullptr};
     const Column* _rowCarrier {nullptr};
+    std::unique_ptr<NLMergeWorkingSet> _workingSet;
 
     // This step's row map, from each emitted row to the input row behind it, fed to the
     // per-column gather that rebuilds the carry set
@@ -3057,15 +3073,18 @@ public:
         return statePtr;
     }
 
-    // Allocate one merge signature's candidate index, owned by the program; every
-    // merge op carrying that signature holds a borrowed pointer, which is how a later
-    // MERGE of the same pattern binds what an earlier one wrote.
-    NLMergeNodeIndex* allocMergeNodeIndex(const LabelSet& labels, bool matchable, ColumnNodeIDs* scanNodes) {
-        auto index = std::make_unique<NLMergeNodeIndex>(labels, matchable, scanNodes);
-        NLMergeNodeIndex* indexPtr = index.get();
-        _mergeNodeIndexes.push_back(std::move(index));
-        return indexPtr;
-    }
+    // The candidate index one chain-node signature already has, or a null pointer for a
+    // signature no chain node of the program has reached yet. Two nodes of the same
+    // labels and key properties look their candidates up in one index, so the label set
+    // is scanned once however many times the query merges the pattern.
+    NLMergeNodeIndex* findMergeNodeIndex(const std::string& signature) const;
+
+    // Adds the index of a signature findMergeNodeIndex found none for, owned by the
+    // program; every chain node of that signature holds a borrowed pointer.
+    NLMergeNodeIndex* addMergeNodeIndex(const std::string& signature,
+                                        const LabelSet& labels,
+                                        bool matchable,
+                                        ColumnNodeIDs* scanNodes);
 
     // The log of every edge this program's merges wrote, owned by the program and
     // shared by all of them: one merge's pending edge is what another's hop extends
@@ -3102,7 +3121,7 @@ private:
     std::vector<std::unique_ptr<NLCollectState>> _collectStates;
     std::vector<std::unique_ptr<NLShortestPathState>> _shortestPathStates;
     std::vector<std::unique_ptr<NLProcedureState>> _procedureStates;
-    std::vector<std::unique_ptr<NLMergeNodeIndex>> _mergeNodeIndexes;
+    std::unordered_map<std::string, std::unique_ptr<NLMergeNodeIndex>> _mergeNodeIndexes;
     NLMergePendingEdges _mergePendingEdges;
     NLMergePendingNodes _mergePendingNodes;
     NLStmtContainer _stmts;

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -784,9 +784,15 @@ public:
     Column* getOutput() const { return _output; }
     PropertyTypeID getPropertyTypeID() const { return _propertyTypeID; }
 
+    // The rows holding a write-buffer offset rather than an ID the graph knows, or null
+    // for an input no merge produced. Such a row reads null.
+    const ColumnMask* getPending() const { return _pending; }
+    void setPending(const ColumnMask* pending) { _pending = pending; }
+
 private:
     const Column* _input {nullptr};
     Column* _output {nullptr};
+    const ColumnMask* _pending {nullptr};
     PropertyTypeID _propertyTypeID;
 };
 
@@ -2488,6 +2494,15 @@ public:
 
     bool isTgtPending() const { return _tgtIsPending; }
 
+    // Row by row, which endpoints are pending, for a column a merge produced and so
+    // mixed. Null for a column that is pending in every row or in none, which the two
+    // flags above then answer for.
+    const ColumnMask* getSrcPendingMask() const { return _srcPendingMask; }
+    const ColumnMask* getTgtPendingMask() const { return _tgtPendingMask; }
+
+    void setSrcPendingMask(const ColumnMask* mask) { _srcPendingMask = mask; }
+    void setTgtPendingMask(const ColumnMask* mask) { _tgtPendingMask = mask; }
+
     ColumnEdgeIDs* getResult() const { return _result; }
 
     const std::vector<Property>& properties() const { return _properties; }
@@ -2501,9 +2516,220 @@ private:
     EdgeTypeID _edgeTypeID;
     const ColumnNodeIDs* _src {nullptr};
     const ColumnNodeIDs* _tgt {nullptr};
+    const ColumnMask* _srcPendingMask {nullptr};
+    const ColumnMask* _tgtPendingMask {nullptr};
     ColumnEdgeIDs* _result {nullptr};
     bool _srcIsPending {false};
     bool _tgtIsPending {false};
+};
+
+// Which way a merge pattern's hop points, from the chain node ahead of it to the one
+// behind. The interpreter's copy of the storage-dialect EdgeDirection, set during
+// translation so execution never reaches into MLIR.
+enum class NLMergeDirection {
+    Undirected = 0,
+    Backward,
+    Forward,
+};
+
+// A node or edge one row of a merge bound: an ID the graph holds, or - when pending -
+// an offset into the change's write buffer for an entity this query wrote and has not
+// committed. The two spaces overlap numerically, so the flag is what tells them apart.
+struct NLMergeRef {
+    uint64_t _id {0};
+    bool _pending {false};
+
+    bool operator==(const NLMergeRef& other) const {
+        return _id == other._id && _pending == other._pending;
+    }
+
+    // The two spaces packed into one integer, so a ref can key a map or a set
+    uint64_t asKey() const { return (_id << 1) | static_cast<uint64_t>(_pending); }
+};
+
+// One property constraint a merge pattern's node or hop puts on a row: the property it
+// names and the column the row's asked-for value comes from, with the appender that
+// turns that value into its part of the key the match looks up.
+struct NLMergeProperty {
+    PropertyType _propertyType;
+    const Column* _values {nullptr};
+    NLKeyAppendFunction _keyAppend {nullptr};
+};
+
+// The graph side of that key: the same property, read out of the graph into a scratch
+// column. Its appender keys a fetched (and so nullable) value the way the row's own
+// appender keys the asked-for one, which is what lets the two keys be compared.
+struct NLMergeScanProperty {
+    PropertyType _propertyType;
+    Column* _values {nullptr};
+    NLKeyAppendFunction _keyAppend {nullptr};
+};
+
+// The nodes the graph holds under one chain-node spec, indexed by the spec's property
+// values. Scanned once, on first use, so a merge driven by many rows pays for one pass
+// over its label set rather than a lookup per row.
+class NLMergeNodeIndex {
+public:
+    NLMergeNodeIndex(const LabelSet& labels, bool matchable, ColumnNodeIDs* scanNodes);
+    ~NLMergeNodeIndex();
+
+    const LabelSet& getLabels() const { return _labels; }
+
+    // False when a label or a key property of the spec is absent from the graph's
+    // schema: no committed node can carry it, so the graph offers no candidate and only
+    // the pending nodes this query wrote can match
+    bool isMatchable() const { return _matchable; }
+
+    bool isBuilt() const { return _built; }
+    void markBuilt() { _built = true; }
+
+    ColumnNodeIDs* getScanNodes() const { return _scanNodes; }
+
+    const std::vector<NLMergeScanProperty>& scanProperties() const { return _scanProperties; }
+    void addScanProperty(const NLMergeScanProperty& property) { _scanProperties.push_back(property); }
+
+    void add(const std::string& key, const NLMergeRef& ref) { _byKey[key].push_back(ref); }
+
+    std::span<const NLMergeRef> find(const std::string& key) const;
+
+private:
+    LabelSet _labels;
+    std::vector<NLMergeScanProperty> _scanProperties;
+    std::unordered_map<std::string, std::vector<NLMergeRef>> _byKey;
+    ColumnNodeIDs* _scanNodes {nullptr};
+    bool _matchable {false};
+    bool _built {false};
+};
+
+// The nodes this query's merges wrote, by the spec that wrote them: a chain node's
+// signature - its label set and key property types - followed by the row's key values.
+// A pending node is in no graph the match reads, so this is where a later row, of this
+// merge or of another one writing the same pattern, binds it rather than writing a
+// second copy. One log per program, shared by every merge op in it.
+class NLMergePendingNodes {
+public:
+    NLMergePendingNodes();
+    ~NLMergePendingNodes();
+
+    void add(const std::string& key, const NLMergeRef& ref) { _byKey[key].push_back(ref); }
+
+    std::span<const NLMergeRef> find(const std::string& key) const;
+
+private:
+    std::unordered_map<std::string, std::vector<NLMergeRef>> _byKey;
+};
+
+// Every edge this query's merges wrote, under each of the two nodes it joins: a pending
+// edge is in no graph the match reads, so this is where a later row's hop finds it. One
+// log per program, shared by every merge op in it.
+class NLMergePendingEdges {
+public:
+    struct Entry {
+        NLMergeRef _other;
+        EdgeTypeID _edgeType;
+        uint64_t _offset {0};
+        std::string _propertyKey;
+    };
+
+    NLMergePendingEdges();
+    ~NLMergePendingEdges();
+
+    void add(const NLMergeRef& source,
+             const NLMergeRef& target,
+             EdgeTypeID edgeType,
+             uint64_t offset,
+             const std::string& propertyKey);
+
+    std::span<const Entry> outOf(const NLMergeRef& node) const;
+    std::span<const Entry> into(const NLMergeRef& node) const;
+
+private:
+    std::unordered_map<uint64_t, std::vector<Entry>> _outgoing;
+    std::unordered_map<uint64_t, std::vector<Entry>> _incoming;
+
+    static std::span<const Entry> lookup(const std::unordered_map<uint64_t, std::vector<Entry>>& edges,
+                                         const NLMergeRef& node);
+};
+
+// nl.merge data: one entry per chain node and one per hop of the pattern, the columns
+// each row's values and bound entities come from, and the chunks the op fills.
+class NLMergeData : public NLFunctionData {
+public:
+    // One node of the chain. A bound node reads its rows from _boundColumn and is never
+    // written; every other one is looked up through _index and, when the pattern is
+    // missing, written under _labelSetHandle with _properties' values.
+    struct Node {
+        std::vector<NLMergeProperty> _properties;
+
+        // What the pending log's keys for this spec start with, so two specs writing
+        // under the same labels and key properties share their entries and two that
+        // do not never collide
+        std::string _signature;
+
+        const ColumnNodeIDs* _boundColumn {nullptr};
+        const ColumnMask* _boundPending {nullptr};
+        NLMergeNodeIndex* _index {nullptr};
+        LabelSetHandle _labelSetHandle;
+        ColumnNodeIDs* _output {nullptr};
+        ColumnMask* _outputPending {nullptr};
+    };
+
+    // One hop of the chain, joining the node ahead of it to the one behind. The match
+    // edge type is invalid when the graph's schema does not have it, which leaves only
+    // the pending edges to match. The scratch chunks below are what a hop constraining
+    // properties reads its candidates' values through.
+    struct Hop {
+        std::vector<NLMergeProperty> _properties;
+        std::vector<NLMergeScanProperty> _scanProperties;
+        EdgeTypeID _matchEdgeType;
+        EdgeTypeID _writeEdgeType;
+        NLMergeDirection _direction {NLMergeDirection::Forward};
+        ColumnNodeIDs* _scanSources {nullptr};
+        ColumnEdgeIDs* _scanEdges {nullptr};
+        ColumnEdgeIDs* _output {nullptr};
+        ColumnMask* _outputPending {nullptr};
+    };
+
+    NLMergeData(NLMergePendingNodes* pendingNodes,
+                NLMergePendingEdges* pendingEdges,
+                ColumnMask* created);
+    ~NLMergeData() override;
+
+    const std::vector<Node>& nodes() const { return _nodes; }
+    const std::vector<Hop>& hops() const { return _hops; }
+    const std::vector<NLCarriedColumn>& carriedColumns() const { return _carriedColumns; }
+
+    std::vector<Node>& nodes() { return _nodes; }
+    std::vector<Hop>& hops() { return _hops; }
+
+    NLMergePendingNodes* getPendingNodes() const { return _pendingNodes; }
+    NLMergePendingEdges* getPendingEdges() const { return _pendingEdges; }
+    ColumnMask* getCreated() const { return _created; }
+
+    // The column whose length is the number of rows the op runs over: a chunk some part
+    // of the pattern reads. Null for a pattern reading none, which is the single row a
+    // MERGE standing on its own writes.
+    const Column* getRowCarrier() const { return _rowCarrier; }
+    void setRowCarrier(const Column* rowCarrier) { _rowCarrier = rowCarrier; }
+
+    void addNode(const Node& node) { _nodes.push_back(node); }
+    void addHop(const Hop& hop) { _hops.push_back(hop); }
+    void addCarriedColumn(const NLCarriedColumn& carried) { _carriedColumns.push_back(carried); }
+
+    ColumnVector<size_t>* getIndices() { return &_indices; }
+
+private:
+    std::vector<Node> _nodes;
+    std::vector<Hop> _hops;
+    std::vector<NLCarriedColumn> _carriedColumns;
+    NLMergePendingNodes* _pendingNodes {nullptr};
+    NLMergePendingEdges* _pendingEdges {nullptr};
+    ColumnMask* _created {nullptr};
+    const Column* _rowCarrier {nullptr};
+
+    // This step's row map, from each emitted row to the input row behind it, fed to the
+    // per-column gather that rebuilds the carry set
+    ColumnVector<size_t> _indices;
 };
 
 class NLSetNodePropertyData : public NLFunctionData {
@@ -2521,9 +2747,22 @@ public:
     const ColumnNodeIDs* getInput() const { return _input; }
     const Column* getValue() const { return _value; }
 
+    // The rows whose node this change wrote and has not committed: those are updated in
+    // the write buffer's pending node rather than recorded as an update to a committed
+    // one. Null for an input no merge produced.
+    const ColumnMask* getPending() const { return _pending; }
+    void setPending(const ColumnMask* pending) { _pending = pending; }
+
+    // The rows the write touches, or null for a write that touches every one: Cypher's
+    // ON CREATE hands over the merge's created mask and ON MATCH its negation.
+    const ColumnMask* getRows() const { return _rows; }
+    void setRows(const ColumnMask* rows) { _rows = rows; }
+
 private:
     const ColumnNodeIDs* _input {nullptr};
     const Column* _value {nullptr};
+    const ColumnMask* _pending {nullptr};
+    const ColumnMask* _rows {nullptr};
     PropertyTypeID _propertyTypeID;
 };
 
@@ -2542,9 +2781,17 @@ public:
     const ColumnEdgeIDs* getInput() const { return _input; }
     const Column* getValue() const { return _value; }
 
+    const ColumnMask* getPending() const { return _pending; }
+    void setPending(const ColumnMask* pending) { _pending = pending; }
+
+    const ColumnMask* getRows() const { return _rows; }
+    void setRows(const ColumnMask* rows) { _rows = rows; }
+
 private:
     const ColumnEdgeIDs* _input {nullptr};
     const Column* _value {nullptr};
+    const ColumnMask* _pending {nullptr};
+    const ColumnMask* _rows {nullptr};
     PropertyTypeID _propertyTypeID;
 };
 
@@ -2810,6 +3057,25 @@ public:
         return statePtr;
     }
 
+    // Allocate one merge signature's candidate index, owned by the program; every
+    // merge op carrying that signature holds a borrowed pointer, which is how a later
+    // MERGE of the same pattern binds what an earlier one wrote.
+    NLMergeNodeIndex* allocMergeNodeIndex(const LabelSet& labels, bool matchable, ColumnNodeIDs* scanNodes) {
+        auto index = std::make_unique<NLMergeNodeIndex>(labels, matchable, scanNodes);
+        NLMergeNodeIndex* indexPtr = index.get();
+        _mergeNodeIndexes.push_back(std::move(index));
+        return indexPtr;
+    }
+
+    // The log of every edge this program's merges wrote, owned by the program and
+    // shared by all of them: one merge's pending edge is what another's hop extends
+    // a candidate with.
+    NLMergePendingEdges* getMergePendingEdges() { return &_mergePendingEdges; }
+
+    // The log of every node this program's merges wrote, the node sibling of the edge
+    // log above and shared the same way.
+    NLMergePendingNodes* getMergePendingNodes() { return &_mergePendingNodes; }
+
     NLStmtContainer* getStmts() { return &_stmts; }
     const NLStmtContainer* getStmts() const { return &_stmts; }
 
@@ -2836,6 +3102,9 @@ private:
     std::vector<std::unique_ptr<NLCollectState>> _collectStates;
     std::vector<std::unique_ptr<NLShortestPathState>> _shortestPathStates;
     std::vector<std::unique_ptr<NLProcedureState>> _procedureStates;
+    std::vector<std::unique_ptr<NLMergeNodeIndex>> _mergeNodeIndexes;
+    NLMergePendingEdges _mergePendingEdges;
+    NLMergePendingNodes _mergePendingNodes;
     NLStmtContainer _stmts;
 };
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -2813,8 +2813,9 @@ private:
 
 class NLDeleteNodeData : public NLFunctionData {
 public:
-    NLDeleteNodeData(const ColumnNodeIDs* input, bool detaching)
+    NLDeleteNodeData(const ColumnNodeIDs* input, bool detaching, ColumnNodeIDs* committed)
         : _input(input),
+        _committed(committed),
         _detaching(detaching)
     {
     }
@@ -2822,22 +2823,51 @@ public:
     const ColumnNodeIDs* getInput() const { return _input; }
     bool isDetaching() const { return _detaching; }
 
+    // The rows naming a node this change wrote and has not committed - a write-buffer
+    // offset rather than an ID the graph holds - or null when no row does. A column a
+    // create produced is such a row throughout, which is what _allPending says.
+    const ColumnMask* getPending() const { return _pending; }
+    void setPending(const ColumnMask* pending) { _pending = pending; }
+
+    bool isAllPending() const { return _allPending; }
+    void setAllPending(bool allPending) { _allPending = allPending; }
+
+    // The scratch the committed rows of a mixed column are gathered into, since the
+    // deletion of those goes through the graph's own IDs
+    ColumnNodeIDs* getCommitted() const { return _committed; }
+
 private:
     const ColumnNodeIDs* _input {nullptr};
+    const ColumnMask* _pending {nullptr};
+    ColumnNodeIDs* _committed {nullptr};
     bool _detaching {false};
+    bool _allPending {false};
 };
 
 class NLDeleteEdgeData : public NLFunctionData {
 public:
-    NLDeleteEdgeData(const ColumnEdgeIDs* input)
-        : _input(input)
+    NLDeleteEdgeData(const ColumnEdgeIDs* input, ColumnEdgeIDs* committed)
+        : _input(input),
+        _committed(committed)
     {
     }
+
+    // The edge siblings of NLDeleteNodeData's
+    const ColumnMask* getPending() const { return _pending; }
+    void setPending(const ColumnMask* pending) { _pending = pending; }
+
+    bool isAllPending() const { return _allPending; }
+    void setAllPending(bool allPending) { _allPending = allPending; }
+
+    ColumnEdgeIDs* getCommitted() const { return _committed; }
 
     const ColumnEdgeIDs* getInput() const { return _input; }
 
 private:
     const ColumnEdgeIDs* _input {nullptr};
+    const ColumnMask* _pending {nullptr};
+    ColumnEdgeIDs* _committed {nullptr};
+    bool _allPending {false};
 };
 
 // nl.output data

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -786,7 +786,7 @@ public:
     PropertyTypeID getPropertyTypeID() const { return _propertyTypeID; }
 
     // The rows holding a write-buffer offset rather than an ID the graph knows, or null
-    // for an input no merge produced. Such a row reads null.
+    // for an input no merge produced. Such a row reads its value out of the write buffer.
     const ColumnMask* getPending() const { return _pending; }
     void setPending(const ColumnMask* pending) { _pending = pending; }
 

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1482,6 +1482,7 @@ void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContaine
 
     ColumnEdgeIDs* result = _memory->alloc<ColumnEdgeIDs>();
     _valueSlots[createEdge.getResult()] = result;
+    _pendingEdgeValues.insert(createEdge.getResult());
 
     NLCreateEdgeData* data = _program->allocFunctionData<NLCreateEdgeData>(
         edgeTypeID,
@@ -1791,7 +1792,11 @@ void NLTranslator::translateDeleteNode(nl::DeleteNode deleteNode, NLStmtContaine
 
     NLDeleteNodeData* data = _program->allocFunctionData<NLDeleteNodeData>(
         inputColumn,
-        deleteNode.getDetach());
+        deleteNode.getDetach(),
+        _memory->alloc<ColumnNodeIDs>());
+
+    data->setPending(getMaskColumn(deleteNode.getPending()));
+    data->setAllPending(_pendingNodeValues.contains(inputValue));
 
     body->emplaceStmt(&NLExecutor::runDeleteNode, data);
 }
@@ -1804,7 +1809,12 @@ void NLTranslator::translateDeleteEdge(nl::DeleteEdge deleteEdge, NLStmtContaine
     const mlir::Value inputValue = deleteEdge.getInputEdges();
     const ColumnEdgeIDs* inputColumn = static_cast<const ColumnEdgeIDs*>(getColumn(inputValue));
 
-    NLDeleteEdgeData* data = _program->allocFunctionData<NLDeleteEdgeData>(inputColumn);
+    NLDeleteEdgeData* data = _program->allocFunctionData<NLDeleteEdgeData>(
+        inputColumn,
+        _memory->alloc<ColumnEdgeIDs>());
+
+    data->setPending(getMaskColumn(deleteEdge.getPending()));
+    data->setAllPending(_pendingEdgeValues.contains(inputValue));
 
     body->emplaceStmt(&NLExecutor::runDeleteEdge, data);
 }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -400,6 +400,17 @@ NLMergeDirection mergeDirectionFromValue(int64_t raw) {
     return NLMergeDirection::Forward;
 }
 
+void appendMergePropertySignature(const std::vector<NLMergeProperty>& properties,
+                                  std::string& signature) {
+    for (const NLMergeProperty& property : properties) {
+        const PropertyTypeID::Type id = property._propertyType._id.getValue();
+        const ValueType valueType = property._propertyType._valueType;
+
+        signature.append(reinterpret_cast<const char*>(&id), sizeof(id));
+        signature.append(reinterpret_cast<const char*>(&valueType), sizeof(valueType));
+    }
+}
+
 // What the pending log's keys for one chain-node spec start with: its label set and the
 // property it keys on, in order. Two specs writing the same pattern share the prefix, so
 // each binds what the other wrote; two that differ never collide.
@@ -412,13 +423,7 @@ void appendMergeNodeSignature(const LabelSet& labels,
         signature.append(reinterpret_cast<const char*>(&integer), sizeof(integer));
     }
 
-    for (const NLMergeProperty& property : properties) {
-        const PropertyTypeID::Type id = property._propertyType._id.getValue();
-        const ValueType valueType = property._propertyType._valueType;
-
-        signature.append(reinterpret_cast<const char*>(&id), sizeof(id));
-        signature.append(reinterpret_cast<const char*>(&valueType), sizeof(valueType));
-    }
+    appendMergePropertySignature(properties, signature);
 }
 
 bool isConstantColumn(const Column* column) {
@@ -1534,6 +1539,8 @@ void NLTranslator::translateMerge(nl::Merge merge, NLStmtContainer* body) {
     const size_t nodeCount = nodeLabels.size();
     const size_t hopCount = nodeCount - 1;
 
+    // A bound node has no result pair of its own: its rows come back through the carry set
+    size_t resultIndex = 0;
     size_t boundIndex = 0;
     size_t nodeValueIndex = 0;
     for (size_t nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
@@ -1547,12 +1554,13 @@ void NLTranslator::translateMerge(nl::Merge merge, NLStmtContainer* body) {
             boundIndex++;
         } else {
             translateMergeNodeSpec(labels, propNames, nodePropValues.slice(nodeValueIndex, propNames.size()), node);
+
+            node._output = static_cast<ColumnNodeIDs*>(allocColumn(results[resultIndex]));
+            node._outputPending = static_cast<ColumnMask*>(allocColumn(results[resultIndex + 1]));
+            resultIndex += 2;
         }
 
         nodeValueIndex += propNames.size();
-
-        node._output = static_cast<ColumnNodeIDs*>(allocColumn(results[2 * nodeIndex]));
-        node._outputPending = static_cast<ColumnMask*>(allocColumn(results[2 * nodeIndex + 1]));
 
         data->addNode(node);
     }
@@ -1599,24 +1607,26 @@ void NLTranslator::translateMerge(nl::Merge merge, NLStmtContainer* body) {
 
         edgeValueIndex += propNames.size();
 
+        appendMergePropertySignature(hop._properties, hop._signature);
+
         hop._scanSources = _memory->alloc<ColumnNodeIDs>();
         hop._scanEdges = _memory->alloc<ColumnEdgeIDs>();
 
-        const size_t hopResult = 2 * nodeCount + 2 * hopIndex;
-        hop._output = static_cast<ColumnEdgeIDs*>(allocColumn(results[hopResult]));
-        hop._outputPending = static_cast<ColumnMask*>(allocColumn(results[hopResult + 1]));
+        hop._output = static_cast<ColumnEdgeIDs*>(allocColumn(results[resultIndex]));
+        hop._outputPending = static_cast<ColumnMask*>(allocColumn(results[resultIndex + 1]));
+        resultIndex += 2;
 
         data->addHop(hop);
     }
 
-    _valueSlots[results[2 * (nodeCount + hopCount)]] = created;
+    _valueSlots[results[resultIndex]] = created;
+    resultIndex++;
 
-    const size_t firstCarried = 2 * (nodeCount + hopCount) + 1;
     for (size_t index = 0; index < carriedColumns.size(); index++) {
         const mlir::Value input = carriedColumns[index];
 
         data->addCarriedColumn({getColumn(input),
-                                allocColumn(results[firstCarried + index]),
+                                allocColumn(results[resultIndex + index]),
                                 selectGatherForChunkType(input.getType())});
     }
 
@@ -1671,13 +1681,20 @@ void NLTranslator::translateMergeNodeSpec(mlir::ArrayAttr labels,
         scanProperties.clear();
     }
 
+    appendMergeNodeSignature(writeLabels, node._properties, node._signature);
+
+    // Every chain node of the same signature looks its candidates up in one index, so
+    // the label set is scanned once however many times the query merges the pattern
+    node._index = _program->findMergeNodeIndex(node._signature);
+    if (node._index) {
+        return;
+    }
+
     ColumnNodeIDs* scanNodes = _memory->alloc<ColumnNodeIDs>();
-    node._index = _program->allocMergeNodeIndex(matchLabels, matchable, scanNodes);
+    node._index = _program->addMergeNodeIndex(node._signature, matchLabels, matchable, scanNodes);
     for (const NLMergeScanProperty& scanProperty : scanProperties) {
         node._index->addScanProperty(scanProperty);
     }
-
-    appendMergeNodeSignature(writeLabels, node._properties, node._signature);
 }
 
 void NLTranslator::translateMergeProperty(llvm::StringRef propName,
@@ -1688,11 +1705,16 @@ void NLTranslator::translateMergeProperty(llvm::StringRef propName,
     const ValueType valueType = valueTypeFromChunkType(propValue.getType());
     const Column* column = getColumn(propValue);
 
-    // Created where the schema lacks it, since a written pattern carries the property
+    // Created where the schema lacks it, since a written pattern carries the property.
+    // Both sides of the key serialize in its registered type: the analyzer lets an
+    // integer constrain a double-typed property, and 5 keys like the 5.0 the graph side
+    // reads back only once converted to it.
     const PropertyType writeType = _metadataBuilder->getOrCreatePropertyType(propName, valueType);
     properties.push_back({._propertyType=writeType,
                           ._values=column,
-                          ._keyAppend=selectMergeKeyAppend(propValue.getType(), column)});
+                          ._keyAppend=selectMergeKeyAppend(propValue.getType(),
+                                                           column,
+                                                           writeType._valueType)});
 
     // The graph's own property, which is what a candidate's value is read back through.
     // Absent means no committed entity carries it, so nothing there can match.
@@ -3605,22 +3627,25 @@ const ColumnMask* NLTranslator::getMaskColumn(mlir::Value chunkValue) const {
     return static_cast<const ColumnMask*>(getColumn(chunkValue));
 }
 
-NLKeyAppendFunction NLTranslator::selectMergeKeyAppend(mlir::Type chunkType, const Column* column) {
+NLKeyAppendFunction NLTranslator::selectMergeKeyAppend(mlir::Type chunkType,
+                                                      const Column* column,
+                                                      ValueType keyType) {
     if (isUntypedNullChunk(chunkType)) {
         return NLExecutor::selectNullMergeKeyAppendFunction();
     }
 
     if (isConstantColumn(column)) {
-        return NLExecutor::selectConstMergeKeyAppendFunction(valueTypeFromChunkType(chunkType));
+        return NLExecutor::selectConstMergeKeyAppendFunction(valueTypeFromChunkType(chunkType), keyType);
     }
 
     const mlir::Type elementType = mlir::cast<nl::ChunkType>(chunkType).getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
-        return NLExecutor::selectOptKeyAppendFunction(valueTypeFromElementType(nullableType.getValueType()));
+        const ValueType nullableValueType = valueTypeFromElementType(nullableType.getValueType());
+        return NLExecutor::selectOptMergeKeyAppendFunction(nullableValueType, keyType);
     }
 
-    return NLExecutor::selectPlainMergeKeyAppendFunction(chunkKindFromElementType(elementType));
+    return NLExecutor::selectPlainMergeKeyAppendFunction(chunkKindFromElementType(elementType), keyType);
 }
 
 NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkType) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -374,6 +374,53 @@ ValueType valueTypeFromChunkType(mlir::Type chunkType) {
     return valueTypeFromElementType(elementType);
 }
 
+NLMergeDirection mergeDirectionFromValue(int64_t raw) {
+    const std::optional<storage::EdgeDirection> direction =
+        storage::symbolizeEdgeDirection(static_cast<uint64_t>(raw));
+
+    if (!direction) {
+        throw IRException("nl.merge carries an unknown edge direction");
+    }
+
+    switch (*direction) {
+        case storage::EdgeDirection::Undirected:
+            return NLMergeDirection::Undirected;
+        break;
+
+        case storage::EdgeDirection::Backward:
+            return NLMergeDirection::Backward;
+        break;
+
+        case storage::EdgeDirection::Forward:
+            return NLMergeDirection::Forward;
+        break;
+    }
+
+    bioassert(false, "Unhandled edge direction");
+    return NLMergeDirection::Forward;
+}
+
+// What the pending log's keys for one chain-node spec start with: its label set and the
+// property it keys on, in order. Two specs writing the same pattern share the prefix, so
+// each binds what the other wrote; two that differ never collide.
+void appendMergeNodeSignature(const LabelSet& labels,
+                              const std::vector<NLMergeProperty>& properties,
+                              std::string& signature) {
+    signature.clear();
+
+    for (const LabelSet::IntegerType integer : labels.integers()) {
+        signature.append(reinterpret_cast<const char*>(&integer), sizeof(integer));
+    }
+
+    for (const NLMergeProperty& property : properties) {
+        const PropertyTypeID::Type id = property._propertyType._id.getValue();
+        const ValueType valueType = property._propertyType._valueType;
+
+        signature.append(reinterpret_cast<const char*>(&id), sizeof(id));
+        signature.append(reinterpret_cast<const char*>(&valueType), sizeof(valueType));
+    }
+}
+
 bool isConstantColumn(const Column* column) {
     return column->getContainerKind() == ContainerKind::code<ColumnConst>();
 }
@@ -606,12 +653,14 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
         } else if (nl::GetNodeProperties getNodeProperties = mlir::dyn_cast<nl::GetNodeProperties>(operation)) {
             translatePropertyFetch(getNodeProperties.getInputNodes(),
                                    getNodeProperties.getPropertyType(),
+                                   getNodeProperties.getPending(),
                                    getNodeProperties.getValues(),
                                    /*isNode=*/true,
                                    body);
         } else if (nl::GetEdgeProperties getEdgeProperties = mlir::dyn_cast<nl::GetEdgeProperties>(operation)) {
             translatePropertyFetch(getEdgeProperties.getInputEdges(),
                                    getEdgeProperties.getPropertyType(),
+                                   getEdgeProperties.getPending(),
                                    getEdgeProperties.getValues(),
                                    /*isNode=*/false,
                                    body);
@@ -673,6 +722,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateCreateNode(createNode, body);
         } else if (nl::CreateEdge createEdge = mlir::dyn_cast<nl::CreateEdge>(operation)) {
             translateCreateEdge(createEdge, body);
+        } else if (nl::Merge merge = mlir::dyn_cast<nl::Merge>(operation)) {
+            translateMerge(merge, body);
         } else if (nl::SetNodeProperty setNodeProperty = mlir::dyn_cast<nl::SetNodeProperty>(operation)) {
             translateSetNodeProperty(setNodeProperty, body);
         } else if (nl::SetEdgeProperty setEdgeProperty = mlir::dyn_cast<nl::SetEdgeProperty>(operation)) {
@@ -1272,6 +1323,7 @@ void NLTranslator::translateEdgeLoop(const IteratorConfig& config,
 
 void NLTranslator::translatePropertyFetch(mlir::Value inputValue,
                                           mlir::Value propertyTypeValue,
+                                          mlir::Value pendingValue,
                                           mlir::Value resultValue,
                                           bool isNode,
                                           NLStmtContainer* body) {
@@ -1299,6 +1351,7 @@ void NLTranslator::translatePropertyFetch(mlir::Value inputValue,
     NLPropertyFetchData* fetchData = _program->allocFunctionData<NLPropertyFetchData>(input,
                                                                                       output,
                                                                                       propertyType->_id);
+    fetchData->setPending(getMaskColumn(pendingValue));
 
     const NLHandlerFunction handler = selectPropertyFetchHandler(isNode, valueType);
     body->emplaceStmt(handler, fetchData);
@@ -1433,6 +1486,9 @@ void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContaine
         tgtIsPending,
         result);
 
+    data->setSrcPendingMask(getMaskColumn(createEdge.getSrcPending()));
+    data->setTgtPendingMask(getMaskColumn(createEdge.getTgtPending()));
+
     const mlir::OperandRange propValues = createEdge.getPropValues();
     const mlir::ArrayAttr propNames = createEdge.getPropNames();
 
@@ -1448,6 +1504,207 @@ void NLTranslator::translateCreateEdge(nl::CreateEdge createEdge, NLStmtContaine
     }
 
     body->emplaceStmt(&NLExecutor::runCreateEdge, data);
+}
+
+void NLTranslator::translateMerge(nl::Merge merge, NLStmtContainer* body) {
+    if (!_metadataBuilder) {
+        throw IRException("nl.merge requires a MetadataBuilder (write transaction)");
+    }
+
+    const mlir::ArrayAttr nodeLabels = merge.getNodeLabels();
+    const mlir::ArrayAttr nodePropNames = merge.getNodePropNames();
+    const mlir::ArrayAttr edgeTypes = merge.getEdgeTypes();
+    const mlir::ArrayAttr edgePropNames = merge.getEdgePropNames();
+    const llvm::ArrayRef<int64_t> directions = merge.getEdgeDirections();
+
+    const mlir::OperandRange boundNodes = merge.getBoundNodes();
+    const mlir::OperandRange boundPending = merge.getBoundPending();
+    const mlir::OperandRange nodePropValues = merge.getNodePropValues();
+    const mlir::OperandRange edgePropValues = merge.getEdgePropValues();
+    const mlir::OperandRange carriedColumns = merge.getCarriedColumns();
+    const mlir::ResultRange results = merge.getResults();
+
+    ColumnMask* created = _memory->alloc<ColumnMask>();
+    created->reserve(_program->getChunkSize());
+
+    NLMergeData* data = _program->allocFunctionData<NLMergeData>(_program->getMergePendingNodes(),
+                                                                 _program->getMergePendingEdges(),
+                                                                 created);
+
+    const size_t nodeCount = nodeLabels.size();
+    const size_t hopCount = nodeCount - 1;
+
+    size_t boundIndex = 0;
+    size_t nodeValueIndex = 0;
+    for (size_t nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
+        const mlir::ArrayAttr labels = mlir::cast<mlir::ArrayAttr>(nodeLabels[nodeIndex]);
+        const mlir::ArrayAttr propNames = mlir::cast<mlir::ArrayAttr>(nodePropNames[nodeIndex]);
+
+        NLMergeData::Node node;
+
+        if (labels.empty()) {
+            node._boundColumn = static_cast<const ColumnNodeIDs*>(getColumn(boundNodes[boundIndex]));
+            boundIndex++;
+        } else {
+            translateMergeNodeSpec(labels, propNames, nodePropValues.slice(nodeValueIndex, propNames.size()), node);
+        }
+
+        nodeValueIndex += propNames.size();
+
+        node._output = static_cast<ColumnNodeIDs*>(allocColumn(results[2 * nodeIndex]));
+        node._outputPending = static_cast<ColumnMask*>(allocColumn(results[2 * nodeIndex + 1]));
+
+        data->addNode(node);
+    }
+
+    // Only a bound node whose column a merge produced carries a mask, so each one names
+    // the chain node it belongs to rather than leaving a hole in a per-node group
+    const llvm::ArrayRef<int64_t> pendingNodes = merge.getPendingNodes();
+    std::vector<NLMergeData::Node>& nodes = data->nodes();
+    for (size_t index = 0; index < pendingNodes.size(); index++) {
+        nodes[pendingNodes[index]]._boundPending = getMaskColumn(boundPending[index]);
+    }
+
+    size_t edgeValueIndex = 0;
+    for (size_t hopIndex = 0; hopIndex < hopCount; hopIndex++) {
+        const llvm::StringRef edgeTypeName = mlir::cast<mlir::StringAttr>(edgeTypes[hopIndex]).getValue();
+        const mlir::ArrayAttr propNames = mlir::cast<mlir::ArrayAttr>(edgePropNames[hopIndex]);
+
+        NLMergeData::Hop hop;
+        hop._writeEdgeType = _metadataBuilder->getOrCreateEdgeType(edgeTypeName);
+        hop._direction = mergeDirectionFromValue(directions[hopIndex]);
+
+        // A type the graph's schema does not have is on no committed edge, so the match
+        // reads the graph only when the name resolves there. It is created above all the
+        // same, since a written hop needs it.
+        const std::optional<EdgeTypeID> matchEdgeType = _view->metadata().edgeTypes().get(edgeTypeName);
+        if (matchEdgeType) {
+            hop._matchEdgeType = *matchEdgeType;
+        }
+
+        bool matchable = matchEdgeType.has_value();
+        for (size_t propIndex = 0; propIndex < propNames.size(); propIndex++) {
+            const llvm::StringRef propName = mlir::cast<mlir::StringAttr>(propNames[propIndex]).getValue();
+            const mlir::Value propValue = edgePropValues[edgeValueIndex + propIndex];
+
+            translateMergeProperty(propName, propValue, hop._properties, hop._scanProperties, matchable);
+        }
+
+        // A property the graph does not have is on no committed edge either, so the hop
+        // reads no candidate rather than reading one it cannot key
+        if (!matchable) {
+            hop._matchEdgeType = EdgeTypeID();
+            hop._scanProperties.clear();
+        }
+
+        edgeValueIndex += propNames.size();
+
+        hop._scanSources = _memory->alloc<ColumnNodeIDs>();
+        hop._scanEdges = _memory->alloc<ColumnEdgeIDs>();
+
+        const size_t hopResult = 2 * nodeCount + 2 * hopIndex;
+        hop._output = static_cast<ColumnEdgeIDs*>(allocColumn(results[hopResult]));
+        hop._outputPending = static_cast<ColumnMask*>(allocColumn(results[hopResult + 1]));
+
+        data->addHop(hop);
+    }
+
+    _valueSlots[results[2 * (nodeCount + hopCount)]] = created;
+
+    const size_t firstCarried = 2 * (nodeCount + hopCount) + 1;
+    for (size_t index = 0; index < carriedColumns.size(); index++) {
+        const mlir::Value input = carriedColumns[index];
+
+        data->addCarriedColumn({getColumn(input),
+                                allocColumn(results[firstCarried + index]),
+                                selectGatherForChunkType(input.getType())});
+    }
+
+    // Every row the op runs over is a row of its inputs, so any of them holding rows of
+    // its own gives their count. A pattern reading only constants runs over one row.
+    for (const mlir::Value input : merge->getOperands()) {
+        const Column* column = getColumn(input);
+        if (!isConstantColumn(column)) {
+            data->setRowCarrier(column);
+            break;
+        }
+    }
+
+    body->emplaceStmt(&NLExecutor::runMerge, data);
+}
+
+void NLTranslator::translateMergeNodeSpec(mlir::ArrayAttr labels,
+                                          mlir::ArrayAttr propNames,
+                                          mlir::OperandRange propValues,
+                                          NLMergeData::Node& node) {
+    // The labels the node is written with, created where the schema lacks them, and the
+    // same set resolved against the graph for the match. A name the graph does not have
+    // is on no committed node, so the conjunction matches nothing there - the way
+    // nl.scan_nodes_by_label treats it - and only what this query wrote can match.
+    LabelSet writeLabels;
+    LabelSet matchLabels;
+    bool matchable = true;
+
+    const LabelMap& graphLabels = _view->metadata().labels();
+    for (const mlir::Attribute attr : labels) {
+        const llvm::StringRef labelName = mlir::cast<mlir::StringAttr>(attr).getValue();
+        writeLabels.set(_metadataBuilder->getOrCreateLabel(labelName));
+
+        const std::optional<LabelID> graphLabel = graphLabels.get(labelName);
+        if (graphLabel) {
+            matchLabels.set(*graphLabel);
+        } else {
+            matchable = false;
+        }
+    }
+
+    node._labelSetHandle = _metadataBuilder->getOrCreateLabelSet(writeLabels);
+
+    std::vector<NLMergeScanProperty> scanProperties;
+    for (size_t propIndex = 0; propIndex < propNames.size(); propIndex++) {
+        const llvm::StringRef propName = mlir::cast<mlir::StringAttr>(propNames[propIndex]).getValue();
+
+        translateMergeProperty(propName, propValues[propIndex], node._properties, scanProperties, matchable);
+    }
+
+    if (!matchable) {
+        scanProperties.clear();
+    }
+
+    ColumnNodeIDs* scanNodes = _memory->alloc<ColumnNodeIDs>();
+    node._index = _program->allocMergeNodeIndex(matchLabels, matchable, scanNodes);
+    for (const NLMergeScanProperty& scanProperty : scanProperties) {
+        node._index->addScanProperty(scanProperty);
+    }
+
+    appendMergeNodeSignature(writeLabels, node._properties, node._signature);
+}
+
+void NLTranslator::translateMergeProperty(llvm::StringRef propName,
+                                          mlir::Value propValue,
+                                          std::vector<NLMergeProperty>& properties,
+                                          std::vector<NLMergeScanProperty>& scanProperties,
+                                          bool& matchable) {
+    const ValueType valueType = valueTypeFromChunkType(propValue.getType());
+    const Column* column = getColumn(propValue);
+
+    // Created where the schema lacks it, since a written pattern carries the property
+    const PropertyType writeType = _metadataBuilder->getOrCreatePropertyType(propName, valueType);
+    properties.push_back({._propertyType=writeType,
+                          ._values=column,
+                          ._keyAppend=selectMergeKeyAppend(propValue.getType(), column)});
+
+    // The graph's own property, which is what a candidate's value is read back through.
+    // Absent means no committed entity carries it, so nothing there can match.
+    const std::optional<PropertyType> graphType = _view->metadata().propTypes().get(propName);
+    if (!graphType) {
+        matchable = false;
+        return;
+    }
+
+    scanProperties.push_back({._propertyType=*graphType,
+                              ._values=allocOptColumnForValueType(graphType->_valueType),
+                              ._keyAppend=NLExecutor::selectOptKeyAppendFunction(graphType->_valueType)});
 }
 
 void NLTranslator::translateSetNodeProperty(nl::SetNodeProperty setNodeProperty, NLStmtContainer* body) {
@@ -1469,6 +1726,9 @@ void NLTranslator::translateSetNodeProperty(nl::SetNodeProperty setNodeProperty,
         propType._id,
         inputColumn,
         valueColumn);
+
+    data->setPending(getMaskColumn(setNodeProperty.getPending()));
+    data->setRows(getMaskColumn(setNodeProperty.getRows()));
 
     body->emplaceStmt(&NLExecutor::runSetNodeProperty, data);
 }
@@ -1492,6 +1752,9 @@ void NLTranslator::translateSetEdgeProperty(nl::SetEdgeProperty setEdgeProperty,
         propType._id,
         inputColumn,
         valueColumn);
+
+    data->setPending(getMaskColumn(setEdgeProperty.getPending()));
+    data->setRows(getMaskColumn(setEdgeProperty.getRows()));
 
     body->emplaceStmt(&NLExecutor::runSetEdgeProperty, data);
 }
@@ -3332,6 +3595,32 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
     }
 
     return NLExecutor::selectCompareFunction(chunkKindFromElementType(elementType));
+}
+
+const ColumnMask* NLTranslator::getMaskColumn(mlir::Value chunkValue) const {
+    if (!chunkValue) {
+        return nullptr;
+    }
+
+    return static_cast<const ColumnMask*>(getColumn(chunkValue));
+}
+
+NLKeyAppendFunction NLTranslator::selectMergeKeyAppend(mlir::Type chunkType, const Column* column) {
+    if (isUntypedNullChunk(chunkType)) {
+        return NLExecutor::selectNullMergeKeyAppendFunction();
+    }
+
+    if (isConstantColumn(column)) {
+        return NLExecutor::selectConstMergeKeyAppendFunction(valueTypeFromChunkType(chunkType));
+    }
+
+    const mlir::Type elementType = mlir::cast<nl::ChunkType>(chunkType).getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        return NLExecutor::selectOptKeyAppendFunction(valueTypeFromElementType(nullableType.getValueType()));
+    }
+
+    return NLExecutor::selectPlainMergeKeyAppendFunction(chunkKindFromElementType(elementType));
 }
 
 NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkType) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -562,8 +562,11 @@ private:
     static NLGatherFunction selectGatherForChunkType(mlir::Type chunkType);
 
     // The appender that keys one row of a merge's property value column, chosen from the
-    // shape the column comes in: a nullable value chunk, a constant, or a plain chunk.
-    static NLKeyAppendFunction selectMergeKeyAppend(mlir::Type chunkType, const Column* column);
+    // shape the column comes in - a nullable value chunk, a constant, or a plain chunk -
+    // and keying in @param keyType, the type the schema holds the property as.
+    static NLKeyAppendFunction selectMergeKeyAppend(mlir::Type chunkType,
+                                                    const Column* column,
+                                                    ValueType keyType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
 

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -560,6 +560,10 @@ private:
     Column* allocColumnForChunkType(mlir::Type chunkType);
     static NLAppendFunction selectAppendForChunkType(mlir::Type chunkType);
     static NLGatherFunction selectGatherForChunkType(mlir::Type chunkType);
+
+    // The appender that keys one row of a merge's property value column, chosen from the
+    // shape the column comes in: a nullable value chunk, a constant, or a plain chunk.
+    static NLKeyAppendFunction selectMergeKeyAppend(mlir::Type chunkType, const Column* column);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
 
@@ -579,6 +583,7 @@ private:
     // column, and record the with-null fetch statement in body
     void translatePropertyFetch(mlir::Value inputValue,
                                 mlir::Value propertyTypeValue,
+                                mlir::Value pendingValue,
                                 mlir::Value resultValue,
                                 bool isNode,
                                 NLStmtContainer* body);
@@ -592,6 +597,26 @@ private:
     void translateCreateNode(mlir::nl::CreateNode createNode, NLStmtContainer* body);
 
     void translateCreateEdge(mlir::nl::CreateEdge createEdge, NLStmtContainer* body);
+
+    void translateMerge(mlir::nl::Merge merge, NLStmtContainer* body);
+
+    // The label set, candidate index and property values of one chain node the merge
+    // looks up and writes, rather than one whose column the query already bound
+    void translateMergeNodeSpec(mlir::ArrayAttr labels,
+                                mlir::ArrayAttr propNames,
+                                mlir::OperandRange propValues,
+                                NLMergeData::Node& node);
+
+    // Resolves one property constraint of a merge pattern on both sides: the row's
+    // asked-for value column with the appender that keys it, and - when the graph's
+    // schema has the property - the scratch column a candidate's value is read back
+    // into. Clears @param matchable when it does not, since nothing committed can then
+    // carry the property.
+    void translateMergeProperty(llvm::StringRef propName,
+                                mlir::Value propValue,
+                                std::vector<NLMergeProperty>& properties,
+                                std::vector<NLMergeScanProperty>& scanProperties,
+                                bool& matchable);
 
     void translateSetNodeProperty(mlir::nl::SetNodeProperty setNodeProperty, NLStmtContainer* body);
 
@@ -681,6 +706,9 @@ private:
     Column* allocListElementColumn();
 
     Column* getColumn(mlir::Value chunkValue) const;
+
+    // The mask an optional boolean chunk operand resolves to, or null for an absent one
+    const ColumnMask* getMaskColumn(mlir::Value chunkValue) const;
     static NLChunkKind getChunkKind(mlir::Type chunkType);
     static NLChunkKind chunkKindFromElementType(mlir::Type elementType);
 };

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -157,6 +157,7 @@ private:
 
     // Set of nl.create_node result SSA values
     llvm::DenseSet<mlir::Value> _pendingNodeValues;
+    llvm::DenseSet<mlir::Value> _pendingEdgeValues;
 
     // nl.limit handle SSA value -> the runtime counter it produces, so the loops,
     // nl.limit_update and nl.output that name the handle find the same counter

--- a/query/ir/interpreter/NLWriteProperties.cpp
+++ b/query/ir/interpreter/NLWriteProperties.cpp
@@ -1,0 +1,172 @@
+#include "NLWriteProperties.h"
+
+#include "columns/AllowedKinds.h"
+#include "columns/ColumnConst.h"
+#include "columns/ColumnKind.h"
+#include "columns/ColumnOperatorDispatcher.h"
+#include "columns/ColumnVector.h"
+#include "reader/GraphReader.h"
+#include "views/GraphView.h"
+
+#include "IRException.h"
+
+using namespace db;
+
+namespace {
+
+class ConstPropertyExtractor {
+public:
+    ConstPropertyExtractor(CommitWriteBuffer::UntypedProperties& buf,
+                           PropertyTypeID propID,
+                           size_t rowCount)
+        : _buf(buf),
+        _propID(propID),
+        _rowCount(rowCount)
+    {
+    }
+
+    template <typename T>
+    void operator()(const ColumnConst<T>* typed) {
+        _buf.clear();
+        _buf.reserve(_rowCount);
+        for (size_t i = 0; i < _rowCount; i++) {
+            _buf.emplace_back(_propID, typed->getRaw());
+        }
+    }
+
+    void operator()(const ColumnConst<types::String::Primitive>* typed) {
+        _buf.clear();
+        _buf.reserve(_rowCount);
+        for (size_t i = 0; i < _rowCount; i++) {
+            _buf.emplace_back(_propID, std::string(typed->getRaw()));
+        }
+    }
+
+    void operator()(const ColumnConst<types::Embedding::Primitive>* typed) {
+        _buf.clear();
+        _buf.reserve(_rowCount);
+        const types::Embedding::Primitive span = typed->getRaw();
+        for (size_t i = 0; i < _rowCount; i++) {
+            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(span.begin(), span.end()));
+        }
+    }
+
+private:
+    CommitWriteBuffer::UntypedProperties& _buf;
+    PropertyTypeID _propID;
+    size_t _rowCount;
+};
+
+class VectorPropertyExtractor {
+public:
+    VectorPropertyExtractor(CommitWriteBuffer::UntypedProperties& buf,
+                            PropertyTypeID propID)
+        : _buf(buf),
+        _propID(propID)
+    {
+    }
+
+    template <typename T>
+    void operator()(const ColumnVector<T>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const T& val : *typed) {
+            _buf.emplace_back(_propID, val);
+        }
+    }
+
+    void operator()(const ColumnVector<types::String::Primitive>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const types::String::Primitive val : *typed) {
+            _buf.emplace_back(_propID, std::string(val));
+        }
+    }
+
+    void operator()(const ColumnVector<types::Embedding::Primitive>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const types::Embedding::Primitive val : *typed) {
+            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(val.begin(), val.end()));
+        }
+    }
+
+    template <typename T>
+    void operator()(const ColumnVector<std::optional<T>>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const std::optional<T>& val : *typed) {
+            if (!val) {
+                throw IRException("Cannot set a property to NULL in CREATE.");
+            }
+            _buf.emplace_back(_propID, *val);
+        }
+    }
+
+    void operator()(const ColumnVector<std::optional<types::String::Primitive>>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const std::optional<types::String::Primitive>& val : *typed) {
+            if (!val) {
+                throw IRException("Cannot set a property to NULL in CREATE.");
+            }
+            _buf.emplace_back(_propID, std::string(*val));
+        }
+    }
+
+    void operator()(const ColumnVector<std::optional<types::Embedding::Primitive>>* typed) {
+        _buf.clear();
+        _buf.reserve(typed->size());
+        for (const std::optional<types::Embedding::Primitive>& val : *typed) {
+            if (!val) {
+                throw IRException("Cannot set a property to NULL in CREATE.");
+            }
+            _buf.emplace_back(_propID, types::Embedding::OwningPrimitive(val->begin(), val->end()));
+        }
+    }
+
+private:
+    CommitWriteBuffer::UntypedProperties& _buf;
+    PropertyTypeID _propID;
+};
+
+}
+
+size_t db::committedNodeCount(const GraphView* view) {
+    if (!view || !view->isValid()) {
+        return 0;
+    }
+
+    const GraphReader reader = view->read();
+    return reader.getTotalNodesAllocated();
+}
+
+size_t db::committedEdgeCount(const GraphView* view) {
+    if (!view || !view->isValid()) {
+        return 0;
+    }
+
+    const GraphReader reader = view->read();
+    return reader.getTotalEdgesAllocated();
+}
+
+void db::extractColumnProperties(const Column* column,
+                                 size_t rowCount,
+                                 PropertyTypeID propID,
+                                 CommitWriteBuffer::UntypedProperties& buf) {
+    using Types = WriteProcessorPropertyTypes;
+
+    const ContainerKind::Code containerKind = ColumnKind::extractContainerKind(column->getKind());
+
+    if (containerKind == ContainerKind::code<ColumnConst>()) {
+        ConstPropertyExtractor extractor(buf, propID, rowCount);
+        ColumnSingleDispatcher<Types::AllowedConst,
+                               ConstPropertyExtractor,
+                               Types::ExcludedConst>::dispatch(column, extractor);
+    } else {
+        VectorPropertyExtractor extractor(buf, propID);
+        ColumnSingleDispatcher<Types::AllowedVector,
+                               VectorPropertyExtractor,
+                               Types::ExcludedVector>::dispatch(column, extractor);
+    }
+}

--- a/query/ir/interpreter/NLWriteProperties.h
+++ b/query/ir/interpreter/NLWriteProperties.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "metadata/PropertyType.h"
+#include "versioning/CommitWriteBuffer.h"
+
+namespace db {
+
+class Column;
+class GraphView;
+
+// Where this change's provisional IDs start. A node or edge it writes is named by the ID
+// it will commit as - one past the last the graph holds, plus the entity's offset in the
+// write buffer - so these are what turn one into the other.
+size_t committedNodeCount(const GraphView* view);
+size_t committedEdgeCount(const GraphView* view);
+
+// The values one property column holds, as the write buffer takes them: one entry per
+// row, owning whatever the column only borrows. What a create, a set and a merge all
+// turn a row's asked-for value into before writing it.
+void extractColumnProperties(const Column* column,
+                             size_t rowCount,
+                             PropertyTypeID propID,
+                             CommitWriteBuffer::UntypedProperties& buf);
+
+}

--- a/query/ir/interpreter/NLWrittenValues.cpp
+++ b/query/ir/interpreter/NLWrittenValues.cpp
@@ -1,0 +1,57 @@
+#include "NLWrittenValues.h"
+
+using namespace db;
+
+NLWrittenValues::NLWrittenValues() {
+}
+
+NLWrittenValues::~NLWrittenValues() {
+}
+
+void NLWrittenValues::indexUpdates(const CommitWriteBuffer* writeBuffer) {
+    _writeBuffer = writeBuffer;
+
+    const CommitWriteBuffer::UpdatedNodes& nodes = writeBuffer->updatedNodes();
+    for (; _indexedNodeUpdates < nodes.size(); _indexedNodeUpdates++) {
+        const CommitWriteBuffer::NodeUpdate& update = nodes[_indexedNodeUpdates];
+        const Key key {._entity=update._idToUpdate.getValue(),
+                       ._property=update._updatedValue.propertyID.getValue()};
+
+        _nodeUpdates[key] = _indexedNodeUpdates;
+    }
+
+    const CommitWriteBuffer::UpdatedEdges& edges = writeBuffer->updatedEdges();
+    for (; _indexedEdgeUpdates < edges.size(); _indexedEdgeUpdates++) {
+        const CommitWriteBuffer::EdgeUpdate& update = edges[_indexedEdgeUpdates];
+        const Key key {._entity=update._idToUpdate.getValue(),
+                       ._property=update._updatedValue.propertyID.getValue()};
+
+        _edgeUpdates[key] = _indexedEdgeUpdates;
+    }
+}
+
+const NLWrittenValues::Value* NLWrittenValues::findNodeUpdate(NodeID node, PropertyTypeID property) const {
+    const Key key {._entity=node.getValue(), ._property=property.getValue()};
+
+    const auto findIt = _nodeUpdates.find(key);
+    if (findIt == end(_nodeUpdates)) {
+        return nullptr;
+    }
+
+    return &_writeBuffer->updatedNodes()[findIt->second]._updatedValue.value;
+}
+
+const NLWrittenValues::Value* NLWrittenValues::findEdgeUpdate(EdgeID edge, PropertyTypeID property) const {
+    const Key key {._entity=edge.getValue(), ._property=property.getValue()};
+
+    const auto findIt = _edgeUpdates.find(key);
+    if (findIt == end(_edgeUpdates)) {
+        return nullptr;
+    }
+
+    return &_writeBuffer->updatedEdges()[findIt->second]._updatedValue.value;
+}
+
+const NLWrittenValues::Value& NLWrittenValues::retain(const Value& value) {
+    return _retained.emplace_back(value);
+}

--- a/query/ir/interpreter/NLWrittenValues.h
+++ b/query/ir/interpreter/NLWrittenValues.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <deque>
+#include <unordered_map>
+
+#include "ID.h"
+#include "metadata/PropertyType.h"
+#include "versioning/CommitWriteBuffer.h"
+
+namespace db {
+
+// What this change has written, as a read later in the same query sees it. The graph a
+// fetch reads holds the values from before the change: an update to a committed entity
+// only lands there at commit, so the fetch has to be told about it here.
+class NLWrittenValues {
+public:
+    using Value = CommitWriteBuffer::SupportedTypeVariant;
+
+    NLWrittenValues();
+    ~NLWrittenValues();
+
+    // Takes in every update the buffer has gathered since the last call. It only ever
+    // appends while a program runs, so what is indexed stays indexed.
+    void indexUpdates(const CommitWriteBuffer* writeBuffer);
+
+    bool hasUpdates() const { return !_nodeUpdates.empty() || !_edgeUpdates.empty(); }
+
+    const Value* findNodeUpdate(NodeID node, PropertyTypeID property) const;
+    const Value* findEdgeUpdate(EdgeID edge, PropertyTypeID property) const;
+
+    // A copy of a value a fetch is about to hand to a column that only borrows it - a
+    // string or an embedding. The change rewrites its own values as the query runs, so
+    // the column would otherwise come to point at bytes a later row has freed.
+    const Value& retain(const Value& value);
+
+private:
+    struct Key {
+        uint64_t _entity {0};
+        uint64_t _property {0};
+
+        bool operator==(const Key& other) const {
+            return _entity == other._entity && _property == other._property;
+        }
+    };
+
+    struct KeyHash {
+        size_t operator()(const Key& key) const {
+            return (key._entity * 1099511628211ull) ^ key._property;
+        }
+    };
+
+    using UpdateIndex = std::unordered_map<Key, size_t, KeyHash>;
+
+    const CommitWriteBuffer* _writeBuffer {nullptr};
+
+    // Each key's row in the buffer's own update list rather than the value itself, since
+    // the list moves what it holds as it grows
+    UpdateIndex _nodeUpdates;
+    UpdateIndex _edgeUpdates;
+
+    size_t _indexedNodeUpdates {0};
+    size_t _indexedEdgeUpdates {0};
+
+    std::deque<Value> _retained;
+};
+
+}

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -15,6 +15,7 @@
 
 #include "IRConstantColumn.h"
 #include "IRRowAlignment.h"
+#include "MergePatternShape.h"
 #include "Procedure.h"
 #include "ProcedureManager.h"
 #include "ProcedureTypeVector.h"
@@ -2310,18 +2311,7 @@ void DBLowering::lowerCallProcedure(mlir::db::CallProcedure call) {
 
     // Anchored on the deepest-bound operand, so a loop-bound argument or carried column
     // is found wherever it sits in the operand list, behind any hoisted constants.
-    mlir::Value anchorChunk;
-    for (const mlir::Value operandChunk : operandChunks) {
-        if (!anchorChunk) {
-            anchorChunk = operandChunk;
-            continue;
-        }
-
-        mlir::Block* const block = deeperBlock(anchorChunk, operandChunk);
-        if (ownerBlock(operandChunk) == block) {
-            anchorChunk = operandChunk;
-        }
-    }
+    const mlir::Value anchorChunk = deepestBoundChunk(operandChunks);
 
     mlir::Block* insertionBlock = _rootBlock;
     if (anchorChunk) {
@@ -2648,19 +2638,10 @@ void DBLowering::lowerCreateEdge(mlir::db::CreateEdge createEdge) {
         propChunks.push_back(mapValue(propValue));
     }
 
-    mlir::Value reference = srcChunk;
-    {
-        mlir::Block* const block = deeperBlock(reference, tgtChunk);
-        if (ownerBlock(tgtChunk) == block) {
-            reference = tgtChunk;
-        }
-    }
-    for (const mlir::Value propChunk : propChunks) {
-        mlir::Block* const block = deeperBlock(reference, propChunk);
-        if (ownerBlock(propChunk) == block) {
-            reference = propChunk;
-        }
-    }
+    llvm::SmallVector<mlir::Value, 8> operandChunks {srcChunk, tgtChunk};
+    operandChunks.append(propChunks.begin(), propChunks.end());
+
+    const mlir::Value reference = deepestBoundChunk(operandChunks);
     setInsertionInto(ownerBlock(reference));
 
     nl::CreateEdge create = _builder.create<nl::CreateEdge>(
@@ -2703,24 +2684,16 @@ void DBLowering::lowerMerge(mlir::db::Merge merge) {
     mapColumns(merge.getEdgePropValues(), edgePropValues);
     mapColumns(merge.getCarriedColumns(), carriedColumns);
 
+    llvm::SmallVector<mlir::Value, 8> operandChunks(boundNodes);
+    operandChunks.append(boundPending.begin(), boundPending.end());
+    operandChunks.append(nodePropValues.begin(), nodePropValues.end());
+    operandChunks.append(edgePropValues.begin(), edgePropValues.end());
+    operandChunks.append(carriedColumns.begin(), carriedColumns.end());
+
     // Inserted into the deepest block, where all the operands are defined. A merge over
     // literals alone reads no chunk, and so opens where the program does.
     mlir::Block* targetBlock = _entryBlock;
-    mlir::Value insertionReference;
-    for (const mlir::Value operand : merge->getOperands()) {
-        const mlir::Value operandChunk = mapValue(operand);
-        if (!insertionReference) {
-            insertionReference = operandChunk;
-            continue;
-        }
-
-        mlir::Block* const block = deeperBlock(insertionReference, operandChunk);
-        if (ownerBlock(operandChunk) == block) {
-            insertionReference = operandChunk;
-        }
-    }
-
-    if (insertionReference) {
+    if (const mlir::Value insertionReference = deepestBoundChunk(operandChunks)) {
         targetBlock = ownerBlock(insertionReference);
     }
 
@@ -2731,11 +2704,12 @@ void DBLowering::lowerMerge(mlir::db::Merge merge) {
     const mlir::Type edgeChunkType = nl::ChunkType::get(context, storage::EdgeIDType::get(context));
     const mlir::Type maskChunkType = nl::ChunkType::get(context, storage::BoolType::get(context));
 
-    const size_t nodeCount = merge.getNodeLabels().size();
-    const size_t hopCount = nodeCount - 1;
+    const mlir::ArrayAttr nodeLabels = merge.getNodeLabels();
+    const size_t hopCount = nodeLabels.size() - 1;
+    const size_t matchedNodeCount = mlir::mergeMatchedNodeCount(nodeLabels);
 
     llvm::SmallVector<mlir::Type, 8> resultTypes;
-    for (size_t nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
+    for (size_t nodeIndex = 0; nodeIndex < matchedNodeCount; nodeIndex++) {
         resultTypes.push_back(nodeChunkType);
         resultTypes.push_back(maskChunkType);
     }
@@ -3064,6 +3038,23 @@ void DBLowering::lowerFilter(mlir::db::FilterOp filter) {
     }
 
     followCardinalityThrough(columnChunks, nlFilter.getResults());
+}
+
+mlir::Value DBLowering::deepestBoundChunk(llvm::ArrayRef<mlir::Value> chunks) {
+    mlir::Value deepest;
+    for (const mlir::Value chunk : chunks) {
+        if (!deepest) {
+            deepest = chunk;
+            continue;
+        }
+
+        mlir::Block* const block = deeperBlock(deepest, chunk);
+        if (ownerBlock(chunk) == block) {
+            deepest = chunk;
+        }
+    }
+
+    return deepest;
 }
 
 mlir::Block* DBLowering::deeperBlock(mlir::Value first, mlir::Value second) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -2799,7 +2799,10 @@ void DBLowering::lowerDeleteNode(mlir::db::DeleteNode deleteNode) {
     // The delete runs where its node chunk is live - the block that owns it.
     setInsertionInto(ownerBlock(inputChunk));
 
-    _builder.create<nl::DeleteNode>(loc, inputChunk, deleteNode.getDetach());
+    _builder.create<nl::DeleteNode>(loc,
+                                    inputChunk,
+                                    deleteNode.getDetach(),
+                                    mapOptionalMask(deleteNode.getPending()));
 }
 
 void DBLowering::lowerDeleteEdge(mlir::db::DeleteEdge deleteEdge) {
@@ -2808,7 +2811,7 @@ void DBLowering::lowerDeleteEdge(mlir::db::DeleteEdge deleteEdge) {
 
     setInsertionInto(ownerBlock(inputChunk));
 
-    _builder.create<nl::DeleteEdge>(loc, inputChunk);
+    _builder.create<nl::DeleteEdge>(loc, inputChunk, mapOptionalMask(deleteEdge.getPending()));
 }
 
 void DBLowering::lowerConstant(mlir::db::ConstantOp constant) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -758,6 +758,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerCreateNode(createNode);
     } else if (mlir::db::CreateEdge createEdge = mlir::dyn_cast<mlir::db::CreateEdge>(operation)) {
         lowerCreateEdge(createEdge);
+    } else if (mlir::db::Merge merge = mlir::dyn_cast<mlir::db::Merge>(operation)) {
+        lowerMerge(merge);
     } else if (mlir::db::SetNodeProperty setNodeProperty = mlir::dyn_cast<mlir::db::SetNodeProperty>(operation)) {
         lowerSetNodeProperty(setNodeProperty);
     } else if (mlir::db::SetEdgeProperty setEdgeProperty = mlir::dyn_cast<mlir::db::SetEdgeProperty>(operation)) {
@@ -1201,7 +1203,8 @@ void DBLowering::lowerGetNodeProperties(mlir::db::GetNodeProperties getNodePrope
     nl::GetNodeProperties fetch = _builder.create<nl::GetNodeProperties>(_builder.getUnknownLoc(),
                                                                          valueChunkType,
                                                                          inputChunk,
-                                                                         handle);
+                                                                         handle,
+                                                                         mapOptionalMask(getNodeProperties.getPending()));
     _valueMap[getNodeProperties.getResult()] = fetch.getValues();
 }
 
@@ -1217,7 +1220,8 @@ void DBLowering::lowerGetEdgeProperties(mlir::db::GetEdgeProperties getEdgePrope
     nl::GetEdgeProperties fetch = _builder.create<nl::GetEdgeProperties>(_builder.getUnknownLoc(),
                                                                          valueChunkType,
                                                                          inputChunk,
-                                                                         handle);
+                                                                         handle,
+                                                                         mapOptionalMask(getEdgeProperties.getPending()));
     _valueMap[getEdgeProperties.getResult()] = fetch.getValues();
 }
 
@@ -2665,8 +2669,111 @@ void DBLowering::lowerCreateEdge(mlir::db::CreateEdge createEdge) {
         tgtChunk,
         createEdge.getEdgeTypeAttr(),
         createEdge.getPropNamesAttr(),
-        propChunks);
+        propChunks,
+        mapOptionalMask(createEdge.getSrcPending()),
+        mapOptionalMask(createEdge.getTgtPending()));
     _valueMap[createEdge.getResult()] = create.getResult();
+}
+
+mlir::Value DBLowering::mapOptionalMask(mlir::Value mask) {
+    if (!mask) {
+        return mlir::Value();
+    }
+
+    return mapValue(mask);
+}
+
+void DBLowering::mapColumns(mlir::OperandRange columns, llvm::SmallVectorImpl<mlir::Value>& chunks) {
+    chunks.clear();
+    for (const mlir::Value column : columns) {
+        chunks.push_back(mapValue(column));
+    }
+}
+
+void DBLowering::lowerMerge(mlir::db::Merge merge) {
+    llvm::SmallVector<mlir::Value, 8> boundNodes;
+    llvm::SmallVector<mlir::Value, 8> boundPending;
+    llvm::SmallVector<mlir::Value, 8> nodePropValues;
+    llvm::SmallVector<mlir::Value, 8> edgePropValues;
+    llvm::SmallVector<mlir::Value, 8> carriedColumns;
+
+    mapColumns(merge.getBoundNodes(), boundNodes);
+    mapColumns(merge.getBoundPending(), boundPending);
+    mapColumns(merge.getNodePropValues(), nodePropValues);
+    mapColumns(merge.getEdgePropValues(), edgePropValues);
+    mapColumns(merge.getCarriedColumns(), carriedColumns);
+
+    // Inserted into the deepest block, where all the operands are defined. A merge over
+    // literals alone reads no chunk, and so opens where the program does.
+    mlir::Block* targetBlock = _entryBlock;
+    mlir::Value insertionReference;
+    for (const mlir::Value operand : merge->getOperands()) {
+        const mlir::Value operandChunk = mapValue(operand);
+        if (!insertionReference) {
+            insertionReference = operandChunk;
+            continue;
+        }
+
+        mlir::Block* const block = deeperBlock(insertionReference, operandChunk);
+        if (ownerBlock(operandChunk) == block) {
+            insertionReference = operandChunk;
+        }
+    }
+
+    if (insertionReference) {
+        targetBlock = ownerBlock(insertionReference);
+    }
+
+    setInsertionInto(targetBlock);
+
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::Type nodeChunkType = nl::ChunkType::get(context, storage::NodeIDType::get(context));
+    const mlir::Type edgeChunkType = nl::ChunkType::get(context, storage::EdgeIDType::get(context));
+    const mlir::Type maskChunkType = nl::ChunkType::get(context, storage::BoolType::get(context));
+
+    const size_t nodeCount = merge.getNodeLabels().size();
+    const size_t hopCount = nodeCount - 1;
+
+    llvm::SmallVector<mlir::Type, 8> resultTypes;
+    for (size_t nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
+        resultTypes.push_back(nodeChunkType);
+        resultTypes.push_back(maskChunkType);
+    }
+
+    for (size_t hopIndex = 0; hopIndex < hopCount; hopIndex++) {
+        resultTypes.push_back(edgeChunkType);
+        resultTypes.push_back(maskChunkType);
+    }
+
+    resultTypes.push_back(maskChunkType);
+
+    for (const mlir::Value carriedChunk : carriedColumns) {
+        resultTypes.push_back(carriedChunk.getType());
+    }
+
+    nl::Merge nlMerge = _builder.create<nl::Merge>(_builder.getUnknownLoc(),
+                                                   resultTypes,
+                                                   merge.getNodeLabelsAttr(),
+                                                   merge.getNodePropNamesAttr(),
+                                                   merge.getEdgeTypesAttr(),
+                                                   merge.getEdgePropNamesAttr(),
+                                                   merge.getEdgeDirectionsAttr(),
+                                                   merge.getPendingNodesAttr(),
+                                                   boundNodes,
+                                                   boundPending,
+                                                   nodePropValues,
+                                                   edgePropValues,
+                                                   carriedColumns);
+
+    const mlir::ResultRange dbResults = merge.getResults();
+    const mlir::ResultRange nlResults = nlMerge.getResults();
+    for (size_t index = 0; index < dbResults.size(); index++) {
+        _valueMap[dbResults[index]] = nlResults[index];
+    }
+
+    // The merge grows or shrinks the rows in flight, so from here on what sizes a
+    // projection of constants alone is its own node chunk
+    _innermostCardinality = nlResults.front();
 }
 
 void DBLowering::lowerSetNodeProperty(mlir::db::SetNodeProperty setNodeProperty) {
@@ -2685,7 +2792,9 @@ void DBLowering::lowerSetNodeProperty(mlir::db::SetNodeProperty setNodeProperty)
         loc,
         inputChunk,
         setNodeProperty.getPropertyAttr(),
-        valueChunk);
+        valueChunk,
+        mapOptionalMask(setNodeProperty.getPending()),
+        mapOptionalMask(setNodeProperty.getRows()));
 }
 
 void DBLowering::lowerSetEdgeProperty(mlir::db::SetEdgeProperty setEdgeProperty) {
@@ -2704,7 +2813,9 @@ void DBLowering::lowerSetEdgeProperty(mlir::db::SetEdgeProperty setEdgeProperty)
         loc,
         inputChunk,
         setEdgeProperty.getPropertyAttr(),
-        valueChunk);
+        valueChunk,
+        mapOptionalMask(setEdgeProperty.getPending()),
+        mapOptionalMask(setEdgeProperty.getRows()));
 }
 
 void DBLowering::lowerDeleteNode(mlir::db::DeleteNode deleteNode) {
@@ -2822,8 +2933,14 @@ void DBLowering::lowerNot(mlir::db::NotOp notOp) {
     const mlir::Type operandType = operandChunk.getType();
     const bool resultNull = isNullableChunk(operandType);
 
-    const mlir::Type boolElement = _builder.getI1Type();
     mlir::MLIRContext* bldCtxt = _builder.getContext();
+
+    // A mask stays a mask through the negation - what nl.merge and the constraint checks
+    // produce - while a predicate over values keeps the i1 element they carry
+    const bool operandIsMask = isa<storage::BoolType>(mlir::cast<nl::ChunkType>(operandType).getElementType());
+    const mlir::Type boolElement = operandIsMask ? storage::BoolType::get(bldCtxt)
+                                                 : mlir::Type(_builder.getI1Type());
+
     mlir::Type resultElement = boolElement;
     if (resultNull) {
         resultElement = storage::NullableType::get(bldCtxt, boolElement);

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -447,6 +447,11 @@ private:
     static mlir::Block* ownerBlock(mlir::Value chunkValue);
     static size_t blockNestingDepth(mlir::Block* block);
 
+    // The chunk of @param chunks bound deepest - the one whose block every other is
+    // valid in, which is where an op reading all of them belongs. A null Value for an
+    // empty range, which is an op reading no chunk at all.
+    mlir::Value deepestBoundChunk(llvm::ArrayRef<mlir::Value> chunks);
+
     // Find the first place where both @param first and @param second are valid
     mlir::Block* deeperBlock(mlir::Value first, mlir::Value second);
 };

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -199,6 +199,8 @@ private:
     void lowerCheckEdgeTypeConstraint(mlir::db::CheckEdgeTypeConstraint checkEdgeTypeConstraint);
     void lowerCreateNode(mlir::db::CreateNode createNode);
     void lowerCreateEdge(mlir::db::CreateEdge createEdge);
+
+    void lowerMerge(mlir::db::Merge merge);
     void lowerSetNodeProperty(mlir::db::SetNodeProperty setNodeProperty);
     void lowerSetEdgeProperty(mlir::db::SetEdgeProperty setEdgeProperty);
     void lowerDeleteNode(mlir::db::DeleteNode deleteNode);
@@ -389,6 +391,13 @@ private:
     // Point the builder just before the terminator of block, where the next
     // lowered op belongs
     void setInsertionInto(mlir::Block* block);
+
+    // The chunks one group of a db op's column operands lowered to, in order
+    void mapColumns(mlir::OperandRange columns, llvm::SmallVectorImpl<mlir::Value>& chunks);
+
+    // The chunk an optional mask operand lowered to, or a null Value for an absent one -
+    // which is what the nl op then carries in its place
+    mlir::Value mapOptionalMask(mlir::Value mask);
 
     // Point the builder just after the loop nest that @param updateBlock belongs to,
     // where an accumulator filled from that block holds its final value. A drain loop

--- a/query/parser/CypherParser.y
+++ b/query/parser/CypherParser.y
@@ -34,6 +34,7 @@
     #include "stmt/ShortestPathStmt.h"
     #include "stmt/CallStmt.h"
     #include "stmt/CreateStmt.h"
+    #include "stmt/MergeStmt.h"
     #include "stmt/SetStmt.h"
     #include "stmt/DeleteStmt.h"
     #include "expr/All.h"
@@ -377,6 +378,9 @@
 %type<db::ShortestPathStmt*> shortestPathSt
 %type<db::CallStmt*> callSt
 %type<db::CreateStmt*> createSt
+%type<db::MergeStmt*> mergeSt
+%type<std::pair<db::SetStmt*, db::SetStmt*>> mergeActionChain
+%type<std::pair<db::SetStmt*, db::SetStmt*>> mergeAction
 %type<db::SetStmt*> setSt
 %type<db::SetItem*> setItem
 %type<db::LoadCSVStmt*> loadCSVSt
@@ -915,7 +919,7 @@ readingStatement
 
 updatingStatement
     : createSt { $$ = $1; }
-    | mergeSt { scanner.notImplemented(@$, "MERGE"); }
+    | mergeSt { $$ = $1; }
     | deleteSt { $$ = $1; }
     | setSt { $$ = $1; }
     | removeSt { scanner.notImplemented(@$, "REMOVE"); }
@@ -1024,18 +1028,36 @@ yieldItem
     ;
 
 mergeSt
-    : MERGE patternPart { scanner.notImplemented(@$, "MERGE"); }
-    | MERGE patternPart mergeActionChain { scanner.notImplemented(@$, "MERGE"); }
+    : MERGE patternPart {
+        Pattern* pattern = Pattern::create(ast);
+        pattern->addElement($2);
+        $$ = MergeStmt::create(ast, pattern);
+        LOC(pattern, @2);
+        LOC($$, @$);
+      }
+    | MERGE patternPart mergeActionChain {
+        Pattern* pattern = Pattern::create(ast);
+        pattern->addElement($2);
+        $$ = MergeStmt::create(ast, pattern);
+        $$->setOnCreate($3.first);
+        $$->setOnMatch($3.second);
+        LOC(pattern, @2);
+        LOC($$, @$);
+      }
     ;
 
 mergeActionChain
-    : mergeAction
-    | mergeActionChain mergeAction
+    : mergeAction { $$ = $1; }
+    | mergeActionChain mergeAction {
+        $$ = $1;
+        ParserUtils::mergeSetClauses($$.first, $2.first);
+        ParserUtils::mergeSetClauses($$.second, $2.second);
+      }
     ;
 
 mergeAction
-    : ON MATCH setSt
-    | ON CREATE setSt
+    : ON MATCH setSt { $$ = std::make_pair(nullptr, $3); }
+    | ON CREATE setSt { $$ = std::make_pair($3, nullptr); }
     ;
 
 setSt

--- a/query/parser/ParserUtils.cpp
+++ b/query/parser/ParserUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "expr/ListExpr.h"
 #include "expr/LiteralExpr.h"
+#include "stmt/SetStmt.h"
 #include "Literal.h"
 #include "ParserException.h"
 
@@ -32,6 +33,21 @@ void ParserUtils::listExprToFloatVector(const ListLiteral* list, std::vector<flo
             }
             out.push_back(static_cast<float>(val));
         }
+    }
+}
+
+void ParserUtils::mergeSetClauses(SetStmt*& held, SetStmt* addition) {
+    if (!addition) {
+        return;
+    }
+
+    if (!held) {
+        held = addition;
+        return;
+    }
+
+    for (SetItem* item : addition->getItems()) {
+        held->addItem(item);
     }
 }
 

--- a/query/parser/ParserUtils.h
+++ b/query/parser/ParserUtils.h
@@ -7,6 +7,7 @@ namespace db {
 class CypherAST;
 class EmbeddingLiteral;
 class ListLiteral;
+class SetStmt;
 
 class ParserUtils {
 public:
@@ -14,6 +15,10 @@ public:
     ~ParserUtils() = delete;
 
     static EmbeddingLiteral* listExprToEmbeddingLiteral(CypherAST* ast, const ListLiteral* list);
+
+    // Folds a repeated ON CREATE / ON MATCH clause into the one already held for that
+    // outcome, so a MERGE keeps a single SET clause per branch
+    static void mergeSetClauses(SetStmt*& held, SetStmt* addition);
 
 private:
     static void listExprToFloatVector(const ListLiteral* list, std::vector<float>& out);

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -131,6 +131,7 @@ void ReadStmtGenerator::generateStmt(const Stmt* stmt) {
         break;
 
         case Stmt::Kind::CREATE:
+        case Stmt::Kind::MERGE:
         case Stmt::Kind::SET:
         case Stmt::Kind::DELETE:
         case Stmt::Kind::RETURN:

--- a/samples/mlir/match_merge_hop.mlir
+++ b/samples/mlir/match_merge_hop.mlir
@@ -1,0 +1,16 @@
+// MATCH (a:Person) MERGE (a)-[e:INTERESTED_IN]->(b:Interest {name: 'Bio'})
+
+func.func @main() {
+  %0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %1 = db.constant("Bio" : !storage.string)
+  %2, %3, %4, %5, %6, %7, %8 = db.merge nodes [[], ["Interest"]] props [[], ["name"]]
+                                        edges ["INTERESTED_IN"] props [[]] dirs [forward]
+                                        bound {%0} pending [] {} values {%1} {} carrying {}
+    : (!db.column<!storage.node_id>, !db.column<!storage.string>)
+      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.edge_id>, !db.column<!storage.bool>,
+          !db.column<!storage.bool>)
+  db.output(%4) : !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/match_merge_hop.mlir
+++ b/samples/mlir/match_merge_hop.mlir
@@ -3,14 +3,13 @@
 func.func @main() {
   %0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
   %1 = db.constant("Bio" : !storage.string)
-  %2, %3, %4, %5, %6, %7, %8 = db.merge nodes [[], ["Interest"]] props [[], ["name"]]
-                                        edges ["INTERESTED_IN"] props [[]] dirs [forward]
-                                        bound {%0} pending [] {} values {%1} {} carrying {}
-    : (!db.column<!storage.node_id>, !db.column<!storage.string>)
+  %2, %3, %4, %5, %6, %7 = db.merge nodes [[], ["Interest"]] props [[], ["name"]]
+                                    edges ["INTERESTED_IN"] props [[]] dirs [forward]
+                                    bound {%0} pending [] {} values {%1} {} carrying {%0}
+    : (!db.column<!storage.node_id>, !db.column<!storage.string>, !db.column<!storage.node_id>)
       -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
-          !db.column<!storage.node_id>, !db.column<!storage.bool>,
           !db.column<!storage.edge_id>, !db.column<!storage.bool>,
-          !db.column<!storage.bool>)
-  db.output(%4) : !db.column<!storage.node_id>
+          !db.column<!storage.bool>, !db.column<!storage.node_id>)
+  db.output(%2) : !db.column<!storage.node_id>
   return
 }

--- a/samples/mlir/match_merge_hop.nl.mlir
+++ b/samples/mlir/match_merge_hop.nl.mlir
@@ -4,15 +4,14 @@ func.func @main() {
   %0 = nl.scan_nodes_by_label(["Person"])
   %1 = nl.constant("Bio" : !storage.string)
   nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
-    %2, %3, %4, %5, %6, %7, %8 = nl.merge nodes [[], ["Interest"]] props [[], ["name"]]
-                                          edges ["INTERESTED_IN"] props [[]] dirs [forward]
-                                          bound {%arg0} pending [] {} values {%1} {} carrying {}
-      : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.string>)
+    %2, %3, %4, %5, %6, %7 = nl.merge nodes [[], ["Interest"]] props [[], ["name"]]
+                                      edges ["INTERESTED_IN"] props [[]] dirs [forward]
+                                      bound {%arg0} pending [] {} values {%1} {} carrying {%arg0}
+      : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.string>, !nl.chunk<!storage.node_id>)
         -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>,
-            !nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>,
             !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.bool>,
-            !nl.chunk<!storage.bool>)
-    nl.output(%4) : !nl.chunk<!storage.node_id>
+            !nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>)
+    nl.output(%2) : !nl.chunk<!storage.node_id>
   }
   return
 }

--- a/samples/mlir/match_merge_hop.nl.mlir
+++ b/samples/mlir/match_merge_hop.nl.mlir
@@ -1,0 +1,18 @@
+// MATCH (a:Person) MERGE (a)-[e:INTERESTED_IN]->(b:Interest {name: 'Bio'})
+
+func.func @main() {
+  %0 = nl.scan_nodes_by_label(["Person"])
+  %1 = nl.constant("Bio" : !storage.string)
+  nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %2, %3, %4, %5, %6, %7, %8 = nl.merge nodes [[], ["Interest"]] props [[], ["name"]]
+                                          edges ["INTERESTED_IN"] props [[]] dirs [forward]
+                                          bound {%arg0} pending [] {} values {%1} {} carrying {}
+      : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.string>)
+        -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>,
+            !nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>,
+            !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.bool>,
+            !nl.chunk<!storage.bool>)
+    nl.output(%4) : !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/merge_node.mlir
+++ b/samples/mlir/merge_node.mlir
@@ -1,0 +1,11 @@
+// MERGE (n:Person {name: 'Alice'})
+
+func.func @main() {
+  %0 = db.constant("Alice" : !storage.string)
+  %1, %2, %3 = db.merge nodes [["Person"]] props [["name"]]
+                        edges [] props [] dirs []
+                        bound {} pending [] {} values {%0} {} carrying {}
+    : (!db.column<!storage.string>)
+      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+  return
+}

--- a/samples/mlir/merge_node.nl.mlir
+++ b/samples/mlir/merge_node.nl.mlir
@@ -1,0 +1,11 @@
+// MERGE (n:Person {name: 'Alice'})
+
+func.func @main() {
+  %0 = nl.constant("Alice" : !storage.string)
+  %1, %2, %3 = nl.merge nodes [["Person"]] props [["name"]]
+                        edges [] props [] dirs []
+                        bound {} pending [] {} values {%0} {} carrying {}
+    : (!nl.chunk<!storage.string>)
+      -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>, !nl.chunk<!storage.bool>)
+  return
+}

--- a/storage/columns/Functions.cpp
+++ b/storage/columns/Functions.cpp
@@ -6,6 +6,7 @@
 
 #include "metadata/LabelMap.h"
 #include "reader/GraphReader.h"
+#include "versioning/CommitWriteBuffer.h"
 #include "views/GraphView.h"
 
 #include "BioAssert.h"
@@ -15,24 +16,52 @@ using namespace db;
 namespace rg = ranges;
 namespace rv = rg::views;
 
-void LabelsFunction::getLabelString(std::string& out, GraphView view, NodeID n) {
-    out.clear();
-    const GraphReader reader = view.read();
+LabelsFunction::LabelsFunction(GraphView view)
+    : _view(view)
+{
+}
 
-    const bool exists = reader.graphHasNode(n);
+LabelsFunction::LabelsFunction(GraphView view, const CommitWriteBuffer* writeBuffer)
+    : _view(view),
+    _writeBuffer(writeBuffer)
+{
+    if (_writeBuffer) {
+        _firstPendingNodeID = _view.read().getTotalNodesAllocated();
+    }
+}
+
+// A node this change wrote is named by the ID it will commit as - one past the last the
+// graph holds, plus its offset in the write buffer - so the ID alone says which of the
+// two holds its labels.
+bool LabelsFunction::isPendingNode(NodeID node) const {
+    return _writeBuffer && node.getValue() >= _firstPendingNodeID;
+}
+
+LabelSetHandle LabelsFunction::readLabelSet(NodeID node) const {
+    if (isPendingNode(node)) {
+        return _writeBuffer->getPendingNode(node.getValue() - _firstPendingNodeID).labelsetHandle;
+    }
+
+    return _view.read().getNodeLabelSet(node);
+}
+
+void LabelsFunction::getLabelString(std::string& out, NodeID node) {
+    out.clear();
+
+    const bool exists = isPendingNode(node) || _view.read().graphHasNode(node);
     if (!exists) {
         out = "null";
         return;
     }
 
-    const LabelSetHandle lblset = reader.getNodeLabelSet(n);
+    const LabelSetHandle lblset = readLabelSet(node);
 
     std::vector<LabelID> labels;
     lblset.decompose(labels);
 
-    bioassert(!labels.empty(), "Could not retrieve labels for node {}.", n.getValue());
+    bioassert(!labels.empty(), "Could not retrieve labels for node {}.", node.getValue());
 
-    const LabelMap& lblMap = view.metadata().labels();
+    const LabelMap& lblMap = _view.metadata().labels();
 
     {
         const LabelID fstLbl = labels.front();
@@ -53,11 +82,34 @@ void LabelsFunction::getLabelString(std::string& out, GraphView view, NodeID n) 
     }
 }
 
-void EdgeTypesFunction::getEdgeTypeString(std::string& out, GraphView view, EdgeID e) {
-    out.clear();
-    const EdgeTypeID et = view.read().getEdgeTypeID(e);
+EdgeTypesFunction::EdgeTypesFunction(GraphView view)
+    : _view(view)
+{
+}
 
-    const EdgeTypeMap& etMap = view.metadata().edgeTypes();
+EdgeTypesFunction::EdgeTypesFunction(GraphView view, const CommitWriteBuffer* writeBuffer)
+    : _view(view),
+    _writeBuffer(writeBuffer)
+{
+    if (_writeBuffer) {
+        _firstPendingEdgeID = _view.read().getTotalEdgesAllocated();
+    }
+}
+
+EdgeTypeID EdgeTypesFunction::readEdgeType(EdgeID edge) const {
+    const bool isPending = _writeBuffer && edge.getValue() >= _firstPendingEdgeID;
+    if (isPending) {
+        return _writeBuffer->getPendingEdge(edge.getValue() - _firstPendingEdgeID).edgeType;
+    }
+
+    return _view.read().getEdgeTypeID(edge);
+}
+
+void EdgeTypesFunction::getEdgeTypeString(std::string& out, EdgeID edge) {
+    out.clear();
+    const EdgeTypeID et = readEdgeType(edge);
+
+    const EdgeTypeMap& etMap = _view.metadata().edgeTypes();
     const std::optional<std::string_view> name = etMap.getName(et);
     bioassert(name, "Could not get name of EdgeTypeID {}.", et.getValue());
 

--- a/storage/columns/Functions.h
+++ b/storage/columns/Functions.h
@@ -12,6 +12,7 @@
 #include "columns/ColumnIDs.h"
 #include "columns/ColumnVector.h"
 #include "TypeUtils.h"
+#include "metadata/LabelSetHandle.h"
 #include "metadata/PropertyType.h"
 #include "views/GraphView.h"
 
@@ -21,6 +22,8 @@
 #include "TuringException.h"
 
 namespace db {
+
+class CommitWriteBuffer;
 
 /**
  * @brief Generic function to apply a generic invokable to two possibly-optional
@@ -55,21 +58,26 @@ public:
     using ArgType = NodeID;
     using ResultType = std::string;
 
-    explicit LabelsFunction(GraphView view)
-        : _view(view)
-    {
-    }
+    explicit LabelsFunction(GraphView view);
 
-    ResultType operator()(const NodeID n) {
-        getLabelString(_tmp, _view, n);
+    // The graph holds none of a change's writes until they commit, so the labels of a
+    // node this one wrote are read out of @param writeBuffer
+    LabelsFunction(GraphView view, const CommitWriteBuffer* writeBuffer);
+
+    ResultType operator()(const NodeID node) {
+        getLabelString(_tmp, node);
         return _tmp;
     }
 
 private:
     GraphView _view;
+    const CommitWriteBuffer* _writeBuffer {nullptr};
+    size_t _firstPendingNodeID {0};
     std::string _tmp;
 
-    static void getLabelString(std::string& out, GraphView view, NodeID n);
+    void getLabelString(std::string& out, NodeID node);
+    bool isPendingNode(NodeID node) const;
+    LabelSetHandle readLabelSet(NodeID node) const;
 };
 
 class EdgeTypesFunction {
@@ -77,21 +85,22 @@ public:
     using ArgType = EdgeID;
     using ResultType = std::string;
 
-    explicit EdgeTypesFunction(GraphView view)
-        : _view(view)
-    {
-    }
+    explicit EdgeTypesFunction(GraphView view);
+    EdgeTypesFunction(GraphView view, const CommitWriteBuffer* writeBuffer);
 
-    ResultType operator()(const EdgeID e) {
-        getEdgeTypeString(_tmp, _view, e);
+    ResultType operator()(const EdgeID edge) {
+        getEdgeTypeString(_tmp, edge);
         return _tmp;
     }
 
 private:
     GraphView _view;
+    const CommitWriteBuffer* _writeBuffer {nullptr};
+    size_t _firstPendingEdgeID {0};
     std::string _tmp;
 
-    static void getEdgeTypeString(std::string& out, GraphView view, EdgeID e);
+    void getEdgeTypeString(std::string& out, EdgeID edge);
+    EdgeTypeID readEdgeType(EdgeID edge) const;
 };
 
 class toIntegerFunction {

--- a/storage/versioning/ChangeConflictChecker.cpp
+++ b/storage/versioning/ChangeConflictChecker.cpp
@@ -139,7 +139,17 @@ void ChangeConflictChecker::checkPendingEdgeConflicts(const ConflictCheckSets& w
                                                       const CommitWriteBuffer& writeBuffer) {
     // Check for pending edges to see if their source or target has write conflict
     const CommitWriteBuffer::PendingEdges& pendingEdges = writeBuffer.pendingEdges();
-    for (const CommitWriteBuffer::PendingEdge& edge : pendingEdges) {
+    const CommitWriteBuffer::DeletedPendingEntities& deleted = writeBuffer.deletedPendingEdges();
+
+    for (size_t offset = 0; offset < pendingEdges.size(); offset++) {
+        // An edge this change deletes again is never created, so what happened to the
+        // nodes it would have joined cannot conflict with it
+        if (deleted.contains(offset)) {
+            continue;
+        }
+
+        const CommitWriteBuffer::PendingEdge& edge = pendingEdges[offset];
+
         // Check if source node was modified
         if (const NodeID* oldSrcID = std::get_if<NodeID>(&edge.src)) {
             const NodeID newSrc = {_entityIDRebaser.rebaseNodeID(*oldSrcID)};

--- a/storage/versioning/CommitBuilder.cpp
+++ b/storage/versioning/CommitBuilder.cpp
@@ -160,7 +160,7 @@ void CommitBuilder::flushWriteBuffer([[maybe_unused]] JobSystem& jobsystem) {
         // We create a single datapart when flushing the buffer,
         // to ensure it is synced with the metadata provided when rebasing main
         DataPartBuilder& dpBuilder = newBuilder();
-        wb.buildPending(dpBuilder);
+        wb.buildPending(dpBuilder, tombstones);
     }
 
     if (wb.containsUpdates()) {

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -129,9 +129,16 @@ void CommitWriteBuffer::addHangingEdges(const GraphView& view) {
     }
 }
 
-void CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
-                                         const PendingNode& node) {
+NodeID CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
+                                          const PendingNode& node,
+                                          bool deleted) {
     const NodeID nodeID = builder.addNode(node.labelsetHandle);
+
+    // A node this commit deletes again keeps its slot, so the offsets a pending edge
+    // names stay valid; the caller tombstones it rather than filling it in
+    if (deleted) {
+        return nodeID;
+    }
 
     // Adding node properties
     for (const auto& [propID, value] : node.properties) {
@@ -150,26 +157,38 @@ void CommitWriteBuffer::buildPendingNode(DataPartBuilder& builder,
     }
 
     _journal.addWrittenNode(nodeID);
+
+    return nodeID;
 }
 
-void CommitWriteBuffer::buildPendingNodes(DataPartBuilder& builder) {
-    for (const auto& node : pendingNodes()) {
-        buildPendingNode(builder, node);
+void CommitWriteBuffer::buildPendingNodes(DataPartBuilder& builder, Tombstones& tombstones) {
+    std::vector<NodeID> deleted;
+
+    for (size_t offset = 0; offset < _pendingNodes.size(); offset++) {
+        const bool isDeleted = _deletedPendingNodes.contains(offset);
+        const NodeID nodeID = buildPendingNode(builder, _pendingNodes[offset], isDeleted);
+
+        if (isDeleted) {
+            deleted.push_back(nodeID);
+        }
     }
+
+    tombstones.addNodeTombstones(deleted);
 }
 
-void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
-                                         const PendingEdge& edge) {
+EdgeID CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
+                                          const PendingEdge& edge,
+                                          bool deleted) {
     // If this edge has source or target which is a node in a previous datapart, check
     // if it has been deleted.
     if (const NodeID* srcID = std::get_if<NodeID>(&edge.src)) {
         if (deletedNodes().contains(*srcID)) {
-            return;
+            return EdgeID::max();
         }
     }
     if (const NodeID* tgtID = std::get_if<NodeID>(&edge.tgt)) {
         if (deletedNodes().contains(*tgtID)) {
-            return;
+            return EdgeID::max();
         }
     }
 
@@ -195,6 +214,11 @@ void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
 
     const EdgeID newEdgeID = newEdgeRecord._edgeID;
 
+    // The edge sibling of buildPendingNode's deleted slot
+    if (deleted) {
+        return newEdgeID;
+    }
+
     for (const auto& [propID, value] : edge.properties) {
         std::visit(
             [&](const auto& val) {
@@ -212,17 +236,74 @@ void CommitWriteBuffer::buildPendingEdge(DataPartBuilder& builder,
     }
 
     _journal.addWrittenEdge(newEdgeID);
+
+    return newEdgeID;
 }
 
-void CommitWriteBuffer::buildPendingEdges(DataPartBuilder& builder) {
-    for (const PendingEdge& edge : pendingEdges()) {
-        buildPendingEdge(builder, edge);
+void CommitWriteBuffer::buildPendingEdges(DataPartBuilder& builder, Tombstones& tombstones) {
+    std::vector<EdgeID> deleted;
+
+    for (size_t offset = 0; offset < _pendingEdges.size(); offset++) {
+        const bool isDeleted = _deletedPendingEdges.contains(offset);
+        const EdgeID edgeID = buildPendingEdge(builder, _pendingEdges[offset], isDeleted);
+
+        if (isDeleted && edgeID.isValid()) {
+            deleted.push_back(edgeID);
+        }
+    }
+
+    tombstones.addEdgeTombstones(deleted);
+}
+
+void CommitWriteBuffer::buildPending(DataPartBuilder& builder, Tombstones& tombstones) {
+    buildPendingNodes(builder, tombstones);
+    buildPendingEdges(builder, tombstones);
+}
+
+void CommitWriteBuffer::addDeletedPendingNode(PendingNodeOffset offset) {
+    _deletedPendingNodes.insert(offset);
+}
+
+void CommitWriteBuffer::addDeletedPendingEdge(size_t offset) {
+    _deletedPendingEdges.insert(offset);
+}
+
+void CommitWriteBuffer::addHangingPendingEdges() {
+    for (size_t offset = 0; offset < _pendingEdges.size(); offset++) {
+        if (touchesDeletedPendingNode(_pendingEdges[offset])) {
+            _deletedPendingEdges.insert(offset);
+        }
     }
 }
 
-void CommitWriteBuffer::buildPending(DataPartBuilder& builder) {
-    buildPendingNodes(builder);
-    buildPendingEdges(builder);
+bool CommitWriteBuffer::pendingNodeHasEdges(PendingNodeOffset offset) const {
+    for (size_t edgeOffset = 0; edgeOffset < _pendingEdges.size(); edgeOffset++) {
+        if (_deletedPendingEdges.contains(edgeOffset)) {
+            continue;
+        }
+
+        const PendingEdge& edge = _pendingEdges[edgeOffset];
+        const bool isSource = std::holds_alternative<PendingNodeOffset>(edge.src)
+            && std::get<PendingNodeOffset>(edge.src) == offset;
+        const bool isTarget = std::holds_alternative<PendingNodeOffset>(edge.tgt)
+            && std::get<PendingNodeOffset>(edge.tgt) == offset;
+
+        if (isSource || isTarget) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool CommitWriteBuffer::touchesDeletedPendingNode(const PendingEdge& edge) const {
+    const auto isDeleted = [this](const ExistingOrPendingNode& node) {
+        const PendingNodeOffset* offset = std::get_if<PendingNodeOffset>(&node);
+
+        return offset && _deletedPendingNodes.contains(*offset);
+    };
+
+    return isDeleted(edge.src) || isDeleted(edge.tgt);
 }
 
 void CommitWriteBuffer::applyNodeUpdates(DataPartBuilder& builder) {

--- a/storage/versioning/CommitWriteBuffer.cpp
+++ b/storage/versioning/CommitWriteBuffer.cpp
@@ -270,25 +270,20 @@ void CommitWriteBuffer::addDeletedPendingEdge(size_t offset) {
 
 void CommitWriteBuffer::addHangingPendingEdges() {
     for (size_t offset = 0; offset < _pendingEdges.size(); offset++) {
-        if (touchesDeletedPendingNode(_pendingEdges[offset])) {
+        if (touchesDeletedNode(_pendingEdges[offset])) {
             _deletedPendingEdges.insert(offset);
         }
     }
 }
 
-bool CommitWriteBuffer::pendingNodeHasEdges(PendingNodeOffset offset) const {
-    for (size_t edgeOffset = 0; edgeOffset < _pendingEdges.size(); edgeOffset++) {
-        if (_deletedPendingEdges.contains(edgeOffset)) {
+bool CommitWriteBuffer::hasPendingEdgesOn(const ExistingOrPendingNode& node) const {
+    for (size_t offset = 0; offset < _pendingEdges.size(); offset++) {
+        if (_deletedPendingEdges.contains(offset)) {
             continue;
         }
 
-        const PendingEdge& edge = _pendingEdges[edgeOffset];
-        const bool isSource = std::holds_alternative<PendingNodeOffset>(edge.src)
-            && std::get<PendingNodeOffset>(edge.src) == offset;
-        const bool isTarget = std::holds_alternative<PendingNodeOffset>(edge.tgt)
-            && std::get<PendingNodeOffset>(edge.tgt) == offset;
-
-        if (isSource || isTarget) {
+        const PendingEdge& edge = _pendingEdges[offset];
+        if (edge.src == node || edge.tgt == node) {
             return true;
         }
     }
@@ -296,11 +291,13 @@ bool CommitWriteBuffer::pendingNodeHasEdges(PendingNodeOffset offset) const {
     return false;
 }
 
-bool CommitWriteBuffer::touchesDeletedPendingNode(const PendingEdge& edge) const {
+bool CommitWriteBuffer::touchesDeletedNode(const PendingEdge& edge) const {
     const auto isDeleted = [this](const ExistingOrPendingNode& node) {
-        const PendingNodeOffset* offset = std::get_if<PendingNodeOffset>(&node);
+        if (const PendingNodeOffset* offset = std::get_if<PendingNodeOffset>(&node)) {
+            return _deletedPendingNodes.contains(*offset);
+        }
 
-        return offset && _deletedPendingNodes.contains(*offset);
+        return _deletedNodes.contains(std::get<NodeID>(node));
     };
 
     return isDeleted(edge.src) || isDeleted(edge.tgt);

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -176,16 +176,17 @@ public:
     const DeletedPendingEntities& deletedPendingEdges() const { return _deletedPendingEdges; }
 
     /**
-     * @brief Marks every pending edge incident to a deleted pending node as deleted too,
-     * the pending counterpart of @ref addHangingEdges.
+     * @brief Marks every pending edge incident to a node this commit deletes - one it
+     * created or one already committed - as deleted too, the pending counterpart of
+     * @ref addHangingEdges.
      */
     void addHangingPendingEdges();
 
     /**
-     * @brief Whether any pending edge is incident to the pending node at @param offset,
-     * which a DELETE without DETACH must refuse.
+     * @brief Whether any pending edge this commit has not deleted is incident to
+     * @param node, which a DELETE without DETACH must refuse.
      */
-    bool pendingNodeHasEdges(PendingNodeOffset offset) const;
+    bool hasPendingEdgesOn(const ExistingOrPendingNode& node) const;
 
     void addNodeUpdate(NodeID id, UntypedProperty& updatedProperty);
     void addEdgeUpdate(EdgeID id, UntypedProperty& updatedProperty);
@@ -257,7 +258,7 @@ private:
 
     EdgeID buildPendingEdge(DataPartBuilder& builder, const PendingEdge& edge, bool deleted);
 
-    bool touchesDeletedPendingNode(const PendingEdge& edge) const;
+    bool touchesDeletedNode(const PendingEdge& edge) const;
 
     void applyNodeUpdates(DataPartBuilder& builder);
     void applyEdgeUpdates(DataPartBuilder& builder);

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -53,6 +53,8 @@ public:
      using PendingEdges = std::vector<PendingEdge>;
      using DeletedNodes = std::unordered_set<NodeID>;
      using DeletedEdges = std::unordered_set<EdgeID>;
+     /// Offsets into @ref _pendingNodes / @ref _pendingEdges of writes this commit drops
+     using DeletedPendingEntities = std::unordered_set<size_t>;
      using UpdatedNodes = std::vector<NodeUpdate>;
      using UpdatedEdges = std::vector<EdgeUpdate>;
      using PendingIndexes = std::vector<WeakArc<Index>>;
@@ -104,7 +106,7 @@ public:
       * as registering all newly created nodes/edges in the associated @ref WriteSet of
       * @ref _journal
       */
-     void buildPending(DataPartBuilder& builder);
+     void buildPending(DataPartBuilder& builder, Tombstones& tombstones);
 
      void applyUpdates(DataPartBuilder& builder);
 
@@ -161,6 +163,30 @@ public:
      */
     void addDeletedNode(const NodeID& newDeletedNode);
 
+    /**
+     * @brief Marks a node this commit creates as deleted again. Its slot is kept, so the
+     * offsets a pending edge names stay valid; the node is built into the datapart and
+     * tombstoned rather than written.
+     */
+    void addDeletedPendingNode(PendingNodeOffset offset);
+
+    void addDeletedPendingEdge(size_t offset);
+
+    const DeletedPendingEntities& deletedPendingNodes() const { return _deletedPendingNodes; }
+    const DeletedPendingEntities& deletedPendingEdges() const { return _deletedPendingEdges; }
+
+    /**
+     * @brief Marks every pending edge incident to a deleted pending node as deleted too,
+     * the pending counterpart of @ref addHangingEdges.
+     */
+    void addHangingPendingEdges();
+
+    /**
+     * @brief Whether any pending edge is incident to the pending node at @param offset,
+     * which a DELETE without DETACH must refuse.
+     */
+    bool pendingNodeHasEdges(PendingNodeOffset offset) const;
+
     void addNodeUpdate(NodeID id, UntypedProperty& updatedProperty);
     void addEdgeUpdate(EdgeID id, UntypedProperty& updatedProperty);
 
@@ -209,6 +235,10 @@ private:
     // Edges to be deleted when this commit commits
     DeletedEdges _deletedEdges;
 
+    // Creations of this commit that it deletes again before committing
+    DeletedPendingEntities _deletedPendingNodes;
+    DeletedPendingEntities _deletedPendingEdges;
+
     UpdatedNodes _updatedNodes;
     UpdatedEdges _updatedEdges;
 
@@ -219,13 +249,15 @@ private:
     PendingEdges& pendingEdges() { return _pendingEdges; }
 
     // Collection of methods to write the buffer to the provided datapart builder
-    void buildPendingNodes(DataPartBuilder& builder);
-    void buildPendingEdges(DataPartBuilder& builder);
+    void buildPendingNodes(DataPartBuilder& builder, Tombstones& tombstones);
+    void buildPendingEdges(DataPartBuilder& builder, Tombstones& tombstones);
 
-    void buildPendingNode(DataPartBuilder& builder, const PendingNode& node);
+    NodeID buildPendingNode(DataPartBuilder& builder, const PendingNode& node, bool deleted);
     void addPendingNodeProperties(DataPartBuilder& builder, const PendingNode& node);
 
-    void buildPendingEdge(DataPartBuilder& builder, const PendingEdge& edge);
+    EdgeID buildPendingEdge(DataPartBuilder& builder, const PendingEdge& edge, bool deleted);
+
+    bool touchesDeletedPendingNode(const PendingEdge& edge) const;
 
     void applyNodeUpdates(DataPartBuilder& builder);
     void applyEdgeUpdates(DataPartBuilder& builder);

--- a/storage/versioning/CommitWriteBuffer.h
+++ b/storage/versioning/CommitWriteBuffer.h
@@ -209,6 +209,9 @@ public:
     PendingNode& getPendingNode(size_t idx) { return _pendingNodes.at(idx); }
     PendingEdge& getPendingEdge(size_t idx) { return _pendingEdges.at(idx); }
 
+    const PendingNode& getPendingNode(size_t idx) const { return _pendingNodes.at(idx); }
+    const PendingEdge& getPendingEdge(size_t idx) const { return _pendingEdges.at(idx); }
+
     const PendingIndexes& pendingIndexes() const { return _pendingIndexes; }
     const DroppedIndexes& droppedIndexes() const { return _droppedIndexes; }
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -385,6 +385,10 @@ target_include_directories(test_query_ir_call_driven_island_codegen PRIVATE ${CM
 
 add_ir_tests(test_query_ir_nldialect NLDialectTest.cpp)
 
+# The db.merge / nl.merge textual form and the shape rules the two ops share.
+add_ir_tests(test_query_ir_merge_dialect MergeDialectTest.cpp)
+target_link_libraries(test_query_ir_merge_dialect PRIVATE turing_db_ir_nldialect_s)
+
 # The keyless collect drain emits its one group whether or not a row arrived, against the
 # shared SimpleGraph fixture and an empty graph.
 add_ir_tests(test_query_ir_keyless_collect_empty_input KeylessCollectEmptyInputTest.cpp)
@@ -1384,6 +1388,38 @@ target_link_libraries(test_query_ir_with_scope PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_with_scope PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_merge_node MergeNodeTest.cpp)
+target_link_libraries(test_query_ir_merge_node PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_merge_node PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_merge_rejection MergeRejectionTest.cpp)
+target_link_libraries(test_query_ir_merge_rejection PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_merge_rejection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_merge_edge MergeEdgeTest.cpp)
+target_link_libraries(test_query_ir_merge_edge PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_merge_edge PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_turing_test(test_query_ir_create_return CreateReturnTest.cpp)
 target_link_libraries(test_query_ir_create_return PRIVATE

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1443,6 +1443,14 @@ target_link_libraries(test_query_ir_create_return PRIVATE turing_ir_test_write_q
 add_turing_test(test_query_ir_create_chain CreateChainTest.cpp)
 target_link_libraries(test_query_ir_create_chain PRIVATE turing_ir_test_write_query_s)
 
+# DELETE of an entity the same query wrote, which the change holds as a pending write.
+add_turing_test(test_query_ir_delete_written DeleteWrittenTest.cpp)
+target_link_libraries(test_query_ir_delete_written PRIVATE turing_ir_test_write_query_s)
+
+# What a projection behind a SET reads back for the property it wrote.
+add_turing_test(test_query_ir_set_readback SetReadbackTest.cpp)
+target_link_libraries(test_query_ir_set_readback PRIVATE turing_ir_test_write_query_s)
+
 add_turing_test(test_query_ir_with_write WithWriteTest.cpp)
 target_link_libraries(test_query_ir_with_write PRIVATE turing_ir_test_write_query_s)
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -21,6 +21,20 @@ target_link_libraries(turing_ir_test_rows_s
             turing_db_interpreter_v3_s)
 target_include_directories(turing_ir_test_rows_s PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# The change / write / read plumbing every test of a writing query needs, over the shared
+# SimpleGraph fixture.
+add_library(turing_ir_test_write_query_s STATIC WriteQueryTest.cpp)
+target_link_libraries(turing_ir_test_write_query_s
+    PUBLIC  turing_ir_test_rows_s
+            turing_testutils_s
+            turing_testenv_s
+            turing_db_s
+            turing_db_examples_s
+            turing_db_system_s
+            turing_db_storage_s
+            turing_db_interpreter_v3_s)
+target_include_directories(turing_ir_test_write_query_s PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_ir_tests(test_query_ir_nlexecutor NLExecutorTest.cpp)
 add_ir_tests(test_query_ir_create_node_edge CreateNodeEdgeTest.cpp)
 add_ir_tests(test_query_ir_dblowering DBLoweringTest.cpp)
@@ -1390,58 +1404,34 @@ target_link_libraries(test_query_ir_with_scope PRIVATE
 target_include_directories(test_query_ir_with_scope PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_turing_test(test_query_ir_merge_node MergeNodeTest.cpp)
-target_link_libraries(test_query_ir_merge_node PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s
-        turing_ir_test_rows_s)
-target_include_directories(test_query_ir_merge_node PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_merge_node PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_merge_rejection MergeRejectionTest.cpp)
-target_link_libraries(test_query_ir_merge_rejection PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s)
-target_include_directories(test_query_ir_merge_rejection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_merge_rejection PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_merge_edge MergeEdgeTest.cpp)
-target_link_libraries(test_query_ir_merge_edge PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s
-        turing_ir_test_rows_s)
-target_include_directories(test_query_ir_merge_edge PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_merge_edge PRIVATE turing_ir_test_write_query_s)
+
+# What the rows around a merge look like once it has fanned them out over the matches it
+# bound, and where an update statement beside it writes.
+add_turing_test(test_query_ir_merge_fan_out MergeFanOutTest.cpp)
+target_link_libraries(test_query_ir_merge_fan_out PRIVATE turing_ir_test_write_query_s)
+
+# The matches a merge chain enumerates when several paths share a node, and when a hop is
+# a self-loop taken either way round.
+add_turing_test(test_query_ir_merge_chain_match MergeChainMatchTest.cpp)
+target_link_libraries(test_query_ir_merge_chain_match PRIVATE turing_ir_test_write_query_s)
+
+# What a merge keys its entities on: the properties one spec names, told apart from
+# another's, and compared against the type the schema holds them as.
+add_turing_test(test_query_ir_merge_key MergeKeyTest.cpp)
+target_link_libraries(test_query_ir_merge_key PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_create_return CreateReturnTest.cpp)
-target_link_libraries(test_query_ir_create_return PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s
-        turing_ir_test_rows_s)
-target_include_directories(test_query_ir_create_return PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_create_return PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_with_write WithWriteTest.cpp)
-target_link_libraries(test_query_ir_with_write PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s
-        turing_ir_test_rows_s)
-target_include_directories(test_query_ir_with_write PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_with_write PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_order_by_aggregate_unprojected_key OrderByAggregateUnprojectedKeyTest.cpp)
 target_link_libraries(test_query_ir_order_by_aggregate_unprojected_key PRIVATE
@@ -1820,15 +1810,7 @@ target_link_libraries(test_query_ir_avg_literal PRIVATE
 target_include_directories(test_query_ir_avg_literal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_turing_test(test_query_ir_multi_match MultiMatchTest.cpp)
-target_link_libraries(test_query_ir_multi_match PRIVATE
-        turing_db_s
-        turing_testenv_s
-        turing_db_examples_s
-        turing_db_system_s
-        turing_db_storage_s
-        turing_db_interpreter_v3_s
-        turing_ir_test_rows_s)
-target_include_directories(test_query_ir_multi_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_query_ir_multi_match PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_anonymous_match AnonymousMatchTest.cpp)
 target_sources(test_query_ir_anonymous_match PRIVATE StringRowSink.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1447,6 +1447,10 @@ target_link_libraries(test_query_ir_create_chain PRIVATE turing_ir_test_write_qu
 add_turing_test(test_query_ir_delete_written DeleteWrittenTest.cpp)
 target_link_libraries(test_query_ir_delete_written PRIVATE turing_ir_test_write_query_s)
 
+# The pending edges a submit checks its ends for, and the deleted ones it must not.
+add_turing_test(test_query_ir_deleted_pending_edge_conflict DeletedPendingEdgeConflictTest.cpp)
+target_link_libraries(test_query_ir_deleted_pending_edge_conflict PRIVATE turing_ir_test_write_query_s)
+
 # What a projection behind a SET reads back for the property it wrote.
 add_turing_test(test_query_ir_set_readback SetReadbackTest.cpp)
 target_link_libraries(test_query_ir_set_readback PRIVATE turing_ir_test_write_query_s)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1427,8 +1427,21 @@ target_link_libraries(test_query_ir_merge_chain_match PRIVATE turing_ir_test_wri
 add_turing_test(test_query_ir_merge_key MergeKeyTest.cpp)
 target_link_libraries(test_query_ir_merge_key PRIVATE turing_ir_test_write_query_s)
 
+# Where a merge's rows read a property: off the graph for a row it bound, out of the
+# change for a row it wrote.
+add_turing_test(test_query_ir_merge_property_read MergePropertyReadTest.cpp)
+target_link_libraries(test_query_ir_merge_property_read PRIVATE turing_ir_test_write_query_s)
+
+# The relationship-isomorphism rule a merge chain binds under.
+add_turing_test(test_query_ir_merge_relationship_uniqueness MergeRelationshipUniquenessTest.cpp)
+target_link_libraries(test_query_ir_merge_relationship_uniqueness PRIVATE turing_ir_test_write_query_s)
+
 add_turing_test(test_query_ir_create_return CreateReturnTest.cpp)
 target_link_libraries(test_query_ir_create_return PRIVATE turing_ir_test_write_query_s)
+
+# The ends each hop of a CREATE chain is written between.
+add_turing_test(test_query_ir_create_chain CreateChainTest.cpp)
+target_link_libraries(test_query_ir_create_chain PRIVATE turing_ir_test_write_query_s)
 
 add_turing_test(test_query_ir_with_write WithWriteTest.cpp)
 target_link_libraries(test_query_ir_with_write PRIVATE turing_ir_test_write_query_s)

--- a/test/query/ir/CreateChainTest.cpp
+++ b/test/query/ir/CreateChainTest.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The hops of a CREATE chain past the first: each is written between the two nodes it
+// joins, whichever of them the change has already committed.
+class CreateChainTest : public WriteQueryTest {
+};
+
+// The chain starts at a node a merge bound - committed, so no offset - and runs on into
+// two nodes the CREATE writes: the second hop joins those two, not the one the chain
+// started at
+TEST_F(CreateChainTest, writesTheSecondHopBetweenTheNodesItJoins) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'x'})", 0);
+
+    expectWriteRowCount("MERGE (m:Tag {name: 'x'}) "
+                        "CREATE (m)-[:LINKS]->(b:Tag {name: 'b'})-[:LINKS]->(c:Tag {name: 'c'})",
+                        0);
+
+    expectRows("MATCH (m:Tag {name: 'x'})-[:LINKS]->(t:Tag) RETURN t.name", {{"b"}});
+    expectRows("MATCH (b:Tag {name: 'b'})-[:LINKS]->(t:Tag) RETURN t.name", {{"c"}});
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN count(*)", {{"2"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -1,136 +1,13 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <string_view>
-
-#include "NLOutputSink.h"
-#include "QueryInterpreterV3.h"
-#include "QueryStatus.h"
-
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
-#include "TuringDB.h"
-#include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
-#include "versioning/ChangeID.h"
-#include "versioning/CommitHash.h"
-
-#include "IRTestRows.h"
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
 
 // A projection reading what a CREATE bound: the rows a CREATE ... RETURN emits, over the
 // nodes and edges the pattern wrote rather than over the ones a MATCH found.
-class CreateReturnTest : public TuringTest {
-protected:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-    }
-
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
-    void submit(const ChangeID& changeID) {
-        QueryCallbacks callbacks;
-        callbacks.setOnOutputData([](const Dataframe*) {});
-
-        const QueryState submitState(_graphName,
-                                     &_env->getMem(),
-                                     &_queryConfig,
-                                     &callbacks,
-                                     CommitHash::head(),
-                                     changeID);
-        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
-        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
-    }
-
-    // The rows a writing query emits, collected in its own change and then submitted, so
-    // a following read sees what it wrote
-    void writeRows(std::string_view query, Rows& rows) {
-        ChangeID changeID;
-        openChange(changeID);
-
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              changeID,
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        sink.sortedRows(rows);
-
-        submit(changeID);
-    }
-
-    void expectWriteRows(std::string_view query, const Rows& expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    // For the entity columns, whose IDs the graph hands out: the count of rows is what the
-    // projection is asked about, not the values
-    void expectWriteRowCount(std::string_view query, size_t expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        EXPECT_EQ(actual.size(), expected) << "query: " << query;
-    }
-
-    void expectRows(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              ChangeID::head(),
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Rows actual;
-        sink.sortedRows(actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
-    }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
+class CreateReturnTest : public WriteQueryTest {
 };
 
 TEST_F(CreateReturnTest, returnsAPropertyOfTheNodeItCreated) {

--- a/test/query/ir/DeleteWrittenTest.cpp
+++ b/test/query/ir/DeleteWrittenTest.cpp
@@ -13,8 +13,8 @@
 using namespace db;
 using namespace turing::test;
 
-// DELETE of an entity the same query wrote. The change holds it as a pending write
-// rather than as a committed ID, so deleting it is dropping that write.
+// DELETE beside the writes of the same query: of an entity the change holds as a pending
+// write rather than as a committed ID, and of one the query has given a relationship to.
 class DeleteWrittenTest : public WriteQueryTest {
 protected:
     void runQuery(std::string_view query, QueryStatus& status) {
@@ -76,6 +76,29 @@ TEST_F(DeleteWrittenTest, refusesToDeleteAJoinedNodeWithoutDetach) {
     EXPECT_FALSE(status.isOk()) << status.getError();
     EXPECT_NE(status.getError().find("DETACH DELETE"), std::string::npos)
         << "status: " << status.getError();
+}
+
+// The node is committed but the relationship hanging off it is not, and a relationship
+// is a relationship: the delete is refused the same way one on a committed edge is
+TEST_F(DeleteWrittenTest, refusesToDeleteACommittedNodeTheQueryJoinedWithoutDetach) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'x'})", 0);
+
+    QueryStatus status;
+    runQuery("MATCH (t:Tag) CREATE (t)-[:LINKS]->(b:Tag {name: 'b'}) DELETE t", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("DETACH DELETE"), std::string::npos)
+        << "status: " << status.getError();
+}
+
+// With DETACH the same query drops the relationship it wrote along with the node
+TEST_F(DeleteWrittenTest, detachDeletesACommittedNodeTheQueryJoined) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'x'})", 0);
+
+    expectWriteRowCount("MATCH (t:Tag) CREATE (t)-[:LINKS]->(b:Tag {name: 'b'}) DETACH DELETE t", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"b"}});
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN a.name", {});
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/DeleteWrittenTest.cpp
+++ b/test/query/ir/DeleteWrittenTest.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// DELETE of an entity the same query wrote. The change holds it as a pending write
+// rather than as a committed ID, so deleting it is dropping that write.
+class DeleteWrittenTest : public WriteQueryTest {
+protected:
+    void runQuery(std::string_view query, QueryStatus& status) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+    }
+};
+
+TEST_F(DeleteWrittenTest, deletesANodeTheSameQueryCreated) {
+    expectWriteRowCount("CREATE (n:Tag {name: 'x'}) DELETE n", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {});
+}
+
+TEST_F(DeleteWrittenTest, deletesANodeTheSameQueryMerged) {
+    expectWriteRowCount("MERGE (n:Tag {name: 'x'}) DELETE n", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {});
+}
+
+// A merge binds Remy rather than writing him, so the delete tombstones the committed
+// node the way a MATCH would
+TEST_F(DeleteWrittenTest, deletesTheCommittedNodeAMergeBound) {
+    expectWriteRowCount("MERGE (p:Person {name: 'Remy'}) DETACH DELETE p", 0);
+
+    expectRows("MATCH (p:Person) RETURN count(p)", {{"7"}});
+}
+
+TEST_F(DeleteWrittenTest, deletesAnEdgeTheSameQueryCreated) {
+    expectWriteRowCount("CREATE (a:Tag {name: 'a'})-[e:LINKS]->(b:Tag {name: 'b'}) DELETE e", 0);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"2"}});
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN a.name", {});
+}
+
+// The hop the same query wrote goes with the node it hangs off
+TEST_F(DeleteWrittenTest, detachDeletesANodeTheSameQueryJoined) {
+    expectWriteRowCount("CREATE (a:Tag {name: 'a'})-[e:LINKS]->(b:Tag {name: 'b'}) DETACH DELETE a", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"b"}});
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN a.name", {});
+}
+
+// Without DETACH the node still carries that hop, so the delete is refused - the same
+// answer a committed node with relationships gets
+TEST_F(DeleteWrittenTest, refusesToDeleteAJoinedNodeWithoutDetach) {
+    QueryStatus status;
+    runQuery("CREATE (a:Tag {name: 'a'})-[e:LINKS]->(b:Tag {name: 'b'}) DELETE a", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("DETACH DELETE"), std::string::npos)
+        << "status: " << status.getError();
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/DeletedPendingEdgeConflictTest.cpp
+++ b/test/query/ir/DeletedPendingEdgeConflictTest.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include "QueryCallbacks.h"
+#include "QueryState.h"
+#include "QueryStatus.h"
+
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The conflict a submit checks a pending edge's ends for, and the edge it must not check:
+// one the same query deleted again is never created, so nothing can conflict with it.
+class DeletedPendingEdgeConflictTest : public WriteQueryTest {
+protected:
+    QueryStatus trySubmit(const ChangeID& changeID) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+
+        return _env->getDB().query("CHANGE SUBMIT", submitState);
+    }
+};
+
+// The first change writes an edge off Remy and deletes it again; the second changes Remy
+// and submits first. The edge is gone, so its end having moved on main is no conflict.
+TEST_F(DeletedPendingEdgeConflictTest, submitsAChangeWhoseWrittenEdgeItDeletedAgain) {
+    ChangeID first;
+    openChange(first);
+    ASSERT_TRUE(runWrite("MATCH (p:Person {name: 'Remy'}) "
+                         "CREATE (p)-[e:LINKS]->(b:Tag {name: 'b'}) "
+                         "DELETE e",
+                         first)
+                    .isOk());
+
+    ChangeID second;
+    openChange(second);
+    ASSERT_TRUE(runWrite("MATCH (p:Person {name: 'Remy'}) SET p.age = 40", second).isOk());
+
+    submit(second);
+
+    const QueryStatus status = trySubmit(first);
+    EXPECT_TRUE(status.isOk()) << status.getError();
+}
+
+// The same change keeping the edge it wrote: that one does conflict
+TEST_F(DeletedPendingEdgeConflictTest, refusesAChangeWhoseWrittenEdgeSurvives) {
+    ChangeID first;
+    openChange(first);
+    ASSERT_TRUE(runWrite("MATCH (p:Person {name: 'Remy'}) "
+                         "CREATE (p)-[e:LINKS]->(b:Tag {name: 'b'})",
+                         first)
+                    .isOk());
+
+    ChangeID second;
+    openChange(second);
+    ASSERT_TRUE(runWrite("MATCH (p:Person {name: 'Remy'}) SET p.age = 40", second).isOk());
+
+    submit(second);
+
+    const QueryStatus status = trySubmit(first);
+    EXPECT_FALSE(status.isOk());
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/IRTestRows.cpp
+++ b/test/query/ir/IRTestRows.cpp
@@ -104,7 +104,7 @@ void renderList(const ListView& list, std::string& out) {
 
 template <typename T>
 void renderValue(const T& value, std::string& out) {
-    if constexpr (std::is_same_v<T, std::string_view>) {
+    if constexpr (std::is_same_v<T, std::string_view> || std::is_same_v<T, std::string>) {
         out = std::string(value);
     } else if constexpr (std::is_same_v<T, types::Bool::Primitive>) {
         out = value ? "true" : "false";
@@ -164,7 +164,8 @@ void turing::test::renderCell(const Column* column, size_t row, std::string& out
                || renderValueCell<uint64_t>(column, row, out)
                || renderValueCell<double>(column, row, out)
                || renderValueCell<types::Bool::Primitive>(column, row, out)
-               || renderValueCell<std::string_view>(column, row, out)) {
+               || renderValueCell<std::string_view>(column, row, out)
+               || renderValueCell<std::string>(column, row, out)) {
         // Rendered by the helper for whichever value type matched
     } else {
         throw std::runtime_error("IRTestRows: unsupported output column type");

--- a/test/query/ir/MergeChainMatchTest.cpp
+++ b/test/query/ir/MergeChainMatchTest.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The matches a merge chain enumerates: one row per path the graph holds, whichever way
+// several of them run through the same node or the same edge.
+class MergeChainMatchTest : public WriteQueryTest {
+};
+
+// Two paths meet at the middle Tag, so the second hop walks that node's edges once
+// however many partial matches reached it: one row per path, not one per (match, edge)
+// pair of a node reached twice
+TEST_F(MergeChainMatchTest, bindsOneRowPerPathThroughASharedMiddleNode) {
+    // A merge writes the whole pattern it does not find, fresh ends and all, so the two
+    // paths only meet at one middle node if that node is bound rather than described
+    expectWriteRowCount("MERGE (m:Tag {name: 'm'})-[:LINKS]->(z:Tag {name: 'z'})", 0);
+    expectWriteRowCount("MATCH (m:Tag {name: 'm'}) MERGE (a:Tag {name: 'a1'})-[:LINKS]->(m)", 0);
+    expectWriteRowCount("MATCH (m:Tag {name: 'm'}) MERGE (a:Tag {name: 'a2'})-[:LINKS]->(m)", 0);
+
+    expectWriteRows("MERGE (a:Tag)-[:LINKS]->(b:Tag)-[:LINKS]->(c:Tag) RETURN a.name, c.name",
+                    {{"a1", "z"}, {"a2", "z"}});
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN count(*)", {{"3"}});
+}
+
+// An undirected hop takes the edge either way round, and a self-loop is an out-edge and
+// an in-edge of the one node: it is one edge, so it binds one row
+TEST_F(MergeChainMatchTest, bindsASelfLoopOnceForAnUndirectedHop) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}) MERGE (a)-[:LOOPS]->(a)", 0);
+
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}) MERGE (a)-[e:LOOPS]-(a) RETURN a.name",
+                    {{"Remy"}});
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[e:LOOPS]->(b) RETURN count(e)", {{"1"}});
+}
+
+// The pending sibling of the case above: the loop the same query wrote is in no graph
+// the match reads, so the undirected hop finds it in the write log - once, from the one
+// side the outgoing pass already covers
+TEST_F(MergeChainMatchTest, bindsAPendingSelfLoopOnceForAnUndirectedHop) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}) "
+                    "MERGE (a)-[:LOOPS]->(a) "
+                    "MERGE (a)-[:LOOPS]-(a) "
+                    "RETURN a.name",
+                    {{"Remy"}});
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[e:LOOPS]->(b) RETURN count(e)", {{"1"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeDialectTest.cpp
+++ b/test/query/ir/MergeDialectTest.cpp
@@ -70,18 +70,18 @@ func.func @main() {
 )mlir";
 
 // A hop between one bound end and one the pattern describes, carrying the bound
-// column past the merge
+// column past the merge. The bound end has no result pair: it comes back through the
+// carry set.
 constexpr const char* mergesAHopOntoABoundNode = R"mlir(
 func.func @main() {
   %a = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
   %tag = db.constant("x" : !storage.string)
-  %m, %m_pending, %b, %b_pending, %e, %e_pending, %created, %carried
+  %b, %b_pending, %e, %e_pending, %created, %carried
     = db.merge nodes [[], ["Tag"]] props [[], ["name"]]
                edges ["TAGGED"] props [["weight"]] dirs [forward]
                bound {%a} pending [] {} values {%tag} {%tag} carrying {%a}
     : (!db.column<!storage.node_id>, !db.column<!storage.string>, !db.column<!storage.string>, !db.column<!storage.node_id>)
       -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
-          !db.column<!storage.node_id>, !db.column<!storage.bool>,
           !db.column<!storage.edge_id>, !db.column<!storage.bool>,
           !db.column<!storage.bool>, !db.column<!storage.node_id>)
   db.output(%b) : !db.column<!storage.node_id>
@@ -109,10 +109,10 @@ func.func @main() {
 // through `bound`
 constexpr const char* mergesALabellessNodeWithNoBoundColumn = R"mlir(
 func.func @main() {
-  %n, %n_pending, %created = db.merge nodes [[]] props [[]]
-                                      edges [] props [] dirs []
-                                      bound {} pending [] {} values {} {} carrying {}
-    : () -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+  %created = db.merge nodes [[]] props [[]]
+                      edges [] props [] dirs []
+                      bound {} pending [] {} values {} {} carrying {}
+    : () -> (!db.column<!storage.bool>)
   return
 }
 )mlir";
@@ -148,15 +148,13 @@ constexpr const char* mergesTwoBoundNodesWithOutOfOrderPendingMasks = R"mlir(
 func.func @main() {
   %a = db.scan_nodes() : !db.column<!storage.node_id>
   %mask = db.check_label_constraint(%a, ["Person"]) : (!db.column<!storage.node_id>) -> !db.column<!storage.bool>
-  %n, %n_pending, %m, %m_pending, %e, %e_pending, %created
+  %e, %e_pending, %created
     = db.merge nodes [[], []] props [[], []]
                edges ["KNOWS"] props [[]] dirs [forward]
                bound {%a, %a} pending [1, 0] {%mask, %mask} values {} {} carrying {}
     : (!db.column<!storage.node_id>, !db.column<!storage.node_id>,
        !db.column<!storage.bool>, !db.column<!storage.bool>)
-      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
-          !db.column<!storage.node_id>, !db.column<!storage.bool>,
-          !db.column<!storage.edge_id>, !db.column<!storage.bool>,
+      -> (!db.column<!storage.edge_id>, !db.column<!storage.bool>,
           !db.column<!storage.bool>)
   return
 }

--- a/test/query/ir/MergeDialectTest.cpp
+++ b/test/query/ir/MergeDialectTest.cpp
@@ -1,0 +1,236 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "NLDialect.h"
+#include "NLOps.h"
+#include "StorageDialect.h"
+#include "StorageEnums.h"
+
+namespace {
+
+// The textual form of db.merge and nl.merge: what a MERGE pattern's chain looks like
+// in each dialect, and the shape rules the two share.
+class MergeDialectTest : public ::testing::Test {
+protected:
+    MergeDialectTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+    // The negative cases install their own swallowing handler, so a diagnostic reaching
+    // here belongs to a program that was meant to parse and is worth printing
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool parses(const char* programText) {
+        return static_cast<bool>(parse(programText));
+    }
+
+    // Printing the module and parsing the text back must give a module that verifies:
+    // the printer and the parser are inverses over the merge's attribute lists.
+    void expectRoundTrips(const char* programText) {
+        const mlir::OwningOpRef<mlir::ModuleOp> module = parse(programText);
+        ASSERT_TRUE(module);
+
+        std::string printed;
+        llvm::raw_string_ostream stream(printed);
+        module.get().print(stream);
+
+        EXPECT_TRUE(parses(printed.c_str())) << printed;
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// One chain node, matched and written by its label and one property value
+constexpr const char* mergesOneNode = R"mlir(
+func.func @main() {
+  %name = db.constant("Alice" : !storage.string)
+  %n, %n_pending, %created = db.merge nodes [["Person"]] props [["name"]]
+                                      edges [] props [] dirs []
+                                      bound {} pending [] {} values {%name} {} carrying {}
+    : (!db.column<!storage.string>)
+      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+  db.output(%n) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A hop between one bound end and one the pattern describes, carrying the bound
+// column past the merge
+constexpr const char* mergesAHopOntoABoundNode = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %tag = db.constant("x" : !storage.string)
+  %m, %m_pending, %b, %b_pending, %e, %e_pending, %created, %carried
+    = db.merge nodes [[], ["Tag"]] props [[], ["name"]]
+               edges ["TAGGED"] props [["weight"]] dirs [forward]
+               bound {%a} pending [] {} values {%tag} {%tag} carrying {%a}
+    : (!db.column<!storage.node_id>, !db.column<!storage.string>, !db.column<!storage.string>, !db.column<!storage.node_id>)
+      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.edge_id>, !db.column<!storage.bool>,
+          !db.column<!storage.bool>, !db.column<!storage.node_id>)
+  db.output(%b) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The nl sibling, driven inside the loop that binds its input chunk
+constexpr const char* mergesOneNodeInALoop = R"mlir(
+func.func @main() {
+  %nodes = nl.scan_nodes()
+  nl.for %node in %nodes : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %n, %n_pending, %created, %carried = nl.merge nodes [["Tag"]] props [[]]
+                                                  edges [] props [] dirs []
+                                                  bound {} pending [] {} values {} {} carrying {%node}
+      : (!nl.chunk<!storage.node_id>)
+        -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.bool>,
+            !nl.chunk<!storage.bool>, !nl.chunk<!storage.node_id>)
+  }
+  return
+}
+)mlir";
+
+// A chain node with no label is one the query bound, so its column has to come in
+// through `bound`
+constexpr const char* mergesALabellessNodeWithNoBoundColumn = R"mlir(
+func.func @main() {
+  %n, %n_pending, %created = db.merge nodes [[]] props [[]]
+                                      edges [] props [] dirs []
+                                      bound {} pending [] {} values {} {} carrying {}
+    : () -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+  return
+}
+)mlir";
+
+// Two chain nodes are joined by exactly one hop
+constexpr const char* mergesTwoNodesWithNoHop = R"mlir(
+func.func @main() {
+  %n, %n_pending, %m, %m_pending, %e, %e_pending, %created
+    = db.merge nodes [["A"], ["B"]] props [[], []]
+               edges [] props [] dirs []
+               bound {} pending [] {} values {} {} carrying {}
+    : () -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
+             !db.column<!storage.node_id>, !db.column<!storage.bool>,
+             !db.column<!storage.edge_id>, !db.column<!storage.bool>,
+             !db.column<!storage.bool>)
+  return
+}
+)mlir";
+
+// One property name per value column
+constexpr const char* mergesANodeWithNoValueForItsProperty = R"mlir(
+func.func @main() {
+  %n, %n_pending, %created = db.merge nodes [["Person"]] props [["name"]]
+                                      edges [] props [] dirs []
+                                      bound {} pending [] {} values {} {} carrying {}
+    : () -> (!db.column<!storage.node_id>, !db.column<!storage.bool>, !db.column<!storage.bool>)
+  return
+}
+)mlir";
+
+// The masks name their chain nodes in increasing order
+constexpr const char* mergesTwoBoundNodesWithOutOfOrderPendingMasks = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %mask = db.check_label_constraint(%a, ["Person"]) : (!db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %n, %n_pending, %m, %m_pending, %e, %e_pending, %created
+    = db.merge nodes [[], []] props [[], []]
+               edges ["KNOWS"] props [[]] dirs [forward]
+               bound {%a, %a} pending [1, 0] {%mask, %mask} values {} {} carrying {}
+    : (!db.column<!storage.node_id>, !db.column<!storage.node_id>,
+       !db.column<!storage.bool>, !db.column<!storage.bool>)
+      -> (!db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.node_id>, !db.column<!storage.bool>,
+          !db.column<!storage.edge_id>, !db.column<!storage.bool>,
+          !db.column<!storage.bool>)
+  return
+}
+)mlir";
+
+TEST_F(MergeDialectTest, parsesAOneNodePattern) {
+    expectRoundTrips(mergesOneNode);
+}
+
+TEST_F(MergeDialectTest, parsesAHopOntoABoundNode) {
+    expectRoundTrips(mergesAHopOntoABoundNode);
+}
+
+TEST_F(MergeDialectTest, parsesTheNLSiblingInALoop) {
+    expectRoundTrips(mergesOneNodeInALoop);
+}
+
+// The direction list prints as keywords rather than as the integers it is stored as
+TEST_F(MergeDialectTest, printsHopDirectionsAsKeywords) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(mergesAHopOntoABoundNode);
+    ASSERT_TRUE(module);
+
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    EXPECT_NE(printed.find("dirs [forward]"), std::string::npos) << printed;
+}
+
+TEST_F(MergeDialectTest, readsTheDirectionOfEachHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(mergesAHopOntoABoundNode);
+    ASSERT_TRUE(module);
+
+    mlir::db::Merge merge;
+    module.get().walk([&](mlir::db::Merge found) {
+        merge = found;
+    });
+    ASSERT_TRUE(merge);
+
+    const llvm::ArrayRef<int64_t> directions = merge.getEdgeDirections();
+    ASSERT_EQ(directions.size(), 1u);
+    EXPECT_EQ(static_cast<mlir::storage::EdgeDirection>(directions[0]), mlir::storage::EdgeDirection::Forward);
+}
+
+TEST_F(MergeDialectTest, verifierRejectsALabellessNodeWithNoBoundColumn) {
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+
+    EXPECT_FALSE(parses(mergesALabellessNodeWithNoBoundColumn));
+}
+
+TEST_F(MergeDialectTest, verifierRejectsTwoNodesWithNoHop) {
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+
+    EXPECT_FALSE(parses(mergesTwoNodesWithNoHop));
+}
+
+TEST_F(MergeDialectTest, verifierRejectsAPropertyNameWithNoValue) {
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+
+    EXPECT_FALSE(parses(mergesANodeWithNoValueForItsProperty));
+}
+
+TEST_F(MergeDialectTest, verifierRejectsOutOfOrderPendingMasks) {
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+
+    EXPECT_FALSE(parses(mergesTwoBoundNodesWithOutOfOrderPendingMasks));
+}
+
+}

--- a/test/query/ir/MergeEdgeTest.cpp
+++ b/test/query/ir/MergeEdgeTest.cpp
@@ -1,0 +1,290 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// MERGE of a path pattern with a hop: the rows it binds when the graph holds the whole
+// pattern, and the entities it writes - all of them, not only the hop - when it does not.
+class MergeEdgeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    void submit(const ChangeID& changeID) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // The rows a writing query emits, collected in its own change and then submitted, so
+    // a following read sees what it wrote
+    void writeRows(std::string_view query, Rows& rows) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        sink.sortedRows(rows);
+
+        submit(changeID);
+    }
+
+    void expectWriteRows(std::string_view query, const Rows& expected) {
+        Rows actual;
+        writeRows(query, actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectWriteRowCount(std::string_view query, size_t expected) {
+        Rows actual;
+        writeRows(query, actual);
+
+        EXPECT_EQ(actual.size(), expected) << "query: " << query;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// Remy knows Adam well already, so the merge binds that hop and writes nothing
+TEST_F(MergeEdgeTest, bindsAHopThePatternFinds) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Adam'}) "
+                    "MERGE (a)-[e:KNOWS_WELL]->(b) "
+                    "RETURN e.name",
+                    {{"Remy -> Adam"}});
+}
+
+// There is no such hop, so the merge writes one between the two bound ends
+TEST_F(MergeEdgeTest, writesAHopBetweenTwoBoundEnds) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "
+                        "MERGE (a)-[e:KNOWS_WELL]->(b)",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[:KNOWS_WELL]->(b) RETURN b.name",
+               {{"Adam"}, {"Luc"}});
+}
+
+// A hop pointing the other way is a different pattern, so the merge writes it
+TEST_F(MergeEdgeTest, writesAHopThePatternFindsOnlyTheOtherWayRound) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (g:Interest {name: 'Ghosts'}) "
+                        "MERGE (a)-[e:KNOWS_WELL]->(g)",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[:KNOWS_WELL]->(b) RETURN b.name",
+               {{"Adam"}, {"Ghosts"}});
+}
+
+// An undirected hop takes the one the graph holds either way round, so this binds the
+// Ghosts -> Remy edge and writes nothing
+TEST_F(MergeEdgeTest, bindsAnUndirectedHopEitherWayRound) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (g:Interest {name: 'Ghosts'}) "
+                    "MERGE (a)-[e:KNOWS_WELL]-(g) "
+                    "RETURN e.name",
+                    {{"Ghosts -> Remy"}});
+}
+
+// A hop the pattern reads backwards binds the edge that points that way
+TEST_F(MergeEdgeTest, bindsABackwardHop) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (g:Interest {name: 'Ghosts'}) "
+                    "MERGE (a)<-[e:KNOWS_WELL]-(g) "
+                    "RETURN e.name",
+                    {{"Ghosts -> Remy"}});
+}
+
+// The property is part of the pattern, so a hop of that type carrying another value is
+// not the pattern and a second hop is written
+TEST_F(MergeEdgeTest, writesAHopWhoseFoundSiblingCarriesAnotherPropertyValue) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Adam'}) "
+                        "MERGE (a)-[e:KNOWS_WELL {duration: 5}]->(b)",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[e:KNOWS_WELL]->(b:Person {name: 'Adam'}) "
+               "RETURN e.duration",
+               {{"20"}, {"5"}});
+}
+
+TEST_F(MergeEdgeTest, bindsAHopCarryingThePropertyValueThePatternAsksFor) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Adam'}) "
+                    "MERGE (a)-[e:KNOWS_WELL {duration: 20}]->(b) "
+                    "RETURN e.name",
+                    {{"Remy -> Adam"}});
+}
+
+// Neither end is bound and no such path exists, so the merge writes the whole pattern -
+// both nodes and the hop - rather than reusing a node that matches one end
+TEST_F(MergeEdgeTest, writesTheWholePatternItDoesNotFind) {
+    expectWriteRows("MERGE (a:Tag {name: 'x'})-[e:LINKS]->(b:Tag {name: 'y'}) "
+                    "RETURN a.name, b.name",
+                    {{"x", "y"}});
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN a.name, b.name", {{"x", "y"}});
+}
+
+// The pattern is found this time, so nothing is written and the found path is bound
+TEST_F(MergeEdgeTest, bindsTheWholePatternItFinds) {
+    expectWriteRows("MERGE (a:Tag {name: 'x'})-[e:LINKS]->(b:Tag {name: 'y'}) RETURN a.name", {{"x"}});
+    expectWriteRows("MERGE (a:Tag {name: 'x'})-[e:LINKS]->(b:Tag {name: 'y'}) RETURN b.name", {{"y"}});
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"2"}});
+}
+
+// The canonical shape: two node merges then a hop merge between what they bound. The
+// hop's ends are entities this change wrote, which no graph the match reads holds, so
+// the pattern is written - once.
+TEST_F(MergeEdgeTest, writesAHopBetweenTwoNodesTheSameQueryWrote) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'x'}) "
+                        "MERGE (b:Tag {name: 'y'}) "
+                        "MERGE (a)-[e:LINKS]->(b)",
+                        0);
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN a.name, b.name", {{"x", "y"}});
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"2"}});
+}
+
+// Two hop merges over the same pair write one edge: the second binds the pending one the
+// first wrote
+TEST_F(MergeEdgeTest, writesOneHopForTwoMergesOfOnePattern) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "
+                        "MERGE (a)-[:KNOWS_WELL]->(b) "
+                        "MERGE (a)-[:KNOWS_WELL]->(b)",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[:KNOWS_WELL]->(b) RETURN b.name",
+               {{"Adam"}, {"Luc"}});
+}
+
+// A three-node chain is matched and written as one pattern
+TEST_F(MergeEdgeTest, writesAChainOfTwoHops) {
+    expectWriteRows("MERGE (a:Tag {name: 'x'})-[:LINKS]->(b:Tag {name: 'y'})-[:LINKS]->(c:Tag {name: 'z'}) "
+                    "RETURN a.name, b.name, c.name",
+                    {{"x", "y", "z"}});
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag)-[:LINKS]->(c:Tag) RETURN a.name, c.name",
+               {{"x", "z"}});
+}
+
+// Each hop of a chain is logged under its own property values, so merging the chain
+// again binds every hop of it rather than writing a second chain
+TEST_F(MergeEdgeTest, writesOneChainForTwoMergesOfOnePattern) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'x'})-[:LINKS {weight: 1}]->(b:Tag {name: 'y'})"
+                        "-[:LINKS {weight: 2}]->(c:Tag {name: 'z'}) "
+                        "MERGE (d:Tag {name: 'x'})-[:LINKS {weight: 1}]->(e:Tag {name: 'y'})"
+                        "-[:LINKS {weight: 2}]->(f:Tag {name: 'z'})",
+                        0);
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN count(*)", {{"2"}});
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"3"}});
+}
+
+// ON CREATE over a hop merge writes the property of the edge it wrote
+TEST_F(MergeEdgeTest, setsThePropertyOfTheHopItWrote) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "
+                        "MERGE (a)-[e:KNOWS_WELL]->(b) ON CREATE SET e.duration = 3",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[e:KNOWS_WELL]->(b:Person {name: 'Luc'}) "
+               "RETURN e.duration",
+               {{"3"}});
+}
+
+// ON MATCH over a hop merge writes the property of the edge it bound
+TEST_F(MergeEdgeTest, setsThePropertyOfTheHopItBound) {
+    expectWriteRowCount("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Adam'}) "
+                        "MERGE (a)-[e:KNOWS_WELL]->(b) ON MATCH SET e.duration = 3",
+                        0);
+
+    expectRows("MATCH (a:Person {name: 'Remy'})-[e:KNOWS_WELL]->(b:Person {name: 'Adam'}) "
+               "RETURN e.duration",
+               {{"3"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeEdgeTest.cpp
+++ b/test/query/ir/MergeEdgeTest.cpp
@@ -1,136 +1,13 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <string_view>
-
-#include "QueryInterpreterV3.h"
-#include "QueryStatus.h"
-
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
-#include "TuringDB.h"
-#include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
-#include "versioning/ChangeID.h"
-#include "versioning/CommitHash.h"
-
-#include "IRTestRows.h"
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
 
 // MERGE of a path pattern with a hop: the rows it binds when the graph holds the whole
 // pattern, and the entities it writes - all of them, not only the hop - when it does not.
-class MergeEdgeTest : public TuringTest {
-protected:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-    }
-
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
-    void submit(const ChangeID& changeID) {
-        QueryCallbacks callbacks;
-        callbacks.setOnOutputData([](const Dataframe*) {});
-
-        const QueryState submitState(_graphName,
-                                     &_env->getMem(),
-                                     &_queryConfig,
-                                     &callbacks,
-                                     CommitHash::head(),
-                                     changeID);
-        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
-        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
-    }
-
-    // The rows a writing query emits, collected in its own change and then submitted, so
-    // a following read sees what it wrote
-    void writeRows(std::string_view query, Rows& rows) {
-        ChangeID changeID;
-        openChange(changeID);
-
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              changeID,
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        sink.sortedRows(rows);
-
-        submit(changeID);
-    }
-
-    void expectWriteRows(std::string_view query, const Rows& expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    void expectWriteRowCount(std::string_view query, size_t expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        EXPECT_EQ(actual.size(), expected) << "query: " << query;
-    }
-
-    void expectRows(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              ChangeID::head(),
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Rows actual;
-        sink.sortedRows(actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
+class MergeEdgeTest : public WriteQueryTest {
 };
 
 // Remy knows Adam well already, so the merge binds that hop and writes nothing

--- a/test/query/ir/MergeFanOutTest.cpp
+++ b/test/query/ir/MergeFanOutTest.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A merge emits one row per match it binds, so the rows in flight around it grow. What
+// every column beside it has to look like once they have.
+class MergeFanOutTest : public WriteQueryTest {
+};
+
+// The value the first merge wrote for t.name is a column of the rows that reached it,
+// and the second merge fans those rows out over the eight Persons it binds: the
+// projection reads the property off that column, so it has to be re-indexed onto the
+// emitted rows along with t's own ID column
+TEST_F(MergeFanOutTest, carriesAWrittenPropertyPastAMergeThatFansTheRowsOut) {
+    const Rows remyPerPerson(8, Row {"Remy"});
+
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) "
+                    "MERGE (t:Tag {name: p.name}) "
+                    "MERGE (q:Person) "
+                    "RETURN t.name",
+                    remyPerPerson);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"Remy"}});
+}
+
+// The same fan-out, read through the merge's own entity rather than its property: one
+// row per Person, each naming the single Tag the first merge wrote
+TEST_F(MergeFanOutTest, carriesAWrittenEntityPastAMergeThatFansTheRowsOut) {
+    expectWriteRowCount("MATCH (p:Person {name: 'Remy'}) "
+                        "MERGE (t:Tag {name: p.name}) "
+                        "MERGE (q:Person) "
+                        "RETURN t.name, q.name",
+                        8);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"1"}});
+}
+
+// The CREATE comes first in the query, so it writes over the one row the query starts
+// with - not over the eight the merge behind it fans out to
+TEST_F(MergeFanOutTest, writesACreateAheadOfAMergeOverTheRowsAheadOfIt) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'x'}) MERGE (q:Person)", 0);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"1"}});
+}
+
+// The other way round: the merge fans the rows out first, so the CREATE behind it writes
+// one node per row it emitted
+TEST_F(MergeFanOutTest, writesACreateBehindAMergeOverTheRowsItEmitted) {
+    expectWriteRowCount("MERGE (q:Person) CREATE (t:Tag {name: 'x'})", 0);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"8"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeFanOutTest.cpp
+++ b/test/query/ir/MergeFanOutTest.cpp
@@ -10,10 +10,9 @@ using namespace turing::test;
 class MergeFanOutTest : public WriteQueryTest {
 };
 
-// The value the first merge wrote for t.name is a column of the rows that reached it,
-// and the second merge fans those rows out over the eight Persons it binds: the
-// projection reads the property off that column, so it has to be re-indexed onto the
-// emitted rows along with t's own ID column
+// The second merge fans the rows the first emitted out over the eight Persons it binds,
+// and the projection reads t.name off the node column and the mask the first produced:
+// both have to be re-indexed onto the emitted rows for the read to land on t
 TEST_F(MergeFanOutTest, carriesAWrittenPropertyPastAMergeThatFansTheRowsOut) {
     const Rows remyPerPerson(8, Row {"Remy"});
 

--- a/test/query/ir/MergeKeyTest.cpp
+++ b/test/query/ir/MergeKeyTest.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// What a merge keys an entity on: the property values it asks for, told apart from the
+// values another spec asks for, and compared against the graph's own whatever type the
+// schema holds them as.
+class MergeKeyTest : public WriteQueryTest {
+};
+
+// The two hops constrain different properties to values with the same bytes, so nothing
+// but the property they name tells the patterns apart: the second pattern is not the
+// first, so it is not found and is written whole - a second chain, ends and all
+TEST_F(MergeKeyTest, writesAHopConstrainingAnotherPropertyToTheSameValue) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'x'})-[:LINKS {alpha: 1}]->(b:Tag {name: 'y'}) "
+                        "MERGE (c:Tag {name: 'x'})-[:LINKS {beta: 1}]->(d:Tag {name: 'y'})",
+                        0);
+
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN count(*)", {{"2"}});
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"4"}});
+}
+
+// The nodes of those two merges do name the same property, so the second binds what the
+// first wrote rather than writing a second copy
+TEST_F(MergeKeyTest, bindsTheNodeAnEarlierMergeOfTheSameSpecWrote) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'x'}) MERGE (b:Tag {name: 'x'})", 0);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"1"}});
+}
+
+// The schema holds score as a double, so the integer the pattern asks for keys as the
+// double the graph reads back: 2 is the 2.0 the node carries, and the merge binds it
+TEST_F(MergeKeyTest, bindsADoubleTypedPropertyAnIntegerConstrains) {
+    expectWriteRowCount("CREATE (s:Score {score: 2.0})", 0);
+
+    expectWriteRowCount("MERGE (s:Score {score: 2}) RETURN s.score", 1);
+
+    expectRows("MATCH (s:Score) RETURN count(s)", {{"1"}});
+}
+
+// The same widening the other way round: nothing carries 3.0, so the merge writes it,
+// and merging the integer again binds what it wrote
+TEST_F(MergeKeyTest, bindsAPendingNodeAnIntegerAndADoubleBothConstrain) {
+    expectWriteRowCount("CREATE (s:Score {score: 2.0})", 0);
+
+    expectWriteRowCount("MERGE (s:Score {score: 3}) MERGE (t:Score {score: 3.0})", 0);
+
+    expectRows("MATCH (s:Score) RETURN count(s)", {{"2"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeNodeTest.cpp
+++ b/test/query/ir/MergeNodeTest.cpp
@@ -1,0 +1,254 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// MERGE of a node pattern: the rows it binds when the graph already holds the node, the
+// node it writes when it does not, and the once-only writing a merge driven by repeated
+// rows owes.
+class MergeNodeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    void submit(const ChangeID& changeID) {
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
+    }
+
+    // The rows a writing query emits, collected in its own change and then submitted, so
+    // a following read sees what it wrote
+    void writeRows(std::string_view query, Rows& rows) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        sink.sortedRows(rows);
+
+        submit(changeID);
+    }
+
+    void expectWriteRows(std::string_view query, const Rows& expected) {
+        Rows actual;
+        writeRows(query, actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectWriteRowCount(std::string_view query, size_t expected) {
+        Rows actual;
+        writeRows(query, actual);
+
+        EXPECT_EQ(actual.size(), expected) << "query: " << query;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// The graph has no Tag, so the merge writes one and the projection reads the value it
+// wrote there
+TEST_F(MergeNodeTest, writesANodeThePatternDoesNotFind) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) RETURN n.name", {{"x"}});
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"x"}});
+}
+
+// Remy is a Person of that name already, so the merge binds him and writes nothing
+TEST_F(MergeNodeTest, bindsTheNodeThePatternFinds) {
+    expectWriteRows("MERGE (n:Person {name: 'Remy'}) RETURN n.name", {{"Remy"}});
+
+    expectRows("MATCH (p:Person) RETURN count(p)", {{"8"}});
+}
+
+// Merging the same pattern twice writes one node: the second statement binds what the
+// first wrote
+TEST_F(MergeNodeTest, writesOneNodeForTwoMergesOfOnePattern) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'x'}) MERGE (b:Tag {name: 'x'})", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"x"}});
+}
+
+// One node per distinct value the list unwinds, not one per row
+TEST_F(MergeNodeTest, writesOneNodePerDistinctRow) {
+    expectWriteRows("UNWIND [1, 1, 2] AS id MERGE (n:Tag {age: id}) RETURN n.age",
+                    {{"1"}, {"1"}, {"2"}});
+
+    expectRows("MATCH (t:Tag) RETURN t.age", {{"1"}, {"2"}});
+}
+
+// A pattern with no property constraint binds every node carrying the label - all eight
+// Persons - and writes nothing
+TEST_F(MergeNodeTest, bindsEveryNodeAPatternWithoutPropertiesFinds) {
+    expectWriteRowCount("MERGE (p:Person) RETURN p", 8);
+}
+
+// The merge runs once per row the match produced, and each row's value keys its own
+// lookup
+TEST_F(MergeNodeTest, writesANodePerMatchedRow) {
+    expectWriteRows("MATCH (p:Person) MERGE (t:Tag {name: p.name}) RETURN t.name",
+                    {{"Adam"}, {"Cyrus"}, {"Doruk"}, {"Luc"},
+                     {"Martina"}, {"Maxime"}, {"Remy"}, {"Suhas"}});
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"8"}});
+}
+
+// The rows the match produced survive the merge's fan-out, so the projection pairs each
+// Person with the tag merged for it
+TEST_F(MergeNodeTest, keepsTheMatchedRowsBesideTheOnesItBound) {
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) MERGE (t:Tag {name: 'x'}) RETURN p.name, t.name",
+                    {{"Remy", "x"}});
+}
+
+// The merge fans one row out over every Person, and count(*) tallies the rows it emitted
+TEST_F(MergeNodeTest, countsTheRowsTheMergeEmitted) {
+    expectWriteRows("MERGE (p:Person) RETURN count(*)", {{"8"}});
+}
+
+// A barrier publishes the rows the merge then runs over, one merge per published row
+TEST_F(MergeNodeTest, writesANodePerRowABarrierPublished) {
+    expectWriteRows("MATCH (p:Person) WITH p.name AS name ORDER BY name LIMIT 2 "
+                    "MERGE (t:Tag {name: name}) "
+                    "RETURN t.name",
+                    {{"Adam"}, {"Cyrus"}});
+}
+
+// The grouping key is a column the merge produced, so each group is one merged node
+TEST_F(MergeNodeTest, groupsTheRowsTheMergeEmitted) {
+    expectWriteRows("MATCH (p:Person) MERGE (t:Tag {name: 'x'}) RETURN t.name, count(*)",
+                    {{"x", "8"}});
+}
+
+// A property the pattern does not key on is null on the node it wrote
+TEST_F(MergeNodeTest, readsNullForAPropertyTheWriteDidNotSet) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) RETURN n.age", {{"null"}});
+}
+
+// The same read on a node the pattern found reads the graph
+TEST_F(MergeNodeTest, readsThePropertyOfTheNodeItFound) {
+    expectWriteRows("MERGE (p:Person {name: 'Remy'}) RETURN p.age", {{"32"}});
+}
+
+// ON CREATE runs over the rows the merge wrote, ON MATCH over the rows it bound
+TEST_F(MergeNodeTest, setsThePropertyOfTheRowsItWrote) {
+    expectWriteRowCount("MERGE (n:Tag {name: 'x'}) ON CREATE SET n.age = 1", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name, t.age", {{"x", "1"}});
+}
+
+TEST_F(MergeNodeTest, leavesThePropertyOfTheRowsItBoundAlone) {
+    expectWriteRowCount("MERGE (p:Person {name: 'Remy'}) ON CREATE SET p.age = 1", 0);
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.age", {{"32"}});
+}
+
+TEST_F(MergeNodeTest, setsThePropertyOfTheRowsItBound) {
+    expectWriteRowCount("MERGE (p:Person {name: 'Remy'}) ON MATCH SET p.age = 1", 0);
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.age", {{"1"}});
+}
+
+TEST_F(MergeNodeTest, leavesThePropertyOfTheRowsItWroteAlone) {
+    expectWriteRowCount("MERGE (n:Tag {name: 'x'}) ON MATCH SET n.age = 1", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name, t.age", {{"x", "null"}});
+}
+
+// A plain SET after a merge touches every row, whichever way the merge bound it
+TEST_F(MergeNodeTest, setsThePropertyOfEveryRow) {
+    expectWriteRowCount("MERGE (n:Tag {name: 'x'}) SET n.age = 2", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.age", {{"2"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeNodeTest.cpp
+++ b/test/query/ir/MergeNodeTest.cpp
@@ -1,27 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <string_view>
-
-#include "QueryInterpreterV3.h"
-#include "QueryStatus.h"
-
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
-#include "TuringDB.h"
-#include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
-#include "versioning/ChangeID.h"
-#include "versioning/CommitHash.h"
-
-#include "IRTestRows.h"
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
@@ -29,109 +8,7 @@ using namespace turing::test;
 // MERGE of a node pattern: the rows it binds when the graph already holds the node, the
 // node it writes when it does not, and the once-only writing a merge driven by repeated
 // rows owes.
-class MergeNodeTest : public TuringTest {
-protected:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-    }
-
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
-    void submit(const ChangeID& changeID) {
-        QueryCallbacks callbacks;
-        callbacks.setOnOutputData([](const Dataframe*) {});
-
-        const QueryState submitState(_graphName,
-                                     &_env->getMem(),
-                                     &_queryConfig,
-                                     &callbacks,
-                                     CommitHash::head(),
-                                     changeID);
-        const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
-        ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
-    }
-
-    // The rows a writing query emits, collected in its own change and then submitted, so
-    // a following read sees what it wrote
-    void writeRows(std::string_view query, Rows& rows) {
-        ChangeID changeID;
-        openChange(changeID);
-
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              changeID,
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        sink.sortedRows(rows);
-
-        submit(changeID);
-    }
-
-    void expectWriteRows(std::string_view query, const Rows& expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    void expectWriteRowCount(std::string_view query, size_t expected) {
-        Rows actual;
-        writeRows(query, actual);
-
-        EXPECT_EQ(actual.size(), expected) << "query: " << query;
-    }
-
-    void expectRows(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              ChangeID::head(),
-                              &_env->getMem(),
-                              &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Rows actual;
-        sink.sortedRows(actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
+class MergeNodeTest : public WriteQueryTest {
 };
 
 // The graph has no Tag, so the merge writes one and the projection reads the value it

--- a/test/query/ir/MergePropertyReadTest.cpp
+++ b/test/query/ir/MergePropertyReadTest.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Where a merge's rows read a property: off the graph for a row it bound, out of the
+// change's write buffer for a row it wrote.
+class MergePropertyReadTest : public WriteQueryTest {
+};
+
+// The pattern keys the tag on the value the match produced and two tags carry it, so the
+// merge binds both: the property is read off the two rows it emitted, not off the one row
+// that drove it
+TEST_F(MergePropertyReadTest, readsTheKeyPropertyOfEveryRowAMergeBound) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'Remy'})", 0);
+    expectWriteRowCount("CREATE (t:Tag {name: 'Remy'})", 0);
+
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) MERGE (t:Tag {name: p.name}) RETURN t.name",
+                    {{"Remy"}, {"Remy"}});
+}
+
+// The schema holds score as a double, so the integer the pattern asks for binds the node
+// carrying 2.0 - and the projection reads that node's own value, not the 2 it asked for
+TEST_F(MergePropertyReadTest, readsTheBoundValueRatherThanTheOneThePatternAsksFor) {
+    expectWriteRowCount("CREATE (s:Score {score: 2.0})", 0);
+
+    expectWriteRows("MERGE (s:Score {score: 2}) RETURN s.score", {{"2.000000"}});
+}
+
+// ON CREATE writes into the change, and the projection behind it reads the value there
+TEST_F(MergePropertyReadTest, readsThePropertyOnCreateSetOnARowItWrote) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) ON CREATE SET n.age = 1 RETURN n.age", {{"1"}});
+}
+
+// ON CREATE leaves a bound row alone, so that row reads the value the graph holds
+TEST_F(MergePropertyReadTest, readsTheGraphValueForARowOnCreateLeftAlone) {
+    expectWriteRows("MERGE (p:Person {name: 'Remy'}) ON CREATE SET p.age = 1 RETURN p.age", {{"32"}});
+}
+
+// A plain SET touches every row, whichever way the merge bound it
+TEST_F(MergePropertyReadTest, readsThePropertyAPlainSetWroteOnAWrittenRow) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) SET n.age = 7 RETURN n.age", {{"7"}});
+}
+
+// A property no write set is absent from the entity the merge wrote
+TEST_F(MergePropertyReadTest, readsNullForAPropertyTheWriteDidNotSet) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) RETURN n.age", {{"null"}});
+}
+
+// The hop sibling: an edge the merge wrote reads the value its own pattern carried
+TEST_F(MergePropertyReadTest, readsThePropertyOfAHopItWrote) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "
+                    "MERGE (a)-[e:KNOWS_WELL {duration: 5}]->(b) "
+                    "RETURN e.duration",
+                    {{"5"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergePropertyReadTest.cpp
+++ b/test/query/ir/MergePropertyReadTest.cpp
@@ -49,6 +49,34 @@ TEST_F(MergePropertyReadTest, readsNullForAPropertyTheWriteDidNotSet) {
     expectWriteRows("MERGE (n:Tag {name: 'x'}) RETURN n.age", {{"null"}});
 }
 
+// The labels of a row the merge wrote are the ones its pattern named, read out of the
+// change: the graph holds nothing at the provisional ID that row carries
+TEST_F(MergePropertyReadTest, readsTheLabelsOfARowItWrote) {
+    expectWriteRows("MERGE (n:Tag {name: 'x'}) RETURN labels(n)", {{"Tag"}});
+}
+
+// A row it bound reads the labels the graph holds for that node, which are the node's own
+// and not the one label the pattern named
+TEST_F(MergePropertyReadTest, readsTheGraphLabelsOfARowItBound) {
+    expectWriteRows("MERGE (p:Person {name: 'Remy'}) RETURN labels(p)",
+                    {{"Person, SoftwareEngineering, Founder"}});
+}
+
+// One merge, both kinds of row: Computers is an Interest the graph holds and Nope is one
+// the merge writes, so each row answers from where its own entity lives
+TEST_F(MergePropertyReadTest, readsTheLabelsOfTheBoundAndWrittenRowsOfOneMerge) {
+    expectWriteRows("UNWIND ['Computers', 'Nope'] AS name MERGE (i:Interest {name: name}) RETURN labels(i)",
+                    {{"Interest"}, {"SoftwareEngineering, Interest"}});
+}
+
+// The type of a hop the merge wrote is the one its pattern named
+TEST_F(MergePropertyReadTest, readsTheTypeOfAHopItWrote) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "
+                    "MERGE (a)-[e:KNOWS_WELL {duration: 5}]->(b) "
+                    "RETURN edgeType(e)",
+                    {{"KNOWS_WELL"}});
+}
+
 // The hop sibling: an edge the merge wrote reads the value its own pattern carried
 TEST_F(MergePropertyReadTest, readsThePropertyOfAHopItWrote) {
     expectWriteRows("MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) "

--- a/test/query/ir/MergeRejectionTest.cpp
+++ b/test/query/ir/MergeRejectionTest.cpp
@@ -1,63 +1,24 @@
 #include <gtest/gtest.h>
 
-#include <memory>
-#include <span>
 #include <string>
 #include <string_view>
 
-#include "NLOutputSink.h"
 #include "QueryInterpreterV3.h"
 #include "QueryStatus.h"
 
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
 #include "TuringDB.h"
 #include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
 #include "versioning/ChangeID.h"
 #include "versioning/CommitHash.h"
 
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
 
-namespace {
-
-// Discards output - the queries under test are rejected before producing rows.
-class NullSink : public NLOutputSink {
-public:
-    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
-};
-
-}
-
 // The MERGE patterns the engine turns away, and what it says about them.
-class MergeRejectionTest : public TuringTest {
-public:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-    }
-
+class MergeRejectionTest : public WriteQueryTest {
 protected:
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
     // Runs a writing query in its own change, leaving the change open: a rejected query
     // writes nothing, so nothing needs submitting
     void runQuery(std::string_view query, QueryStatus& status) {
@@ -91,11 +52,6 @@ protected:
 
         return _env->getDB().query(query, state);
     }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
 };
 
 // Every node carries at least one label, so a pattern that would have to write a
@@ -151,6 +107,31 @@ TEST_F(MergeRejectionTest, rejectsMergeOnThePipelineEngine) {
     EXPECT_FALSE(status.isOk());
     EXPECT_NE(status.getError().find("MERGE is only supported by the MLIR query engine"), std::string::npos)
         << status.getError();
+}
+
+// MERGE writes the pattern it does not find, and a variable-length hop names no one
+// path to write: Cypher has no such write pattern, so it is turned away rather than
+// silently written as a single hop
+TEST_F(MergeRejectionTest, rejectsAVariableLengthHop) {
+    QueryStatus status;
+    runQuery("MATCH (a:Person), (b:Person) MERGE (a)-[:KNOWS_WELL]->{1,3}(b)", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("Variable length relationships cannot be used in a write pattern"),
+              std::string::npos)
+        << status.getError();
+}
+
+// A CREATE's rows hold provisional IDs this change has not committed and a tombstone
+// names a committed ID, so deleting them is turned away rather than tombstoning
+// whichever committed node a provisional ID collides with
+TEST_F(MergeRejectionTest, rejectsADeleteOfWhatACreateWrote) {
+    QueryStatus status;
+    runQuery("CREATE (n:Tag {name: 'x'}) DELETE n", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("a CREATE in the same query writes it"), std::string::npos)
+        << "status: " << status.getError();
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/MergeRejectionTest.cpp
+++ b/test/query/ir/MergeRejectionTest.cpp
@@ -87,18 +87,6 @@ TEST_F(MergeRejectionTest, rejectsAPatternBindingWhatACreateInTheSameQueryWrote)
         << "status: " << status.getError();
 }
 
-// A merge's rows mix committed entities with entities this change wrote, and a tombstone
-// names a committed ID, so the mixture is turned away rather than tombstoning whichever
-// committed node a provisional ID collides with
-TEST_F(MergeRejectionTest, rejectsADeleteOfWhatAMergeBound) {
-    QueryStatus status;
-    runQuery("MERGE (n:Tag {name: 'x'}) DELETE n", status);
-
-    EXPECT_FALSE(status.isOk()) << status.getError();
-    EXPECT_NE(status.getError().find("a MERGE in the same query binds it"), std::string::npos)
-        << "status: " << status.getError();
-}
-
 // The pipeline engine has no MERGE, and says so rather than reporting a shape it failed
 // to plan
 TEST_F(MergeRejectionTest, rejectsMergeOnThePipelineEngine) {
@@ -120,18 +108,6 @@ TEST_F(MergeRejectionTest, rejectsAVariableLengthHop) {
     EXPECT_NE(status.getError().find("Variable length relationships cannot be used in a write pattern"),
               std::string::npos)
         << status.getError();
-}
-
-// A CREATE's rows hold provisional IDs this change has not committed and a tombstone
-// names a committed ID, so deleting them is turned away rather than tombstoning
-// whichever committed node a provisional ID collides with
-TEST_F(MergeRejectionTest, rejectsADeleteOfWhatACreateWrote) {
-    QueryStatus status;
-    runQuery("CREATE (n:Tag {name: 'x'}) DELETE n", status);
-
-    EXPECT_FALSE(status.isOk()) << status.getError();
-    EXPECT_NE(status.getError().find("a CREATE in the same query writes it"), std::string::npos)
-        << "status: " << status.getError();
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/MergeRejectionTest.cpp
+++ b/test/query/ir/MergeRejectionTest.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Discards output - the queries under test are rejected before producing rows.
+class NullSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const>, size_t, size_t) override {}
+};
+
+}
+
+// The MERGE patterns the engine turns away, and what it says about them.
+class MergeRejectionTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    // Runs a writing query in its own change, leaving the change open: a rejected query
+    // writes nothing, so nothing needs submitting
+    void runQuery(std::string_view query, QueryStatus& status) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        NullSink sink;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+    }
+
+    // The v2 engine, which the analyzer turns a MERGE away from
+    QueryStatus runOnPipelineEngine(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState state(_graphName,
+                               &_env->getMem(),
+                               &_queryConfig,
+                               &callbacks,
+                               CommitHash::head(),
+                               changeID);
+
+        return _env->getDB().query(query, state);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// Every node carries at least one label, so a pattern that would have to write a
+// label-less one names something the graph cannot hold
+TEST_F(MergeRejectionTest, rejectsANodePatternWithoutALabel) {
+    QueryStatus status;
+    runQuery("MERGE (n {name: 'x'})", status);
+
+    EXPECT_FALSE(status.isOk());
+    EXPECT_NE(status.getError().find("Node pattern must have at least one label"), std::string::npos)
+        << status.getError();
+}
+
+// Every edge carries exactly one type, so a hop that would have to write an untyped one
+// is turned away
+TEST_F(MergeRejectionTest, rejectsAHopWithoutAnEdgeType) {
+    QueryStatus status;
+    runQuery("MATCH (a:Person), (b:Person) MERGE (a)-[e]->(b)", status);
+
+    EXPECT_FALSE(status.isOk());
+    EXPECT_NE(status.getError().find("Edge pattern must have at least one edge type"), std::string::npos)
+        << status.getError();
+}
+
+// A CREATE's entities are provisional and the graph a merge reads holds none of them, so
+// a merge that would have to bind one is turned away rather than binding the wrong node
+TEST_F(MergeRejectionTest, rejectsAPatternBindingWhatACreateInTheSameQueryWrote) {
+    QueryStatus status;
+    runQuery("CREATE (a:Tag {name: 'x'}) MERGE (a)-[:LINKS]->(b:Tag {name: 'y'})", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("a CREATE in the same query writes it"), std::string::npos)
+        << "status: " << status.getError();
+}
+
+// A merge's rows mix committed entities with entities this change wrote, and a tombstone
+// names a committed ID, so the mixture is turned away rather than tombstoning whichever
+// committed node a provisional ID collides with
+TEST_F(MergeRejectionTest, rejectsADeleteOfWhatAMergeBound) {
+    QueryStatus status;
+    runQuery("MERGE (n:Tag {name: 'x'}) DELETE n", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("a MERGE in the same query binds it"), std::string::npos)
+        << "status: " << status.getError();
+}
+
+// The pipeline engine has no MERGE, and says so rather than reporting a shape it failed
+// to plan
+TEST_F(MergeRejectionTest, rejectsMergeOnThePipelineEngine) {
+    const QueryStatus status = runOnPipelineEngine("MERGE (n:Tag {name: 'x'})");
+
+    EXPECT_FALSE(status.isOk());
+    EXPECT_NE(status.getError().find("MERGE is only supported by the MLIR query engine"), std::string::npos)
+        << status.getError();
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeRelationshipUniquenessTest.cpp
+++ b/test/query/ir/MergeRelationshipUniquenessTest.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Each hop of a merge chain binds an edge of its own - Cypher's relationship isomorphism -
+// which is what stops an undirected chain from walking back along the edge it arrived on.
+class MergeRelationshipUniquenessTest : public WriteQueryTest {
+};
+
+// The graph holds one LINKS edge, and both hops are undirected: the second would walk
+// back along the first's edge, which is not a match, so the whole chain is written
+TEST_F(MergeRelationshipUniquenessTest, writesAChainRatherThanWalkingOneEdgeTwice) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'a'})-[:LINKS]->(b:Tag {name: 'b'})", 0);
+
+    expectWriteRowCount("MERGE (x:Tag)-[:LINKS]-(y:Tag)-[:LINKS]-(z:Tag)", 0);
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"5"}});
+    expectRows("MATCH (a:Tag)-[:LINKS]->(b:Tag) RETURN count(*)", {{"3"}});
+}
+
+// The rule excludes a repeated edge and nothing else: a chain over two distinct ones is
+// still found, so nothing is written
+TEST_F(MergeRelationshipUniquenessTest, bindsAChainOverTwoDistinctEdges) {
+    expectWriteRowCount("MERGE (a:Tag {name: 'a'})-[:LINKS]->(b:Tag {name: 'b'})"
+                        "-[:LINKS]->(c:Tag {name: 'c'})",
+                        0);
+
+    expectWriteRows("MERGE (x:Tag {name: 'a'})-[:LINKS]-(y:Tag {name: 'b'})"
+                    "-[:LINKS]-(z:Tag {name: 'c'}) "
+                    "RETURN z.name",
+                    {{"c"}});
+
+    expectRows("MATCH (t:Tag) RETURN count(t)", {{"3"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MultiMatchTest.cpp
+++ b/test/query/ir/MultiMatchTest.cpp
@@ -1,28 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <string_view>
-
-#include "NLOutputSink.h"
-#include "QueryInterpreterV3.h"
-#include "QueryStatus.h"
-
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
-#include "TuringDB.h"
-#include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
-#include "versioning/ChangeID.h"
-#include "versioning/CommitHash.h"
-
-#include "IRTestRows.h"
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
@@ -31,111 +9,7 @@ using namespace turing::test;
 // WITH between them: the clauses that share a variable join on it, and the ones that share
 // nothing cross. simpledb holds 18 nodes - 8 Persons and 10 Interests - over 18 edges, 3
 // of them KNOWS_WELL and 15 INTERESTED_IN.
-class MultiMatchTest : public TuringTest {
-protected:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-    }
-
-    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              ChangeID::head(),
-                              &_env->getMem(),
-                              sink);
-
-        return status;
-    }
-
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
-    // Runs a writing query in its own change and submits it, so a following read sees it
-    void applyWrite(std::string_view query) {
-        ChangeID changeID;
-        openChange(changeID);
-
-        NullSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              changeID,
-                              &_env->getMem(),
-                              &sink);
-
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        QueryCallbacks callbacks;
-        callbacks.setOnOutputData([](const Dataframe*) {});
-
-        const QueryState submitState(_graphName,
-                                     &_env->getMem(),
-                                     &_queryConfig,
-                                     &callbacks,
-                                     CommitHash::head(),
-                                     changeID);
-        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
-        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
-    }
-
-    void expectRows(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Rows actual;
-        sink.sortedRows(actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    void expectRowsInOrder(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        std::string actualText;
-        describeRows(sink.rows(), actualText);
-
-        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    void expectCounts(std::string_view query, const Counts& expected) {
-        CountSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Counts actual;
-        sink.sortedCounts(actual);
-
-        EXPECT_EQ(actual, expected) << "query: " << query;
-    }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
+class MultiMatchTest : public WriteQueryTest {
 };
 
 // Two clauses sharing no variable and carrying no filter cross into every ordered pair of

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -799,7 +799,7 @@ TEST_F(NLDialectTest, verifierAcceptsSetNodeProperty) {
     const mlir::Value nodeChunk = entryBlock.getArgument(0);
     const mlir::Value valueChunk = entryBlock.getArgument(1);
 
-    mlir::nl::SetNodeProperty setNode = builder.create<mlir::nl::SetNodeProperty>(loc, nodeChunk, builder.getStringAttr("age"), valueChunk);
+    mlir::nl::SetNodeProperty setNode = builder.create<mlir::nl::SetNodeProperty>(loc, nodeChunk, builder.getStringAttr("age"), valueChunk, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -826,7 +826,7 @@ TEST_F(NLDialectTest, verifierAcceptsSetEdgeProperty) {
     const mlir::Value edgeChunk = entryBlock.getArgument(0);
     const mlir::Value valueChunk = entryBlock.getArgument(1);
 
-    mlir::nl::SetEdgeProperty setEdge = builder.create<mlir::nl::SetEdgeProperty>(loc, edgeChunk, builder.getStringAttr("weight"), valueChunk);
+    mlir::nl::SetEdgeProperty setEdge = builder.create<mlir::nl::SetEdgeProperty>(loc, edgeChunk, builder.getStringAttr("weight"), valueChunk, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -853,7 +853,7 @@ TEST_F(NLDialectTest, verifierRejectsEmptySetProperty) {
     const mlir::Value nodeChunk = entryBlock.getArgument(0);
     const mlir::Value valueChunk = entryBlock.getArgument(1);
 
-    builder.create<mlir::nl::SetNodeProperty>(loc, nodeChunk, builder.getStringAttr(""), valueChunk);
+    builder.create<mlir::nl::SetNodeProperty>(loc, nodeChunk, builder.getStringAttr(""), valueChunk, mlir::Value(), mlir::Value());
     builder.create<mlir::func::ReturnOp>(loc);
 
     // The diagnostics are swallowed so the deliberate verifier failure does not

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -875,7 +875,7 @@ TEST_F(NLDialectTest, verifierAcceptsDeleteNodeDetach) {
     mlir::Block& entryBlock = function.getBody().front();
     const mlir::Value chunk = entryBlock.getArgument(0);
 
-    mlir::nl::DeleteNode deleteNode = builder.create<mlir::nl::DeleteNode>(loc, chunk, /*detach=*/true);
+    mlir::nl::DeleteNode deleteNode = builder.create<mlir::nl::DeleteNode>(loc, chunk, /*detach=*/true, mlir::Value {});
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -894,7 +894,7 @@ TEST_F(NLDialectTest, verifierAcceptsDeleteNodeNoDetach) {
     mlir::Block& entryBlock = function.getBody().front();
     const mlir::Value chunk = entryBlock.getArgument(0);
 
-    mlir::nl::DeleteNode deleteNode = builder.create<mlir::nl::DeleteNode>(loc, chunk, /*detach=*/false);
+    mlir::nl::DeleteNode deleteNode = builder.create<mlir::nl::DeleteNode>(loc, chunk, /*detach=*/false, mlir::Value {});
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
@@ -914,7 +914,7 @@ TEST_F(NLDialectTest, verifierAcceptsDeleteEdge) {
     builder.setInsertionPointToStart(function.addEntryBlock());
     const mlir::Value edgeChunk = function.getBody().front().getArgument(0);
 
-    mlir::nl::DeleteEdge deleteEdge = builder.create<mlir::nl::DeleteEdge>(loc, edgeChunk);
+    mlir::nl::DeleteEdge deleteEdge = builder.create<mlir::nl::DeleteEdge>(loc, edgeChunk, mlir::Value {});
     builder.create<mlir::func::ReturnOp>(loc);
 
     EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));

--- a/test/query/ir/SetReadbackTest.cpp
+++ b/test/query/ir/SetReadbackTest.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "WriteQueryTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// What a projection behind a SET reads: the value the statement just wrote, not the one
+// the graph held before it.
+class SetReadbackTest : public WriteQueryTest {
+};
+
+TEST_F(SetReadbackTest, readsThePropertyAPlainSetWroteOnAMatchedNode) {
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) SET p.age = 99 RETURN p.age", {{"99"}});
+
+    expectRows("MATCH (p:Person {name: 'Remy'}) RETURN p.age", {{"99"}});
+}
+
+// A merge's ON MATCH writes over the rows it bound, which are entities the graph holds
+TEST_F(SetReadbackTest, readsThePropertyOnMatchSetOnARowItBound) {
+    expectWriteRows("MERGE (p:Person {name: 'Remy'}) ON MATCH SET p.age = 1 RETURN p.age", {{"1"}});
+}
+
+// A property the node did not carry reads as the value the SET gave it, not as null
+TEST_F(SetReadbackTest, readsThePropertyASetAddedToANodeWithoutIt) {
+    expectWriteRowCount("CREATE (t:Tag {name: 'x'})", 0);
+
+    expectWriteRows("MATCH (t:Tag) SET t.age = 5 RETURN t.age", {{"5"}});
+}
+
+// A string is read back as the value the SET wrote, whose bytes the change owns
+TEST_F(SetReadbackTest, readsTheStringAPlainSetWrote) {
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) SET p.name = 'Remi' RETURN p.name", {{"Remi"}});
+}
+
+// The edge sibling of the first case
+TEST_F(SetReadbackTest, readsThePropertyAPlainSetWroteOnAMatchedEdge) {
+    expectWriteRows("MATCH (a:Person {name: 'Remy'})-[e:KNOWS_WELL]->(b:Person {name: 'Adam'}) "
+                    "SET e.duration = 3 "
+                    "RETURN e.duration",
+                    {{"3"}});
+}
+
+// The value the SET computes is read off the graph, so the expression sees what the
+// property held before the statement wrote to it
+TEST_F(SetReadbackTest, readsTheValueTheSetComputedFromTheOldOne) {
+    expectWriteRows("MATCH (p:Person {name: 'Remy'}) SET p.age = p.age + 1 RETURN p.age", {{"33"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/WithWriteTest.cpp
+++ b/test/query/ir/WithWriteTest.cpp
@@ -1,115 +1,28 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <string_view>
-
-#include "NLOutputSink.h"
-#include "QueryInterpreterV3.h"
-#include "QueryStatus.h"
-
-#include "Graph.h"
-#include "QueryConfig.h"
-#include "SimpleGraph.h"
-#include "SystemAccessor.h"
-#include "SystemManager.h"
-#include "TuringDB.h"
-#include "dataframe/Dataframe.h"
-#include "versioning/Change.h"
-#include "versioning/ChangeID.h"
-#include "versioning/CommitHash.h"
-
-#include "IRTestRows.h"
-#include "TuringTest.h"
-#include "TuringTestEnv.h"
+#include "WriteQueryTest.h"
 
 using namespace db;
 using namespace turing::test;
 
 // The writes a query part after a WITH performs: one per row the barrier published, over
 // the entities it published rather than the ones the match produced.
-class WithWriteTest : public TuringTest {
+class WithWriteTest : public WriteQueryTest {
 protected:
-    void initialize() override {
-        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
-        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
-
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        Graph* graph = system.createGraph(_graphName);
-        SimpleGraph::createSimpleGraph(graph);
-    }
-
-    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              ChangeID::head(),
-                              &_env->getMem(),
-                              sink);
-
-        return status;
-    }
-
-    void openChange(ChangeID& changeID) {
-        SystemAccessor system = _env->getSystemManager().accessUnique();
-        const auto res = system.newChange(_graphName);
-        ASSERT_TRUE(res);
-
-        changeID = res.value()->id();
-    }
-
-    QueryStatus runWrite(std::string_view query, const ChangeID& changeID) {
-        NullSink sink;
-        QueryStatus status;
-        _interpreter->execute(status,
-                              query,
-                              _graphName,
-                              CommitHash::head(),
-                              changeID,
-                              &_env->getMem(),
-                              &sink);
-
-        return status;
-    }
-
-    // Runs a writing query in its own change and submits it, so a following read sees it
-    void applyWrite(std::string_view query) {
-        ChangeID changeID;
-        openChange(changeID);
-
-        const QueryStatus status = runWrite(query, changeID);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        QueryCallbacks callbacks;
-        callbacks.setOnOutputData([](const Dataframe*) {});
-
-        const QueryState submitState(_graphName,
-                                     &_env->getMem(),
-                                     &_queryConfig,
-                                     &callbacks,
-                                     CommitHash::head(),
-                                     changeID);
-        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
-        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed";
-    }
-
     // A write the engine turns away has to name what is wrong with the query, rather than
     // trip an assertion on the way down
-    void expectWriteRejected(std::string_view query, QueryStatus::Status stage) {
-        ChangeID changeID;
+    void expectWriteRejected(std::string_view query, db::QueryStatus::Status stage) {
+        db::ChangeID changeID;
         openChange(changeID);
 
-        const QueryStatus status = runWrite(query, changeID);
+        const db::QueryStatus status = runWrite(query, changeID);
         ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
 
         const std::string& error = status.getError();
 
         EXPECT_EQ(status.getStatus(), stage)
             << "query: " << query
-            << "\nstage: " << QueryStatusDescription::value(status.getStatus())
+            << "\nstage: " << db::QueryStatusDescription::value(status.getStatus())
             << "\nerror: " << error;
 
         EXPECT_EQ(error.find("Unexpected exception"), std::string::npos)
@@ -118,38 +31,6 @@ protected:
             << "query: " << query << "\nerror: " << error;
     }
 
-    void expectRows(std::string_view query, const Rows& expected) {
-        RowSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Rows actual;
-        sink.sortedRows(actual);
-
-        Rows sortedExpected = expected;
-        std::sort(sortedExpected.begin(), sortedExpected.end());
-
-        std::string actualText;
-        describeRows(actual, actualText);
-
-        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
-    }
-
-    void expectCounts(std::string_view query, const Counts& expected) {
-        CountSink sink;
-        const QueryStatus status = runQuery(query, &sink);
-        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
-
-        Counts actual;
-        sink.sortedCounts(actual);
-
-        EXPECT_EQ(actual, expected) << "query: " << query;
-    }
-
-    const std::string _graphName = "simpledb";
-    std::unique_ptr<TuringTestEnv> _env;
-    std::unique_ptr<QueryInterpreterV3> _interpreter;
-    QueryConfig _queryConfig;
 };
 
 // The SET runs over the one row the cut left, which is Adam: the first Person in name order

--- a/test/query/ir/WriteQueryTest.cpp
+++ b/test/query/ir/WriteQueryTest.cpp
@@ -1,0 +1,171 @@
+#include "WriteQueryTest.h"
+
+#include <algorithm>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/CommitHash.h"
+
+using namespace db;
+using namespace turing::test;
+
+WriteQueryTest::WriteQueryTest() {
+}
+
+WriteQueryTest::~WriteQueryTest() {
+}
+
+void WriteQueryTest::initialize() {
+    _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+    _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+    SystemAccessor system = _env->getSystemManager().accessUnique();
+    Graph* graph = system.createGraph(_graphName);
+    SimpleGraph::createSimpleGraph(graph);
+}
+
+void WriteQueryTest::openChange(ChangeID& changeID) {
+    SystemAccessor system = _env->getSystemManager().accessUnique();
+    const auto res = system.newChange(_graphName);
+    ASSERT_TRUE(res);
+
+    changeID = res.value()->id();
+}
+
+void WriteQueryTest::submit(const ChangeID& changeID) {
+    QueryCallbacks callbacks;
+    callbacks.setOnOutputData([](const Dataframe*) {});
+
+    const QueryState submitState(_graphName,
+                                 &_env->getMem(),
+                                 &_queryConfig,
+                                 &callbacks,
+                                 CommitHash::head(),
+                                 changeID);
+    const QueryStatus status = _env->getDB().query("CHANGE SUBMIT", submitState);
+    ASSERT_TRUE(status.isOk()) << "CHANGE SUBMIT failed";
+}
+
+QueryStatus WriteQueryTest::runQuery(std::string_view query, NLOutputSink* sink) {
+    QueryStatus status;
+    _interpreter->execute(status,
+                          query,
+                          _graphName,
+                          CommitHash::head(),
+                          ChangeID::head(),
+                          &_env->getMem(),
+                          sink);
+
+    return status;
+}
+
+QueryStatus WriteQueryTest::runWrite(std::string_view query, const ChangeID& changeID) {
+    NullSink sink;
+    QueryStatus status;
+    _interpreter->execute(status,
+                          query,
+                          _graphName,
+                          CommitHash::head(),
+                          changeID,
+                          &_env->getMem(),
+                          &sink);
+
+    return status;
+}
+
+void WriteQueryTest::applyWrite(std::string_view query) {
+    ChangeID changeID;
+    openChange(changeID);
+
+    const QueryStatus status = runWrite(query, changeID);
+    ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+    submit(changeID);
+}
+
+void WriteQueryTest::writeRows(std::string_view query, Rows& rows) {
+    ChangeID changeID;
+    openChange(changeID);
+
+    RowSink sink;
+    QueryStatus status;
+    _interpreter->execute(status,
+                          query,
+                          _graphName,
+                          CommitHash::head(),
+                          changeID,
+                          &_env->getMem(),
+                          &sink);
+    ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+    sink.sortedRows(rows);
+
+    submit(changeID);
+}
+
+void WriteQueryTest::expectWriteRows(std::string_view query, const Rows& expected) {
+    Rows actual;
+    writeRows(query, actual);
+
+    Rows sortedExpected = expected;
+    std::sort(sortedExpected.begin(), sortedExpected.end());
+
+    std::string actualText;
+    describeRows(actual, actualText);
+
+    EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+}
+
+void WriteQueryTest::expectWriteRowCount(std::string_view query, size_t expected) {
+    Rows actual;
+    writeRows(query, actual);
+
+    EXPECT_EQ(actual.size(), expected) << "query: " << query;
+}
+
+void WriteQueryTest::expectRows(std::string_view query, const Rows& expected) {
+    RowSink sink;
+    const QueryStatus status = runQuery(query, &sink);
+    ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+    Rows actual;
+    sink.sortedRows(actual);
+
+    Rows sortedExpected = expected;
+    std::sort(sortedExpected.begin(), sortedExpected.end());
+
+    std::string actualText;
+    describeRows(actual, actualText);
+
+    EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+}
+
+void WriteQueryTest::expectRowsInOrder(std::string_view query, const Rows& expected) {
+    RowSink sink;
+    const QueryStatus status = runQuery(query, &sink);
+    ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+    std::string actualText;
+    describeRows(sink.rows(), actualText);
+
+    EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+}
+
+void WriteQueryTest::expectCounts(std::string_view query, const Counts& expected) {
+    CountSink sink;
+    const QueryStatus status = runQuery(query, &sink);
+    ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+    Counts actual;
+    sink.sortedCounts(actual);
+
+    EXPECT_EQ(actual, expected) << "query: " << query;
+}

--- a/test/query/ir/WriteQueryTest.h
+++ b/test/query/ir/WriteQueryTest.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <stddef.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "QueryConfig.h"
+#include "QueryStatus.h"
+#include "versioning/ChangeID.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+namespace db {
+class NLOutputSink;
+class QueryInterpreterV3;
+}
+
+namespace turing::test {
+
+// The change plumbing a test of a writing query needs: a SimpleGraph to write into, a
+// change per writing query and a submit behind it, so a following read sees what the
+// query wrote.
+class WriteQueryTest : public TuringTest {
+public:
+    WriteQueryTest();
+    ~WriteQueryTest() override;
+
+protected:
+    void initialize() override;
+
+    void openChange(db::ChangeID& changeID);
+    void submit(const db::ChangeID& changeID);
+
+    // A reading query at the graph's head, and a writing one in @param changeID
+    db::QueryStatus runQuery(std::string_view query, db::NLOutputSink* sink);
+    db::QueryStatus runWrite(std::string_view query, const db::ChangeID& changeID);
+
+    // Runs a writing query in its own change and submits it, so a following read sees it
+    void applyWrite(std::string_view query);
+
+    // The rows a writing query emits, collected in its own change and then submitted, so
+    // a following read sees what it wrote
+    void writeRows(std::string_view query, Rows& rows);
+
+    void expectWriteRows(std::string_view query, const Rows& expected);
+
+    // For the entity columns, whose IDs the graph hands out: the count of rows is what
+    // the projection is asked about, not the values
+    void expectWriteRowCount(std::string_view query, size_t expected);
+
+    // The rows a reading query emits at the graph's head, behind every change a
+    // preceding write submitted
+    void expectRows(std::string_view query, const Rows& expected);
+    void expectRowsInOrder(std::string_view query, const Rows& expected);
+    void expectCounts(std::string_view query, const Counts& expected);
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<db::QueryInterpreterV3> _interpreter;
+    db::QueryConfig _queryConfig;
+};
+
+}


### PR DESCRIPTION
Implement MERGE.

```
MERGE (n:Person {name: 'Alice'})

MATCH (p:Person) MERGE (t:Tag {name: p.name}) RETURN t.name

UNWIND [1, 1, 2] AS id MERGE (n:Tag {age: id})

MERGE (p:Person {name: 'Remy'}) ON CREATE SET p.age = 1 ON MATCH SET p.age = 33

MATCH (a:Person {name: 'Remy'}), (b:Person {name: 'Luc'}) MERGE (a)-[e:KNOWS_WELL]->(b)

MATCH (a:Person), (g:Interest) MERGE (a)-[e:KNOWS_WELL]-(g)

MATCH (a:Person), (g:Interest) MERGE (a)<-[e:KNOWS_WELL]-(g)

MERGE (a:Person {name: 'Remy'})-[e:KNOWS_WELL {duration: 20}]->(b:Person {name: 'Adam'})

MERGE (a:Tag {name: 'x'})-[:LINKS]->(b:Tag {name: 'y'})-[:LINKS]->(c:Tag {name: 'z'})

MERGE (a:Tag {name: 'x'})
MERGE (b:Tag {name: 'y'})
MERGE (a)-[:LINKS]->(b)
```

* One db.merge/nl.merge operation per path pattern.  MERGE (a:P {n:1})-[:K]->(b:P {n:2}) writes a new a and b if no such hop exists
* Execution in NLMergeExecutor in a separate translation unit
* Uses a mask to distinguish between committed ColumnNodeIDs and PendingNodeID/PendingEdgeID. The merge implementation has to support pending and non-pending IDs.
* Existing operations get_node_properties, get_edge_properties, set_node_property, set_edge_property, delete_node, delete_edge, create_edge have been modified to support both ColumnNodeIDs and pending IDs as input because they can be fed by the merge. By cypher syntax write statements can only occur after read statements so expansion operations do not need to care.

db.merge operation syntax:
```
<results> = db.merge nodes <node_labels>   props <node_prop_names>
                     edges <edge_types>    props <edge_prop_names> dirs <edge_directions>
                     bound {<bound_nodes>} pending <pending_nodes> {<bound_pending>}
                     values {<node_prop_values>} {<edge_prop_values>}
                     carrying {<carried_columns>}
``` 

Example:
```
samples/mlir/match_merge_hop.mlir
MATCH (a:Person) MERGE (a)-[e:INTERESTED_IN]->(b:Interest {name: 'Bio'}):

%0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
%1 = db.constant("Bio" : !storage.string)
%2, %3, %4, %5, %6, %7 = db.merge nodes [[], ["Interest"]] props [[], ["name"]]
                                  edges ["INTERESTED_IN"] props [[]] dirs [forward]
                                  bound {%0} pending [] {} values {%1} {} carrying {%0}
``` 
