### PR TITLE
MLIR: query composition tests and bug fix

### DIFF
--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -182,6 +182,29 @@ void FunctionDecls::initDefault() {
     maxDouble->setReturnTypes({{EvaluatedType::Double}});
     maxDouble->setIsAggregate(true);
 
+    // An extremum asks only that the group's values be ordered against each other, which
+    // Cypher orders strings and booleans by as much as numbers: min(n.name) is the least
+    // name of the group, and false orders below true.
+    FunctionSignature* minString = createFunction("min");
+    minString->setArguments({EvaluatedType::String});
+    minString->setReturnTypes({{EvaluatedType::String}});
+    minString->setIsAggregate(true);
+
+    FunctionSignature* maxString = createFunction("max");
+    maxString->setArguments({EvaluatedType::String});
+    maxString->setReturnTypes({{EvaluatedType::String}});
+    maxString->setIsAggregate(true);
+
+    FunctionSignature* minBool = createFunction("min");
+    minBool->setArguments({EvaluatedType::Bool});
+    minBool->setReturnTypes({{EvaluatedType::Bool}});
+    minBool->setIsAggregate(true);
+
+    FunctionSignature* maxBool = createFunction("max");
+    maxBool->setArguments({EvaluatedType::Bool});
+    maxBool->setReturnTypes({{EvaluatedType::Bool}});
+    maxBool->setIsAggregate(true);
+
     FunctionSignature* avgInt = createFunction("avg");
     avgInt->setArguments({EvaluatedType::Integer});
     avgInt->setReturnTypes({{EvaluatedType::Double}});

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -3186,7 +3186,10 @@ void DBProgramGenerator::translateOrderBy(const Projection* projection,
         // ORDER BY 1, n.name orders by n.name alone. An alias is only another spelling of
         // the item it was given to, so a key naming the alias of a constant item is that
         // same constant key - and the sort was handed no column to key it on either
-        const bool isConstantKey = !keyExpr->isDynamic();
+        //
+        // An aggregate is not constant however it spells its argument: count(*) reads no
+        // row and still takes a value per group, which is what orders the groups
+        const bool isConstantKey = !keyExpr->isDynamic() && !keyExpr->isAggregate();
         const bool namesAConstantItem = isProjected && sortedItem == sortedItems.end();
 
         if (isConstantKey || namesAConstantItem) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -863,7 +863,7 @@ bool DBProgramGenerator::closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* co
 
         if (kind == Stmt::Kind::WITH) {
             return false;
-        } else if (kind == Stmt::Kind::MATCH) {
+        } else if (kind == Stmt::Kind::MATCH || kind == Stmt::Kind::UNWIND) {
             return true;
         }
     }

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -169,8 +169,8 @@ private:
     void generateCSVLoads(std::span<Stmt* const> stmts);
 
     // Whether this statement closes a part on the cut it carries: a MATCH whose ORDER BY,
-    // SKIP or LIMIT reads the rows that MATCH produced, which a later MATCH of the same
-    // part would otherwise have crossed into them first
+    // SKIP or LIMIT reads the rows that MATCH produced, which a later MATCH or UNWIND of
+    // the same part would otherwise have crossed into them first
     bool closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* const> following) const;
 
     void generateTraversal(std::span<Stmt* const> stmts);

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1004,6 +1004,13 @@ void distinctKeyAppendListElementColumn(const Column* column, size_t row, std::s
     distinctAppendElementBytes(key, raw[row]);
 }
 
+// Serialize one row of a list column into the row key, so two rows key alike when their
+// lists hold equal elements - the equality Cypher gives two lists.
+void distinctKeyAppendListColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<ListView>*>(column)->getRaw();
+    distinctAppendListBytes(key, raw[row]);
+}
+
 // Count the non-null cells of a type-erased column of tagged scalars, so count(x) over a
 // heterogeneous unwind charges the same rows a nullable value column would.
 size_t countNonNullElementsColumn(const Column* column) {
@@ -4206,7 +4213,7 @@ NLKeyAppendFunction NLExecutor::selectKeyAppendFunction(NLChunkKind kind) {
         break;
 
         case NLChunkKind::List:
-            throw IRException("A list column cannot be a DISTINCT or grouping key: a list has no scalar value to key on");
+            return &distinctKeyAppendListColumn;
         break;
     }
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1632,3 +1632,14 @@ target_link_libraries(test_query_ir_list_grouping_key PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_list_grouping_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_min_max_orderable MinMaxOrderableTest.cpp)
+target_link_libraries(test_query_ir_min_max_orderable PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_min_max_orderable PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1621,3 +1621,14 @@ target_link_libraries(test_query_ir_match_cut_unwind PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_match_cut_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_list_grouping_key ListGroupingKeyTest.cpp)
+target_link_libraries(test_query_ir_list_grouping_key PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_list_grouping_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1599,3 +1599,14 @@ target_link_libraries(test_query_ir_order_by_aggregate_key PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_order_by_aggregate_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_complex_composition ComplexCompositionTest.cpp)
+target_link_libraries(test_query_ir_complex_composition PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_complex_composition PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1610,3 +1610,14 @@ target_link_libraries(test_query_ir_complex_composition PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_complex_composition PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_match_cut_unwind MatchCutUnwindTest.cpp)
+target_link_libraries(test_query_ir_match_cut_unwind PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_match_cut_unwind PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1588,3 +1588,14 @@ target_link_libraries(test_query_ir_trim_unread_columns_cypher PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_trim_unread_columns_cypher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_order_by_aggregate_key OrderByAggregateKeyTest.cpp)
+target_link_libraries(test_query_ir_order_by_aggregate_key PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_order_by_aggregate_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/ComplexCompositionTest.cpp
+++ b/test/query/ir/ComplexCompositionTest.cpp
@@ -1,0 +1,238 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Long compositions of everything a read query can drive rows with at once: several
+// MATCHes, a barrier carrying a cut, an UNWIND, a procedure or two, and two or three
+// levels of aggregation over the result. Each expectation below is derived from the
+// simpledb fixture rather than observed, so a wrong row is a wrong answer and not a
+// changed one.
+//
+// The counts the derivations rest on, pinned by the first test: the graph holds
+// 18 nodes, 9 labels and 2 edge types. Fifteen Person -[:INTERESTED_IN]-> Interest rows
+// reach ten interests, with Gym drawing three people, Bio / Computers / Cooking two each,
+// and the remaining six one each. Out of every node, Remy has four edges, Adam three,
+// Cyrus / Luc / Maxime / Suhas two, Doruk / Martina / Ghosts one.
+class ComplexCompositionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    // The rows in the order the query emits them, for the compositions ending on an
+    // ORDER BY over their groups
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// Every composition below multiplies its rows by one or both of these, so a change to the
+// fixture's schema shows up here rather than as an unexplained arithmetic failure.
+TEST_F(ComplexCompositionTest, pinsTheSchemaCountsTheDerivationsRestOn) {
+    expectRowsInOrder("CALL db.labels() YIELD label RETURN count(*)", {{"9"}});
+    expectRowsInOrder("CALL db.edgeTypes() YIELD edgeType RETURN count(*)", {{"2"}});
+    expectRowsInOrder("MATCH (n) RETURN count(*)", {{"18"}});
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) RETURN count(*)", {{"15"}});
+}
+
+// Three MATCHes behind a cut, crossed with two procedures and an UNWIND, reduced three
+// times over. Each seed contributes 2 passes * 2 edge types * 9 labels = 36 rows for
+// every edge out of every person interested in it, so grandRows is 36 times that fan-out
+// and topReached is the widest out-degree among those people.
+TEST_F(ComplexCompositionTest, reducesACutTwoHopThroughTwoProceduresAndThreeLevels) {
+    expectRowsInOrder("MATCH (p:Person)-[r1:INTERESTED_IN]->(i:Interest) "
+                      "WITH p, i, r1.proficiency AS prof ORDER BY p.name, i.name SKIP 1 LIMIT 10 "
+                      "MATCH (i)<-[r2:INTERESTED_IN]-(q:Person) "
+                      "MATCH (q)-[r3]->(j) "
+                      "UNWIND [1, 2] AS pass "
+                      "CALL db.edgeTypes() YIELD edgeType "
+                      "CALL db.labels() YIELD label "
+                      "WITH p.name AS person, i.name AS seed, q.name AS via, pass, edgeType, "
+                      "     count(*) AS labelRows, count(DISTINCT label) AS labels, "
+                      "     count(DISTINCT j.name) AS reached "
+                      "WITH person, seed, pass, count(*) AS viaTypePairs, sum(labelRows) AS allRows, "
+                      "     max(reached) AS maxReached, collect(DISTINCT via) AS vias "
+                      "WITH person, seed, count(*) AS passes, sum(allRows) AS grandRows, "
+                      "     max(maxReached) AS topReached "
+                      "ORDER BY person, seed "
+                      "RETURN person, seed, passes, grandRows, topReached",
+                      {{"Adam", "Cooking", "2", "144", "3"},
+                       {"Cyrus", "Gym", "2", "180", "2"},
+                       {"Cyrus", "Travel", "2", "72", "2"},
+                       {"Doruk", "Gym", "2", "180", "2"},
+                       {"Luc", "Animals", "2", "72", "2"},
+                       {"Luc", "Computers", "2", "216", "4"},
+                       {"Martina", "Cooking", "2", "144", "3"},
+                       {"Maxime", "Bio", "2", "180", "3"},
+                       {"Maxime", "Padel", "2", "72", "2"},
+                       {"Remy", "Computers", "2", "216", "4"}});
+}
+
+// The interests reachable from each cut seed through the people who share it. allRows is
+// the (via, reached) fan-out times the 2 passes and 2 edge types crossed into it, and
+// maxVia is how many people the most-shared reached interest was found through.
+TEST_F(ComplexCompositionTest, countsDistinctReachesOverATwoHopFanOut) {
+    expectRowsInOrder("MATCH (p:Person)-[r:INTERESTED_IN]->(i:Interest) "
+                      "WITH p, i, count(*) AS one ORDER BY p.name, i.name LIMIT 6 "
+                      "MATCH (i)<-[:INTERESTED_IN]-(q:Person) "
+                      "MATCH (q)-[:INTERESTED_IN]->(j:Interest) "
+                      "UNWIND [1, 2] AS pass "
+                      "CALL db.edgeTypes() YIELD edgeType "
+                      "WITH p.name AS person, i.name AS seed, j.name AS reached, pass, "
+                      "     count(*) AS rows, count(DISTINCT q.name) AS via "
+                      "WITH person, seed, count(DISTINCT reached) AS reachedCount, "
+                      "     sum(rows) AS allRows, max(via) AS maxVia "
+                      "ORDER BY person, seed "
+                      "RETURN person, seed, reachedCount, allRows, maxVia",
+                      {{"Adam", "Bio", "3", "16", "2"},
+                       {"Adam", "Cooking", "2", "12", "2"},
+                       {"Cyrus", "Gym", "3", "20", "3"},
+                       {"Cyrus", "Travel", "2", "8", "1"},
+                       {"Doruk", "Gym", "3", "20", "3"},
+                       {"Luc", "Animals", "2", "8", "1"}});
+}
+
+// Two procedures crossed onto a node pair and reduced away entirely: each of the 9 labels
+// pairs with each of the 2 edge types over all 324 node pairs, so the grand total is
+// 9 * 2 * 324 and no key survives to the last projection.
+TEST_F(ComplexCompositionTest, crossesTwoProceduresThroughThreeAggregationLevels) {
+    expectRowsInOrder("MATCH (a) MATCH (b) "
+                      "CALL db.labels() YIELD label "
+                      "CALL db.edgeTypes() YIELD edgeType "
+                      "WITH label, edgeType, count(*) AS pairs "
+                      "WITH label, count(*) AS types, sum(pairs) AS total "
+                      "WITH count(*) AS labels, sum(total) AS grand, max(types) AS maxTypes "
+                      "RETURN labels, grand, maxTypes",
+                      {{"9", "5832", "2"}});
+}
+
+// The same shape over enough rows to span several chunks: 18^4 node quadruples crossed
+// with 9 labels is 944784 rows, grouped down to one row per label and then cut to five of
+// them, so the cut and the collect run over groups the aggregation folded across chunk
+// boundaries.
+TEST_F(ComplexCompositionTest, cutsTheGroupsOfAChunkCrossingProcedureCross) {
+    expectRowsInOrder("MATCH (a) MATCH (b) MATCH (c) MATCH (d) "
+                      "CALL db.labels() YIELD label "
+                      "WITH label, count(*) AS rows "
+                      "WITH label, rows ORDER BY label SKIP 2 LIMIT 5 "
+                      "WITH collect(label) AS labels, sum(rows) AS total, count(*) AS kept "
+                      "RETURN labels, total, kept",
+                      {{"[Founder, Interest, Person, Sales, SleepDisturber]", "524880", "5"}});
+}
+
+// A cut window of eight interests, each crossed with the people who share it and then
+// with every label: labelHits is the fan-out repeated per label, so hits is 9 times it
+// and maxHits is the fan-out itself.
+TEST_F(ComplexCompositionTest, reducesTheFansOfEachCutInterestOverEveryLabel) {
+    expectRowsInOrder("MATCH (p:Person)-[r:INTERESTED_IN]->(i:Interest) "
+                      "WITH p, i, r.proficiency AS prof ORDER BY p.name, i.name SKIP 2 LIMIT 8 "
+                      "MATCH (i)<-[:INTERESTED_IN]-(other:Person) "
+                      "CALL db.labels() YIELD label "
+                      "WITH p.name AS person, i.name AS interest, label, "
+                      "     count(*) AS labelHits, collect(other.name) AS others "
+                      "WITH person, interest, count(*) AS labels, sum(labelHits) AS hits, "
+                      "     max(labelHits) AS maxHits "
+                      "ORDER BY person, interest "
+                      "RETURN person, interest, labels, hits, maxHits",
+                      {{"Cyrus", "Gym", "9", "27", "3"},
+                       {"Cyrus", "Travel", "9", "9", "1"},
+                       {"Doruk", "Gym", "9", "27", "3"},
+                       {"Luc", "Animals", "9", "9", "1"},
+                       {"Luc", "Computers", "9", "18", "2"},
+                       {"Martina", "Cooking", "9", "18", "2"},
+                       {"Maxime", "Bio", "9", "18", "2"},
+                       {"Maxime", "Padel", "9", "9", "1"}});
+}
+
+// Every interest joined to itself through the people who share it, which is one row per
+// ordered pair of its fans: the squared fan-outs sum to 27 whichever pass and edge type
+// they are crossed with, and Gym's three fans are the widest group.
+TEST_F(ComplexCompositionTest, countsDistinctEndpointsOfEverySharedInterest) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "MATCH (i)<-[:INTERESTED_IN]-(q:Person) "
+                      "UNWIND [1, 2] AS pass "
+                      "CALL db.edgeTypes() YIELD edgeType "
+                      "WITH pass, edgeType, i.name AS interest, count(*) AS rows, "
+                      "     count(DISTINCT p.name) AS ps, count(DISTINCT q.name) AS qs, "
+                      "     collect(DISTINCT p.name) AS people "
+                      "WITH pass, edgeType, count(*) AS interests, sum(rows) AS totalRows, "
+                      "     max(ps) AS maxPs "
+                      "ORDER BY pass, edgeType "
+                      "RETURN pass, edgeType, interests, totalRows, maxPs",
+                      {{"1", "INTERESTED_IN", "10", "27", "3"},
+                       {"1", "KNOWS_WELL", "10", "27", "3"},
+                       {"2", "INTERESTED_IN", "10", "27", "3"},
+                       {"2", "KNOWS_WELL", "10", "27", "3"}});
+}
+
+// Two UNWINDs and two procedures stacked with no MATCH under them at all: the rows are
+// driven entirely by the literal lists and the procedure results, and every (x, y) pair
+// sees each of the 2 edge types carrying all 9 labels.
+TEST_F(ComplexCompositionTest, reducesTwoStackedUnwindsAndTwoProcedures) {
+    expectRowsInOrder("UNWIND [1, 2] AS x "
+                      "CALL db.edgeTypes() YIELD edgeType "
+                      "UNWIND [3, 4] AS y "
+                      "CALL db.labels() YIELD label "
+                      "WITH x, y, edgeType, count(*) AS labels "
+                      "WITH x, y, count(*) AS types, sum(labels) AS total "
+                      "ORDER BY x, y "
+                      "RETURN x, y, types, total",
+                      {{"1", "3", "2", "18"},
+                       {"1", "4", "2", "18"},
+                       {"2", "3", "2", "18"},
+                       {"2", "4", "2", "18"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/ListGroupingKeyTest.cpp
+++ b/test/query/ir/ListGroupingKeyTest.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The interests of each of the eight simpledb people, which is what a WITH publishing a
+// collect leaves for the next barrier to group on: eight lists, no two of them equal, so
+// grouping on the list alone tells every person's rows apart.
+const Rows interestListsWithOneRowEach = {
+    {"[Ghosts, Computers, Eighties]", "1"},
+    {"[Bio, Cooking]", "1"},
+    {"[Bio, Padel]", "1"},
+    {"[Animals, Computers]", "1"},
+    {"[Cooking]", "1"},
+    {"[Gym, JiuJitsu]", "1"},
+    {"[Gym, Travel]", "1"},
+    {"[Gym]", "1"},
+};
+
+const Rows interestLists = {
+    {"[Ghosts, Computers, Eighties]"},
+    {"[Bio, Cooking]"},
+    {"[Bio, Padel]"},
+    {"[Animals, Computers]"},
+    {"[Cooking]"},
+    {"[Gym, JiuJitsu]"},
+    {"[Gym, Travel]"},
+    {"[Gym]"},
+};
+
+}
+
+// A list is a value of the language like any other: two of them are equal when their
+// elements are, so a list column groups and dedups on that equality. A grouping key or a
+// DISTINCT over a collected list is valid Cypher, and the rows it reduces are the ones
+// whose lists are equal.
+class ListGroupingKeyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(ListGroupingKeyTest, groupsOnACollectedList) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p, collect(i.name) AS interests "
+               "WITH interests, count(*) AS people RETURN interests, people",
+               interestListsWithOneRowEach);
+}
+
+TEST_F(ListGroupingKeyTest, dedupsOnACollectedList) {
+    expectRows("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+               "WITH p, collect(i.name) AS interests RETURN DISTINCT interests",
+               interestLists);
+}
+
+// One list crossed with the ten interests: the whole cross product is the single group
+// the one list keys, so the count is every row of it.
+TEST_F(ListGroupingKeyTest, groupsOnAListCarriedAcrossACrossProduct) {
+    expectRows("MATCH (p:Person) WHERE p.name = 'Remy' WITH collect(p.name) AS people "
+               "MATCH (i:Interest) RETURN people, count(*)",
+               {{"[Remy]", "10"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MatchCutUnwindTest.cpp
+++ b/test/query/ir/MatchCutUnwindTest.cpp
@@ -1,0 +1,137 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A cut a MATCH carries is charged to the rows that MATCH produced. An UNWIND written
+// after it opens a dataflow of its own and crosses those rows, so the cut has to have
+// been applied before the cross: charging it to the crossed rows spends the limit on
+// repetitions of the first row and drops the rest of the matched entities outright.
+class MatchCutUnwindTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    // An UNWIND does not order what it crosses, so the rows are compared as a set
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The two people the limit keeps are Adam and Cyrus, and each is crossed with both
+// elements of the list: four rows, and Cyrus is one of them.
+TEST_F(MatchCutUnwindTest, crossesTheUnwindWithTheRowsTheLimitKept) {
+    expectRows("MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x RETURN a.name, x",
+               {{"Adam", "1"}, {"Adam", "2"}, {"Cyrus", "1"}, {"Cyrus", "2"}});
+}
+
+TEST_F(MatchCutUnwindTest, countsTheRowsTheLimitKeptCrossedWithTheUnwind) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x RETURN count(*)", {4});
+}
+
+// A SKIP is charged to the same rows: the two people left after six are dropped, each
+// crossed with both elements.
+TEST_F(MatchCutUnwindTest, crossesTheUnwindWithTheRowsTheSkipKept) {
+    expectRows("MATCH (a:Person) ORDER BY a.name SKIP 6 UNWIND [1, 2] AS x RETURN a.name, x",
+               {{"Remy", "1"}, {"Remy", "2"}, {"Suhas", "1"}, {"Suhas", "2"}});
+}
+
+// Every person the limit kept reaches the group of each unwound value, so both lists hold
+// both of them: a cut charged to the crossed rows loses one of the two entirely.
+TEST_F(MatchCutUnwindTest, collectsEveryRowTheLimitKept) {
+    expectRows("MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x "
+               "WITH x, collect(a.name) AS people RETURN x, people",
+               {{"1", "[Adam, Cyrus]"}, {"2", "[Adam, Cyrus]"}});
+}
+
+TEST_F(MatchCutUnwindTest, crossesTwoUnwindsWithTheRowsTheLimitKept) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name LIMIT 2 "
+                 "UNWIND [1, 2] AS x UNWIND [3, 4] AS y RETURN count(*)",
+                 {8});
+}
+
+// The same cut spelled on a barrier, which already charges it to the matched rows: the
+// MATCH-level cut above has to land on the same four rows as this.
+TEST_F(MatchCutUnwindTest, cutsAtABarrierBeforeTheUnwind) {
+    expectRows("MATCH (a:Person) WITH a ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x RETURN a.name, x",
+               {{"Adam", "1"}, {"Adam", "2"}, {"Cyrus", "1"}, {"Cyrus", "2"}});
+}
+
+// A MATCH written after the UNWIND already closes the part on its cut, so the two people
+// are crossed with both elements and then with the ten interests.
+TEST_F(MatchCutUnwindTest, cutsWhenAMatchFollowsTheUnwind) {
+    expectCounts("MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x "
+                 "MATCH (i:Interest) RETURN count(*)",
+                 {40});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MinMaxOrderableTest.cpp
+++ b/test/query/ir/MinMaxOrderableTest.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// min and max reduce a group to one of the values it holds, which asks only that the
+// values be ordered against each other. Strings and booleans are ordered by the language,
+// so they reduce as numbers do rather than being turned away as invalid arguments.
+class MinMaxOrderableTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(MinMaxOrderableTest, reducesTheLeastAndGreatestName) {
+    expectRowsInOrder("MATCH (p:Person) RETURN min(p.name), max(p.name)", {{"Adam", "Suhas"}});
+}
+
+// The two extremes of each person's interests, which for a group of one are both that one
+// value.
+TEST_F(MinMaxOrderableTest, reducesTheLeastAndGreatestNameOfEachGroup) {
+    expectRowsInOrder("MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest) "
+                      "RETURN p.name, min(i.name), max(i.name) ORDER BY p.name",
+                      {{"Adam", "Bio", "Cooking"},
+                       {"Cyrus", "Gym", "Travel"},
+                       {"Doruk", "Gym", "Gym"},
+                       {"Luc", "Animals", "Computers"},
+                       {"Martina", "Cooking", "Cooking"},
+                       {"Maxime", "Bio", "Padel"},
+                       {"Remy", "Computers", "Ghosts"},
+                       {"Suhas", "Gym", "JiuJitsu"}});
+}
+
+// The interests that carry the property hold both booleans, and false orders below true.
+// The ones carrying no isReal at all reduce to nothing, as a null does for every other
+// aggregate.
+TEST_F(MinMaxOrderableTest, reducesTheLeastAndGreatestBoolean) {
+    expectRowsInOrder("MATCH (i:Interest) RETURN min(i.isReal), max(i.isReal)", {{"false", "true"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/OrderByAggregateKeyTest.cpp
+++ b/test/query/ir/OrderByAggregateKeyTest.cpp
@@ -1,0 +1,181 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The eight simpledb people with an out-edge, ordered by how many they have and then by
+// name: the order ORDER BY count(*) DESC, a.name asks for over the seventeen out-edge
+// rows of MATCH (a:Person)-->(b).
+const Rows peopleByOutDegreeDescending = {
+    {"Remy"}, {"Adam"}, {"Cyrus"}, {"Luc"}, {"Maxime"}, {"Suhas"}, {"Doruk"}, {"Martina"},
+};
+
+const Rows peopleByOutDegreeAscending = {
+    {"Doruk"}, {"Martina"}, {"Cyrus"}, {"Luc"}, {"Maxime"}, {"Suhas"}, {"Adam"}, {"Remy"},
+};
+
+const Rows peopleAndOutDegreeDescending = {
+    {"Remy", "4"},
+    {"Adam", "3"},
+    {"Cyrus", "2"},
+    {"Luc", "2"},
+    {"Maxime", "2"},
+    {"Suhas", "2"},
+    {"Doruk", "1"},
+    {"Martina", "1"},
+};
+
+}
+
+// An ORDER BY keyed on an aggregate orders the groups by what the aggregate reduced for
+// each of them. count(*) reduces a value per group like every other aggregate, so it is a
+// key like every other one - the argument it reads no column through says nothing about
+// whether the key varies from group to group.
+class OrderByAggregateKeyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    // The rows in the order the query emits them, which is what an ORDER BY is
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheirCountOfRows) {
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*) DESC, a.name",
+                      peopleByOutDegreeDescending);
+}
+
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheirCountOfRowsAscending) {
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*), a.name",
+                      peopleByOutDegreeAscending);
+}
+
+// The top-N shape the key exists for: the three people with the most out-edges, not the
+// three that come first alphabetically.
+TEST_F(OrderByAggregateKeyTest, takesTheGroupsWithTheMostRows) {
+    const Rows topThree {peopleByOutDegreeDescending.begin(), peopleByOutDegreeDescending.begin() + 3};
+
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*) DESC, a.name LIMIT 3",
+                      topThree);
+}
+
+// The key orders the groups whether or not the projection returns the count as well.
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheProjectedCountOfRows) {
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name, count(*) ORDER BY count(*) DESC, a.name",
+                      peopleAndOutDegreeDescending);
+}
+
+// With no second key the surviving group is whichever one holds the fewest rows, and one
+// row is the fewest any group of a match holds: only the count it kept is the query's
+// answer, since the people holding it are tied.
+TEST_F(OrderByAggregateKeyTest, takesTheGroupWithTheFewestRows) {
+    expectCounts("MATCH (a:Person)-->(b) RETURN a.name, count(*) ORDER BY count(*) LIMIT 1", {1});
+}
+
+// count(1) reduces a value per group as count(*) does, so it is a key on the same terms.
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheirCountOverAConstant) {
+    const Rows topThree {peopleByOutDegreeDescending.begin(), peopleByOutDegreeDescending.begin() + 3};
+
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(1) DESC, a.name LIMIT 3",
+                      topThree);
+}
+
+// An item may carry an aggregate without being one, and so may a key: negating the count
+// orders the groups by it ascending, which is the descending order of the count itself.
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByAnArithmeticOverTheirCountOfRows) {
+    const Rows topThree {peopleByOutDegreeDescending.begin(), peopleByOutDegreeDescending.begin() + 3};
+
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*) * -1, a.name LIMIT 3",
+                      topThree);
+}
+
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheirCountOfRowsAtABarrier) {
+    expectRowsInOrder("MATCH (a:Person)-->(b) WITH a.name AS person, count(*) AS outEdges "
+                      "ORDER BY count(*) DESC, person LIMIT 3 RETURN person, outEdges",
+                      {{"Remy", "4"}, {"Adam", "3"}, {"Cyrus", "2"}});
+}
+
+// The same order asked for through a key that reads a column, and through the alias of
+// the count: the two spellings that already order the groups, so the key above has to
+// land on the same rows as these.
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByACountOverAColumn) {
+    const Rows topThree {peopleByOutDegreeDescending.begin(), peopleByOutDegreeDescending.begin() + 3};
+
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(b) DESC, a.name LIMIT 3",
+                      topThree);
+}
+
+TEST_F(OrderByAggregateKeyTest, ordersGroupsByTheAliasOfTheirCountOfRows) {
+    expectRowsInOrder("MATCH (a:Person)-->(b) RETURN a.name, count(*) AS outEdges "
+                      "ORDER BY outEdges DESC, a.name LIMIT 3",
+                      {{"Remy", "4"}, {"Adam", "3"}, {"Cyrus", "2"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Try to generate complex or intricate queries and found bugs along the way

```
MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*) DESC, a.name LIMIT 3

MATCH (a:Person)-->(b) RETURN a.name, count(*) ORDER BY count(*) DESC, a.name

MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(1) DESC, a.name LIMIT 3

MATCH (a:Person)-->(b) RETURN a.name ORDER BY count(*) * -1, a.name LIMIT 3

MATCH (a:Person)-->(b)
WITH a.name AS person, count(*) AS outEdges ORDER BY count(*) DESC, person LIMIT 3
RETURN person, outEdges

MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x RETURN a.name, x

MATCH (a:Person) ORDER BY a.name LIMIT 2 UNWIND [1, 2] AS x
WITH x, collect(a.name) AS people
RETURN x, people

MATCH (p:Person)-[:INTERESTED_IN]->(i:Interest)
WITH p, collect(i.name) AS interests
WITH interests, count(*) AS people
RETURN interests, people

MATCH (p:Person) WHERE p.name = 'Remy' WITH collect(p.name) AS people
MATCH (i:Interest)
RETURN people, count(*)

MATCH (p:Person) RETURN min(p.name), max(p.name)

MATCH (i:Interest) RETURN min(i.isReal), max(i.isReal)

MATCH (a) MATCH (b) MATCH (c) MATCH (d)
CALL db.labels() YIELD label
WITH label, count(*) AS rows
WITH label, rows ORDER BY label SKIP 2 LIMIT 5
WITH collect(label) AS labels, sum(rows) AS total, count(*) AS kept
RETURN labels, total, kept

MATCH (p:Person)-[r1:INTERESTED_IN]->(i:Interest)
WITH p, i, r1.proficiency AS prof ORDER BY p.name, i.name SKIP 1 LIMIT 10
MATCH (i)<-[r2:INTERESTED_IN]-(q:Person)
MATCH (q)-[r3]->(j)
UNWIND [1, 2] AS pass
CALL db.edgeTypes() YIELD edgeType
CALL db.labels() YIELD label
WITH p.name AS person, i.name AS seed, q.name AS via, pass, edgeType,
     count(*) AS labelRows, count(DISTINCT label) AS labels,
     count(DISTINCT j.name) AS reached
WITH person, seed, pass, count(*) AS viaTypePairs, sum(labelRows) AS allRows,
     max(reached) AS maxReached, collect(DISTINCT via) AS vias
WITH person, seed, count(*) AS passes, sum(allRows) AS grandRows,
     max(maxReached) AS topReached
ORDER BY person, seed
RETURN person, seed, passes, grandRows, topReached
```
