### PR TITLE
Shell: fit result tables to the terminal instead of overflowing on long values

### DIFF
--- a/tools/turingdb/CMakeLists.txt
+++ b/tools/turingdb/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(turingdb_sources
     TuringDBTool.cpp
     TuringShell.cpp
+    ShellTable.cpp
     LineNoiseHandle.cpp
     ProtectedLineNoiseSink.cpp
     StartCmd.cpp
@@ -18,7 +19,6 @@ target_link_libraries(turingdb PUBLIC
     turing_db_proto_client_s
     turing_db_interpreter_v3_s
     argparse
-    tabulate
     linenoise_s
     termcolor)
 

--- a/tools/turingdb/ShellTable.cpp
+++ b/tools/turingdb/ShellTable.cpp
@@ -1,0 +1,270 @@
+#include "ShellTable.h"
+
+#include <stddef.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <algorithm>
+#include <numeric>
+#include <ostream>
+
+#include "BioAssert.h"
+
+using namespace db;
+
+namespace {
+
+constexpr size_t fallbackTerminalWidth = 80;
+constexpr size_t minimumColumnWidth = 4;
+constexpr size_t hangingIndentWidth = 2;
+
+// "| " on the left of a cell and " " on its right
+constexpr size_t cellDecorationWidth = 3;
+
+size_t getTerminalWidth() {
+    winsize window {};
+    const bool hasWindowSize = ioctl(STDOUT_FILENO, TIOCGWINSZ, &window) == 0;
+
+    if (hasWindowSize && window.ws_col > 0) {
+        return window.ws_col;
+    }
+
+    return fallbackTerminalWidth;
+}
+
+std::string_view trimTrailingNewLines(std::string_view text) {
+    while (!text.empty() && text.back() == '\n') {
+        text.remove_suffix(1);
+    }
+
+    return text;
+}
+
+bool isContinuationByte(char byte) {
+    return (static_cast<unsigned char>(byte) & 0xC0) == 0x80;
+}
+
+size_t getDisplayWidth(std::string_view text) {
+    const ptrdiff_t characters = std::count_if(text.begin(), text.end(), [](char byte) { return !isContinuationByte(byte); });
+
+    return static_cast<size_t>(characters);
+}
+
+// Where the given number of characters ends, so a cut never splits a multi-byte character
+size_t getByteOffset(std::string_view line, size_t characters) {
+    size_t offset = 0;
+
+    for (size_t character = 0; character < characters && offset < line.size(); character++) {
+        offset++;
+
+        while (offset < line.size() && isContinuationByte(line[offset])) {
+            offset++;
+        }
+    }
+
+    return offset;
+}
+
+size_t getTextWidth(std::string_view text) {
+    size_t maxWidth = 0;
+    size_t start = 0;
+
+    while (start <= text.size()) {
+        const size_t newLine = text.find('\n', start);
+        const size_t end = (newLine == std::string_view::npos) ? text.size() : newLine;
+
+        maxWidth = std::max(maxWidth, getDisplayWidth(text.substr(start, end - start)));
+
+        if (newLine == std::string_view::npos) {
+            return maxWidth;
+        }
+
+        start = newLine + 1;
+    }
+
+    return maxWidth;
+}
+
+size_t getIndentWidth(std::string_view line) {
+    const size_t firstWord = line.find_first_not_of(' ');
+
+    return (firstWord == std::string_view::npos) ? 0 : firstWord;
+}
+
+size_t findBreak(std::string_view line, size_t width) {
+    const size_t end = getByteOffset(line, width);
+
+    if (end == line.size()) {
+        return end;
+    }
+
+    const size_t space = line.find_last_of(' ', end);
+    const bool breaksOnSpace = space != std::string_view::npos && space > getIndentWidth(line);
+
+    if (breaksOnSpace) {
+        return space;
+    }
+
+    return end;
+}
+
+void wrapLine(std::string_view line, size_t width, std::vector<std::string>& lines) {
+    if (getDisplayWidth(line) <= width) {
+        lines.emplace_back(line);
+        return;
+    }
+
+    const size_t indent = std::min(getIndentWidth(line) + hangingIndentWidth, width / 2);
+    const std::string hangingIndent(indent, ' ');
+
+    bool firstLine = true;
+    while (!line.empty()) {
+        const size_t available = firstLine ? width : width - indent;
+        const size_t end = findBreak(line, available);
+
+        std::string& wrapped = lines.emplace_back(firstLine ? std::string() : hangingIndent);
+        wrapped += line.substr(0, end);
+
+        line.remove_prefix(end);
+
+        const size_t nextWord = line.find_first_not_of(' ');
+        line.remove_prefix((nextWord == std::string_view::npos) ? line.size() : nextWord);
+
+        firstLine = false;
+    }
+}
+
+void wrapCell(std::string_view text, size_t width, std::vector<std::string>& lines) {
+    text = trimTrailingNewLines(text);
+
+    size_t start = 0;
+    while (start <= text.size()) {
+        const size_t newLine = text.find('\n', start);
+        const size_t end = (newLine == std::string_view::npos) ? text.size() : newLine;
+
+        wrapLine(text.substr(start, end - start), width, lines);
+
+        if (newLine == std::string_view::npos) {
+            return;
+        }
+
+        start = newLine + 1;
+    }
+}
+
+// Narrows the widest columns first, so a single long column does not steal the
+// budget from the short ones next to it
+void shrinkToBudget(std::vector<size_t>& widths, size_t budget) {
+    std::vector<size_t> narrowestFirst(widths.size());
+    std::iota(narrowestFirst.begin(), narrowestFirst.end(), 0);
+    std::sort(narrowestFirst.begin(),
+              narrowestFirst.end(),
+              [&widths](size_t left, size_t right) { return widths[left] < widths[right]; });
+
+    size_t remaining = budget;
+    size_t columnsLeft = widths.size();
+
+    for (const size_t column : narrowestFirst) {
+        const size_t share = remaining / columnsLeft;
+
+        if (widths[column] > share) {
+            widths[column] = std::max(share, minimumColumnWidth);
+        }
+
+        remaining -= std::min(remaining, widths[column]);
+        columnsLeft--;
+    }
+}
+
+void printSeparator(std::ostream& out, const std::vector<size_t>& widths) {
+    for (const size_t width : widths) {
+        out << '+' << std::string(width + cellDecorationWidth - 1, '-');
+    }
+
+    out << "+\n";
+}
+
+void printRow(std::ostream& out, const std::vector<std::string>& row, const std::vector<size_t>& widths) {
+    std::vector<std::vector<std::string>> cells(widths.size());
+    size_t height = 1;
+
+    for (size_t column = 0; column < widths.size(); column++) {
+        if (column < row.size()) {
+            wrapCell(row[column], widths[column], cells[column]);
+        }
+
+        height = std::max(height, cells[column].size());
+    }
+
+    for (size_t line = 0; line < height; line++) {
+        for (size_t column = 0; column < widths.size(); column++) {
+            const std::vector<std::string>& cell = cells[column];
+            const std::string_view text = (line < cell.size()) ? std::string_view(cell[line]) : std::string_view();
+            const size_t textWidth = getDisplayWidth(text);
+            const size_t padding = (textWidth < widths[column]) ? widths[column] - textWidth : 0;
+
+            out << "| " << text << std::string(padding + 1, ' ');
+        }
+
+        out << "|\n";
+    }
+}
+
+}
+
+ShellTable::ShellTable() {
+}
+
+ShellTable::~ShellTable() {
+}
+
+void ShellTable::startRow() {
+    _rows.emplace_back();
+}
+
+void ShellTable::addCell(std::string_view value) {
+    bioassert(!_rows.empty(), "A shell table cell was added outside of a row");
+
+    std::vector<std::string>& row = _rows.back();
+    row.emplace_back(value);
+
+    _columnCount = std::max(_columnCount, row.size());
+}
+
+void ShellTable::computeColumnWidths(std::vector<size_t>& widths) const {
+    widths.assign(_columnCount, 0);
+
+    for (const std::vector<std::string>& row : _rows) {
+        for (size_t column = 0; column < row.size(); column++) {
+            widths[column] = std::max(widths[column], getTextWidth(row[column]));
+        }
+    }
+
+    const size_t naturalWidth = std::accumulate(widths.begin(), widths.end(), size_t {0});
+    const size_t decorationWidth = _columnCount * cellDecorationWidth + 1;
+    const size_t terminalWidth = getTerminalWidth();
+
+    if (naturalWidth + decorationWidth <= terminalWidth) {
+        return;
+    }
+
+    const size_t smallestTable = decorationWidth + _columnCount * minimumColumnWidth;
+    const size_t budget = (terminalWidth > smallestTable) ? terminalWidth - decorationWidth : _columnCount * minimumColumnWidth;
+
+    shrinkToBudget(widths, budget);
+}
+
+void ShellTable::print(std::ostream& out) const {
+    if (_rows.empty()) {
+        return;
+    }
+
+    std::vector<size_t> widths;
+    computeColumnWidths(widths);
+
+    printSeparator(out, widths);
+
+    for (const std::vector<std::string>& row : _rows) {
+        printRow(out, row, widths);
+        printSeparator(out, widths);
+    }
+}

--- a/tools/turingdb/ShellTable.h
+++ b/tools/turingdb/ShellTable.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stddef.h>
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace db {
+
+// A result table sized to the terminal: the columns share the width the terminal has,
+// and a cell line longer than its column is wrapped under a hanging indent rather than
+// pushing the box past the right edge, where the terminal would rewrap it over the borders.
+class ShellTable {
+public:
+    ShellTable();
+    ~ShellTable();
+
+    void startRow();
+    void addCell(std::string_view value);
+
+    void print(std::ostream& out) const;
+
+private:
+    std::vector<std::vector<std::string>> _rows;
+    size_t _columnCount {0};
+
+    void computeColumnWidths(std::vector<size_t>& widths) const;
+};
+
+}

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -13,7 +13,6 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
-#include <tabulate/table.hpp>
 #include <termcolor/termcolor.hpp>
 #include <range/v3/view/drop.hpp>
 
@@ -21,6 +20,7 @@
 #include "Graph.h"
 #include "SystemManager.h"
 #include "LineNoiseHandle.h"
+#include "ShellTable.h"
 #include "LocalMemory.h"
 
 #include "NLOutputSink.h"
@@ -592,64 +592,60 @@ void asString(std::string& out, const ListView lv) {
 }
 
 template <typename T>
-void tabulateWrite(tabulate::RowStream& rs, const T& value) {
+void writeValue(ShellTable& table, const T& value) {
     std::string out;
     asString(out, value);
-    rs << out;
+    table.addCell(out);
 }
 
-struct TabulateCell {
-    tabulate::RowStream& _rowStream;
+struct CellWriter {
+    ShellTable& _table;
     size_t _row {0};
 
     template <typename T>
     void operator()(const ColumnVector<T>* column) {
-        tabulateWrite(_rowStream, column->at(_row));
+        writeValue(_table, column->at(_row));
     }
 
     template <typename T>
     void operator()(const ColumnConst<T>* column) {
-        tabulateWrite(_rowStream, column->at(_row));
+        writeValue(_table, column->at(_row));
     }
 };
 
-void tabulateCell(tabulate::RowStream& rs, const Column* column, size_t row) {
-    TabulateCell cell(rs, row);
+void writeColumnCell(ShellTable& table, const Column* column, size_t row) {
+    CellWriter cell(table, row);
 
     using Dispatcher = ColumnSingleDispatcher<OutputtedTypes::Allowed,
-                                              TabulateCell,
+                                              CellWriter,
                                               OutputtedTypes::Excluded>;
 
     Dispatcher::dispatch(column, cell);
 }
 
-void queryCallback(size_t execCount, const Dataframe* df, tabulate::Table& table) {
+void queryCallback(size_t execCount, const Dataframe* df, ShellTable& table) {
     const size_t rowCount = df->getLogicalRowCount();
 
     if (execCount == 0) {
         // Write header row
-        tabulate::RowStream headerRow;
+        table.startRow();
         for (const NamedColumn* namedCol : df->cols()) {
             const std::string_view name = namedCol->getName();
             if (name.empty()) {
                 const ColumnTag tag = namedCol->getTag();
-                headerRow << "$" + std::to_string(tag.getValue());
+                table.addCell("$" + std::to_string(tag.getValue()));
             } else {
-                headerRow << name;
+                table.addCell(name);
             }
         }
-
-        table.add_row(std::move(headerRow));
     }
 
     // Write data rows
     for (size_t i = 0; i < rowCount; ++i) {
-        tabulate::RowStream rs;
+        table.startRow();
         for (const NamedColumn* namedCol : df->cols()) {
-            tabulateCell(rs, namedCol->getColumn(), i);
+            writeColumnCell(table, namedCol->getColumn(), i);
         }
-
-        table.add_row(std::move(rs));
     }
 }
 
@@ -669,14 +665,13 @@ public:
             return;
         }
 
-        tabulate::RowStream headerRow;
+        _table.startRow();
         std::string header;
         for (size_t columnIndex = 0; columnIndex < _columnNames.size(); columnIndex++) {
             columnHeader(header, columnIndex);
-            headerRow << header;
+            _table.addCell(header);
         }
 
-        _table.add_row(std::move(headerRow));
         _headerWritten = true;
     }
 
@@ -687,33 +682,31 @@ public:
         }
 
         if (!_headerWritten) {
-            tabulate::RowStream headerRow;
+            _table.startRow();
             std::string header;
             for (size_t columnIndex = 0; columnIndex < chunks.size(); columnIndex++) {
                 columnHeader(header, columnIndex);
-                headerRow << header;
+                _table.addCell(header);
             }
 
-            _table.add_row(std::move(headerRow));
             _headerWritten = true;
         }
 
         for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
-            tabulate::RowStream rs;
+            _table.startRow();
             for (const Column* col : chunks) {
-                tabulateCell(rs, col, rowIndex);
+                writeColumnCell(_table, col, rowIndex);
             }
 
-            _table.add_row(std::move(rs));
             _rowCount++;
         }
     }
 
-    tabulate::Table& getTable() { return _table; }
+    ShellTable& getTable() { return _table; }
     size_t getRowCount() const { return _rowCount; }
 
 private:
-    tabulate::Table _table;
+    ShellTable _table;
     std::vector<std::string> _columnNames;
     size_t _rowCount {0};
     bool _headerWritten {false};
@@ -758,7 +751,8 @@ void TuringShell::runMLIRQuery(std::string_view query) {
     }
 
     if (!_quiet) {
-        std::cout << sink.getTable() << "\n";
+        sink.getTable().print(std::cout);
+        std::cout << "\n";
     }
 
     std::cout << "Query returned " << sink.getRowCount() << " rows.\n";
@@ -817,7 +811,7 @@ void TuringShell::processLine(std::string& line) {
     }
 
     // Execute query
-    tabulate::Table table;
+    ShellTable table;
     size_t rowCount = 0;
 
     QueryStatus res;
@@ -876,7 +870,8 @@ void TuringShell::processLine(std::string& line) {
     }
 
     if (!_quiet) {
-        std::cout << table << "\n";
+        table.print(std::cout);
+        std::cout << "\n";
     }
 
     {


### PR DESCRIPTION
Fit the shell result tables to the terminal.