### PR TITLE
MLIR: compare v3 with a brute-force match on the suite's join queries

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory(list-buffer)
 add_subdirectory(mlir)
 add_subdirectory(query_bench)
 add_subdirectory(vardeps)
+add_subdirectory(match-brute-force)
 
 set (SCRIPT_LIST_CONTENT "")
 list (LENGTH SAMPLE_LIST SAMPLE_COUNT)

--- a/samples/match-brute-force/CMakeLists.txt
+++ b/samples/match-brute-force/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(SAMPLE_NAME match-brute-force)
+set(SOURCES main.cpp)
+
+turing_sample(${SAMPLE_NAME} ${SOURCES})
+
+target_link_libraries(${SAMPLE_NAME} PRIVATE
+    turing_common_s
+    turing_db_storage_s
+    turing_db_memory_s
+    turing_db_system_s
+    turing_db_examples_s
+    turing_db_interpreter_v3_s
+    turing_db_s
+)

--- a/samples/match-brute-force/main.cpp
+++ b/samples/match-brute-force/main.cpp
@@ -1,0 +1,344 @@
+#include <stdlib.h>
+#include <algorithm>
+#include <map>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <argparse.hpp>
+#include <spdlog/spdlog.h>
+
+#include "TuringDB.h"
+#include "TuringConfig.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+#include "NLOutputSink.h"
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "LocalMemory.h"
+#include "reader/GraphReader.h"
+#include "datapart/EdgeRecord.h"
+#include "versioning/Transaction.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+#include "columns/ColumnIDs.h"
+#include "ID.h"
+
+#include "ToolInit.h"
+
+using namespace db;
+
+namespace {
+
+using Row = std::vector<uint64_t>;
+using RowCounts = std::map<Row, size_t>;
+using Adjacency = std::vector<std::vector<NodeID>>;
+
+constexpr std::string_view graphName = "simpledb";
+
+constexpr std::string_view joinBadKeysQuery =
+    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g) RETURN a";
+
+constexpr std::string_view doubleDiamondQuery =
+    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g";
+
+constexpr std::string_view doubleDiamondLimitQuery =
+    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g LIMIT 10";
+
+constexpr size_t doubleDiamondLimit = 10;
+
+struct Binding {
+    NodeID _a;
+    NodeID _b;
+    NodeID _c;
+    NodeID _d;
+    NodeID _e;
+    NodeID _f;
+    NodeID _g;
+    NodeID _h;
+    NodeID _i;
+    NodeID _j;
+};
+
+using BoundVariable = NodeID Binding::*;
+
+constexpr BoundVariable returnA[] = {&Binding::_a};
+constexpr BoundVariable returnACEG[] = {&Binding::_a, &Binding::_c, &Binding::_e, &Binding::_g};
+
+class NodeRowSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override;
+
+    const std::vector<Row>& getRows() const { return _rows; }
+
+private:
+    std::vector<Row> _rows;
+};
+
+void NodeRowSink::appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) {
+    for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+        Row& row = _rows.emplace_back();
+        for (const Column* chunk : chunks) {
+            const ColumnNodeIDs* nodeIDs = static_cast<const ColumnNodeIDs*>(chunk);
+            row.push_back(nodeIDs->getRaw()[rowIndex].getValue());
+        }
+    }
+}
+
+void readOutNeighbours(std::vector<NodeID>& nodes, Adjacency& outNeighbours, Graph* graph) {
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    nodes.clear();
+    uint64_t maxNodeID = 0;
+    for (auto it = reader.scanNodes().begin(); it.isValid(); it.next()) {
+        const NodeID node = it.get();
+        nodes.push_back(node);
+        maxNodeID = std::max(maxNodeID, node.getValue());
+    }
+
+    outNeighbours.assign(maxNodeID + 1, {});
+    for (const NodeID node : nodes) {
+        const ColumnNodeIDs source {node};
+        for (const EdgeRecord& edge : reader.getOutEdges(&source)) {
+            outNeighbours[node.getValue()].push_back(edge._otherID);
+        }
+    }
+}
+
+const std::vector<NodeID>& outOf(const Adjacency& outNeighbours, NodeID node) {
+    return outNeighbours[node.getValue()];
+}
+
+bool hasEdge(const Adjacency& outNeighbours, NodeID source, NodeID target) {
+    const std::vector<NodeID>& targets = outOf(outNeighbours, source);
+    return std::find(targets.begin(), targets.end(), target) != targets.end();
+}
+
+void matchDiamond(std::vector<Binding>& bindings, std::span<const NodeID> nodes, const Adjacency& outNeighbours) {
+    bindings.clear();
+
+    for (const NodeID a : nodes) {
+        for (const NodeID b : outOf(outNeighbours, a)) {
+            for (const NodeID c : nodes) {
+                for (const NodeID d : outOf(outNeighbours, c)) {
+                    for (const NodeID e : outOf(outNeighbours, d)) {
+                        for (const NodeID f : outOf(outNeighbours, a)) {
+                            for (const NodeID g : outOf(outNeighbours, f)) {
+                                if (hasEdge(outNeighbours, c, g)) {
+                                    bindings.push_back({a, b, c, d, e, f, g});
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// The repeated (e) and (h) patterns name variables the diamond already binds, so they add no loop.
+void matchDoubleDiamond(std::vector<Binding>& bindings, std::span<const NodeID> nodes, const Adjacency& outNeighbours) {
+    std::vector<Binding> diamonds;
+    matchDiamond(diamonds, nodes, outNeighbours);
+
+    bindings.clear();
+    for (const Binding& diamond : diamonds) {
+        for (const NodeID h : nodes) {
+            for (const NodeID i : nodes) {
+                for (const NodeID j : outOf(outNeighbours, diamond._c)) {
+                    Binding binding = diamond;
+                    binding._h = h;
+                    binding._i = i;
+                    binding._j = j;
+                    bindings.push_back(binding);
+                }
+            }
+        }
+    }
+}
+
+void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const BoundVariable> returnItems) {
+    rows.clear();
+
+    Row row;
+    for (const Binding& binding : bindings) {
+        row.clear();
+        for (const BoundVariable variable : returnItems) {
+            row.push_back((binding.*variable).getValue());
+        }
+        rows[row]++;
+    }
+}
+
+void countRows(RowCounts& counts, std::span<const Row> rows) {
+    counts.clear();
+    for (const Row& row : rows) {
+        counts[row]++;
+    }
+}
+
+size_t totalRows(const RowCounts& counts) {
+    size_t total = 0;
+    for (const auto& [row, count] : counts) {
+        total += count;
+    }
+    return total;
+}
+
+void formatRow(std::string& text, const Row& row) {
+    text.clear();
+    for (const uint64_t value : row) {
+        if (!text.empty()) {
+            text += ",";
+        }
+        text += std::to_string(value);
+    }
+}
+
+bool runV3(std::vector<Row>& rows, QueryInterpreterV3& interpreter, LocalMemory& memory, std::string_view query) {
+    NodeRowSink sink;
+    QueryStatus status;
+    interpreter.execute(status, query, graphName, CommitHash::head(), ChangeID::head(), &memory, &sink);
+    memory.clear();
+
+    if (!status.isOk()) {
+        spdlog::error("v3 failed on '{}': {}", query, status.getError());
+        return false;
+    }
+
+    rows = sink.getRows();
+    return true;
+}
+
+bool compareRows(std::string_view query, const RowCounts& bruteForce, const RowCounts& v3) {
+    spdlog::info("{}", query);
+    spdlog::info("  brute force: {} rows, {} distinct", totalRows(bruteForce), bruteForce.size());
+    spdlog::info("  v3:          {} rows, {} distinct", totalRows(v3), v3.size());
+
+    bool matched = true;
+    std::string text;
+
+    for (const auto& [row, count] : bruteForce) {
+        const auto it = v3.find(row);
+        const size_t v3Count = it == v3.end() ? 0 : it->second;
+        if (v3Count != count) {
+            formatRow(text, row);
+            spdlog::error("  row [{}]: brute force {} times, v3 {} times", text, count, v3Count);
+            matched = false;
+        }
+    }
+
+    for (const auto& [row, count] : v3) {
+        if (!bruteForce.contains(row)) {
+            formatRow(text, row);
+            spdlog::error("  row [{}]: brute force 0 times, v3 {} times", text, count);
+            matched = false;
+        }
+    }
+
+    spdlog::info("  {}", matched ? "identical" : "DIFFERENT");
+    return matched;
+}
+
+bool checkLimitedRows(std::string_view query, const RowCounts& bruteForce, std::span<const Row> v3Rows, size_t limit) {
+    spdlog::info("{}", query);
+
+    const size_t expectedCount = std::min(limit, totalRows(bruteForce));
+    bool matched = v3Rows.size() == expectedCount;
+    if (!matched) {
+        spdlog::error("  v3 returned {} rows, the limit admits {}", v3Rows.size(), expectedCount);
+    }
+
+    std::string text;
+    for (const Row& row : v3Rows) {
+        if (!bruteForce.contains(row)) {
+            formatRow(text, row);
+            spdlog::error("  row [{}] is not a match of the pattern", text);
+            matched = false;
+        }
+    }
+
+    spdlog::info("  {}", matched ? "every row is a match" : "DIFFERENT");
+    return matched;
+}
+
+}
+
+int main(int argc, const char** argv) {
+    ToolInit toolInit("match-brute-force");
+
+    auto& argParser = toolInit.getArgParser();
+
+    std::string turingDirArg;
+    argParser.add_argument("-turing-dir")
+             .metavar("path")
+             .store_into(turingDirArg)
+             .help("Root Turing directory (defaults to SAMPLE_DIR/.turing)");
+
+    toolInit.init(argc, argv);
+
+    fs::Path turingDir;
+    if (!turingDirArg.empty()) {
+        turingDir = fs::Path(turingDirArg);
+        if (!turingDir.toAbsolute()) {
+            spdlog::error("Failed to get absolute path of turing directory {}", turingDirArg);
+            return EXIT_FAILURE;
+        }
+    } else {
+        turingDir = fs::Path(SAMPLE_DIR) / ".turing";
+    }
+
+    TuringConfig config;
+    config.setTuringDirectory(turingDir);
+    config.setSyncedOnDisk(false);
+
+    TuringDB db(&config);
+    db.init();
+
+    Graph* graph = nullptr;
+    {
+        SystemAccessor system = db.getSystemManager().accessUnique();
+        graph = system.createGraph(graphName);
+    }
+    SimpleGraph::createSimpleGraph(graph);
+
+    std::vector<NodeID> nodes;
+    Adjacency outNeighbours;
+    readOutNeighbours(nodes, outNeighbours, graph);
+
+    LocalMemory memory;
+    QueryInterpreterV3 interpreter(&db.getSystemManager());
+
+    std::vector<Binding> bindings;
+    RowCounts bruteForce;
+    RowCounts v3;
+    std::vector<Row> rows;
+    bool allMatched = true;
+
+    matchDiamond(bindings, nodes, outNeighbours);
+    project(bruteForce, bindings, returnA);
+    if (!runV3(rows, interpreter, memory, joinBadKeysQuery)) {
+        return EXIT_FAILURE;
+    }
+    countRows(v3, rows);
+    allMatched = compareRows(joinBadKeysQuery, bruteForce, v3) && allMatched;
+
+    matchDoubleDiamond(bindings, nodes, outNeighbours);
+    project(bruteForce, bindings, returnACEG);
+    if (!runV3(rows, interpreter, memory, doubleDiamondQuery)) {
+        return EXIT_FAILURE;
+    }
+    countRows(v3, rows);
+    allMatched = compareRows(doubleDiamondQuery, bruteForce, v3) && allMatched;
+
+    if (!runV3(rows, interpreter, memory, doubleDiamondLimitQuery)) {
+        return EXIT_FAILURE;
+    }
+    allMatched = checkLimitedRows(doubleDiamondLimitQuery, bruteForce, rows, doubleDiamondLimit) && allMatched;
+
+    return allMatched ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/samples/match-brute-force/main.cpp
+++ b/samples/match-brute-force/main.cpp
@@ -22,6 +22,7 @@
 #include "LocalMemory.h"
 #include "reader/GraphReader.h"
 #include "datapart/EdgeRecord.h"
+#include "metadata/GraphMetadata.h"
 #include "metadata/PropertyType.h"
 #include "versioning/Transaction.h"
 #include "versioning/ChangeID.h"
@@ -39,13 +40,28 @@ namespace {
 
 using Row = std::vector<std::string>;
 using RowCounts = std::map<Row, size_t>;
+using Properties = std::map<std::string, std::string, std::less<>>;
 
 constexpr std::string_view graphName = "simpledb";
 
+struct MatchNode {
+    std::vector<std::string> _labels;
+    Properties _properties;
+};
+
+struct MatchEdge {
+    NodeID _source;
+    NodeID _target;
+    std::string _type;
+    Properties _properties;
+};
+
 struct MatchGraph {
-    std::vector<NodeID> _nodes;
+    std::vector<NodeID> _nodeIDs;
+    std::vector<MatchNode> _nodes;
+    std::vector<MatchEdge> _edges;
+    std::vector<std::vector<EdgeID>> _outEdges;
     std::vector<std::vector<NodeID>> _outNeighbours;
-    std::vector<std::string> _names;
 };
 
 struct Binding {
@@ -60,15 +76,19 @@ struct Binding {
     NodeID _i;
     NodeID _j;
     NodeID _x;
+    EdgeID _e1;
+    EdgeID _e2;
 };
 
-using BoundVariable = NodeID Binding::*;
+using BoundNode = NodeID Binding::*;
+using BoundEdge = EdgeID Binding::*;
 using MatchFunction = void (*)(std::vector<Binding>&, const MatchGraph&);
 using WherePredicate = bool (*)(const Binding&, const MatchGraph&);
 
 struct ReturnItem {
-    BoundVariable _variable {nullptr};
-    bool _name {false};
+    BoundNode _node {nullptr};
+    BoundEdge _edge {nullptr};
+    std::string_view _property;
 };
 
 struct SuiteCase {
@@ -80,6 +100,31 @@ struct SuiteCase {
     size_t _limit {0};
 };
 
+void valueText(std::string& text, NodeID id) {
+    text = std::to_string(id.getValue());
+}
+
+void valueText(std::string& text, std::string_view value) {
+    text = std::string(value);
+}
+
+void valueText(std::string& text, int64_t value) {
+    text = std::to_string(value);
+}
+
+void valueText(std::string& text, CustomBool value) {
+    text = value ? "true" : "false";
+}
+
+template <typename T>
+void valueText(std::string& text, const std::optional<T>& value) {
+    if (value) {
+        valueText(text, *value);
+    } else {
+        text = "null";
+    }
+}
+
 class TextRowSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override;
@@ -89,6 +134,8 @@ public:
 private:
     std::vector<Row> _rows;
 
+    template <typename T>
+    static bool readCell(std::string& text, const Column* chunk, size_t rowIndex);
     static void cellText(std::string& text, const Column* chunk, size_t rowIndex);
 };
 
@@ -101,49 +148,112 @@ void TextRowSink::appendChunks(std::span<const Column* const> chunks, size_t off
     }
 }
 
-void TextRowSink::cellText(std::string& text, const Column* chunk, size_t rowIndex) {
-    const ColumnKind::Code kind = chunk->getKind();
+template <typename T>
+bool TextRowSink::readCell(std::string& text, const Column* chunk, size_t rowIndex) {
+    if (chunk->getKind() != ColumnVector<T>::staticKind()) {
+        return false;
+    }
 
-    if (kind == ColumnNodeIDs::staticKind()) {
-        const ColumnNodeIDs* nodes = static_cast<const ColumnNodeIDs*>(chunk);
-        text = std::to_string(nodes->getRaw()[rowIndex].getValue());
-    } else if (kind == ColumnVector<std::string_view>::staticKind()) {
-        const ColumnVector<std::string_view>* strings = static_cast<const ColumnVector<std::string_view>*>(chunk);
-        text = std::string(strings->getRaw()[rowIndex]);
-    } else if (kind == ColumnOptVector<std::string_view>::staticKind()) {
-        const ColumnOptVector<std::string_view>* strings = static_cast<const ColumnOptVector<std::string_view>*>(chunk);
-        const std::optional<std::string_view>& value = strings->getRaw()[rowIndex];
-        text = value ? std::string(*value) : "null";
-    } else {
+    const ColumnVector<T>* column = static_cast<const ColumnVector<T>*>(chunk);
+    valueText(text, column->getRaw()[rowIndex]);
+    return true;
+}
+
+void TextRowSink::cellText(std::string& text, const Column* chunk, size_t rowIndex) {
+    const bool read = readCell<NodeID>(text, chunk, rowIndex)
+                   || readCell<std::string_view>(text, chunk, rowIndex)
+                   || readCell<std::optional<std::string_view>>(text, chunk, rowIndex)
+                   || readCell<int64_t>(text, chunk, rowIndex)
+                   || readCell<std::optional<int64_t>>(text, chunk, rowIndex)
+                   || readCell<CustomBool>(text, chunk, rowIndex)
+                   || readCell<std::optional<CustomBool>>(text, chunk, rowIndex);
+
+    if (!read) {
         throw TuringException("The sample cannot read a column of type " + std::string(chunk->getTypeName()));
     }
+}
+
+template <typename T>
+void readNodeProperties(MatchGraph& graph, const GraphReader& reader, PropertyTypeID typeID, std::string_view name) {
+    for (auto it = reader.scanNodeProperties<T>(typeID).begin(); it.isValid(); ++it) {
+        MatchNode& node = graph._nodes[it.getCurrentNodeID().getValue()];
+        valueText(node._properties[std::string(name)], it.get());
+    }
+}
+
+template <typename T>
+void readEdgeProperties(MatchGraph& graph, const GraphReader& reader, PropertyTypeID typeID, std::string_view name) {
+    for (auto it = reader.scanEdgeProperties<T>(typeID).begin(); it.isValid(); ++it) {
+        MatchEdge& edge = graph._edges[it.getCurrentEdgeID().getValue()];
+        valueText(edge._properties[std::string(name)], it.get());
+    }
+}
+
+template <typename T>
+void readProperties(MatchGraph& graph, const GraphReader& reader, PropertyTypeID typeID, std::string_view name) {
+    readNodeProperties<T>(graph, reader, typeID, name);
+    readEdgeProperties<T>(graph, reader, typeID, name);
 }
 
 void readMatchGraph(MatchGraph& matchGraph, Graph* graph) {
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphView view = transaction.viewGraph();
     const GraphReader reader = transaction.readGraph();
+    const GraphMetadata& metadata = view.metadata();
 
-    matchGraph._nodes.clear();
+    matchGraph._nodeIDs.clear();
     uint64_t maxNodeID = 0;
     for (auto it = reader.scanNodes().begin(); it.isValid(); it.next()) {
         const NodeID node = it.get();
-        matchGraph._nodes.push_back(node);
+        matchGraph._nodeIDs.push_back(node);
         maxNodeID = std::max(maxNodeID, node.getValue());
     }
 
+    matchGraph._nodes.assign(maxNodeID + 1, {});
+    matchGraph._edges.assign(reader.getEdgeCount(), {});
+    matchGraph._outEdges.assign(maxNodeID + 1, {});
     matchGraph._outNeighbours.assign(maxNodeID + 1, {});
-    for (const NodeID node : matchGraph._nodes) {
+
+    std::vector<LabelID> labelIDs;
+    for (const NodeID node : matchGraph._nodeIDs) {
+        MatchNode& matchNode = matchGraph._nodes[node.getValue()];
+
+        labelIDs.clear();
+        reader.getNodeLabelSet(node).decompose(labelIDs);
+        for (const LabelID labelID : labelIDs) {
+            matchNode._labels.emplace_back(metadata.labels().getName(labelID).value());
+        }
+
         const ColumnNodeIDs source {node};
-        for (const EdgeRecord& edge : reader.getOutEdges(&source)) {
-            matchGraph._outNeighbours[node.getValue()].push_back(edge._otherID);
+        for (const EdgeRecord& record : reader.getOutEdges(&source)) {
+            MatchEdge& edge = matchGraph._edges[record._edgeID.getValue()];
+            edge._source = node;
+            edge._target = record._otherID;
+            edge._type = std::string(metadata.edgeTypes().getName(record._edgeTypeID).value());
+
+            matchGraph._outEdges[node.getValue()].push_back(record._edgeID);
+            matchGraph._outNeighbours[node.getValue()].push_back(record._otherID);
         }
     }
 
-    matchGraph._names.assign(maxNodeID + 1, "");
-    const PropertyType nameType = view.metadata().propTypes().get("name").value();
-    for (auto it = reader.scanNodeProperties<types::String>(nameType._id).begin(); it.isValid(); ++it) {
-        matchGraph._names[it.getCurrentNodeID().getValue()] = std::string(it.get());
+    for (const PropertyTypeMap::Pair& pair : metadata.propTypes()) {
+        const PropertyType& type = pair._pt;
+        const std::string_view name = *pair._name;
+
+        switch (type._valueType) {
+            case ValueType::Int64:
+                readProperties<types::Int64>(matchGraph, reader, type._id, name);
+            break;
+            case ValueType::String:
+                readProperties<types::String>(matchGraph, reader, type._id, name);
+            break;
+            case ValueType::Bool:
+                readProperties<types::Bool>(matchGraph, reader, type._id, name);
+            break;
+            default:
+                throw TuringException("The sample cannot read properties of type " + std::string(ValueTypeName::value(type._valueType)));
+            break;
+        }
     }
 }
 
@@ -151,8 +261,12 @@ const std::vector<NodeID>& outOf(const MatchGraph& graph, NodeID node) {
     return graph._outNeighbours[node.getValue()];
 }
 
-const std::string& nameOf(const MatchGraph& graph, NodeID node) {
-    return graph._names[node.getValue()];
+const std::vector<EdgeID>& outEdgesOf(const MatchGraph& graph, NodeID node) {
+    return graph._outEdges[node.getValue()];
+}
+
+const MatchEdge& edgeOf(const MatchGraph& graph, EdgeID edge) {
+    return graph._edges[edge.getValue()];
 }
 
 bool hasEdge(const MatchGraph& graph, NodeID source, NodeID target) {
@@ -160,13 +274,52 @@ bool hasEdge(const MatchGraph& graph, NodeID source, NodeID target) {
     return std::find(targets.begin(), targets.end(), target) != targets.end();
 }
 
+bool hasLabel(const MatchGraph& graph, NodeID node, std::string_view label) {
+    const std::vector<std::string>& labels = graph._nodes[node.getValue()]._labels;
+    return std::find(labels.begin(), labels.end(), label) != labels.end();
+}
+
+const std::string* propertyOf(const Properties& properties, std::string_view name) {
+    const auto it = properties.find(name);
+    return it == properties.end() ? nullptr : &it->second;
+}
+
+const std::string* propertyOf(const MatchGraph& graph, NodeID node, std::string_view name) {
+    return propertyOf(graph._nodes[node.getValue()]._properties, name);
+}
+
+const std::string* propertyOf(const MatchGraph& graph, EdgeID edge, std::string_view name) {
+    return propertyOf(edgeOf(graph, edge)._properties, name);
+}
+
+// A comparison with a null property is null in Cypher, which a WHERE treats as false.
+bool sameProperty(const std::string* left, const std::string* right) {
+    return left && right && *left == *right;
+}
+
+bool differentProperty(const std::string* left, const std::string* right) {
+    return left && right && *left != *right;
+}
+
+bool sameProperty(const MatchGraph& graph, NodeID left, NodeID right, std::string_view name) {
+    return sameProperty(propertyOf(graph, left, name), propertyOf(graph, right, name));
+}
+
+bool differentProperty(const MatchGraph& graph, NodeID left, NodeID right, std::string_view name) {
+    return differentProperty(propertyOf(graph, left, name), propertyOf(graph, right, name));
+}
+
+bool sameProperty(const MatchGraph& graph, EdgeID left, EdgeID right, std::string_view name) {
+    return sameProperty(propertyOf(graph, left, name), propertyOf(graph, right, name));
+}
+
 // Extends every binding with one more node having an edge into its x, for a further (v)-->(x) pattern.
-void addNodeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph, BoundVariable variable) {
+void addNodeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph, BoundNode variable) {
     std::vector<Binding> partials;
     partials.swap(bindings);
 
     for (const Binding& partial : partials) {
-        for (const NodeID node : graph._nodes) {
+        for (const NodeID node : graph._nodeIDs) {
             if (hasEdge(graph, node, partial._x)) {
                 Binding binding = partial;
                 binding.*variable = node;
@@ -176,10 +329,59 @@ void addNodeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph, Bound
     }
 }
 
+// Extends every binding with one more Person, for a further (v:Person) pattern.
+void addPerson(std::vector<Binding>& bindings, const MatchGraph& graph, BoundNode variable) {
+    std::vector<Binding> partials;
+    partials.swap(bindings);
+
+    for (const Binding& partial : partials) {
+        for (const NodeID node : graph._nodeIDs) {
+            if (hasLabel(graph, node, "Person")) {
+                Binding binding = partial;
+                binding.*variable = node;
+                bindings.push_back(binding);
+            }
+        }
+    }
+}
+
+// Extends every binding with a (person:Person)-[edge:edgeType]->(target) hop; an empty edgeType
+// accepts every edge type.
+void addPersonHop(std::vector<Binding>& bindings,
+                  const MatchGraph& graph,
+                  BoundNode person,
+                  BoundEdge edge,
+                  BoundNode target,
+                  std::string_view edgeType) {
+    std::vector<Binding> partials;
+    partials.swap(bindings);
+
+    for (const Binding& partial : partials) {
+        for (const NodeID node : graph._nodeIDs) {
+            if (!hasLabel(graph, node, "Person")) {
+                continue;
+            }
+
+            for (const EdgeID edgeID : outEdgesOf(graph, node)) {
+                const MatchEdge& matchEdge = edgeOf(graph, edgeID);
+                if (!edgeType.empty() && matchEdge._type != edgeType) {
+                    continue;
+                }
+
+                Binding binding = partial;
+                binding.*person = node;
+                binding.*edge = edgeID;
+                binding.*target = matchEdge._target;
+                bindings.push_back(binding);
+            }
+        }
+    }
+}
+
 void matchTwoIntoX(std::vector<Binding>& bindings, const MatchGraph& graph) {
     bindings.clear();
 
-    for (const NodeID a : graph._nodes) {
+    for (const NodeID a : graph._nodeIDs) {
         for (const NodeID x : outOf(graph, a)) {
             Binding binding;
             binding._a = a;
@@ -231,9 +433,9 @@ void matchTwoIntoXTwoOutToE(std::vector<Binding>& bindings, const MatchGraph& gr
 void matchTwoHopWalk(std::vector<Binding>& bindings, const MatchGraph& graph) {
     bindings.clear();
 
-    for (const NodeID b : graph._nodes) {
+    for (const NodeID b : graph._nodeIDs) {
         for (const NodeID c : outOf(graph, b)) {
-            for (const NodeID a : graph._nodes) {
+            for (const NodeID a : graph._nodeIDs) {
                 if (hasEdge(graph, a, b)) {
                     Binding binding;
                     binding._a = a;
@@ -249,9 +451,9 @@ void matchTwoHopWalk(std::vector<Binding>& bindings, const MatchGraph& graph) {
 void matchDiamond(std::vector<Binding>& bindings, const MatchGraph& graph) {
     bindings.clear();
 
-    for (const NodeID a : graph._nodes) {
+    for (const NodeID a : graph._nodeIDs) {
         for (const NodeID b : outOf(graph, a)) {
-            for (const NodeID c : graph._nodes) {
+            for (const NodeID c : graph._nodeIDs) {
                 for (const NodeID d : outOf(graph, c)) {
                     for (const NodeID e : outOf(graph, d)) {
                         for (const NodeID f : outOf(graph, a)) {
@@ -275,8 +477,8 @@ void matchDoubleDiamond(std::vector<Binding>& bindings, const MatchGraph& graph)
 
     bindings.clear();
     for (const Binding& diamond : diamonds) {
-        for (const NodeID h : graph._nodes) {
-            for (const NodeID i : graph._nodes) {
+        for (const NodeID h : graph._nodeIDs) {
+            for (const NodeID i : graph._nodeIDs) {
                 for (const NodeID j : outOf(graph, diamond._c)) {
                     Binding binding = diamond;
                     binding._h = h;
@@ -289,19 +491,82 @@ void matchDoubleDiamond(std::vector<Binding>& bindings, const MatchGraph& graph)
     }
 }
 
+void matchTwoPersons(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.assign(1, Binding {});
+    addPerson(bindings, graph, &Binding::_a);
+    addPerson(bindings, graph, &Binding::_b);
+}
+
+void matchPersonInterestAndPerson(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.assign(1, Binding {});
+    addPersonHop(bindings, graph, &Binding::_a, &Binding::_e1, &Binding::_b, "INTERESTED_IN");
+    std::erase_if(bindings, [&](const Binding& binding) { return !hasLabel(graph, binding._b, "Interest"); });
+    addPerson(bindings, graph, &Binding::_c);
+}
+
+void matchTwoPersonHops(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.assign(1, Binding {});
+    addPersonHop(bindings, graph, &Binding::_a, &Binding::_e1, &Binding::_b, "");
+    addPersonHop(bindings, graph, &Binding::_c, &Binding::_e2, &Binding::_d, "");
+}
+
+void matchTwoPersonInterests(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.assign(1, Binding {});
+    addPersonHop(bindings, graph, &Binding::_a, &Binding::_e1, &Binding::_b, "INTERESTED_IN");
+    addPersonHop(bindings, graph, &Binding::_c, &Binding::_e2, &Binding::_d, "INTERESTED_IN");
+}
+
 bool namesPairUp(const Binding& binding, const MatchGraph& graph) {
-    const bool aIsB = nameOf(graph, binding._a) == nameOf(graph, binding._b);
-    const bool bIsC = nameOf(graph, binding._b) == nameOf(graph, binding._c);
+    const bool aIsB = sameProperty(graph, binding._a, binding._b, "name");
+    const bool bIsC = sameProperty(graph, binding._b, binding._c, "name");
     return aIsB || bIsC;
 }
 
 bool namesPairUpOrBIsX(const Binding& binding, const MatchGraph& graph) {
-    const bool bIsX = nameOf(graph, binding._b) == nameOf(graph, binding._x);
+    const bool bIsX = sameProperty(graph, binding._b, binding._x, "name");
     return namesPairUp(binding, graph) || bIsX;
+}
+
+bool aNamedLikeC(const Binding& binding, const MatchGraph& graph) {
+    return sameProperty(graph, binding._a, binding._c, "name");
+}
+
+bool samePhD(const Binding& binding, const MatchGraph& graph) {
+    return sameProperty(graph, binding._a, binding._b, "hasPhD");
+}
+
+bool sameFrenchness(const Binding& binding, const MatchGraph& graph) {
+    return sameProperty(graph, binding._a, binding._c, "isFrench");
+}
+
+bool sameDuration(const Binding& binding, const MatchGraph& graph) {
+    return sameProperty(graph, binding._e1, binding._e2, "duration");
+}
+
+bool sameAge(const Binding& binding, const MatchGraph& graph) {
+    return sameProperty(graph, binding._a, binding._b, "age");
+}
+
+bool sameInterestOfDifferentPeople(const Binding& binding, const MatchGraph& graph) {
+    const bool sameInterest = sameProperty(graph, binding._b, binding._d, "name");
+    const bool differentPeople = differentProperty(graph, binding._a, binding._c, "name");
+    return sameInterest && differentPeople;
 }
 
 void filter(std::vector<Binding>& bindings, const MatchGraph& graph, WherePredicate where) {
     std::erase_if(bindings, [&](const Binding& binding) { return !where(binding, graph); });
+}
+
+void returnText(std::string& text, const Binding& binding, const ReturnItem& item, const MatchGraph& graph) {
+    if (item._edge) {
+        const std::string* value = propertyOf(graph, binding.*item._edge, item._property);
+        text = value ? *value : "null";
+    } else if (item._property.empty()) {
+        valueText(text, binding.*item._node);
+    } else {
+        const std::string* value = propertyOf(graph, binding.*item._node, item._property);
+        text = value ? *value : "null";
+    }
 }
 
 void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const ReturnItem> returnItems, const MatchGraph& graph) {
@@ -311,8 +576,7 @@ void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const
     for (const Binding& binding : bindings) {
         row.clear();
         for (const ReturnItem& item : returnItems) {
-            const NodeID node = binding.*item._variable;
-            row.push_back(item._name ? nameOf(graph, node) : std::to_string(node.getValue()));
+            returnText(row.emplace_back(), binding, item, graph);
         }
         rows[row]++;
     }
@@ -407,29 +671,64 @@ bool checkLimitedRows(const RowCounts& bruteForce, std::span<const Row> v3Rows, 
     return matched;
 }
 
-constexpr ReturnItem returnA[] = {{&Binding::_a, false}};
-constexpr ReturnItem returnABC[] = {{&Binding::_a, false}, {&Binding::_b, false}, {&Binding::_c, false}};
-constexpr ReturnItem returnACEG[] = {{&Binding::_a, false},
-                                     {&Binding::_c, false},
-                                     {&Binding::_e, false},
-                                     {&Binding::_g, false}};
-constexpr ReturnItem returnNamesABX[] = {{&Binding::_a, true}, {&Binding::_b, true}, {&Binding::_x, true}};
-constexpr ReturnItem returnNamesABC[] = {{&Binding::_a, true}, {&Binding::_b, true}, {&Binding::_c, true}};
-constexpr ReturnItem returnNamesABCX[] = {{&Binding::_a, true},
-                                          {&Binding::_b, true},
-                                          {&Binding::_c, true},
-                                          {&Binding::_x, true}};
-constexpr ReturnItem returnNamesABCDX[] = {{&Binding::_a, true},
-                                           {&Binding::_b, true},
-                                           {&Binding::_c, true},
-                                           {&Binding::_d, true},
-                                           {&Binding::_x, true}};
-constexpr ReturnItem returnNamesABCDEX[] = {{&Binding::_a, true},
-                                            {&Binding::_b, true},
-                                            {&Binding::_c, true},
-                                            {&Binding::_d, true},
-                                            {&Binding::_e, true},
-                                            {&Binding::_x, true}};
+constexpr ReturnItem returnID(BoundNode node) {
+    return {node, nullptr, {}};
+}
+
+constexpr ReturnItem returnProperty(BoundNode node, std::string_view property) {
+    return {node, nullptr, property};
+}
+
+constexpr ReturnItem returnEdgeProperty(BoundEdge edge, std::string_view property) {
+    return {nullptr, edge, property};
+}
+
+constexpr ReturnItem returnA[] = {returnID(&Binding::_a)};
+constexpr ReturnItem returnABC[] = {returnID(&Binding::_a), returnID(&Binding::_b), returnID(&Binding::_c)};
+constexpr ReturnItem returnACEG[] = {returnID(&Binding::_a),
+                                     returnID(&Binding::_c),
+                                     returnID(&Binding::_e),
+                                     returnID(&Binding::_g)};
+constexpr ReturnItem returnNamesABX[] = {returnProperty(&Binding::_a, "name"),
+                                         returnProperty(&Binding::_b, "name"),
+                                         returnProperty(&Binding::_x, "name")};
+constexpr ReturnItem returnNamesABC[] = {returnProperty(&Binding::_a, "name"),
+                                         returnProperty(&Binding::_b, "name"),
+                                         returnProperty(&Binding::_c, "name")};
+constexpr ReturnItem returnNamesACB[] = {returnProperty(&Binding::_a, "name"),
+                                         returnProperty(&Binding::_c, "name"),
+                                         returnProperty(&Binding::_b, "name")};
+constexpr ReturnItem returnNamesABCX[] = {returnProperty(&Binding::_a, "name"),
+                                          returnProperty(&Binding::_b, "name"),
+                                          returnProperty(&Binding::_c, "name"),
+                                          returnProperty(&Binding::_x, "name")};
+constexpr ReturnItem returnNamesABCDX[] = {returnProperty(&Binding::_a, "name"),
+                                           returnProperty(&Binding::_b, "name"),
+                                           returnProperty(&Binding::_c, "name"),
+                                           returnProperty(&Binding::_d, "name"),
+                                           returnProperty(&Binding::_x, "name")};
+constexpr ReturnItem returnNamesABCDEX[] = {returnProperty(&Binding::_a, "name"),
+                                            returnProperty(&Binding::_b, "name"),
+                                            returnProperty(&Binding::_c, "name"),
+                                            returnProperty(&Binding::_d, "name"),
+                                            returnProperty(&Binding::_e, "name"),
+                                            returnProperty(&Binding::_x, "name")};
+constexpr ReturnItem returnNamesABAndPhDs[] = {returnProperty(&Binding::_a, "name"),
+                                               returnProperty(&Binding::_b, "name"),
+                                               returnProperty(&Binding::_a, "hasPhD"),
+                                               returnProperty(&Binding::_b, "hasPhD")};
+constexpr ReturnItem returnNamesABCAndFrenchness[] = {returnProperty(&Binding::_a, "name"),
+                                                      returnProperty(&Binding::_b, "name"),
+                                                      returnProperty(&Binding::_c, "name"),
+                                                      returnProperty(&Binding::_a, "isFrench")};
+constexpr ReturnItem returnNamesABCDAndDuration[] = {returnProperty(&Binding::_a, "name"),
+                                                     returnProperty(&Binding::_b, "name"),
+                                                     returnProperty(&Binding::_c, "name"),
+                                                     returnProperty(&Binding::_d, "name"),
+                                                     returnEdgeProperty(&Binding::_e1, "duration")};
+constexpr ReturnItem returnNamesABAndAge[] = {returnProperty(&Binding::_a, "name"),
+                                              returnProperty(&Binding::_b, "name"),
+                                              returnProperty(&Binding::_a, "age")};
 
 constexpr SuiteCase suiteCases[] = {
     {"success-reads-joins-on-filters-0",
@@ -467,6 +766,30 @@ constexpr SuiteCase suiteCases[] = {
     {"success-reads-match-where-3",
      "MATCH (a)-->(x), (b)-->(x), (c)-->(x) WHERE (a.name = b.name) OR (b.name = c.name) OR (b.name = x.name) RETURN a.name, b.name, c.name",
      matchThreeIntoX, namesPairUpOrBIsX, returnNamesABC},
+
+    {"success-reads-constraint-0",
+     "MATCH (b)-->(c), (a { name: c.name })-->(b) RETURN a, b, c;",
+     matchTwoHopWalk, aNamedLikeC, returnABC},
+
+    {"value-hash-join-where-0",
+     "MATCH (a:Person), (b:Person) WHERE a.hasPhD = b.hasPhD RETURN a.name, b.name, a.hasPhD, b.hasPhD",
+     matchTwoPersons, samePhD, returnNamesABAndPhDs},
+
+    {"value-hash-join-where-1",
+     "MATCH (a:Person)-[:INTERESTED_IN]->(b:Interest), (c:Person) WHERE a.isFrench = c.isFrench RETURN a.name, b.name, c.name, a.isFrench",
+     matchPersonInterestAndPerson, sameFrenchness, returnNamesABCAndFrenchness},
+
+    {"value-hash-join-where-2",
+     "MATCH (a:Person)-[e1]->(b), (c:Person)-[e2]->(d) WHERE e1.duration = e2.duration RETURN a.name, b.name, c.name, d.name, e1.duration",
+     matchTwoPersonHops, sameDuration, returnNamesABCDAndDuration},
+
+    {"value-hash-join-where-3",
+     "MATCH (a:Person), (b:Person) WHERE a.age = b.age RETURN a.name, b.name, a.age",
+     matchTwoPersons, sameAge, returnNamesABAndAge},
+
+    {"value-hash-join-where-4",
+     "MATCH (a:Person)-[:INTERESTED_IN]->(b) MATCH (c:Person)-[:INTERESTED_IN]->(d) WHERE b.name = d.name AND a.name <> c.name RETURN a.name, c.name, b.name",
+     matchTwoPersonInterests, sameInterestOfDifferentPeople, returnNamesACB},
 
     {"join-bad-keys-error",
      "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g) RETURN a",

--- a/samples/match-brute-force/main.cpp
+++ b/samples/match-brute-force/main.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -21,34 +22,31 @@
 #include "LocalMemory.h"
 #include "reader/GraphReader.h"
 #include "datapart/EdgeRecord.h"
+#include "metadata/PropertyType.h"
 #include "versioning/Transaction.h"
 #include "versioning/ChangeID.h"
 #include "versioning/CommitHash.h"
 #include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
 #include "ID.h"
 
 #include "ToolInit.h"
+#include "TuringException.h"
 
 using namespace db;
 
 namespace {
 
-using Row = std::vector<uint64_t>;
+using Row = std::vector<std::string>;
 using RowCounts = std::map<Row, size_t>;
-using Adjacency = std::vector<std::vector<NodeID>>;
 
 constexpr std::string_view graphName = "simpledb";
 
-constexpr std::string_view joinBadKeysQuery =
-    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g) RETURN a";
-
-constexpr std::string_view doubleDiamondQuery =
-    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g";
-
-constexpr std::string_view doubleDiamondLimitQuery =
-    "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g LIMIT 10";
-
-constexpr size_t doubleDiamondLimit = 10;
+struct MatchGraph {
+    std::vector<NodeID> _nodes;
+    std::vector<std::vector<NodeID>> _outNeighbours;
+    std::vector<std::string> _names;
+};
 
 struct Binding {
     NodeID _a;
@@ -61,14 +59,28 @@ struct Binding {
     NodeID _h;
     NodeID _i;
     NodeID _j;
+    NodeID _x;
 };
 
 using BoundVariable = NodeID Binding::*;
+using MatchFunction = void (*)(std::vector<Binding>&, const MatchGraph&);
+using WherePredicate = bool (*)(const Binding&, const MatchGraph&);
 
-constexpr BoundVariable returnA[] = {&Binding::_a};
-constexpr BoundVariable returnACEG[] = {&Binding::_a, &Binding::_c, &Binding::_e, &Binding::_g};
+struct ReturnItem {
+    BoundVariable _variable {nullptr};
+    bool _name {false};
+};
 
-class NodeRowSink : public NLOutputSink {
+struct SuiteCase {
+    std::string_view _test;
+    std::string_view _query;
+    MatchFunction _match {nullptr};
+    WherePredicate _where {nullptr};
+    std::span<const ReturnItem> _returnItems;
+    size_t _limit {0};
+};
+
+class TextRowSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override;
 
@@ -76,59 +88,175 @@ public:
 
 private:
     std::vector<Row> _rows;
+
+    static void cellText(std::string& text, const Column* chunk, size_t rowIndex);
 };
 
-void NodeRowSink::appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) {
+void TextRowSink::appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) {
     for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
         Row& row = _rows.emplace_back();
         for (const Column* chunk : chunks) {
-            const ColumnNodeIDs* nodeIDs = static_cast<const ColumnNodeIDs*>(chunk);
-            row.push_back(nodeIDs->getRaw()[rowIndex].getValue());
+            cellText(row.emplace_back(), chunk, rowIndex);
         }
     }
 }
 
-void readOutNeighbours(std::vector<NodeID>& nodes, Adjacency& outNeighbours, Graph* graph) {
+void TextRowSink::cellText(std::string& text, const Column* chunk, size_t rowIndex) {
+    const ColumnKind::Code kind = chunk->getKind();
+
+    if (kind == ColumnNodeIDs::staticKind()) {
+        const ColumnNodeIDs* nodes = static_cast<const ColumnNodeIDs*>(chunk);
+        text = std::to_string(nodes->getRaw()[rowIndex].getValue());
+    } else if (kind == ColumnVector<std::string_view>::staticKind()) {
+        const ColumnVector<std::string_view>* strings = static_cast<const ColumnVector<std::string_view>*>(chunk);
+        text = std::string(strings->getRaw()[rowIndex]);
+    } else if (kind == ColumnOptVector<std::string_view>::staticKind()) {
+        const ColumnOptVector<std::string_view>* strings = static_cast<const ColumnOptVector<std::string_view>*>(chunk);
+        const std::optional<std::string_view>& value = strings->getRaw()[rowIndex];
+        text = value ? std::string(*value) : "null";
+    } else {
+        throw TuringException("The sample cannot read a column of type " + std::string(chunk->getTypeName()));
+    }
+}
+
+void readMatchGraph(MatchGraph& matchGraph, Graph* graph) {
     const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphView view = transaction.viewGraph();
     const GraphReader reader = transaction.readGraph();
 
-    nodes.clear();
+    matchGraph._nodes.clear();
     uint64_t maxNodeID = 0;
     for (auto it = reader.scanNodes().begin(); it.isValid(); it.next()) {
         const NodeID node = it.get();
-        nodes.push_back(node);
+        matchGraph._nodes.push_back(node);
         maxNodeID = std::max(maxNodeID, node.getValue());
     }
 
-    outNeighbours.assign(maxNodeID + 1, {});
-    for (const NodeID node : nodes) {
+    matchGraph._outNeighbours.assign(maxNodeID + 1, {});
+    for (const NodeID node : matchGraph._nodes) {
         const ColumnNodeIDs source {node};
         for (const EdgeRecord& edge : reader.getOutEdges(&source)) {
-            outNeighbours[node.getValue()].push_back(edge._otherID);
+            matchGraph._outNeighbours[node.getValue()].push_back(edge._otherID);
+        }
+    }
+
+    matchGraph._names.assign(maxNodeID + 1, "");
+    const PropertyType nameType = view.metadata().propTypes().get("name").value();
+    for (auto it = reader.scanNodeProperties<types::String>(nameType._id).begin(); it.isValid(); ++it) {
+        matchGraph._names[it.getCurrentNodeID().getValue()] = std::string(it.get());
+    }
+}
+
+const std::vector<NodeID>& outOf(const MatchGraph& graph, NodeID node) {
+    return graph._outNeighbours[node.getValue()];
+}
+
+const std::string& nameOf(const MatchGraph& graph, NodeID node) {
+    return graph._names[node.getValue()];
+}
+
+bool hasEdge(const MatchGraph& graph, NodeID source, NodeID target) {
+    const std::vector<NodeID>& targets = outOf(graph, source);
+    return std::find(targets.begin(), targets.end(), target) != targets.end();
+}
+
+// Extends every binding with one more node having an edge into its x, for a further (v)-->(x) pattern.
+void addNodeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph, BoundVariable variable) {
+    std::vector<Binding> partials;
+    partials.swap(bindings);
+
+    for (const Binding& partial : partials) {
+        for (const NodeID node : graph._nodes) {
+            if (hasEdge(graph, node, partial._x)) {
+                Binding binding = partial;
+                binding.*variable = node;
+                bindings.push_back(binding);
+            }
         }
     }
 }
 
-const std::vector<NodeID>& outOf(const Adjacency& outNeighbours, NodeID node) {
-    return outNeighbours[node.getValue()];
-}
-
-bool hasEdge(const Adjacency& outNeighbours, NodeID source, NodeID target) {
-    const std::vector<NodeID>& targets = outOf(outNeighbours, source);
-    return std::find(targets.begin(), targets.end(), target) != targets.end();
-}
-
-void matchDiamond(std::vector<Binding>& bindings, std::span<const NodeID> nodes, const Adjacency& outNeighbours) {
+void matchTwoIntoX(std::vector<Binding>& bindings, const MatchGraph& graph) {
     bindings.clear();
 
-    for (const NodeID a : nodes) {
-        for (const NodeID b : outOf(outNeighbours, a)) {
-            for (const NodeID c : nodes) {
-                for (const NodeID d : outOf(outNeighbours, c)) {
-                    for (const NodeID e : outOf(outNeighbours, d)) {
-                        for (const NodeID f : outOf(outNeighbours, a)) {
-                            for (const NodeID g : outOf(outNeighbours, f)) {
-                                if (hasEdge(outNeighbours, c, g)) {
+    for (const NodeID a : graph._nodes) {
+        for (const NodeID x : outOf(graph, a)) {
+            Binding binding;
+            binding._a = a;
+            binding._x = x;
+            bindings.push_back(binding);
+        }
+    }
+
+    addNodeIntoX(bindings, graph, &Binding::_b);
+}
+
+void matchThreeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    matchTwoIntoX(bindings, graph);
+    addNodeIntoX(bindings, graph, &Binding::_c);
+}
+
+void matchFourIntoX(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    matchThreeIntoX(bindings, graph);
+    addNodeIntoX(bindings, graph, &Binding::_d);
+}
+
+void matchFiveIntoX(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    matchFourIntoX(bindings, graph);
+    addNodeIntoX(bindings, graph, &Binding::_e);
+}
+
+void matchTwoIntoXTwoOutToE(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    std::vector<Binding> intoX;
+    matchTwoIntoX(intoX, graph);
+
+    bindings.clear();
+    for (const Binding& partial : intoX) {
+        for (const NodeID c : outOf(graph, partial._x)) {
+            for (const NodeID e : outOf(graph, c)) {
+                for (const NodeID d : outOf(graph, partial._x)) {
+                    if (hasEdge(graph, d, e)) {
+                        Binding binding = partial;
+                        binding._c = c;
+                        binding._d = d;
+                        binding._e = e;
+                        bindings.push_back(binding);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void matchTwoHopWalk(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+
+    for (const NodeID b : graph._nodes) {
+        for (const NodeID c : outOf(graph, b)) {
+            for (const NodeID a : graph._nodes) {
+                if (hasEdge(graph, a, b)) {
+                    Binding binding;
+                    binding._a = a;
+                    binding._b = b;
+                    binding._c = c;
+                    bindings.push_back(binding);
+                }
+            }
+        }
+    }
+}
+
+void matchDiamond(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+
+    for (const NodeID a : graph._nodes) {
+        for (const NodeID b : outOf(graph, a)) {
+            for (const NodeID c : graph._nodes) {
+                for (const NodeID d : outOf(graph, c)) {
+                    for (const NodeID e : outOf(graph, d)) {
+                        for (const NodeID f : outOf(graph, a)) {
+                            for (const NodeID g : outOf(graph, f)) {
+                                if (hasEdge(graph, c, g)) {
                                     bindings.push_back({a, b, c, d, e, f, g});
                                 }
                             }
@@ -141,15 +269,15 @@ void matchDiamond(std::vector<Binding>& bindings, std::span<const NodeID> nodes,
 }
 
 // The repeated (e) and (h) patterns name variables the diamond already binds, so they add no loop.
-void matchDoubleDiamond(std::vector<Binding>& bindings, std::span<const NodeID> nodes, const Adjacency& outNeighbours) {
+void matchDoubleDiamond(std::vector<Binding>& bindings, const MatchGraph& graph) {
     std::vector<Binding> diamonds;
-    matchDiamond(diamonds, nodes, outNeighbours);
+    matchDiamond(diamonds, graph);
 
     bindings.clear();
     for (const Binding& diamond : diamonds) {
-        for (const NodeID h : nodes) {
-            for (const NodeID i : nodes) {
-                for (const NodeID j : outOf(outNeighbours, diamond._c)) {
+        for (const NodeID h : graph._nodes) {
+            for (const NodeID i : graph._nodes) {
+                for (const NodeID j : outOf(graph, diamond._c)) {
                     Binding binding = diamond;
                     binding._h = h;
                     binding._i = i;
@@ -161,14 +289,30 @@ void matchDoubleDiamond(std::vector<Binding>& bindings, std::span<const NodeID> 
     }
 }
 
-void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const BoundVariable> returnItems) {
+bool namesPairUp(const Binding& binding, const MatchGraph& graph) {
+    const bool aIsB = nameOf(graph, binding._a) == nameOf(graph, binding._b);
+    const bool bIsC = nameOf(graph, binding._b) == nameOf(graph, binding._c);
+    return aIsB || bIsC;
+}
+
+bool namesPairUpOrBIsX(const Binding& binding, const MatchGraph& graph) {
+    const bool bIsX = nameOf(graph, binding._b) == nameOf(graph, binding._x);
+    return namesPairUp(binding, graph) || bIsX;
+}
+
+void filter(std::vector<Binding>& bindings, const MatchGraph& graph, WherePredicate where) {
+    std::erase_if(bindings, [&](const Binding& binding) { return !where(binding, graph); });
+}
+
+void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const ReturnItem> returnItems, const MatchGraph& graph) {
     rows.clear();
 
     Row row;
     for (const Binding& binding : bindings) {
         row.clear();
-        for (const BoundVariable variable : returnItems) {
-            row.push_back((binding.*variable).getValue());
+        for (const ReturnItem& item : returnItems) {
+            const NodeID node = binding.*item._variable;
+            row.push_back(item._name ? nameOf(graph, node) : std::to_string(node.getValue()));
         }
         rows[row]++;
     }
@@ -191,16 +335,16 @@ size_t totalRows(const RowCounts& counts) {
 
 void formatRow(std::string& text, const Row& row) {
     text.clear();
-    for (const uint64_t value : row) {
+    for (const std::string& value : row) {
         if (!text.empty()) {
             text += ",";
         }
-        text += std::to_string(value);
+        text += value;
     }
 }
 
 bool runV3(std::vector<Row>& rows, QueryInterpreterV3& interpreter, LocalMemory& memory, std::string_view query) {
-    NodeRowSink sink;
+    TextRowSink sink;
     QueryStatus status;
     interpreter.execute(status, query, graphName, CommitHash::head(), ChangeID::head(), &memory, &sink);
     memory.clear();
@@ -214,8 +358,7 @@ bool runV3(std::vector<Row>& rows, QueryInterpreterV3& interpreter, LocalMemory&
     return true;
 }
 
-bool compareRows(std::string_view query, const RowCounts& bruteForce, const RowCounts& v3) {
-    spdlog::info("{}", query);
+bool compareRows(const RowCounts& bruteForce, const RowCounts& v3) {
     spdlog::info("  brute force: {} rows, {} distinct", totalRows(bruteForce), bruteForce.size());
     spdlog::info("  v3:          {} rows, {} distinct", totalRows(v3), v3.size());
 
@@ -244,9 +387,7 @@ bool compareRows(std::string_view query, const RowCounts& bruteForce, const RowC
     return matched;
 }
 
-bool checkLimitedRows(std::string_view query, const RowCounts& bruteForce, std::span<const Row> v3Rows, size_t limit) {
-    spdlog::info("{}", query);
-
+bool checkLimitedRows(const RowCounts& bruteForce, std::span<const Row> v3Rows, size_t limit) {
     const size_t expectedCount = std::min(limit, totalRows(bruteForce));
     bool matched = v3Rows.size() == expectedCount;
     if (!matched) {
@@ -265,6 +406,80 @@ bool checkLimitedRows(std::string_view query, const RowCounts& bruteForce, std::
     spdlog::info("  {}", matched ? "every row is a match" : "DIFFERENT");
     return matched;
 }
+
+constexpr ReturnItem returnA[] = {{&Binding::_a, false}};
+constexpr ReturnItem returnABC[] = {{&Binding::_a, false}, {&Binding::_b, false}, {&Binding::_c, false}};
+constexpr ReturnItem returnACEG[] = {{&Binding::_a, false},
+                                     {&Binding::_c, false},
+                                     {&Binding::_e, false},
+                                     {&Binding::_g, false}};
+constexpr ReturnItem returnNamesABX[] = {{&Binding::_a, true}, {&Binding::_b, true}, {&Binding::_x, true}};
+constexpr ReturnItem returnNamesABC[] = {{&Binding::_a, true}, {&Binding::_b, true}, {&Binding::_c, true}};
+constexpr ReturnItem returnNamesABCX[] = {{&Binding::_a, true},
+                                          {&Binding::_b, true},
+                                          {&Binding::_c, true},
+                                          {&Binding::_x, true}};
+constexpr ReturnItem returnNamesABCDX[] = {{&Binding::_a, true},
+                                           {&Binding::_b, true},
+                                           {&Binding::_c, true},
+                                           {&Binding::_d, true},
+                                           {&Binding::_x, true}};
+constexpr ReturnItem returnNamesABCDEX[] = {{&Binding::_a, true},
+                                            {&Binding::_b, true},
+                                            {&Binding::_c, true},
+                                            {&Binding::_d, true},
+                                            {&Binding::_e, true},
+                                            {&Binding::_x, true}};
+
+constexpr SuiteCase suiteCases[] = {
+    {"success-reads-joins-on-filters-0",
+     "MATCH (a)-->(x), (b)-->(x) RETURN a.name, b.name, x.name",
+     matchTwoIntoX, nullptr, returnNamesABX},
+
+    {"success-reads-joins-on-filters-2",
+     "MATCH (a)-->(x), (b)-->(x), (c)-->(x), (d)-->(x) RETURN a.name, b.name, c.name, d.name, x.name",
+     matchFourIntoX, nullptr, returnNamesABCDX},
+
+    {"success-reads-joins-on-filters-3",
+     "MATCH (a)-->(x), (b)-->(x), (c)-->(x), (d)-->(x) RETURN a.name, b.name, c.name, d.name, x.name",
+     matchFourIntoX, nullptr, returnNamesABCDX},
+
+    {"success-reads-joins-on-filters-4",
+     "MATCH (a)-->(x), (b)-->(x), (c)-->(x), (d)-->(x), (e)-->(x) RETURN a.name, b.name, c.name, d.name, e.name, x.name",
+     matchFiveIntoX, nullptr, returnNamesABCDEX},
+
+    {"success-reads-joins-on-filters-5",
+     "MATCH (a)-->(x), (b)-->(x), (x)-->(c)-->(e), (x)-->(d)-->(e) RETURN a",
+     matchTwoIntoXTwoOutToE, nullptr, returnA},
+
+    {"success-reads-match-8",
+     "MATCH (b)-->(c), (a)-->(b) RETURN a, b, c;",
+     matchTwoHopWalk, nullptr, returnABC},
+
+    {"success-reads-match-9",
+     "MATCH (b)-->(c), (a)-->(b)-->(c) RETURN a, b, c;",
+     matchTwoHopWalk, nullptr, returnABC},
+
+    {"success-reads-match-where-2",
+     "MATCH (a)-->(x), (b)-->(x), (c)-->(x) WHERE (a.name = b.name) OR (b.name = c.name) RETURN a.name, b.name, c.name, x.name",
+     matchThreeIntoX, namesPairUp, returnNamesABCX},
+
+    {"success-reads-match-where-3",
+     "MATCH (a)-->(x), (b)-->(x), (c)-->(x) WHERE (a.name = b.name) OR (b.name = c.name) OR (b.name = x.name) RETURN a.name, b.name, c.name",
+     matchThreeIntoX, namesPairUpOrBIsX, returnNamesABC},
+
+    {"join-bad-keys-error",
+     "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g) RETURN a",
+     matchDiamond, nullptr, returnA},
+
+    {"large-double-diamond-join without its LIMIT",
+     "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g",
+     matchDoubleDiamond, nullptr, returnACEG},
+
+    {"large-double-diamond-join",
+     "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g LIMIT 10",
+     matchDoubleDiamond, nullptr, returnACEG, 10},
+};
 
 }
 
@@ -306,9 +521,8 @@ int main(int argc, const char** argv) {
     }
     SimpleGraph::createSimpleGraph(graph);
 
-    std::vector<NodeID> nodes;
-    Adjacency outNeighbours;
-    readOutNeighbours(nodes, outNeighbours, graph);
+    MatchGraph matchGraph;
+    readMatchGraph(matchGraph, graph);
 
     LocalMemory memory;
     QueryInterpreterV3 interpreter(&db.getSystemManager());
@@ -319,26 +533,27 @@ int main(int argc, const char** argv) {
     std::vector<Row> rows;
     bool allMatched = true;
 
-    matchDiamond(bindings, nodes, outNeighbours);
-    project(bruteForce, bindings, returnA);
-    if (!runV3(rows, interpreter, memory, joinBadKeysQuery)) {
-        return EXIT_FAILURE;
-    }
-    countRows(v3, rows);
-    allMatched = compareRows(joinBadKeysQuery, bruteForce, v3) && allMatched;
+    for (const SuiteCase& suiteCase : suiteCases) {
+        suiteCase._match(bindings, matchGraph);
+        if (suiteCase._where) {
+            filter(bindings, matchGraph, suiteCase._where);
+        }
+        project(bruteForce, bindings, suiteCase._returnItems, matchGraph);
 
-    matchDoubleDiamond(bindings, nodes, outNeighbours);
-    project(bruteForce, bindings, returnACEG);
-    if (!runV3(rows, interpreter, memory, doubleDiamondQuery)) {
-        return EXIT_FAILURE;
-    }
-    countRows(v3, rows);
-    allMatched = compareRows(doubleDiamondQuery, bruteForce, v3) && allMatched;
+        if (!runV3(rows, interpreter, memory, suiteCase._query)) {
+            return EXIT_FAILURE;
+        }
 
-    if (!runV3(rows, interpreter, memory, doubleDiamondLimitQuery)) {
-        return EXIT_FAILURE;
+        spdlog::info("{}", suiteCase._test);
+        spdlog::info("  {}", suiteCase._query);
+
+        if (suiteCase._limit == 0) {
+            countRows(v3, rows);
+            allMatched = compareRows(bruteForce, v3) && allMatched;
+        } else {
+            allMatched = checkLimitedRows(bruteForce, rows, suiteCase._limit) && allMatched;
+        }
     }
-    allMatched = checkLimitedRows(doubleDiamondLimitQuery, bruteForce, rows, doubleDiamondLimit) && allMatched;
 
     return allMatched ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/samples/match-brute-force/main.cpp
+++ b/samples/match-brute-force/main.cpp
@@ -2,12 +2,14 @@
 #include <algorithm>
 #include <map>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include <argparse.hpp>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include "TuringDB.h"
@@ -85,11 +87,24 @@ using BoundEdge = EdgeID Binding::*;
 using MatchFunction = void (*)(std::vector<Binding>&, const MatchGraph&);
 using WherePredicate = bool (*)(const Binding&, const MatchGraph&);
 
+enum class Aggregate {
+    None,
+    Count,
+    CountRows,
+    Avg,
+};
+
 struct ReturnItem {
     BoundNode _node {nullptr};
     BoundEdge _edge {nullptr};
     std::string_view _property;
+    std::string_view _constant;
+    Aggregate _aggregate {Aggregate::None};
 };
+
+// Reads the value a query orders on out of a projected row, for the cases that assert an
+// ordering rather than a set of rows
+using RowKey = void (*)(std::string&, const Row&, const MatchGraph&);
 
 struct SuiteCase {
     std::string_view _test;
@@ -98,6 +113,7 @@ struct SuiteCase {
     WherePredicate _where {nullptr};
     std::span<const ReturnItem> _returnItems;
     size_t _limit {0};
+    RowKey _orderKey {nullptr};
 };
 
 void valueText(std::string& text, NodeID id) {
@@ -112,8 +128,19 @@ void valueText(std::string& text, int64_t value) {
     text = std::to_string(value);
 }
 
+// A count is an unsigned column, which needs an exact overload of its own: without one the
+// conversions to the signed, floating point and boolean overloads are all viable
+void valueText(std::string& text, uint64_t value) {
+    text = std::to_string(value);
+}
+
 void valueText(std::string& text, CustomBool value) {
     text = value ? "true" : "false";
+}
+
+// v3 renders a double the way fmt does, so 32.0 reads as "32" and not as "32.000000"
+void valueText(std::string& text, double value) {
+    text = fmt::format("{}", value);
 }
 
 template <typename T>
@@ -166,7 +193,11 @@ void TextRowSink::cellText(std::string& text, const Column* chunk, size_t rowInd
                    || readCell<int64_t>(text, chunk, rowIndex)
                    || readCell<std::optional<int64_t>>(text, chunk, rowIndex)
                    || readCell<CustomBool>(text, chunk, rowIndex)
-                   || readCell<std::optional<CustomBool>>(text, chunk, rowIndex);
+                   || readCell<std::optional<CustomBool>>(text, chunk, rowIndex)
+                   || readCell<double>(text, chunk, rowIndex)
+                   || readCell<std::optional<double>>(text, chunk, rowIndex)
+                   || readCell<uint64_t>(text, chunk, rowIndex)
+                   || readCell<std::optional<uint64_t>>(text, chunk, rowIndex);
 
     if (!read) {
         throw TuringException("The sample cannot read a column of type " + std::string(chunk->getTypeName()));
@@ -313,6 +344,18 @@ bool sameProperty(const MatchGraph& graph, EdgeID left, EdgeID right, std::strin
     return sameProperty(propertyOf(graph, left, name), propertyOf(graph, right, name));
 }
 
+// WHERE NOT TRUE, which no row satisfies.
+bool never(const Binding& binding, const MatchGraph& graph) {
+    return false;
+}
+
+// The name of the node a row returns first, which MATCH (n) ORDER BY n.name orders on.
+void nameOfFirstNode(std::string& text, const Row& row, const MatchGraph& graph) {
+    const NodeID node {std::stoull(row.front())};
+    const std::string* name = propertyOf(graph, node, "name");
+    text = name ? *name : "null";
+}
+
 // Extends every binding with one more node having an edge into its x, for a further (v)-->(x) pattern.
 void addNodeIntoX(std::vector<Binding>& bindings, const MatchGraph& graph, BoundNode variable) {
     std::vector<Binding> partials;
@@ -448,6 +491,53 @@ void matchTwoHopWalk(std::vector<Binding>& bindings, const MatchGraph& graph) {
     }
 }
 
+// Every node, bound to a.
+void matchEveryNode(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+
+    for (const NodeID node : graph._nodeIDs) {
+        Binding binding;
+        binding._a = node;
+        bindings.push_back(binding);
+    }
+}
+
+// Every ordered pair of nodes, for the uncorrelated (a), (b) cartesian product.
+void matchEveryNodePair(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+
+    for (const NodeID left : graph._nodeIDs) {
+        for (const NodeID right : graph._nodeIDs) {
+            Binding binding;
+            binding._a = left;
+            binding._b = right;
+            bindings.push_back(binding);
+        }
+    }
+}
+
+// The one row a query with no MATCH reads, which an aggregate with no input still reduces.
+void matchOneEmptyRow(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+    bindings.emplace_back();
+}
+
+// A two hop walk closing on the node it started from, for (a)-->(b)-->(a).
+void matchTwoHopLoop(std::vector<Binding>& bindings, const MatchGraph& graph) {
+    bindings.clear();
+
+    for (const NodeID a : graph._nodeIDs) {
+        for (const NodeID b : outOf(graph, a)) {
+            if (hasEdge(graph, b, a)) {
+                Binding binding;
+                binding._a = a;
+                binding._b = b;
+                bindings.push_back(binding);
+            }
+        }
+    }
+}
+
 void matchDiamond(std::vector<Binding>& bindings, const MatchGraph& graph) {
     bindings.clear();
 
@@ -558,7 +648,9 @@ void filter(std::vector<Binding>& bindings, const MatchGraph& graph, WherePredic
 }
 
 void returnText(std::string& text, const Binding& binding, const ReturnItem& item, const MatchGraph& graph) {
-    if (item._edge) {
+    if (!item._constant.empty()) {
+        text = item._constant;
+    } else if (item._edge) {
         const std::string* value = propertyOf(graph, binding.*item._edge, item._property);
         text = value ? *value : "null";
     } else if (item._property.empty()) {
@@ -578,6 +670,106 @@ void project(RowCounts& rows, std::span<const Binding> bindings, std::span<const
         for (const ReturnItem& item : returnItems) {
             returnText(row.emplace_back(), binding, item, graph);
         }
+        rows[row]++;
+    }
+}
+
+bool aggregates(std::span<const ReturnItem> returnItems) {
+    return std::ranges::any_of(returnItems, [](const ReturnItem& item) {
+        return item._aggregate != Aggregate::None;
+    });
+}
+
+// The value an aggregate reduces for one binding, null when the property is absent: a node
+// or edge variable itself is never null, so count over one counts the group's rows
+const std::string* aggregatedValue(const Binding& binding, const ReturnItem& item, const MatchGraph& graph) {
+    if (item._property.empty()) {
+        return nullptr;
+    }
+
+    return propertyOf(graph, binding.*item._node, item._property);
+}
+
+void aggregateText(std::string& text, const ReturnItem& item, std::span<const Binding> group, const MatchGraph& graph) {
+    switch (item._aggregate) {
+        case Aggregate::CountRows:
+            valueText(text, static_cast<int64_t>(group.size()));
+            return;
+        break;
+
+        case Aggregate::Count: {
+            size_t counted = 0;
+            for (const Binding& binding : group) {
+                const bool countsTheVariable = item._property.empty();
+                if (countsTheVariable || aggregatedValue(binding, item, graph)) {
+                    counted++;
+                }
+            }
+
+            valueText(text, static_cast<int64_t>(counted));
+            return;
+        }
+        break;
+
+        case Aggregate::Avg: {
+            double total = 0;
+            size_t counted = 0;
+            for (const Binding& binding : group) {
+                const std::string* value = aggregatedValue(binding, item, graph);
+                if (value) {
+                    total += std::stod(*value);
+                    counted++;
+                }
+            }
+
+            if (counted == 0) {
+                text = "null";
+                return;
+            }
+
+            valueText(text, total / static_cast<double>(counted));
+            return;
+        }
+        break;
+
+        case Aggregate::None:
+            throw TuringException("Not an aggregate");
+        break;
+    }
+}
+
+// Groups the bindings on the return items that are not aggregates, then reduces each
+// aggregate over the bindings of one group
+void projectGrouped(RowCounts& rows, std::span<const Binding> bindings, std::span<const ReturnItem> returnItems, const MatchGraph& graph) {
+    rows.clear();
+
+    std::map<Row, std::vector<Binding>> groups;
+
+    Row key;
+    for (const Binding& binding : bindings) {
+        key.clear();
+        for (const ReturnItem& item : returnItems) {
+            if (item._aggregate == Aggregate::None) {
+                returnText(key.emplace_back(), binding, item, graph);
+            }
+        }
+
+        groups[key].push_back(binding);
+    }
+
+    Row row;
+    for (const auto& [groupKey, group] : groups) {
+        row.clear();
+
+        size_t keyIndex = 0;
+        for (const ReturnItem& item : returnItems) {
+            if (item._aggregate == Aggregate::None) {
+                row.push_back(groupKey[keyIndex++]);
+            } else {
+                aggregateText(row.emplace_back(), item, group, graph);
+            }
+        }
+
         rows[row]++;
     }
 }
@@ -671,6 +863,30 @@ bool checkLimitedRows(const RowCounts& bruteForce, std::span<const Row> v3Rows, 
     return matched;
 }
 
+// A query with no total order may emit tied rows in any order, so an ordering is asserted
+// as the rows of the pattern read out in a non-decreasing key, not as one exact sequence
+bool checkOrderedRows(const RowCounts& bruteForce, std::span<const Row> v3Rows, RowKey rowKey, const MatchGraph& graph) {
+    RowCounts v3;
+    countRows(v3, v3Rows);
+
+    bool matched = compareRows(bruteForce, v3);
+
+    std::string previous;
+    std::string current;
+    for (const Row& row : v3Rows) {
+        rowKey(current, row, graph);
+        if (!previous.empty() && current < previous) {
+            spdlog::error("  key '{}' follows '{}'", current, previous);
+            matched = false;
+        }
+
+        previous = current;
+    }
+
+    spdlog::info("  {}", matched ? "ordered" : "OUT OF ORDER");
+    return matched;
+}
+
 constexpr ReturnItem returnID(BoundNode node) {
     return {node, nullptr, {}};
 }
@@ -681,6 +897,22 @@ constexpr ReturnItem returnProperty(BoundNode node, std::string_view property) {
 
 constexpr ReturnItem returnEdgeProperty(BoundEdge edge, std::string_view property) {
     return {nullptr, edge, property};
+}
+
+constexpr ReturnItem returnConstant(std::string_view value) {
+    return {nullptr, nullptr, {}, value};
+}
+
+constexpr ReturnItem countOf(BoundNode node) {
+    return {node, nullptr, {}, {}, Aggregate::Count};
+}
+
+constexpr ReturnItem countOfRows() {
+    return {nullptr, nullptr, {}, {}, Aggregate::CountRows};
+}
+
+constexpr ReturnItem averageOf(BoundNode node, std::string_view property) {
+    return {node, nullptr, property, {}, Aggregate::Avg};
 }
 
 constexpr ReturnItem returnA[] = {returnID(&Binding::_a)};
@@ -729,6 +961,13 @@ constexpr ReturnItem returnNamesABCDAndDuration[] = {returnProperty(&Binding::_a
 constexpr ReturnItem returnNamesABAndAge[] = {returnProperty(&Binding::_a, "name"),
                                               returnProperty(&Binding::_b, "name"),
                                               returnProperty(&Binding::_a, "age")};
+constexpr ReturnItem returnAB[] = {returnID(&Binding::_a), returnID(&Binding::_b)};
+constexpr ReturnItem returnACountB[] = {returnID(&Binding::_a), countOf(&Binding::_b)};
+constexpr ReturnItem returnCountAAndB[] = {countOf(&Binding::_a), returnID(&Binding::_b)};
+constexpr ReturnItem returnCountAAndCountB[] = {countOf(&Binding::_a), countOf(&Binding::_b)};
+constexpr ReturnItem returnAverageAgeAndA[] = {averageOf(&Binding::_a, "age"), returnID(&Binding::_a)};
+constexpr ReturnItem returnTrue[] = {returnConstant("true")};
+constexpr ReturnItem returnIncrementedCount[] = {returnConstant("109")};
 
 constexpr SuiteCase suiteCases[] = {
     {"success-reads-joins-on-filters-0",
@@ -802,6 +1041,38 @@ constexpr SuiteCase suiteCases[] = {
     {"large-double-diamond-join",
      "MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g LIMIT 10",
      matchDoubleDiamond, nullptr, returnACEG, 10},
+
+    {"fail-reads-loop-0",
+     "MATCH (a)-->(b)-->(a) RETURN a, b;",
+     matchTwoHopLoop, nullptr, returnAB},
+
+    {"where-not-true-return-not-false",
+     "MATCH (n) WHERE NOT TRUE RETURN NOT FALSE",
+     matchEveryNode, never, returnTrue},
+
+    {"count-m-return-n",
+     "MATCH (n), (m) RETURN n, count(m)",
+     matchEveryNodePair, nullptr, returnACountB},
+
+    {"count-n-return-m",
+     "MATCH (n), (m) RETURN count(n), m",
+     matchEveryNodePair, nullptr, returnCountAAndB},
+
+    {"return-count-n-count-m",
+     "MATCH (n), (m) RETURN COUNT(n), COUNT(m)",
+     matchEveryNodePair, nullptr, returnCountAAndCountB},
+
+    {"count-wildcard-increment-empty-input",
+     "RETURN ++++++++++++++++++++++++++++++++COUNT(*)++++++++9++++++++++++++++++++++++++++++99",
+     matchOneEmptyRow, nullptr, returnIncrementedCount},
+
+    {"avg-mixed-return-error",
+     "MATCH (n) RETURN avg(n.age), n",
+     matchEveryNode, nullptr, returnAverageAgeAndA},
+
+    {"fail-reads-order-by-0",
+     "MATCH (n) ORDER BY n.name RETURN n",
+     matchEveryNode, nullptr, returnA, 0, nameOfFirstNode},
 };
 
 }
@@ -861,7 +1132,11 @@ int main(int argc, const char** argv) {
         if (suiteCase._where) {
             filter(bindings, matchGraph, suiteCase._where);
         }
-        project(bruteForce, bindings, suiteCase._returnItems, matchGraph);
+        if (aggregates(suiteCase._returnItems)) {
+            projectGrouped(bruteForce, bindings, suiteCase._returnItems, matchGraph);
+        } else {
+            project(bruteForce, bindings, suiteCase._returnItems, matchGraph);
+        }
 
         if (!runV3(rows, interpreter, memory, suiteCase._query)) {
             return EXIT_FAILURE;
@@ -870,7 +1145,9 @@ int main(int argc, const char** argv) {
         spdlog::info("{}", suiteCase._test);
         spdlog::info("  {}", suiteCase._query);
 
-        if (suiteCase._limit == 0) {
+        if (suiteCase._orderKey) {
+            allMatched = checkOrderedRows(bruteForce, rows, suiteCase._orderKey, matchGraph) && allMatched;
+        } else if (suiteCase._limit == 0) {
             countRows(v3, rows);
             allMatched = compareRows(bruteForce, v3) && allMatched;
         } else {


### PR DESCRIPTION
Add a sample that checks the v3 engine against a brute-force implementation of the query test suite join tests.

```
join-bad-keys-error
MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g) RETURN a
brute force 160 rows, v3 160 rows, v2 624 rows

large-double-diamond-join
MATCH (a)-->(b),(c)-->(d)-->(e),(a)-->(f)-->(g),(c)-->(g),(h),(i),(e),(h),(c)-->(j) RETURN a,c,e,g LIMIT 10
brute force 155520 rows before the LIMIT, v3 155520 rows, v2 544320 rows

success-reads-joins-on-filters-0
MATCH (a)-->(x), (b)-->(x) RETURN a.name, b.name, x.name
brute force 32 rows, v3 32 rows, v2 32 rows in another order

success-reads-joins-on-filters-2
success-reads-joins-on-filters-3
MATCH (a)-->(x), (b)-->(x), (c)-->(x), (d)-->(x) RETURN a.name, b.name, c.name, d.name, x.name
brute force 152 rows, v3 152 rows, v2 152 rows in another order

success-reads-joins-on-filters-4
MATCH (a)-->(x), (b)-->(x), (c)-->(x), (d)-->(x), (e)-->(x) RETURN a.name, b.name, c.name, d.name, e.name, x.name
brute force 378 rows, v3 378 rows, v2 378 rows in another order

success-reads-joins-on-filters-5
MATCH (a)-->(x), (b)-->(x), (x)-->(c)-->(e), (x)-->(d)-->(e) RETURN a
brute force 32 rows, v3 32 rows, v2 PLAN ERROR

success-reads-match-8
MATCH (b)-->(c), (a)-->(b) RETURN a, b, c
brute force 12 rows, v3 12 rows, v2 12 rows in another order

success-reads-match-9
MATCH (b)-->(c), (a)-->(b)-->(c) RETURN a, b, c
brute force 12 rows, v3 12 rows, v2 PLAN ERROR

success-reads-match-where-2
MATCH (a)-->(x), (b)-->(x), (c)-->(x) WHERE (a.name = b.name) OR (b.name = c.name) RETURN a.name, b.name, c.name, x.name
brute force 46 rows, v3 46 rows, v2 46 rows in another order

success-reads-match-where-3
MATCH (a)-->(x), (b)-->(x), (c)-->(x) WHERE (a.name = b.name) OR (b.name = c.name) OR (b.name = x.name) RETURN a.name, b.name, c.name
brute force 46 rows, v3 46 rows, v2 46 rows in another order

success-reads-constraint-0
MATCH (b)-->(c), (a { name: c.name })-->(b) RETURN a, b, c
brute force 4 rows, v3 4 rows, v2 4 rows in another order

value-hash-join-where-0
MATCH (a:Person), (b:Person) WHERE a.hasPhD = b.hasPhD RETURN a.name, b.name, a.hasPhD, b.hasPhD
brute force 32 rows, v3 32 rows, v2 32 rows in another order

value-hash-join-where-1
MATCH (a:Person)-[:INTERESTED_IN]->(b:Interest), (c:Person) WHERE a.isFrench = c.isFrench RETURN a.name, b.name, c.name, a.isFrench
brute force 60 rows, v3 60 rows, v2 60 rows in another order

value-hash-join-where-2
MATCH (a:Person)-[e1]->(b), (c:Person)-[e2]->(d) WHERE e1.duration = e2.duration RETURN a.name, b.name, c.name, d.name, e1.duration
brute force 27 rows, v3 27 rows, v2 27 rows in another order

value-hash-join-where-3
MATCH (a:Person), (b:Person) WHERE a.age = b.age RETURN a.name, b.name, a.age
brute force 4 rows, v3 4 rows, v2 4 rows in another order

value-hash-join-where-4
MATCH (a:Person)-[:INTERESTED_IN]->(b) MATCH (c:Person)-[:INTERESTED_IN]->(d) WHERE b.name = d.name AND a.name <> c.name RETURN a.name, c.name, b.name
brute force 12 rows, v3 12 rows, v2 12 rows in another order
```
