### PR TITLE
CSV: fill both columns of a field named by position and by header

### DIFF
--- a/io/csv/CSVParser.cpp
+++ b/io/csv/CSVParser.cpp
@@ -6,6 +6,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <span>
+#include <string>
+#include <vector>
+
 #include <spdlog/spdlog.h>
 
 #include "columns/ColumnStringTable.h"
@@ -66,6 +71,16 @@ void skipBOMInline(const char*& cursor, const char* end) {
         && static_cast<unsigned char>(cursor[1]) == 0xBB
         && static_cast<unsigned char>(cursor[2]) == 0xBF) {
         cursor += 3;
+    }
+}
+
+void markLastFieldReaders(std::span<const size_t> fieldIndices, std::vector<bool>& lastReaders) {
+    lastReaders.assign(fieldIndices.size(), true);
+
+    for (size_t column = 0; column + 1 < fieldIndices.size(); column++) {
+        const std::span<const size_t> laterColumns = fieldIndices.subspan(column + 1);
+
+        lastReaders[column] = std::ranges::find(laterColumns, fieldIndices[column]) == laterColumns.end();
     }
 }
 
@@ -445,6 +460,11 @@ size_t CSVParser::readChunk(size_t maxRows,
 
     output->clear();
 
+    // Two accesses to one field - row[0] beside row.name - resolve to the same index, so
+    // a column takes the field's characters only when no later column reads it too.
+    std::vector<bool> lastReaders;
+    markLastFieldReaders(fieldIndices, lastReaders);
+
     size_t rowsRead = 0;
 
     while (rowsRead < maxRows) {
@@ -456,7 +476,14 @@ size_t CSVParser::readChunk(size_t maxRows,
         }
 
         for (size_t i = 0; i < fieldIndices.size(); i++) {
-            output->getFieldColumn(i)->push_back(std::move(_fields[fieldIndices[i]]));
+            std::string& field = _fields[fieldIndices[i]];
+            ColumnStringTable::StringColumn* const column = output->getFieldColumn(i);
+
+            if (lastReaders[i]) {
+                column->push_back(std::move(field));
+            } else {
+                column->push_back(field);
+            }
         }
         rowsRead++;
     }

--- a/test/query/ir/LoadCSVSourceTest.cpp
+++ b/test/query/ir/LoadCSVSourceTest.cpp
@@ -162,6 +162,23 @@ TEST_F(LoadCSVSourceTest, readsAFieldNamedTwiceOnce) {
                {{"Alice", "Alice"}, {"Bob", "Bob"}, {"Charlie", "Charlie"}});
 }
 
+// A position and a header naming the same field are declared apart - positions against
+// positions, headers against headers - so the load reads that field once per access.
+// Both accesses still carry the characters the file holds.
+TEST_F(LoadCSVSourceTest, readsAFieldNamedByPositionAndByHeader) {
+    expectRows("LOAD CSV 'headed.csv' WITH HEADERS AS row "
+               "RETURN row[0] AS byPosition, row.name AS byHeader",
+               {{"Alice", "Alice"}, {"Bob", "Bob"}, {"Charlie", "Charlie"}});
+
+    expectRows("LOAD CSV 'headed.csv' WITH HEADERS AS row "
+               "RETURN row.name AS byHeader, row[0] AS byPosition",
+               {{"Alice", "Alice"}, {"Bob", "Bob"}, {"Charlie", "Charlie"}});
+
+    expectRows("LOAD CSV 'headed.csv' WITH HEADERS AS row "
+               "RETURN row[1] AS byPosition, row.age AS byHeader, row[2] AS city",
+               {{"30", "30", "London"}, {"25", "25", "Paris"}, {"35", "35", "Berlin"}});
+}
+
 // An unaliased item is named after the text the query wrote, as every other projected
 // expression is.
 TEST_F(LoadCSVSourceTest, namesAnUnaliasedFieldAfterItsText) {


### PR DESCRIPTION
Fill both columns when a query names one CSV field by position and by header.

```
LOAD CSV 'headed.csv' WITH HEADERS AS row RETURN row[0] AS byPosition, row.name AS byHeader
  before   Alice ""      Bob ""     Charlie ""
  after    Alice Alice   Bob Bob    Charlie Charlie

LoadCSVStmt::declareField dedups positions against positions and headers against headers,
so row[0] and row.name are declared as two fields.
resolveCSVFieldIndices resolves both to file index 0: fieldIndices = [0, 0].
CSVParser::readChunk moved _fields[0] into the first column, and the second column pushed
the moved-from string.

readChunk now moves a field only into its last reader and copies into the earlier ones.

test/query/ir/LoadCSVSourceTest.cpp
  LoadCSVSourceTest.readsAFieldNamedByPositionAndByHeader
    row[0] AS byPosition, row.name AS byHeader
    row.name AS byHeader, row[0] AS byPosition
    row[1] AS byPosition, row.age AS byHeader, row[2] AS city
```
