### PR TITLE
MLIR: get_out_edges_by_type

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -965,6 +965,7 @@ void DBProgramGenerator::runPasses() {
     passManager.addPass(mlir::db::createFuseUnwindEquality());
     passManager.addPass(mlir::db::createFuseScanByNodeIDs());
     passManager.addPass(mlir::db::createFuseScanEdges());
+    passManager.addPass(mlir::db::createFuseEdgesByType());
     passManager.addPass(mlir::db::createTrimUnreadColumns());
 
     if (mlir::failed(passManager.run(*_module))) {

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -157,6 +157,18 @@ void GetEdges::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
     }
 }
 
+void GetOutEdgesByType::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+    for (Value result : getResults()) {
+        setNameFn(result, "");
+    }
+}
+
+void GetInEdgesByType::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+    for (Value result : getResults()) {
+        setNameFn(result, "");
+    }
+}
+
 // Builds the op from just the result types - the left factor's yielded columns
 // followed by the right factor's - and creates the two empty factor blocks. The
 // caller fills each region and terminates it with a db.yield whose operands

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -441,7 +441,7 @@ def GetEdges : TuringOp<"get_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInt
 /**
 * GetOutEdgesByType
 */
-def GetOutEdgesByType : TuringOp<"get_out_edges_by_type", [Pure]> {
+def GetOutEdgesByType : TuringOp<"get_out_edges_by_type", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Fetch the out-edges of one edge type, filtering carried columns alongside";
 
   let description = [{
@@ -487,7 +487,7 @@ def GetOutEdgesByType : TuringOp<"get_out_edges_by_type", [Pure]> {
 /**
 * GetInEdgesByType
 */
-def GetInEdgesByType : TuringOp<"get_in_edges_by_type", [Pure]> {
+def GetInEdgesByType : TuringOp<"get_in_edges_by_type", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Fetch the in-edges of one edge type, filtering carried columns alongside";
 
   let description = [{

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -28,6 +28,7 @@ namespace mlir::db {
 #define GEN_PASS_DEF_FUSEUNWINDEQUALITY
 #define GEN_PASS_DEF_FUSESCANBYNODEIDS
 #define GEN_PASS_DEF_FUSESCANEDGES
+#define GEN_PASS_DEF_FUSEEDGESBYTYPE
 #define GEN_PASS_DEF_TRIMUNREADCOLUMNS
 #include "DBPasses.h.inc"
 
@@ -842,6 +843,137 @@ struct FuseScanEdges : public impl::FuseScanEdgesBase<FuseScanEdges> {
             }
 
             fuseScanEdges(hop, scan, builder);
+        }
+    }
+};
+
+// A directed hop whose rows are then cut down to one edge type: the by-type hop spelled the
+// long way, since the walk itself can keep the edges of that type and never build the rows
+// the filter goes on to drop.
+struct TypedHop {
+    Operation* _hop {nullptr};
+    CheckEdgeTypeConstraint _check;
+    StringAttr _edgeType;
+};
+
+bool matchTypedHop(FilterOp filter, TypedHop& typedHop) {
+    CheckEdgeTypeConstraint check = filter.getMask().getDefiningOp<CheckEdgeTypeConstraint>();
+    if (!check) {
+        return false;
+    }
+
+    // An edge carries exactly one type, so a single required type is an equality a hop can
+    // walk; several of them are a set match no one hop expresses.
+    const ArrayAttr edgeTypes = check.getEdgeTypes();
+    if (edgeTypes.size() != 1) {
+        return false;
+    }
+
+    StringAttr edgeType = dyn_cast<StringAttr>(edgeTypes[0]);
+    if (!edgeType) {
+        return false;
+    }
+
+    const Value edgeTypeIds = check.getEdgeTypeIds();
+    Operation* const hop = edgeTypeIds.getDefiningOp();
+    if (!hop || !isa<GetOutEdges, GetInEdges>(hop)) {
+        return false;
+    }
+
+    constexpr size_t etypesResultIndex = 2;
+    if (edgeTypeIds != hop->getResult(etypesResultIndex)) {
+        return false;
+    }
+
+    // Every column the filter cuts has to be one the hop bound, or the fused hop has nothing
+    // of its own to hand back in its place.
+    for (const Value column : filter.getColumnsToFilter()) {
+        if (column.getDefiningOp() != hop) {
+            return false;
+        }
+    }
+
+    // And nothing outside the pair may read the hop, or that reader would go on seeing the
+    // rows the type turns away.
+    for (const Value result : hop->getResults()) {
+        for (Operation* const user : result.getUsers()) {
+            const bool readsThePair = user == filter.getOperation() || user == check.getOperation();
+            if (!readsThePair) {
+                return false;
+            }
+        }
+    }
+
+    typedHop = TypedHop {._hop = hop, ._check = check, ._edgeType = edgeType};
+
+    return true;
+}
+
+template <typename ByTypeOp>
+Operation* createByTypeHop(Operation* hop, StringAttr edgeType, mlir::OpBuilder& builder) {
+    const Operation::result_range results = hop->getResults();
+
+    ByTypeOp byTypeHop = builder.create<ByTypeOp>(hop->getLoc(),
+                                                  results[0].getType(),
+                                                  results[1].getType(),
+                                                  results[2].getType(),
+                                                  results[3].getType(),
+                                                  results.drop_front(hopFixedResultCount).getTypes(),
+                                                  hop->getOperand(0),
+                                                  edgeType,
+                                                  hop->getOperands().drop_front());
+
+    return byTypeHop.getOperation();
+}
+
+void fuseEdgesByType(FilterOp filter, const TypedHop& typedHop, mlir::OpBuilder& builder) {
+    Operation* const hop = typedHop._hop;
+
+    builder.setInsertionPoint(hop);
+
+    // A by-type hop declares the same four fixed results and the same carry set behind them,
+    // so the plain hop's results map onto it one for one.
+    Operation* const byTypeHop = isa<GetOutEdges>(hop)
+                                     ? createByTypeHop<GetOutEdgesByType>(hop, typedHop._edgeType, builder)
+                                     : createByTypeHop<GetInEdgesByType>(hop, typedHop._edgeType, builder);
+
+    hop->replaceAllUsesWith(byTypeHop);
+
+    // The hop now yields the rows the filter used to leave, so each column the filter handed
+    // on is the one it was given.
+    const Operation::operand_range columns = filter.getColumnsToFilter();
+    const mlir::ResultRange filtered = filter.getFilteredColumns();
+    for (size_t index = 0; index < filtered.size(); index++) {
+        filtered[index].replaceAllUsesWith(columns[index]);
+    }
+
+    filter.erase();
+    eraseIfUnused(typedHop._check);
+    hop->erase();
+}
+
+struct FuseEdgesByType : public impl::FuseEdgesByTypeBase<FuseEdgesByType> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        // Collect first: fusing erases the filter, its check and its hop, which would
+        // invalidate the walk.
+        llvm::SmallVector<FilterOp> filters;
+        root->walk([&](FilterOp filter) {
+            TypedHop typedHop;
+            if (matchTypedHop(filter, typedHop)) {
+                filters.push_back(filter);
+            }
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (FilterOp filter : filters) {
+            TypedHop typedHop;
+            if (!matchTypedHop(filter, typedHop)) {
+                continue;
+            }
+
+            fuseEdgesByType(filter, typedHop, builder);
         }
     }
 };

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -28,6 +28,11 @@ def FuseScanEdges : Pass<"fuse_scan_edges"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def FuseEdgesByType : Pass<"fuse_edges_by_type"> {
+    let summary = "Fuse a directed hop and the edge-type filter over it into a by-type hop";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 def TrimUnreadColumns : Pass<"trim_unread_columns"> {
     let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products and grouping ops";
     let dependentDialects = ["mlir::db::DB"];

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -259,6 +259,29 @@ target_link_libraries(test_query_ir_fuse_scan_edges_codegen PRIVATE
         turing_db_storage_s)
 target_include_directories(test_query_ir_fuse_scan_edges_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# The by-type fusion tests check the rewritten db program, then lower and run it against
+# the shared SimpleGraph fixture to compare its rows with the plain hop and filter's.
+add_ir_tests(test_query_ir_fuse_edges_by_type FuseEdgesByTypeTest.cpp)
+target_link_libraries(test_query_ir_fuse_edges_by_type PRIVATE turing_db_examples_s)
+
+add_turing_test(test_query_ir_fuse_edges_by_type_codegen FuseEdgesByTypeCodegenTest.cpp)
+target_link_libraries(test_query_ir_fuse_edges_by_type_codegen PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_storagedialect_s
+        turing_db_ir_common_s
+        turing_db_storage_s)
+target_include_directories(test_query_ir_fuse_edges_by_type_codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_fuse_scan_by_node_ids_codegen FuseScanByNodeIDsCodegenTest.cpp)
 target_link_libraries(test_query_ir_fuse_scan_by_node_ids_codegen PRIVATE
         turing_db_s

--- a/test/query/ir/FuseEdgesByTypeCodegenTest.cpp
+++ b/test/query/ir/FuseEdgesByTypeCodegenTest.cpp
@@ -1,0 +1,208 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+}
+
+// Generates the db program a Cypher query compiles to, passes included, so a test reads
+// the shape the engine will lower rather than a hand-written approximation of it.
+class FuseEdgesByTypeCodegenTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+protected:
+    mlir::OwningOpRef<mlir::ModuleOp> generate(std::string_view query) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&_context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        return owningModule;
+    }
+
+    // No plain hop and no edge-type check is left: the walk itself keeps the type.
+    void expectFusedToTypedHop(mlir::ModuleOp module) {
+        EXPECT_EQ(countOps<mlir::db::GetOutEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::GetInEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(module), 0u);
+    }
+
+private:
+    const std::string _graphName {"simpledb"};
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+    mlir::MLIRContext _context;
+};
+
+TEST_F(FuseEdgesByTypeCodegenTest, typedHopOffALabelScanBecomesATypedHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a:Person)-[:KNOWS_WELL]->(b) RETURN a, b");
+
+    expectFusedToTypedHop(*module);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdgesByType hop = hops.front();
+    EXPECT_EQ(hop.getEdgeType(), "KNOWS_WELL");
+    EXPECT_TRUE(hop.getInputNodes().getDefiningOp<mlir::db::ScanNodesByLabel>());
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::Operation::operand_range columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], hop.getSrcids());
+    EXPECT_EQ(columns[1], hop.getTgtids());
+}
+
+TEST_F(FuseEdgesByTypeCodegenTest, reverseTypedHopBecomesATypedInHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a:Person)<-[:KNOWS_WELL]-(b) RETURN a, b");
+
+    expectFusedToTypedHop(*module);
+
+    llvm::SmallVector<mlir::db::GetInEdgesByType> hops = collect<mlir::db::GetInEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_EQ(hops.front().getEdgeType(), "KNOWS_WELL");
+}
+
+TEST_F(FuseEdgesByTypeCodegenTest, edgePropertyIsReadOffTheTypedHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (a:Person)-[r:KNOWS_WELL]->(b) RETURN a, r.name, b");
+
+    expectFusedToTypedHop(*module);
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+
+    llvm::SmallVector<mlir::db::GetEdgeProperties> properties = collect<mlir::db::GetEdgeProperties>(*module);
+    ASSERT_EQ(properties.size(), 1u);
+    EXPECT_EQ(properties.front().getInputEdges(), hops.front().getEids());
+}
+
+// The edge type is applied before the target's labels, so the hop fuses and the label
+// constraint stays behind it as an ordinary filter.
+TEST_F(FuseEdgesByTypeCodegenTest, labelledTargetKeepsItsFilterBehindTheTypedHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (a:Person)-[:KNOWS_WELL]->(b:Interest) RETURN a, b");
+
+    expectFusedToTypedHop(*module);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::CheckLabelConstraint>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+}
+
+// A predicate on the far end sits behind the type check, so the hop fuses under it.
+TEST_F(FuseEdgesByTypeCodegenTest, predicateOnTheTargetKeepsTheTypedHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (a:Person)-[:KNOWS_WELL]->(b) WHERE b.name = 'Remy' RETURN a, b");
+
+    expectFusedToTypedHop(*module);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 1u);
+}
+
+TEST_F(FuseEdgesByTypeCodegenTest, bothHopsOfATypedChainFuse) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module =
+        generate("MATCH (a:Person)-[:KNOWS_WELL]->(b)-[:INTERESTED_IN]->(c) RETURN a, c");
+
+    expectFusedToTypedHop(*module);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 2u);
+    EXPECT_EQ(hops[0].getEdgeType(), "KNOWS_WELL");
+    EXPECT_EQ(hops[1].getEdgeType(), "INTERESTED_IN");
+    EXPECT_EQ(hops[1].getInputNodes(), hops[0].getTgtids());
+}
+
+// A whole-graph scan and its hop are the edge set, which the edge-scan fusion takes first;
+// the type check then narrows that scan rather than the walk.
+TEST_F(FuseEdgesByTypeCodegenTest, typedHopOffAWholeGraphScanStaysAnEdgeScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a)-[:KNOWS_WELL]->(b) RETURN a, b");
+
+    EXPECT_EQ(countOps<mlir::db::ScanEdges>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(*module), 1u);
+}
+
+TEST_F(FuseEdgesByTypeCodegenTest, undirectedTypedHopKeepsItsTypeCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("MATCH (a:Person)-[:KNOWS_WELL]-(b) RETURN a, b");
+
+    EXPECT_EQ(countOps<mlir::db::GetEdges>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::GetInEdgesByType>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(*module), 1u);
+}

--- a/test/query/ir/FuseEdgesByTypeTest.cpp
+++ b/test/query/ir/FuseEdgesByTypeTest.cpp
@@ -1,0 +1,432 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <span>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "Graph.h"
+#include "columns/ColumnIDs.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "LocalMemory.h"
+#include "SimpleGraph.h"
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+// Accumulates the two node-ID columns of an emitted (source, target) pair.
+class CollectingPairSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const ColumnNodeIDs* sources = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        const ColumnNodeIDs* targets = dynamic_cast<const ColumnNodeIDs*>(chunks[1]);
+        ASSERT_NE(sources, nullptr);
+        ASSERT_NE(targets, nullptr);
+
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            _pairs.emplace_back((*sources)[rowIndex].getValue(), (*targets)[rowIndex].getValue());
+        }
+    }
+
+    void sortedPairs(std::vector<std::pair<uint64_t, uint64_t>>& pairs) const {
+        pairs = _pairs;
+        std::sort(pairs.begin(), pairs.end());
+    }
+
+private:
+    std::vector<std::pair<uint64_t, uint64_t>> _pairs;
+};
+
+// MATCH (a)-[:KNOWS_WELL]->(b) RETURN a, b
+const char* const typedOutHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf = db.filter(%knows, {%s, %e, %et, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)<-[:KNOWS_WELL]-(b) RETURN a, b, whose columns hold the same edge set: the hop
+// walks predecessors, but srcids is still the edge's own source and tgtids its target.
+const char* const typedInHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf = db.filter(%knows, {%s, %e, %et, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a:Person)-[:KNOWS_WELL]->(b) RETURN a.age, b: the age read before the hop rides it
+// as a carried column and the filter cuts it beside the edge columns.
+const char* const typedHopCarryingAColumn = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes_by_label(["Person"]) : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %s, %e, %et, %t, %agec = db.get_out_edges(%a, {%age}) : (!db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<i64>)
+  %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf, %agef = db.filter(%knows, {%s, %e, %et, %t, %agec}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<i64>)
+  db.output(%agef, %tf) : !db.column<i64>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A check over two required types: an edge carries one type, so the pair is a set match no
+// single by-type hop walks.
+const char* const twoRequiredTypes = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %either = db.check_edge_type_constraint(%et, ["KNOWS_WELL", "INTERESTED_IN"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf = db.filter(%either, {%s, %e, %et, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[:KNOWS_WELL]-(b) RETURN a, b: the undirected hop has no by-type sibling.
+const char* const typedUndirectedHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf = db.filter(%knows, {%s, %e, %et, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A property read off the hop's own target column: it is neither a column the fused hop
+// produces nor one the filter cuts, so its rows would stop matching the ones beside it.
+const char* const typedHopReadPastItsFilter = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %name = db.get_node_properties(%t, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %sf, %ef, %etf, %tf, %namef = db.filter(%knows, {%s, %e, %et, %t, %name}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<none>)
+  db.output(%sf, %tf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[:KNOWS_WELL]->(b)-[:INTERESTED_IN]->(c) RETURN a, c
+const char* const twoTypedHopChain = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %knows = db.check_edge_type_constraint(%et1, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %s1f, %e1f, %et1f, %t1f = db.filter(%knows, {%s1, %e1, %et1, %t1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %s1c = db.get_out_edges(%t1f, {%s1f}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %likes = db.check_edge_type_constraint(%et2, ["INTERESTED_IN"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %s2f, %e2f, %et2f, %t2f, %s1cf = db.filter(%likes, {%s2, %e2, %et2, %t2, %s1c}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%s1cf, %t2f) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (a)-[:KNOWS_WELL]->(b) MATCH (m) RETURN a, b, m
+const char* const typedHopInCrossProductFactor = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %a = db.scan_nodes() : !db.column<!storage.node_id>
+    %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+    %knows = db.check_edge_type_constraint(%et, ["KNOWS_WELL"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+    %sf, %ef, %etf, %tf = db.filter(%knows, {%s, %e, %et, %t}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+    db.yield %sf, %tf : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  } factor {
+    %m = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %m : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+}
+
+class FuseEdgesByTypeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+        _context.getOrLoadDialect<mlir::nl::NL>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool runFuse(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createFuseEdgesByType());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    // The module still holds its plain hop, its type check and the filter over them.
+    void expectUntouched(mlir::ModuleOp module) {
+        EXPECT_EQ(countOps<mlir::db::GetOutEdgesByType>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::GetInEdgesByType>(module), 0u);
+
+        const size_t hops = countOps<mlir::db::GetOutEdges>(module)
+                            + countOps<mlir::db::GetInEdges>(module)
+                            + countOps<mlir::db::GetEdges>(module);
+        EXPECT_EQ(hops, 1u);
+
+        EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(module), 1u);
+        EXPECT_EQ(countOps<mlir::db::FilterOp>(module), 1u);
+    }
+
+    // Neither the check nor the filter it fed is left, and the fused hop reads what the
+    // plain one read.
+    void expectFusedHop(mlir::ModuleOp module, mlir::Operation* hop, llvm::StringRef edgeType) {
+        ASSERT_NE(hop, nullptr);
+
+        EXPECT_EQ(countOps<mlir::db::GetOutEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::GetInEdges>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(module), 0u);
+        EXPECT_EQ(countOps<mlir::db::FilterOp>(module), 0u);
+
+        EXPECT_EQ(hop->getAttrOfType<mlir::StringAttr>("edge_type").getValue(), edgeType);
+    }
+
+    // Lowers the db program as it stands and interprets it over the graph, filling
+    // the (source, target) pairs it emits, sorted.
+    void runPairs(mlir::ModuleOp module,
+                  const GraphView& view,
+                  std::vector<std::pair<uint64_t, uint64_t>>& pairs) {
+        const mlir::func::FuncOp dbFunction = module.lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&_context));
+        DBLowering lowering(&_context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        CollectingPairSink sink;
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+
+        sink.sortedPairs(pairs);
+    }
+
+    // The pairs the program emits before the fusion and after it, over simpledb.
+    void runPairsBeforeAndAfterFusion(const char* programText,
+                                      std::vector<std::pair<uint64_t, uint64_t>>& unfused,
+                                      std::vector<std::pair<uint64_t, uint64_t>>& fused) {
+        auto graph = Graph::create();
+        SimpleGraph::createSimpleGraph(graph.get());
+
+        const FrozenCommitTx transaction = graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView& view = reader.getView();
+
+        const mlir::OwningOpRef<mlir::ModuleOp> unfusedModule = parse(programText);
+        ASSERT_TRUE(unfusedModule);
+        runPairs(*unfusedModule, view, unfused);
+
+        const mlir::OwningOpRef<mlir::ModuleOp> fusedModule = parse(programText);
+        ASSERT_TRUE(fusedModule);
+        ASSERT_TRUE(runFuse(*fusedModule));
+        ASSERT_EQ(countOps<mlir::db::FilterOp>(*fusedModule), 0u);
+        runPairs(*fusedModule, view, fused);
+    }
+
+    mlir::MLIRContext _context;
+};
+
+TEST_F(FuseEdgesByTypeTest, fusesOutHopAndItsTypeCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedOutHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdgesByType hop = hops.front();
+
+    expectFusedHop(*module, hop, "KNOWS_WELL");
+    EXPECT_TRUE(hop.getInputNodes().getDefiningOp<mlir::db::ScanNodes>());
+
+    // The output reads the fused hop's source and target columns directly.
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::Operation::operand_range columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], hop.getSrcids());
+    EXPECT_EQ(columns[1], hop.getTgtids());
+}
+
+TEST_F(FuseEdgesByTypeTest, fusesInHopAndItsTypeCheck) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedInHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetInEdgesByType> hops = collect<mlir::db::GetInEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+
+    expectFusedHop(*module, hops.front(), "KNOWS_WELL");
+}
+
+TEST_F(FuseEdgesByTypeTest, fusedHopKeepsTheColumnItCarried) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedHopCarryingAColumn);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdgesByType hop = hops.front();
+
+    expectFusedHop(*module, hop, "KNOWS_WELL");
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> properties = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(properties.size(), 1u);
+
+    const mlir::Operation::operand_range carried = hop.getColumnsToFilter();
+    ASSERT_EQ(carried.size(), 1u);
+    EXPECT_EQ(carried[0], properties.front().getResult());
+
+    const mlir::ResultRange filtered = hop.getFilteredColumns();
+    ASSERT_EQ(filtered.size(), 1u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns()[0], filtered[0]);
+}
+
+TEST_F(FuseEdgesByTypeTest, fusesBothHopsOfATypedChain) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoTypedHopChain);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 2u);
+    EXPECT_EQ(hops[0].getEdgeType(), "KNOWS_WELL");
+    EXPECT_EQ(hops[1].getEdgeType(), "INTERESTED_IN");
+
+    EXPECT_EQ(countOps<mlir::db::GetOutEdges>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::CheckEdgeTypeConstraint>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::FilterOp>(*module), 0u);
+
+    // The second hop walks the first hop's targets and carries its sources along.
+    EXPECT_EQ(hops[1].getInputNodes(), hops[0].getTgtids());
+    const mlir::Operation::operand_range carried = hops[1].getColumnsToFilter();
+    ASSERT_EQ(carried.size(), 1u);
+    EXPECT_EQ(carried[0], hops[0].getSrcids());
+}
+
+TEST_F(FuseEdgesByTypeTest, fusesInsideCrossProductFactor) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedHopInCrossProductFactor);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdgesByType> hops = collect<mlir::db::GetOutEdgesByType>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+
+    expectFusedHop(*module, hops.front(), "KNOWS_WELL");
+}
+
+TEST_F(FuseEdgesByTypeTest, leavesACheckOverTwoTypesAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoRequiredTypes);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+
+    expectUntouched(*module);
+}
+
+TEST_F(FuseEdgesByTypeTest, leavesAnUndirectedHopAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedUndirectedHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+
+    expectUntouched(*module);
+}
+
+TEST_F(FuseEdgesByTypeTest, leavesAHopReadPastItsFilterAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(typedHopReadPastItsFilter);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runFuse(*module));
+
+    expectUntouched(*module);
+}
+
+TEST_F(FuseEdgesByTypeTest, outHopEmitsTheSameEdgesFused) {
+    std::vector<std::pair<uint64_t, uint64_t>> unfused;
+    std::vector<std::pair<uint64_t, uint64_t>> fused;
+    runPairsBeforeAndAfterFusion(typedOutHop, unfused, fused);
+
+    // simpledb's KNOWS_WELL edges: Remy (0) <-> Adam (1), and Ghosts (6) -> Remy (0).
+    const std::vector<std::pair<uint64_t, uint64_t>> expected {{0, 1}, {1, 0}, {6, 0}};
+    EXPECT_EQ(unfused, expected);
+    EXPECT_EQ(fused, expected);
+}
+
+TEST_F(FuseEdgesByTypeTest, inHopEmitsTheSameEdgesFused) {
+    std::vector<std::pair<uint64_t, uint64_t>> unfused;
+    std::vector<std::pair<uint64_t, uint64_t>> fused;
+    runPairsBeforeAndAfterFusion(typedInHop, unfused, fused);
+
+    const std::vector<std::pair<uint64_t, uint64_t>> expected {{0, 1}, {1, 0}, {6, 0}};
+    EXPECT_EQ(unfused, expected);
+    EXPECT_EQ(fused, expected);
+}
+
+TEST_F(FuseEdgesByTypeTest, chainEmitsTheSameRowsFused) {
+    std::vector<std::pair<uint64_t, uint64_t>> unfused;
+    std::vector<std::pair<uint64_t, uint64_t>> fused;
+    runPairsBeforeAndAfterFusion(twoTypedHopChain, unfused, fused);
+
+    EXPECT_FALSE(unfused.empty());
+    EXPECT_EQ(unfused, fused);
+}

--- a/test/query/ir/UnwindCollectSeedTest.cpp
+++ b/test/query/ir/UnwindCollectSeedTest.cpp
@@ -169,8 +169,8 @@ TEST_F(UnwindCollectSeedTest, theUnwoundNodeIsTheHopsInput) {
     });
     ASSERT_TRUE(unwind);
 
-    mlir::db::GetOutEdges hop;
-    module->walk([&hop](mlir::db::GetOutEdges found) {
+    mlir::db::GetOutEdgesByType hop;
+    module->walk([&hop](mlir::db::GetOutEdgesByType found) {
         hop = found;
     });
     ASSERT_TRUE(hop);


### PR DESCRIPTION
Emit the by-type edge hops.

```
MATCH (a:Person)-[:KNOWS_WELL]->(b) RETURN a, b

%0 = db.scan_nodes_by_label(["Person"]) : ...
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : ...
%5 = db.check_edge_type_constraint(%3, ["KNOWS_WELL"]) : ...
%6:2 = db.filter(%5, {%4, %1}) : ...
db.output(%6#1, %6#0) names ["a", "b"] : ...

%0 = db.scan_nodes_by_label(["Person"]) : ...
%1, %2, %3, %4 = db.get_out_edges_by_type(%0, "KNOWS_WELL", {}) : ...
db.output(%1, %4) names ["a", "b"] : ...


MATCH (a:Person)-[:KNOWS_WELL]->(b)-[:INTERESTED_IN]->(c) RETURN a, c

%0 = db.scan_nodes_by_label(["Person"]) : ...
%1, %2, %3, %4 = db.get_out_edges(%0, {}) : ...
%5 = db.check_edge_type_constraint(%3, ["KNOWS_WELL"]) : ...
%6:2 = db.filter(%5, {%4, %1}) : ...
%7, %8, %9, %10, %11 = db.get_out_edges(%6#0, {%6#1}) : ...
%12 = db.check_edge_type_constraint(%9, ["INTERESTED_IN"]) : ...
%13:2 = db.filter(%12, {%10, %11}) : ...
db.output(%13#1, %13#0) names ["a", "c"] : ...

%0 = db.scan_nodes_by_label(["Person"]) : ...
%1, %2, %3, %4 = db.get_out_edges_by_type(%0, "KNOWS_WELL", {}) : ...
%5, %6, %7, %8, %9 = db.get_out_edges_by_type(%4, "INTERESTED_IN", {%1}) : ...
db.output(%9, %8) names ["a", "c"] : ...
```
