### PR TITLE
MLIR: reuse a property already read of the same rows

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -124,7 +124,7 @@ using DBPassFactory = std::unique_ptr<mlir::Pass> (*)();
 // The optimisation pipeline every query runs through, in order. An EXPLAIN prefix
 // reporting on a pass walks the same table one pass at a time, which is what keeps the
 // pipeline it reports on and the pipeline that runs the same one.
-const std::array<DBPassFactory, 9> dbPassPipeline = {
+const std::array<DBPassFactory, 10> dbPassPipeline = {
     &mlir::db::createFuseScanByLabel,
     &mlir::db::createPushDownFilters,
     &mlir::db::createFuseUnwindEquality,
@@ -133,6 +133,7 @@ const std::array<DBPassFactory, 9> dbPassPipeline = {
     &mlir::db::createFuseScanEdges,
     &mlir::db::createFuseEdgesByType,
     &mlir::db::createFuseScanEdgesByType,
+    &mlir::db::createReusePropertyReads,
     &mlir::db::createTrimUnreadColumns,
 };
 

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -31,6 +31,7 @@ namespace mlir::db {
 #define GEN_PASS_DEF_FUSESCANEDGES
 #define GEN_PASS_DEF_FUSEEDGESBYTYPE
 #define GEN_PASS_DEF_FUSESCANEDGESBYTYPE
+#define GEN_PASS_DEF_REUSEPROPERTYREADS
 #define GEN_PASS_DEF_TRIMUNREADCOLUMNS
 #include "DBPasses.h.inc"
 
@@ -1597,6 +1598,155 @@ struct FuseScanByPropertyValue : public impl::FuseScanByPropertyValueBase<FuseSc
                                               matchPropertyValueScanChain,
                                               fuseScanByPropertyValue,
                                               builder);
+    }
+};
+
+// The ops whose results hold the rows of their operands selected, reordered or repeated as
+// a whole, values untouched, so a property read of an operand and carried through is the
+// column a read of the result would have produced. group_aggregate and collect are not
+// among them - a group's rows are not its input's - and neither is remove_duplicates,
+// whose dedup key is every column it carries, so a wider carry set drops different rows.
+bool mapsRowsThrough(Operation* op) {
+    return isEdgeHop(op) || isa<FilterOp, Unwind, Limit, Skip, Sort>(op);
+}
+
+// The operand whose rows a result's rows are drawn from, if any: each carried column comes
+// back at its own position, and a hop's input re-surfaces as srcids, or tgtids when it
+// walks backwards.
+bool matchRowSourceOperand(Operation* op, const CarrySetLayout& layout, size_t resultIndex, size_t& operandIndex) {
+    if (resultIndex >= layout._resultOffset) {
+        operandIndex = layout._operandOffset + (resultIndex - layout._resultOffset);
+        return true;
+    } else if (isEdgeHop(op)) {
+        constexpr size_t srcResultIndex = 0;
+        constexpr size_t tgtResultIndex = 3;
+        const size_t inputResultIndex = isReverseHop(op) ? tgtResultIndex : srcResultIndex;
+
+        if (resultIndex == inputResultIndex) {
+            operandIndex = 0;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool matchPropertyRead(Operation* op, StringAttr& property, bool& nodeProperty) {
+    if (GetNodeProperties read = dyn_cast<GetNodeProperties>(op)) {
+        property = read.getPropertyAttr();
+        nodeProperty = true;
+        return true;
+    } else if (GetEdgeProperties read = dyn_cast<GetEdgeProperties>(op)) {
+        property = read.getPropertyAttr();
+        nodeProperty = false;
+        return true;
+    }
+
+    return false;
+}
+
+// Widens an op's carry set by one column and hands back the result it comes out as. A carry
+// set is the trailing operands and the trailing results of the op holding it, so the column
+// appends to both; an op's arity is fixed once built, hence the rebuild.
+Value appendCarriedColumn(Operation* op, Value column, mlir::OpBuilder& builder) {
+    llvm::SmallVector<Value> operands;
+    llvm::append_range(operands, op->getOperands());
+    operands.push_back(column);
+
+    llvm::SmallVector<Type> types;
+    llvm::append_range(types, op->getResultTypes());
+    types.push_back(column.getType());
+
+    OperationState state(op->getLoc(), op->getName());
+    state.addOperands(operands);
+    state.addTypes(types);
+    state.addAttributes(op->getAttrs());
+
+    builder.setInsertionPoint(op);
+    Operation* const widened = builder.create(state);
+
+    op->replaceAllUsesWith(widened->getResults().drop_back());
+    op->erase();
+
+    return widened->getResults().back();
+}
+
+// The column holding `property` for the rows of `column`, taken from a read already
+// standing before `useSite` and carried down through the ops in between when that read was
+// taken further up the chain. Null when there is none: this adds no read of its own.
+Value propertyColumnOf(Value column, StringAttr property, bool nodeProperty, Operation* useSite, mlir::OpBuilder& builder) {
+    for (Operation* const user : column.getUsers()) {
+        StringAttr userProperty;
+        bool userReadsNodes = false;
+        if (user == useSite || !matchPropertyRead(user, userProperty, userReadsNodes)) {
+            continue;
+        }
+
+        const bool readsTheSameProperty = userReadsNodes == nodeProperty && userProperty == property;
+        const bool standsBeforeTheUse = user->getBlock() == useSite->getBlock() && user->isBeforeInBlock(useSite);
+
+        if (readsTheSameProperty && standsBeforeTheUse) {
+            return user->getResult(0);
+        }
+    }
+
+    Operation* const def = column.getDefiningOp();
+    if (!def || !mapsRowsThrough(def)) {
+        return {};
+    }
+
+    CarrySetLayout layout;
+    const bool carries = matchCarrySetLayout(def, layout);
+    bioassert(carries, "A row-mapping op has a carry set");
+
+    size_t sourceOperandIndex = 0;
+    const size_t resultIndex = cast<OpResult>(column).getResultNumber();
+    if (!matchRowSourceOperand(def, layout, resultIndex, sourceOperandIndex)) {
+        return {};
+    }
+
+    const Value source = def->getOperand(sourceOperandIndex);
+    const Value sourceProperty = propertyColumnOf(source, property, nodeProperty, def, builder);
+    if (!sourceProperty) {
+        return {};
+    }
+
+    const size_t carriedColumnCount = carriedCount(def, layout);
+    for (size_t carriedIndex = 0; carriedIndex < carriedColumnCount; carriedIndex++) {
+        if (def->getOperand(layout._operandOffset + carriedIndex) == sourceProperty) {
+            return def->getResult(layout._resultOffset + carriedIndex);
+        }
+    }
+
+    return appendCarriedColumn(def, sourceProperty, builder);
+}
+
+struct ReusePropertyReads : public impl::ReusePropertyReadsBase<ReusePropertyReads> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        llvm::SmallVector<Operation*> reads;
+        root->walk([&](Operation* op) {
+            if (isa<GetNodeProperties, GetEdgeProperties>(op)) {
+                reads.push_back(op);
+            }
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (Operation* const read : reads) {
+            StringAttr property;
+            bool nodeProperty = false;
+            const bool isPropertyRead = matchPropertyRead(read, property, nodeProperty);
+            bioassert(isPropertyRead, "A collected op is a property read");
+
+            const Value reused = propertyColumnOf(read->getOperand(0), property, nodeProperty, read, builder);
+            if (!reused) {
+                continue;
+            }
+
+            read->getResult(0).replaceAllUsesWith(reused);
+            read->erase();
+        }
     }
 };
 

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -43,6 +43,11 @@ def FuseScanEdgesByType : Pass<"fuse_scan_edges_by_type"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def ReusePropertyReads : Pass<"reuse_property_reads"> {
+    let summary = "Reuse a property already read of the same rows instead of reading it again";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 def TrimUnreadColumns : Pass<"trim_unread_columns"> {
     let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products and grouping ops";
     let dependentDialects = ["mlir::db::DB"];

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -235,6 +235,7 @@ add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
 add_ir_tests(test_query_ir_fuse_scan_by_node_ids FuseScanByNodeIDsTest.cpp)
 add_ir_tests(test_query_ir_fuse_scan_by_property_value FuseScanByPropertyValueTest.cpp)
 add_ir_tests(test_query_ir_trim_unread_columns TrimUnreadColumnsTest.cpp)
+add_ir_tests(test_query_ir_reuse_property_reads ReusePropertyReadsTest.cpp)
 
 # The edge-scan fusion tests check the rewritten db program, then lower and run it
 # against the shared SimpleGraph fixture to compare its rows with the unfused hop's.
@@ -1771,6 +1772,17 @@ target_link_libraries(test_query_ir_trim_unread_columns_cypher PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_trim_unread_columns_cypher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_reuse_property_reads_cypher ReusePropertyReadsCypherTest.cpp)
+target_sources(test_query_ir_reuse_property_reads_cypher PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_reuse_property_reads_cypher PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_reuse_property_reads_cypher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_turing_test(test_query_ir_order_by_aggregate_key OrderByAggregateKeyTest.cpp)
 target_link_libraries(test_query_ir_order_by_aggregate_key PRIVATE

--- a/test/query/ir/ReusePropertyReadsCypherTest.cpp
+++ b/test/query/ir/ReusePropertyReadsCypherTest.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The query shapes that read one property twice over the same rows, run on simpledb: the
+// rows have to come out as they did when each read fetched the property again.
+class ReusePropertyReadsCypherTest : public TuringTest {
+public:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+protected:
+    void expectRows(std::string_view query, std::vector<StringRowSink::Row> expected) {
+        StringRowSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        std::sort(expected.begin(), expected.end());
+        EXPECT_EQ(rows, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// Remy and Adam are the only nodes with an age, both 32. Codegen splits the conjunction
+// into a filter per conjunct, so the age is read once per filter and once for the RETURN.
+TEST_F(ReusePropertyReadsCypherTest, readsTheAgeOfARangeOnBothSides) {
+    expectRows("MATCH (n) WHERE n.age > 20 AND n.age < 50 RETURN n.name", {{"Remy"}, {"Adam"}});
+}
+
+TEST_F(ReusePropertyReadsCypherTest, returnsTheAgeItFilteredOn) {
+    expectRows("MATCH (n) WHERE n.age > 20 RETURN n.age, n.age + 1", {{"32", "33"}, {"32", "33"}});
+}
+
+// The Remy <-> Adam pair and Remy's INTERESTED_IN edges last 20, Luc -> Animals 20 and
+// Luc -> Computers 15; Ghosts -> Remy lasts 200.
+TEST_F(ReusePropertyReadsCypherTest, readsAnEdgePropertyOnBothSidesOfARange) {
+    expectRows("MATCH (a)-[e]->(b) WHERE e.duration > 15 AND e.duration < 100 RETURN e.name",
+               {{"Remy -> Adam"}, {"Remy -> Ghosts"}, {"Remy -> Eighties"},
+                {"Adam -> Remy"}, {"Luc -> Animals"}});
+}
+
+TEST_F(ReusePropertyReadsCypherTest, ordersByTheNameItReturns) {
+    expectRows("MATCH (p:Person) RETURN p.name ORDER BY p.name",
+               {{"Adam"}, {"Cyrus"}, {"Doruk"}, {"Luc"}, {"Martina"}, {"Maxime"}, {"Remy"}, {"Suhas"}});
+}
+
+TEST_F(ReusePropertyReadsCypherTest, cutsTheRowsItOrderedByAName) {
+    expectRows("MATCH (p:Person) WITH p ORDER BY p.name SKIP 1 LIMIT 3 RETURN p.name",
+               {{"Cyrus"}, {"Doruk"}, {"Luc"}});
+}
+
+// Remy has four edges out and Adam three, so the age the filter read has to reach the
+// projection through the hop that expanded those rows.
+TEST_F(ReusePropertyReadsCypherTest, readsTheSourceAgeAcrossAHop) {
+    expectRows("MATCH (a)-[e]->(b) WHERE a.age > 20 RETURN a.age, e.name, b.name",
+               {{"32", "Remy -> Adam", "Adam"},
+                {"32", "Remy -> Ghosts", "Ghosts"},
+                {"32", "Remy -> Computers", "Computers"},
+                {"32", "Remy -> Eighties", "Eighties"},
+                {"32", "Adam -> Remy", "Remy"},
+                {"32", "Adam -> Bio", "Bio"},
+                {"32", "Adam -> Cooking", "Cooking"}});
+}
+
+// The name of the source is read after two hops, past a filter on a property of its own.
+TEST_F(ReusePropertyReadsCypherTest, readsTheSourceNameAcrossTwoHops) {
+    expectRows("MATCH (a)-[e]->(b)-->(c) WHERE a.age > 20 RETURN a.name, c.name",
+               {{"Remy", "Remy"}, {"Remy", "Bio"}, {"Remy", "Cooking"}, {"Remy", "Remy"},
+                {"Adam", "Adam"}, {"Adam", "Ghosts"}, {"Adam", "Computers"}, {"Adam", "Eighties"}});
+}
+
+// The target name is filtered on and returned, while the source age rides the same hop.
+TEST_F(ReusePropertyReadsCypherTest, readsBothEndsOfAHopTwice) {
+    expectRows("MATCH (a)-->(b) WHERE a.age > 20 AND b.name <> 'Bio' RETURN a.age, b.name",
+               {{"32", "Adam"}, {"32", "Ghosts"}, {"32", "Computers"},
+                {"32", "Eighties"}, {"32", "Remy"}, {"32", "Cooking"}});
+}

--- a/test/query/ir/ReusePropertyReadsTest.cpp
+++ b/test/query/ir/ReusePropertyReadsTest.cpp
@@ -1,0 +1,476 @@
+#include <gtest/gtest.h>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "StorageDialect.h"
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+template <typename OpType>
+size_t countOps(mlir::ModuleOp module) {
+    return collect<OpType>(module).size();
+}
+
+}
+
+class ReusePropertyReadsTest : public ::testing::Test {
+protected:
+    ReusePropertyReadsTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool runReuse(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createReusePropertyReads());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    // The production order: the reuse widens the carry sets, then the trim cuts back the
+    // columns the collapsed reads left behind.
+    bool runReuseThenTrim(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createReusePropertyReads());
+        passManager.addPass(mlir::db::createTrimUnreadColumns());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// MATCH (n) RETURN n.age, n.age + 1
+const char* const twoReadsOfOneColumn = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %again = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %one = db.constant(1 : i64)
+  %sum = db.add %again, %one : (!db.column<none>, !db.column<i64>) -> !db.column<none>
+  db.output(%age, %sum) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, collapsesTwoReadsOfTheSameColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoReadsOfOneColumn);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+
+    llvm::SmallVector<mlir::db::AddOp> sums = collect<mlir::db::AddOp>(*module);
+    ASSERT_EQ(sums.size(), 1u);
+    EXPECT_EQ(sums.front().getLhs(), reads.front().getResult());
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_EQ(outputs.front().getColumns().size(), 2u);
+    EXPECT_EQ(outputs.front().getColumns()[0], reads.front().getResult());
+}
+
+// A read of another property of the same column has nothing to share.
+const char* const twoPropertiesOfOneColumn = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %name = db.get_node_properties(%n, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %name) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, keepsTheReadsOfTwoProperties) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoPropertiesOfOneColumn);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    EXPECT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 2u);
+}
+
+// MATCH (n) WHERE n.age > 42 AND n.age < 50 RETURN n, as codegen splits it: one filter per
+// conjunct, and the second reads the age of the rows the first kept.
+const char* const splitRangeFilter = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %low = db.constant(42 : i64)
+  %above = db.gt %age, %low : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kept = db.filter(%above, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %keptAge = db.get_node_properties(%kept, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %high = db.constant(50 : i64)
+  %below = db.lt %keptAge, %high : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %left = db.filter(%below, {%kept}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%left) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesTheAgeThroughTheFilterOfARange) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(splitRangeFilter);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+
+    llvm::SmallVector<mlir::db::ScanNodes> scans = collect<mlir::db::ScanNodes>(*module);
+    ASSERT_EQ(scans.size(), 1u);
+    EXPECT_EQ(reads.front().getInputNodes(), scans.front().getResult());
+
+    // The first filter now carries the age beside the nodes, and the second predicate reads
+    // that carried column.
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+    mlir::db::FilterOp firstFilter = filters[0];
+    ASSERT_EQ(firstFilter.getColumnsToFilter().size(), 2u);
+    EXPECT_EQ(firstFilter.getColumnsToFilter()[1], reads.front().getResult());
+
+    llvm::SmallVector<mlir::db::LtOp> comparisons = collect<mlir::db::LtOp>(*module);
+    ASSERT_EQ(comparisons.size(), 1u);
+    EXPECT_EQ(comparisons.front().getLhs(), firstFilter.getResult(1));
+}
+
+// MATCH (n) WHERE n.age > 42 AND n.age < 50 RETURN n.age: the projection reads the age a
+// third time, two filters down from the read that stays.
+const char* const splitRangeFilterReturningAge = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %low = db.constant(42 : i64)
+  %above = db.gt %age, %low : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kept = db.filter(%above, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %keptAge = db.get_node_properties(%kept, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %high = db.constant(50 : i64)
+  %below = db.lt %keptAge, %high : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %left = db.filter(%below, {%kept}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %leftAge = db.get_node_properties(%left, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%leftAge) : !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesTheAgeDownToTheProjection) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(splitRangeFilterReturningAge);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+    mlir::db::FilterOp secondFilter = filters[1];
+    ASSERT_EQ(secondFilter.getColumnsToFilter().size(), 2u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_EQ(outputs.front().getColumns().size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front(), secondFilter.getResult(1));
+}
+
+// With nothing left reading the node column, the trim drops it from the second filter and
+// the projection rides the carried age alone.
+TEST_F(ReusePropertyReadsTest, leavesTheTrimAFilterOfOneColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(splitRangeFilterReturningAge);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuseThenTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+    EXPECT_EQ(filters[1].getColumnsToFilter().size(), 1u);
+}
+
+// MATCH (a)-->(b) WHERE a.age > 42 RETURN a.age: the hop stands between the two reads.
+const char* const readAcrossAHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %low = db.constant(42 : i64)
+  %above = db.gt %age, %low : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kept = db.filter(%above, {%a}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%kept, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %hoppedAge = db.get_node_properties(%s, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%hoppedAge, %t) : !db.column<none>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesTheAgeThroughAHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAcrossAHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdges hop = hops.front();
+    ASSERT_EQ(hop.getColumnsToFilter().size(), 1u);
+    ASSERT_EQ(hop.getFilteredColumns().size(), 1u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns()[0], hop.getFilteredColumns()[0]);
+}
+
+// A reverse hop hands the input node column back as tgtids, not as srcids.
+const char* const readAcrossAReverseHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %s, %e, %et, %t = db.get_in_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %hoppedAge = db.get_node_properties(%t, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %hoppedAge) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesTheAgeThroughAReverseHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAcrossAReverseHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::GetInEdges> hops = collect<mlir::db::GetInEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    EXPECT_EQ(hops.front().getFilteredColumns().size(), 1u);
+}
+
+// The node a forward hop reaches is not the node it started from, so its property is a read
+// of its own.
+const char* const readOfTheHopTarget = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%a, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %targetAge = db.get_node_properties(%t, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %targetAge) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, keepsTheReadOfAHopTarget) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readOfTheHopTarget);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    EXPECT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 2u);
+    EXPECT_EQ(collect<mlir::db::GetOutEdges>(*module).front().getColumnsToFilter().size(), 0u);
+}
+
+// MATCH (n) WITH n ORDER BY n.age SKIP 1 LIMIT 2 RETURN n.age
+const char* const readAcrossASortAndCuts = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %sn, %sage = db.sort(%n, %age) keys [1] ascending [true] : (!db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  %kn = db.skip(%sn) count 1 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %ln = db.limit(%kn) count 2 : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %cutAge = db.get_node_properties(%ln, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%cutAge) : !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesTheSortKeyThroughTheCuts) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAcrossASortAndCuts);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::Skip> skips = collect<mlir::db::Skip>(*module);
+    ASSERT_EQ(skips.size(), 1u);
+    EXPECT_EQ(skips.front().getColumns().size(), 2u);
+
+    llvm::SmallVector<mlir::db::Limit> limits = collect<mlir::db::Limit>(*module);
+    ASSERT_EQ(limits.size(), 1u);
+    ASSERT_EQ(limits.front().getColumns().size(), 2u);
+
+    // The sort still orders by the age it already held, at the index it was given.
+    llvm::SmallVector<mlir::db::Sort> sorts = collect<mlir::db::Sort>(*module);
+    ASSERT_EQ(sorts.size(), 1u);
+    ASSERT_EQ(sorts.front().getKeyColumns().size(), 1u);
+    EXPECT_EQ(sorts.front().getKeyColumns()[0], 1);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front(), limits.front().getResult(1));
+}
+
+// Every column of a remove_duplicates is part of its dedup key, so carrying the age through
+// it would change which rows survive: the second read stays.
+const char* const readAcrossRemoveDuplicates = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %dn = db.remove_duplicates(%n) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %dage = db.get_node_properties(%dn, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %dage) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, keepsTheReadPastARemoveDuplicates) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAcrossRemoveDuplicates);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    EXPECT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 2u);
+    EXPECT_EQ(collect<mlir::db::RemoveDuplicates>(*module).front().getColumns().size(), 1u);
+}
+
+// A group's rows are not the rows it grouped, so the age of a key is not the age of the
+// nodes that fell into it.
+const char* const readAcrossAGroupAggregate = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %gn, %gc = db.group_aggregate(%n, %n) keys 1 aggregates [count] : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<ui64>)
+  %gage = db.get_node_properties(%gn, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %gage, %gc) : !db.column<none>, !db.column<none>, !db.column<ui64>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, keepsTheReadPastAGroupAggregate) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAcrossAGroupAggregate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    EXPECT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 2u);
+    EXPECT_EQ(collect<mlir::db::GroupAggregate>(*module).front().getColumns().size(), 2u);
+}
+
+// A read standing after the filter it would have to be carried through cannot be the one
+// that is kept.
+const char* const readAfterTheFilter = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %name = db.get_node_properties(%n, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %who = db.constant("Remy" : !storage.string)
+  %mask = db.neq %name, %who : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %kept = db.filter(%mask, {%n}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %keptAge = db.get_node_properties(%kept, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%age, %keptAge) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, keepsAReadStandingAfterTheFilter) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(readAfterTheFilter);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    EXPECT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 3u);
+    EXPECT_EQ(collect<mlir::db::FilterOp>(*module).front().getColumnsToFilter().size(), 1u);
+}
+
+// The edge read of an edge property is the counterpart of the node one, and a node read
+// never stands in for it.
+const char* const edgePropertyAcrossAFilter = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %weight = db.get_edge_properties(%e, "weight") : (!db.column<!storage.edge_id>) -> !db.column<none>
+  %low = db.constant(1 : i64)
+  %above = db.gt %weight, %low : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kept = db.filter(%above, {%e}) : (!db.column<!storage.bool>, !db.column<!storage.edge_id>) -> !db.column<!storage.edge_id>
+  %keptWeight = db.get_edge_properties(%kept, "weight") : (!db.column<!storage.edge_id>) -> !db.column<none>
+  db.output(%keptWeight) : !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, carriesAnEdgePropertyThroughAFilter) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(edgePropertyAcrossAFilter);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetEdgeProperties> reads = collect<mlir::db::GetEdgeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    ASSERT_EQ(filters.front().getColumnsToFilter().size(), 2u);
+    EXPECT_EQ(filters.front().getColumnsToFilter()[1], reads.front().getResult());
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front(), filters.front().getResult(1));
+}
+
+// A carry set already holding the column is reused rather than widened again.
+const char* const twoReadsPastOneCarriedAge = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %low = db.constant(42 : i64)
+  %above = db.gt %age, %low : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
+  %kn, %kage = db.filter(%above, {%n, %age}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
+  %readAgain = db.get_node_properties(%kn, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%kage, %readAgain) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(ReusePropertyReadsTest, reusesAColumnTheCarrySetAlreadyHolds) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(twoReadsPastOneCarriedAge);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runReuse(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    ASSERT_EQ(countOps<mlir::db::GetNodeProperties>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 1u);
+    EXPECT_EQ(filters.front().getColumnsToFilter().size(), 2u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns()[0], filters.front().getResult(1));
+    EXPECT_EQ(outputs.front().getColumns()[1], filters.front().getResult(1));
+}


### PR DESCRIPTION
Eliminate common property reads.

```
MATCH (n) WHERE n.age > 42 AND n.age < 50 RETURN n

before reuse_property_reads
  %0 = db.scan_nodes() : !db.column<!storage.node_id>
  %1 = db.get_node_properties(%0, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
  %2 = db.constant(42 : i64)
  %3 = db.gt %1, %2 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
  %4 = db.filter(%3, {%0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
  %5 = db.get_node_properties(%4, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
  %6 = db.constant(50 : i64)
  %7 = db.lt %5, %6 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
  %8 = db.filter(%7, {%4}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
  db.output(%8) names ["n"] : !db.column<!storage.node_id>

after reuse_property_reads
  %0 = db.scan_nodes() : !db.column<!storage.node_id>
  %1 = db.get_node_properties(%0, "age") : (!db.column<!storage.node_id>) -> !db.column<none>
  %2 = db.constant(42 : i64)
  %3 = db.gt %1, %2 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
  %4:2 = db.filter(%3, {%0, %1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<none>) -> (!db.column<!storage.node_id>, !db.column<none>)
  %5 = db.constant(50 : i64)
  %6 = db.lt %4#1, %5 : (!db.column<none>, !db.column<i64>) -> !db.column<!storage.bool>
  %7 = db.filter(%6, {%4#0}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
  db.output(%7) names ["n"] : !db.column<!storage.node_id>
```
