### PR TITLE
MLIR: fuse scan nodes + get_out_edges into scan_edges

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -964,6 +964,7 @@ void DBProgramGenerator::runPasses() {
     passManager.addPass(mlir::db::createPushDownFilters());
     passManager.addPass(mlir::db::createFuseUnwindEquality());
     passManager.addPass(mlir::db::createFuseScanByNodeIDs());
+    passManager.addPass(mlir::db::createFuseScanEdges());
     passManager.addPass(mlir::db::createTrimUnreadColumns());
 
     if (mlir::failed(passManager.run(*_module))) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -27,6 +27,7 @@ namespace mlir::db {
 #define GEN_PASS_DEF_PUSHDOWNFILTERS
 #define GEN_PASS_DEF_FUSEUNWINDEQUALITY
 #define GEN_PASS_DEF_FUSESCANBYNODEIDS
+#define GEN_PASS_DEF_FUSESCANEDGES
 #define GEN_PASS_DEF_TRIMUNREADCOLUMNS
 #include "DBPasses.h.inc"
 
@@ -774,6 +775,73 @@ struct FuseScanByNodeIDs : public impl::FuseScanByNodeIDsBase<FuseScanByNodeIDs>
             }
 
             fuseScanByNodeIDs(filter, chain, builder);
+        }
+    }
+};
+
+// A hop over a whole-graph node scan walks every node's edges, which is the whole edge
+// set - what a scan_edges produces on its own.
+bool matchWholeEdgeSetHop(Operation* hop, ScanNodes& scan) {
+    // get_edges walks both directions, so over every node it reports each edge twice, once
+    // from each endpoint, and the by-type hops keep one type. Only the directed untyped
+    // hops read the edge set a scan_edges produces.
+    if (!isa<GetOutEdges, GetInEdges>(hop)) {
+        return false;
+    }
+
+    // Operand 0 is the input node column and anything after it is a carry set, row-aligned
+    // with the scan and with no counterpart in a scan_edges to be rewired to.
+    if (hop->getNumOperands() != 1) {
+        return false;
+    }
+
+    scan = hop->getOperand(0).getDefiningOp<ScanNodes>();
+    if (!scan) {
+        return false;
+    }
+
+    // The fused form drops the node column, so a second reader of it keeps the scan alive.
+    return scan.getResult().hasOneUse();
+}
+
+void fuseScanEdges(Operation* hop, ScanNodes scan, mlir::OpBuilder& builder) {
+    builder.setInsertionPoint(hop);
+
+    // Both directed hops fill srcids and tgtids with the edge's own source and target -
+    // the direction only decided which side was walked from - so the hop's four results
+    // map one-for-one onto the edge scan's, which are declared in the same order.
+    ScanEdges edgeScan = builder.create<ScanEdges>(hop->getLoc(),
+                                                   hop->getResult(0).getType(),
+                                                   hop->getResult(1).getType(),
+                                                   hop->getResult(2).getType(),
+                                                   hop->getResult(3).getType());
+
+    hop->replaceAllUsesWith(edgeScan.getOperation());
+    hop->erase();
+    scan.erase();
+}
+
+struct FuseScanEdges : public impl::FuseScanEdgesBase<FuseScanEdges> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        // Collect first: fusing erases the hop and its scan, which would invalidate the walk.
+        llvm::SmallVector<Operation*> hops;
+        root->walk([&](Operation* op) {
+            ScanNodes scan;
+            if (matchWholeEdgeSetHop(op, scan)) {
+                hops.push_back(op);
+            }
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (Operation* const hop : hops) {
+            ScanNodes scan;
+            if (!matchWholeEdgeSetHop(hop, scan)) {
+                continue;
+            }
+
+            fuseScanEdges(hop, scan, builder);
         }
     }
 };

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -23,6 +23,11 @@ def FuseScanByNodeIDs : Pass<"fuse_scan_by_node_ids"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def FuseScanEdges : Pass<"fuse_scan_edges"> {
+    let summary = "Fuse a whole-graph node scan and its directed untyped hop into a scan_edges";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 def TrimUnreadColumns : Pass<"trim_unread_columns"> {
     let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products and grouping ops";
     let dependentDialects = ["mlir::db::DB"];

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -234,8 +234,31 @@ add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
 add_ir_tests(test_query_ir_fuse_scan_by_node_ids FuseScanByNodeIDsTest.cpp)
 add_ir_tests(test_query_ir_trim_unread_columns TrimUnreadColumnsTest.cpp)
 
+# The edge-scan fusion tests check the rewritten db program, then lower and run it
+# against the shared SimpleGraph fixture to compare its rows with the unfused hop's.
+add_ir_tests(test_query_ir_fuse_scan_edges FuseScanEdgesTest.cpp)
+target_link_libraries(test_query_ir_fuse_scan_edges PRIVATE turing_db_examples_s)
+
 # The codegen-level cases compile Cypher through the parser, analyzer and DBProgramGenerator
 # against the shared SimpleGraph fixture and read the db program the pass pipeline leaves.
+add_turing_test(test_query_ir_fuse_scan_edges_codegen FuseScanEdgesCodegenTest.cpp)
+target_link_libraries(test_query_ir_fuse_scan_edges_codegen PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s)
+target_include_directories(test_query_ir_fuse_scan_edges_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_fuse_scan_by_node_ids_codegen FuseScanByNodeIDsCodegenTest.cpp)
 target_link_libraries(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE
         turing_db_s

--- a/test/query/ir/CallDrivenIslandCodegenTest.cpp
+++ b/test/query/ir/CallDrivenIslandCodegenTest.cpp
@@ -140,7 +140,8 @@ TEST_F(CallDrivenIslandCodegenTest, secondYieldedColumnDeclinesTheDrivenPath) {
         generate("CALL db.getNodes([0]) YIELD id AS a, inEdgeCount MATCH (a)-->(m), (x) RETURN a, m, x, inEdgeCount");
 
     EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 2u);
-    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 2u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 1u);
     EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 1u);
 }
 
@@ -149,7 +150,8 @@ TEST_F(CallDrivenIslandCodegenTest, yieldedPatternEndpointsDeclineTheDrivenPath)
         generate("CALL db.getEdges([0]) YIELD src, tgt MATCH (src)-->(tgt), (x) RETURN src, tgt, x");
 
     EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 2u);
-    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 2u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 1u);
     EXPECT_EQ(countOps<mlir::db::EqOp>(*module), 2u);
 }
 

--- a/test/query/ir/FuseScanEdgesCodegenTest.cpp
+++ b/test/query/ir/FuseScanEdgesCodegenTest.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+}
+
+// Generates the db program a Cypher query compiles to, passes included, so a test reads
+// the shape the engine will lower rather than a hand-written approximation of it.
+class FuseScanEdgesCodegenTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+    // The program opens on one edge scan and no node scan or hop is left.
+    void expectFusedToEdgeScan(mlir::ModuleOp module) {
+        EXPECT_EQ(countOps<mlir::db::ScanEdges>(module), 1u);
+        EXPECT_EQ(countOps<mlir::db::ScanNodes>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::GetOutEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::GetInEdges>(module), 0u);
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(FuseScanEdgesCodegenTest, bothEndpointsOfAHopBecomeAnEdgeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-->(b) RETURN a, b");
+
+    expectFusedToEdgeScan(*module);
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+    mlir::db::ScanEdges edgeScan = edgeScans.front();
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::Operation::operand_range columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], edgeScan.getSrcids());
+    EXPECT_EQ(columns[1], edgeScan.getTgtids());
+}
+
+TEST_F(FuseScanEdgesCodegenTest, targetOnlyProjectionBecomesAnEdgeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-->(b) RETURN b");
+
+    expectFusedToEdgeScan(*module);
+}
+
+TEST_F(FuseScanEdgesCodegenTest, reverseHopBecomesAnEdgeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)<--(b) RETURN a, b");
+
+    expectFusedToEdgeScan(*module);
+}
+
+TEST_F(FuseScanEdgesCodegenTest, edgeVariableAndItsPropertyReadOffTheEdgeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-[r]->(b) RETURN a, r.name, b");
+
+    expectFusedToEdgeScan(*module);
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+
+    // The edge property is read off the scan's own edge-ID column.
+    llvm::SmallVector<mlir::db::GetEdgeProperties> properties = collect<mlir::db::GetEdgeProperties>(*module);
+    ASSERT_EQ(properties.size(), 1u);
+    EXPECT_EQ(properties.front().getInputEdges(), edgeScans.front().getEids());
+}
+
+TEST_F(FuseScanEdgesCodegenTest, labelledEndpointKeepsItsNodeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a:Person)-->(b) RETURN a, b");
+
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodesByLabel>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 1u);
+}
+
+// A relationship type compiles to a plain hop and a type check over its edge column, not
+// to a get_out_edges_by_type, so the hop fuses and the check narrows the edge scan.
+TEST_F(FuseScanEdgesCodegenTest, typedEdgeFusesAndKeepsItsTypeCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-[:KNOWS_WELL]->(b) RETURN a, b");
+
+    expectFusedToEdgeScan(*module);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(*module), 0u);
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+
+    llvm::SmallVector<mlir::db::CheckEdgeTypeConstraint> checks = collect<mlir::db::CheckEdgeTypeConstraint>(*module);
+    ASSERT_EQ(checks.size(), 1u);
+    EXPECT_EQ(checks.front().getEdgeTypeIds(), edgeScans.front().getEtypes());
+}
+
+TEST_F(FuseScanEdgesCodegenTest, undirectedHopKeepsItsNodeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)--(b) RETURN a, b");
+
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetEdges>(*module), 1u);
+}
+
+TEST_F(FuseScanEdgesCodegenTest, sourcePredicateSinksToTheScanAndKeepsIt) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-->(b) WHERE a.name = 'Remy' RETURN a, b");
+
+    // The predicate sank onto a's scan, so the hop no longer expands the raw scan.
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 1u);
+}
+
+TEST_F(FuseScanEdgesCodegenTest, twoHopChainFusesOnlyItsFirstHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-->(b)-->(c) RETURN a, c");
+
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 1u);
+}

--- a/test/query/ir/FuseScanEdgesTest.cpp
+++ b/test/query/ir/FuseScanEdgesTest.cpp
@@ -1,0 +1,437 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <span>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "Graph.h"
+#include "columns/ColumnIDs.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "LocalMemory.h"
+#include "SimpleGraph.h"
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+// Accumulates the two node-ID columns of an emitted (source, target) pair.
+class CollectingPairSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const ColumnNodeIDs* sources = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        const ColumnNodeIDs* targets = dynamic_cast<const ColumnNodeIDs*>(chunks[1]);
+        ASSERT_NE(sources, nullptr);
+        ASSERT_NE(targets, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _pairs.emplace_back((*sources)[rowIndex].getValue(), (*targets)[rowIndex].getValue());
+        }
+    }
+
+    void sortedPairs(std::vector<std::pair<uint64_t, uint64_t>>& pairs) const {
+        pairs = _pairs;
+        std::sort(pairs.begin(), pairs.end());
+    }
+
+private:
+    std::vector<std::pair<uint64_t, uint64_t>> _pairs;
+};
+
+// MATCH (a)-->(b) RETURN a, b
+const char* const outHopOverFullScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)<--(b) RETURN a, b, whose four columns hold the same edge set: the hop
+// walks predecessors, but srcids is still the edge's own source and tgtids its target.
+const char* const inHopOverFullScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a:Person)-->(b) RETURN a, b
+const char* const outHopOverLabelScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-->(b) WHERE a = 1 OR a = 3 RETURN a, b, once the ID filter fused into the scan
+const char* const outHopOverConstScan = R"mlir(
+func.func @main() {
+  %a = db.const_scan_nodes([1, 3]) : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)--(b) RETURN a, b: the undirected hop walks both directions, so over
+// every node it reports each edge twice - once from each endpoint.
+const char* const undirectedHopOverFullScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[:KNOWS]->(b) RETURN a, b
+const char* const typedHopOverFullScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %srcs, %eids, %etypes, %tgts = db.get_out_edges_by_type(%a, "KNOWS", {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%srcs, %tgts) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A hop carrying a column read off its own input: the carried column is row-aligned
+// with the scan, and a scan_edges has nothing to filter it against.
+const char* const hopCarryingAColumn = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %srcs, %eids, %etypes, %tgts, %agef = db.get_out_edges(%a, {%age}) : (!db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<i64>)
+  db.output(%tgts, %agef) : !db.column<!storage.node_id>, !db.column<i64>
+  return
+}
+)mlir";
+
+// Two hops off the same scan: the raw node column has a second reader, which the
+// fused form no longer produces.
+const char* const twoHopsOffOneScan = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %t1, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %t2, %c = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%b, %c) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-->(b)-->(c) RETURN a, c: only the first hop expands the scan.
+const char* const twoHopChain = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %a1, %e0, %et0, %b = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %b2, %e1, %et1, %c, %a2 = db.get_out_edges(%b, {%a1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%a2, %c) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-->(b) MATCH (m) RETURN a, b, m
+const char* const outHopInCrossProductFactor = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    %srcs, %eids, %etypes, %tgts = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+    db.yield %srcs, %tgts : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+}
+
+class FuseScanEdgesTest : public TuringTest {
+protected:
+    void initialize() override {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool runFuse(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createFuseScanEdges());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    // The module holds exactly its original scan and hop and no edge scan.
+    void expectUntouched(mlir::ModuleOp module, size_t hopCount) {
+        EXPECT_EQ(countOps<mlir::db::ScanEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::ScanNodes>(module)
+                      + countOps<mlir::db::ScanNodesByLabel>(module)
+                      + countOps<mlir::db::ConstScanNodes>(module),
+                  1u);
+
+        const size_t hops = countOps<mlir::db::GetOutEdges>(module)
+                            + countOps<mlir::db::GetInEdges>(module)
+                            + countOps<mlir::db::GetEdges>(module)
+                            + countOps<mlir::db::GetOutEdgesByType>(module);
+        EXPECT_EQ(hops, hopCount);
+    }
+
+    // Lowers the db program as it stands and interprets it over the graph, filling
+    // the (source, target) pairs it emits, sorted.
+    void runPairs(mlir::ModuleOp module,
+                  const GraphView& view,
+                  std::vector<std::pair<uint64_t, uint64_t>>& pairs) {
+        const mlir::func::FuncOp dbFunction = module.lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&_context));
+        DBLowering lowering(&_context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        CollectingPairSink sink;
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+
+        sink.sortedPairs(pairs);
+    }
+
+    // The pairs the program emits before the fusion and after it, over simpledb.
+    void runPairsBeforeAndAfterFusion(const char* programText,
+                                      std::vector<std::pair<uint64_t, uint64_t>>& unfused,
+                                      std::vector<std::pair<uint64_t, uint64_t>>& fused) {
+        auto graph = Graph::create();
+        SimpleGraph::createSimpleGraph(graph.get());
+
+        const FrozenCommitTx transaction = graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView& view = reader.getView();
+
+        const mlir::OwningOpRef<mlir::ModuleOp> unfusedModule = parse(programText);
+        ASSERT_TRUE(unfusedModule);
+        runPairs(*unfusedModule, view, unfused);
+
+        const mlir::OwningOpRef<mlir::ModuleOp> fusedModule = parse(programText);
+        ASSERT_TRUE(fusedModule);
+        ASSERT_TRUE(runFuse(*fusedModule));
+        ASSERT_EQ(countOps<mlir::db::ScanEdges>(*fusedModule), 1u);
+        runPairs(*fusedModule, view, fused);
+    }
+
+    mlir::MLIRContext _context;
+};
+
+TEST_F(FuseScanEdgesTest, fusesFullScanAndOutHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(outHopOverFullScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+    mlir::db::ScanEdges edgeScan = edgeScans.front();
+
+    // The output reads the edge scan's source and target columns directly.
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::Operation::operand_range columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], edgeScan.getSrcids());
+    EXPECT_EQ(columns[1], edgeScan.getTgtids());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 0u);
+}
+
+TEST_F(FuseScanEdgesTest, fusesFullScanAndInHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(inHopOverFullScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+    mlir::db::ScanEdges edgeScan = edgeScans.front();
+
+    // The in-hop's four results map to the edge scan's in the same order: the
+    // direction decided which side was walked from, not which column holds what.
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::Operation::operand_range columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], edgeScan.getSrcids());
+    EXPECT_EQ(columns[1], edgeScan.getTgtids());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::GetInEdges>(*module), 0u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesLabelledScanAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(outHopOverLabelScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 1u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesConstScanAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(outHopOverConstScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 1u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesUndirectedHopAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(undirectedHopOverFullScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 1u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesTypedHopAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedHopOverFullScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 1u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesHopCarryingAColumnAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(hopCarryingAColumn);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 1u);
+}
+
+TEST_F(FuseScanEdgesTest, leavesScanWithASecondReaderAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoHopsOffOneScan);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    expectUntouched(*module, 2u);
+}
+
+TEST_F(FuseScanEdgesTest, fusesOnlyTheFirstHopOfATwoHopChain) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoHopChain);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+    mlir::db::ScanEdges edgeScan = edgeScans.front();
+
+    // The second hop walks on from the edge scan's targets, carrying its sources.
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdges secondHop = hops.front();
+    EXPECT_EQ(secondHop.getInputNodes(), edgeScan.getTgtids());
+    ASSERT_EQ(secondHop.getColumnsToFilter().size(), 1u);
+    EXPECT_EQ(secondHop.getColumnsToFilter().front(), edgeScan.getSrcids());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+}
+
+TEST_F(FuseScanEdgesTest, fusesInsideCrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(outHopInCrossProductFactor);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::ScanEdges> edgeScans = collect<mlir::db::ScanEdges>(*module);
+    ASSERT_EQ(edgeScans.size(), 1u);
+    mlir::db::ScanEdges edgeScan = edgeScans.front();
+
+    // The edge scan took the hop's place inside the left factor, which now yields
+    // its two node columns; the right factor's node scan is untouched.
+    llvm::SmallVector<mlir::db::CrossProduct> products = collect<mlir::db::CrossProduct>(*module);
+    ASSERT_EQ(products.size(), 1u);
+    mlir::db::CrossProduct product = products.front();
+
+    mlir::db::Yield leftYield = mlir::cast<mlir::db::Yield>(product.getLeftFactor().front().getTerminator());
+    const mlir::Operation::operand_range yielded = leftYield.getColumns();
+    ASSERT_EQ(yielded.size(), 2u);
+    EXPECT_EQ(yielded[0], edgeScan.getSrcids());
+    EXPECT_EQ(yielded[1], edgeScan.getTgtids());
+
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 0u);
+}
+
+TEST_F(FuseScanEdgesTest, emitsTheSameEdgesAsTheOutHop) {
+    std::vector<std::pair<uint64_t, uint64_t>> unfused;
+    std::vector<std::pair<uint64_t, uint64_t>> fused;
+    runPairsBeforeAndAfterFusion(outHopOverFullScan, unfused, fused);
+
+    EXPECT_FALSE(unfused.empty());
+    EXPECT_EQ(fused, unfused);
+}
+
+TEST_F(FuseScanEdgesTest, emitsTheSameEdgesAsTheInHop) {
+    std::vector<std::pair<uint64_t, uint64_t>> unfused;
+    std::vector<std::pair<uint64_t, uint64_t>> fused;
+    runPairsBeforeAndAfterFusion(inHopOverFullScan, unfused, fused);
+
+    EXPECT_FALSE(unfused.empty());
+    EXPECT_EQ(fused, unfused);
+}


### PR DESCRIPTION
Fuse a whole-graph node scan and its hop into an edge scan.

```
MATCH (a)-->(b) RETURN a, b

// before
%0 = db.scan_nodes() : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
db.output(%1, %4) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>

// after
%0, %1, %2, %3 = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
db.output(%0, %3) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>


MATCH (a)<--(b) RETURN a, b

// before
%0 = db.scan_nodes() : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_in_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
db.output(%4, %1) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>

// after
%0, %1, %2, %3 = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
db.output(%3, %0) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>


MATCH (a)-[r]->(b) RETURN a, r.name, b

// before
%0 = db.scan_nodes() : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
%5 = db.get_edge_properties(%2, "name") : (!db.column<!storage.edge_id>) -> !db.column<none>
db.output(%1, %5, %4) names ["a", "r.name", "b"] : !db.column<!storage.node_id>, !db.column<none>, !db.column<!storage.node_id>

// after
%0, %1, %2, %3 = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
%4 = db.get_edge_properties(%1, "name") : (!db.column<!storage.edge_id>) -> !db.column<none>
db.output(%0, %4, %3) names ["a", "r.name", "b"] : !db.column<!storage.node_id>, !db.column<none>, !db.column<!storage.node_id>


MATCH (a)-[:KNOWS_WELL]->(b) RETURN a, b

// before
%0 = db.scan_nodes() : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
%5 = db.check_edge_type_constraint(%3, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
%6:2 = db.filter(%5, {%4, %1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
db.output(%6#1, %6#0) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>

// after
%0, %1, %2, %3 = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
%4 = db.check_edge_type_constraint(%2, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
%5:2 = db.filter(%4, {%3, %0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
db.output(%5#1, %5#0) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>


MATCH (a)-->(b)-->(c) RETURN a, c

// before
%0 = db.scan_nodes() : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
%5, %6, %7, %8, %9 = db.get_out_edges(%4, {%1}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
db.output(%9, %8) names ["a", "c"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>

// after
%0, %1, %2, %3 = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
%4, %5, %6, %7, %8 = db.get_out_edges(%3, {%0}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
db.output(%8, %7) names ["a", "c"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>


MATCH (a:Person)-->(b) RETURN a, b

// unchanged
%0 = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
db.output(%1, %4) names ["a", "b"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
```
