### PR TITLE
MLIR: implement OPTIONAL MATCH

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -76,6 +76,7 @@
 - @feedback_dump_object_bytes.md — bulk-write trivially-copyable object bytes, layouts pinned by central static_asserts; no staging
 - @feedback_doc_utility_functions.md — one-line WHAT comment above each free function in tool .cpp drivers
 - @feedback_minimal_comments.md — write almost no comments; default is none, hard cap 2-4 lines when one is justified
+- @feedback_plain_prose.md — write plainly: one claim per sentence, concrete numbers, no ornament
 - @feedback_no_optimisation_in_codegen.md — no liveness/dead-column/use-later analysis in DBProgramGenerator; optimisation belongs in an MLIR pass
 
 ## Workflow Preferences

--- a/.claude/memory/feedback_plain_prose.md
+++ b/.claude/memory/feedback_plain_prose.md
@@ -1,0 +1,41 @@
+Write plainly. Short declarative sentences, concrete numbers, no ornament.
+
+**Why:** Remy on PR #867: "Your bullet points look like AI splot garbage. Make them
+understandable. Look at how I write myself." The bullets were grammatical but
+written in a mannered register that reads as machine-generated.
+
+The tells, all from that one draft:
+- Inverted or portentous phrasing: "That is how a null node or edge is spelled",
+  "an edge having no null endpoint", "which is the anti-join".
+- Hedged symmetry instead of a fact: "writes nothing where it can, and is rejected
+  where it cannot" for "skips the null rows; CREATE is rejected".
+- Trailing qualifiers that add nothing: "whatever the input chunk says", "again",
+  "of its own".
+- Abstraction where a number was available: "returns the rows it missed" instead of
+  "returns all 8 people, 6 with a null friend".
+
+Naming, from the follow-up questions on the same PR ("What does 'padded rows' mean?",
+"There is no join in turingdb?"):
+- Don't rename a thing the reader already knows. The clause is OPTIONAL MATCH; calling
+  it "the join" made every bullet that used it undecodable. Prose in the tree may say
+  "a left outer join of the rows in flight" as description - that does not make "the
+  join" a name for the clause, and there is no join operator in the engine.
+- A term the code uses is still unexplained on first contact in a PR. "Padded row"
+  appears in NLTypes.td, DBLowering.h and ~20 test comments, and still needed defining
+  in the bullet that introduced it.
+- Introduce a term where it is first used, then reuse it. Don't reach for a synonym
+  ("anti-join") that raises the same question again.
+
+**How to apply:**
+- One claim per sentence. Then the number, query, or name that shows it.
+- Prefer numerals and concrete names: "0", "[]", "2 rows, not 8", "6 people with no
+  KNOWS_WELL edge".
+- Cut any clause that would survive deletion without loss of meaning.
+- Don't restate a claim in a second, more elegant form.
+- This applies to PR bodies, comments, and user-facing text alike - see
+  [[feedback_minimal_comments]] for the comment-specific rule and
+  [[feedback_pr_body_plain_sentence]] for PR shape.
+
+Remy's own PR bodies are the reference: one imperative sentence, then a fenced code
+block of bare facts (queries, or before/after IR dumps). **None of them use bullet
+points.** Bullets appear only when asked for; the default is sentence + block.

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -230,6 +230,16 @@ void ExprAnalyzer::analyzeBinaryExpr(BinaryExpr* expr) {
                 break;
             }
 
+            // n IS NULL over a node or an edge, which an OPTIONAL MATCH leaves null when
+            // its pattern missed. Only the MLIR engine can bind such a variable
+            const bool comparesEntityToNull =
+                pair == TypePairBitset(EvaluatedType::NodePattern, EvaluatedType::Null)
+                || pair == TypePairBitset(EvaluatedType::EdgePattern, EvaluatedType::Null);
+
+            if (_isV3 && comparesEntityToNull) {
+                break;
+            }
+
             const std::string error = fmt::format(
                 "Operands are not valid or compatible types: '{}' and '{}'",
                 EvaluatedTypeName::value(a),

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -124,8 +124,8 @@ void ReadStmtAnalyzer::analyze(Stmt* stmt) {
 }
 
 void ReadStmtAnalyzer::analyze(const MatchStmt* matchSt) {
-    if (matchSt->isOptional()) {
-        throwError("OPTIONAL MATCH not supported", matchSt);
+    if (matchSt->isOptional() && !_isV3) { // only supported by MLIR v3
+        throwError("OPTIONAL MATCH not yet supported.", matchSt);
     }
 
     const Pattern* pattern = matchSt->getPattern();

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -163,10 +163,10 @@ void fillPipelinePassNames(std::vector<std::string_view>& passNames) {
     }
 }
 
-// Under a name no Cypher identifier can be, the way the dependency graph names an
-// anonymised variable, so an OPTIONAL MATCH's row tag is carried alongside the columns its
-// pattern walks without a query variable ever resolving to it
-constexpr std::string_view optionalTagName {"'optional_tag"};
+// The row tag an OPTIONAL MATCH carries beside the columns its pattern walks. A backtick
+// can appear in no Cypher identifier, quoted or not, so no variable of the query's own is
+// ever taken for the tag - the columns are keyed by name.
+constexpr std::string_view optionalTagName {"`optional_tag"};
 
 using UnaryFunctionEmitter = mlir::Value (*)(mlir::OpBuilder& builder,
                                              mlir::Location loc,
@@ -2202,8 +2202,11 @@ void DBProgramGenerator::generateStatementOperations(std::span<Stmt* const> stmt
             const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt);
             generateMatchConstraints(matchStmt);
             generateMatchFilter(matchStmt);
-            generateMatchOrderBy(matchStmt);
-            generateMatchWindow(matchStmt);
+
+            if (!matchStmt->isOptional()) {
+                generateMatchOrderBy(matchStmt);
+                generateMatchWindow(matchStmt);
+            }
         } else if (kind == Stmt::Kind::CALL && !drivesTheTraversal) {
             generateCall(static_cast<const CallStmt*>(stmt));
         } else if (kind == Stmt::Kind::VECTOR_SEARCH && !drivesTheTraversal) {
@@ -3714,6 +3717,11 @@ void DBProgramGenerator::generateWith(const WithStmt* with) {
 }
 
 void DBProgramGenerator::generateOptionalMatch(std::span<Stmt* const> stmt) {
+    // rebindScope carries a column and its name, which is all a read needs. A created
+    // entity is more than that - a pending mask and the properties written on it - and
+    // Cypher puts every reading clause ahead of every updating one, so none is in scope.
+    bioassert(_part._createdEntities.empty(), "An OPTIONAL MATCH cannot follow a CREATE");
+
     llvm::SmallVector<PublishedColumn> scopeColumns;
     collectPublishedColumns(scopeColumns);
 
@@ -3823,6 +3831,11 @@ void DBProgramGenerator::generateOptionalMatch(std::span<Stmt* const> stmt) {
     published.append(constants.begin(), constants.end());
 
     rebindScope(published);
+
+    // An OPTIONAL MATCH's cut reads the rows the join produced, the padded ones included
+    const MatchStmt* matchStmt = static_cast<const MatchStmt*>(stmt.front());
+    generateMatchOrderBy(matchStmt);
+    generateMatchWindow(matchStmt);
 }
 
 void DBProgramGenerator::broadcastConstantProjection(llvm::SmallVectorImpl<mlir::Value>& projected) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -163,6 +163,11 @@ void fillPipelinePassNames(std::vector<std::string_view>& passNames) {
     }
 }
 
+// Under a name no Cypher identifier can be, the way the dependency graph names an
+// anonymised variable, so an OPTIONAL MATCH's row tag is carried alongside the columns its
+// pattern walks without a query variable ever resolving to it
+constexpr std::string_view optionalTagName {"'optional_tag"};
+
 using UnaryFunctionEmitter = mlir::Value (*)(mlir::OpBuilder& builder,
                                              mlir::Location loc,
                                              mlir::db::ColumnType resultType,
@@ -1014,14 +1019,36 @@ void DBProgramGenerator::generateQueryParts(const SinglePartQuery* query) {
         const Stmt* stmt = stmts[index];
 
         if (stmt->getKind() == Stmt::Kind::WITH) {
-            generatePart(stmts.subspan(partBegin, index - partBegin));
+            generateOptionalParts(stmts.subspan(partBegin, index - partBegin));
             generateWith(static_cast<const WithStmt*>(stmt));
             partBegin = index + 1;
         } else if (closesPartOnItsCut(stmt, stmts.subspan(index + 1))) {
-            generatePart(stmts.subspan(partBegin, index + 1 - partBegin));
+            generateOptionalParts(stmts.subspan(partBegin, index + 1 - partBegin));
             publishInFlightColumns();
             partBegin = index + 1;
         }
+    }
+
+    if (partBegin < stmts.size()) {
+        generateOptionalParts(stmts.subspan(partBegin));
+    }
+}
+
+void DBProgramGenerator::generateOptionalParts(std::span<Stmt* const> stmts) {
+    const auto isOptionalMatch = [](const Stmt* stmt) {
+        return stmt->getKind() == Stmt::Kind::MATCH
+               && static_cast<const MatchStmt*>(stmt)->isOptional();
+    };
+
+    size_t partBegin = 0;
+    for (size_t index = 0; index < stmts.size(); index++) {
+        if (!isOptionalMatch(stmts[index])) {
+            continue;
+        }
+
+        generatePart(stmts.subspan(partBegin, index - partBegin));
+        generateOptionalMatch(stmts.subspan(index, 1));
+        partBegin = index + 1;
     }
 
     if (partBegin < stmts.size()) {
@@ -3686,6 +3713,118 @@ void DBProgramGenerator::generateWith(const WithStmt* with) {
     applyPredicateFilters(conjuncts);
 }
 
+void DBProgramGenerator::generateOptionalMatch(std::span<Stmt* const> stmt) {
+    llvm::SmallVector<PublishedColumn> scopeColumns;
+    collectPublishedColumns(scopeColumns);
+
+    // A constant holds one value standing for every row rather than rows of its own, so it
+    // is no row of this join: it stays bound where it is and the pattern reads it there
+    llvm::SmallVector<PublishedColumn> inputs;
+    llvm::SmallVector<PublishedColumn> constants;
+
+    for (const PublishedColumn& column : scopeColumns) {
+        if (yieldsConstantColumn(column._column)) {
+            constants.push_back(column);
+        } else {
+            inputs.push_back(column);
+        }
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    mlir::Block* const outerBlock = _opBuilder.getInsertionBlock();
+
+    // Built into a scratch region: the op's results are the columns the pattern turns out
+    // to yield, which is known only once it is generated
+    mlir::Region pattern;
+    mlir::Block* const patternBlock = new mlir::Block(); // Region destructor frees it
+    pattern.push_back(patternBlock);
+
+    llvm::SmallVector<mlir::Value> inputColumns;
+    llvm::SmallVector<PublishedColumn> patternScope;
+    for (const PublishedColumn& input : inputs) {
+        inputColumns.push_back(input._column);
+        patternScope.push_back({input._decl, input._name, patternBlock->addArgument(input._column.getType(), loc)});
+    }
+
+    // No input column means no input row to tag: the rows the pattern joins onto are the
+    // single empty row the query starts from, which any match marks
+    const bool tagsRows = !inputs.empty();
+    mlir::Value tagArgument;
+    if (tagsRows) {
+        const mlir::db::ColumnType tagType = allocColumnType(_opBuilder.getIntegerType(64, /*isSigned=*/false));
+        tagArgument = patternBlock->addArgument(tagType, loc);
+    }
+
+    patternScope.append(constants.begin(), constants.end());
+
+    rebindScope(patternScope);
+
+    const VariableDependency* tagVariable = nullptr;
+    if (tagsRows) {
+        tagVariable = _vdg.registerBoundVariable(optionalTagName, nullptr);
+        registerValue(tagVariable, tagArgument);
+    }
+
+    _opBuilder.setInsertionPointToStart(patternBlock);
+    generatePart(stmt);
+
+    llvm::SmallVector<PublishedColumn> matched;
+    collectPublishedColumns(matched);
+
+    const auto findMatched = [&matched](std::string_view name) {
+        const auto foundIt = std::ranges::find(matched, name, &PublishedColumn::_name);
+        bioassert(foundIt != matched.end(), "Column '{}' lost by an OPTIONAL MATCH pattern", name);
+        return foundIt;
+    };
+
+    const auto boundOutside = [&inputs, &constants](std::string_view name) {
+        const auto sameName = [name](const PublishedColumn& candidate) {
+            return candidate._name == name;
+        };
+
+        return std::ranges::any_of(inputs, sameName) || std::ranges::any_of(constants, sameName);
+    };
+
+    // The columns the pattern contributes: the ones it joins onto first, in operand order,
+    // then the variables of its own - what a row it missed comes back with null
+    llvm::SmallVector<PublishedColumn> yielded;
+    for (const PublishedColumn& input : inputs) {
+        yielded.push_back(*findMatched(input._name));
+    }
+
+    for (const PublishedColumn& column : matched) {
+        if (column._name == optionalTagName || boundOutside(column._name)) {
+            continue;
+        }
+
+        yielded.push_back(column);
+    }
+
+    llvm::SmallVector<mlir::Value> yieldedColumns;
+    llvm::SmallVector<mlir::Type> resultTypes;
+    for (const PublishedColumn& column : yielded) {
+        yieldedColumns.push_back(column._column);
+        resultTypes.push_back(column._column.getType());
+    }
+
+    const mlir::Value carriedTag = tagsRows ? _part._varMap.at(tagVariable).back() : mlir::Value();
+    _opBuilder.create<mlir::db::OptionalYield>(loc, carriedTag, yieldedColumns);
+
+    _opBuilder.setInsertionPointToEnd(outerBlock);
+
+    auto optionalMatch = _opBuilder.create<mlir::db::OptionalMatch>(loc, resultTypes, inputColumns);
+    optionalMatch.getPattern().takeBody(pattern);
+
+    llvm::SmallVector<PublishedColumn> published {yielded};
+    for (size_t index = 0; index < published.size(); index++) {
+        published[index]._column = optionalMatch.getResult(index);
+    }
+
+    published.append(constants.begin(), constants.end());
+
+    rebindScope(published);
+}
+
 void DBProgramGenerator::broadcastConstantProjection(llvm::SmallVectorImpl<mlir::Value>& projected) {
     const bool constantsAlone = std::ranges::all_of(projected, [](mlir::Value column) {
         return yieldsConstantColumn(column);
@@ -3719,25 +3858,27 @@ void DBProgramGenerator::publishBoundColumns(const Projection* projection,
     const Projection::PublishedDecls& publishedDecls = projection->publishedDecls();
     bioassert(publishedDecls.size() == names.size(), "One declaration per column a WITH publishes expected");
 
+    llvm::SmallVector<PublishedColumn> published;
+    for (size_t index = 0; index < names.size(); index++) {
+        const llvm::StringRef name = names[index];
+        published.push_back({publishedDecls[index], std::string(name.data(), name.size()), columns[index]});
+    }
+
+    rebindScope(published);
+}
+
+void DBProgramGenerator::rebindScope(llvm::ArrayRef<PublishedColumn> published) {
     _part = PartScope {};
     _vdg.clear();
 
-    for (size_t index = 0; index < names.size(); index++) {
-        const llvm::StringRef name = names[index];
-        bioassert(!name.empty(), "Column a WITH publishes without a name");
+    for (const PublishedColumn& column : published) {
+        bioassert(!column._name.empty(), "Bound column without a name");
 
-        const std::string_view boundName {name.data(), name.size()};
-        registerValue(_vdg.registerBoundVariable(boundName, publishedDecls[index]), columns[index]);
+        registerValue(_vdg.registerBoundVariable(column._name, column._decl), column._column);
     }
 }
 
-void DBProgramGenerator::publishInFlightColumns() {
-    // A cut opens no scope of its own, so the part below reads these columns through the
-    // very declarations the part above bound them to. Each name is copied out: the
-    // variables holding them are the ones this clears, and the part below is opened with
-    // them
-    llvm::SmallVector<PublishedColumn> published;
-
+void DBProgramGenerator::collectPublishedColumns(llvm::SmallVectorImpl<PublishedColumn>& published) const {
     forEachVariableColumn([&published](const VarDecl* decl, std::string_view name, mlir::Value column) {
         const auto sameName = [name](const PublishedColumn& candidate) {
             return candidate._name == name;
@@ -3757,13 +3898,13 @@ void DBProgramGenerator::publishInFlightColumns() {
     std::ranges::sort(published, [](const PublishedColumn& left, const PublishedColumn& right) {
         return left._name < right._name;
     });
+}
 
-    _part = PartScope {};
-    _vdg.clear();
+void DBProgramGenerator::publishInFlightColumns() {
+    llvm::SmallVector<PublishedColumn> published;
+    collectPublishedColumns(published);
 
-    for (const PublishedColumn& column : published) {
-        registerValue(_vdg.registerBoundVariable(column._name, column._decl), column._column);
-    }
+    rebindScope(published);
 }
 
 void DBProgramGenerator::forEachVariableColumn(const VariableColumnBinding& bind) const {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -204,6 +204,11 @@ private:
 
     void generateQueryParts(const SinglePartQuery* query);
 
+    // The statements between two WITH barriers, split again at each OPTIONAL MATCH: an
+    // optional pattern keeps the rows it does not match, so it cannot be walked with the
+    // mandatory patterns beside it and closes the traversal before it the way a barrier does
+    void generateOptionalParts(std::span<Stmt* const> stmts);
+
     // One query part: the statements between two WITH barriers
     void generatePart(std::span<Stmt* const> stmts);
 
@@ -217,6 +222,12 @@ private:
     // SKIP or LIMIT reads the rows that MATCH produced, which a later MATCH or UNWIND of
     // the same part would otherwise have crossed into them first
     bool closesPartOnItsCut(const Stmt* stmt, std::span<Stmt* const> following) const;
+
+    // Emits the db.optional_match of one OPTIONAL MATCH, given as the single-statement
+    // @param stmt: the columns in flight become the rows its pattern joins onto, the
+    // pattern is generated into the op's region as a part of its own, and the op's
+    // results - those rows with the ones the pattern missed added back - take the scope over
+    void generateOptionalMatch(std::span<Stmt* const> stmt);
 
     void generateTraversal(std::span<Stmt* const> stmts);
 
@@ -514,6 +525,15 @@ private:
     // Publishes every column in scope under the name it already carries, so the part that
     // follows a cut reads them the way it reads what a WITH published
     void publishInFlightColumns();
+
+    // Every column in scope, deduplicated by name and in name order so the columns a cut
+    // or an OPTIONAL MATCH carries are the query's choice and not the addresses'
+    void collectPublishedColumns(llvm::SmallVectorImpl<PublishedColumn>& published) const;
+
+    // Drops the scope and opens a fresh one holding these columns alone: what a barrier or
+    // a cut publishes, and what an OPTIONAL MATCH hands to its pattern and then to the rest
+    // of the query
+    void rebindScope(llvm::ArrayRef<PublishedColumn> published);
 
     // The column each variable in scope is bound to, under the declaration and the name
     // it carries: the traversal variables, what a CALL yielded, what a CREATE wrote, and

--- a/query/ir/dialect/db/DBDialect.td
+++ b/query/ir/dialect/db/DBDialect.td
@@ -20,7 +20,12 @@ def DB : Dialect {
 
 def ConstantThroughOperands : NativeOpTrait<"ConstantThroughOperands">;
 
-// Base, from which all TuringDB dialects are derived
+// Base, from which all TuringDB dialects are derived.
+//
+// Pure on an op here says it reads the graph and writes nothing - not that it keeps the
+// row count. db.limit, db.sort, db.cross_product and db.optional_match all change the
+// number of rows and all carry Pure, so a canonicalizer added to the pass pipeline has to
+// be told to leave them alone.
 class TuringOp<string mnemonic, list<Trait> traits = []>
     : Op<DB, mnemonic, traits>;
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -831,3 +831,87 @@ LogicalResult VectorSearch::verify() {
     return success();
 }
 
+// The region's entry block stands for the rows in flight: one argument per input
+// column, then the row tag. The db.optional_yield names the tag and the columns
+// the region contributes - the input columns as the pattern left them, then the
+// pattern's own variables - and the op's results are exactly those columns. A
+// pattern variable is what a row the pattern missed comes back with null, so it
+// has to be an ID column: those carry an invalid ID, which is how a null entity
+// is spelled, where a property value column would need a null of its own.
+LogicalResult OptionalMatch::verify() {
+    Block& patternBlock = getPattern().front();
+
+    auto yield = dyn_cast_or_null<OptionalYield>(patternBlock.empty() ? nullptr : &patternBlock.back());
+    if (!yield) {
+        return emitOpError("pattern region must end with a db.optional_yield");
+    }
+
+    const size_t inputCount = getInputColumns().size();
+
+    // No input column means no input row to tag: the rows the pattern joins onto are
+    // the single empty row the query starts from.
+    const size_t expectedArguments = inputCount == 0 ? 0 : inputCount + 1;
+
+    if (patternBlock.getNumArguments() != expectedArguments) {
+        return emitOpError("pattern region takes one argument per input column plus the row tag, ")
+               << "expected " << expectedArguments << " but has " << patternBlock.getNumArguments();
+    }
+
+    const bool tagsRows = inputCount != 0;
+    const bool yieldsATag = yield.getTag() != nullptr;
+
+    if (tagsRows != yieldsATag) {
+        return emitOpError("the pattern yields a row tag exactly when the op takes input columns");
+    }
+
+    for (size_t inputIndex = 0; inputIndex < inputCount; inputIndex++) {
+        if (patternBlock.getArgument(inputIndex).getType() != getInputColumns()[inputIndex].getType()) {
+            return emitOpError("pattern argument ") << inputIndex << " must have the type of input column "
+                                                    << inputIndex;
+        }
+    }
+
+    const ValueRange yieldedColumns = yield.getColumns();
+    if (yieldedColumns.empty()) {
+        return emitOpError("pattern must yield at least one column");
+    }
+
+    if (yieldedColumns.size() < inputCount) {
+        return emitOpError("pattern must yield at least one column per input column, expected ")
+               << inputCount << " but has " << yieldedColumns.size();
+    }
+
+    for (size_t inputIndex = 0; inputIndex < inputCount; inputIndex++) {
+        if (yieldedColumns[inputIndex].getType() != getInputColumns()[inputIndex].getType()) {
+            return emitOpError("yielded column ") << inputIndex << " must have the type of input column "
+                                                  << inputIndex;
+        }
+    }
+
+    for (size_t columnIndex = inputCount; columnIndex < yieldedColumns.size(); columnIndex++) {
+        const auto column = llvm::dyn_cast<ColumnType>(yieldedColumns[columnIndex].getType());
+        const mlir::Type elementType = column ? column.getType() : mlir::Type();
+        const bool isEntityColumn = llvm::isa_and_present<storage::NodeIDType, storage::EdgeIDType>(elementType);
+
+        if (!isEntityColumn) {
+            return emitOpError("pattern variable column ")
+                   << columnIndex << " must be a node or edge ID column, so a missed match can be null";
+        }
+    }
+
+    const Operation::result_type_range resultTypes = getOperation()->getResultTypes();
+    if (resultTypes.size() != yieldedColumns.size()) {
+        return emitOpError("expects ") << yieldedColumns.size()
+                                       << " results, the columns the pattern yields, but has "
+                                       << resultTypes.size();
+    }
+
+    for (size_t resultIndex = 0; resultIndex < resultTypes.size(); resultIndex++) {
+        if (resultTypes[resultIndex] != yieldedColumns[resultIndex].getType()) {
+            return emitOpError("result ") << resultIndex << " must be the yielded column type "
+                                          << yieldedColumns[resultIndex].getType();
+        }
+    }
+
+    return success();
+}

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -882,7 +882,16 @@ LogicalResult OptionalMatch::verify() {
     }
 
     for (size_t inputIndex = 0; inputIndex < inputCount; inputIndex++) {
-        if (yieldedColumns[inputIndex].getType() != getInputColumns()[inputIndex].getType()) {
+        const mlir::Type inputType = getInputColumns()[inputIndex].getType();
+
+        // A traversal rebinds its source to a typed ID column, so a pattern walking from a
+        // column whose element type is still unspecified - what a CALL yields - hands it
+        // back refined. Any other change of type is a carry set that lost track of a column.
+        const auto inputColumn = llvm::dyn_cast<ColumnType>(inputType);
+        const bool refinesAnUnspecifiedColumn = inputColumn
+                                                && llvm::isa<mlir::NoneType>(inputColumn.getType());
+
+        if (yieldedColumns[inputIndex].getType() != inputType && !refinesAnUnspecifiedColumn) {
             return emitOpError("yielded column ") << inputIndex << " must have the type of input column "
                                                   << inputIndex;
         }

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1892,7 +1892,8 @@ def OptionalMatch : TuringOp<"optional_match", [Pure]> {
     or edge is an invalid ID (`ID::isValid()`), which reads as null through a
     property fetch and renders as null, so no column type changes here.
 
-    Reading the graph is deterministic, so the op is Pure.
+    Reading the graph is deterministic and the op writes nothing, so it is Pure -
+    which says nothing about the row count, and this op changes it.
   }];
 
   let arguments = (ins Variadic<Column>:$input_columns);

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1854,4 +1854,84 @@ def ShortestPath : TuringOp<"shortest_path", [Pure]> {
   }];
 }
 
+/**
+* OptionalMatch
+*/
+def OptionalMatch : TuringOp<"optional_match", [Pure]> {
+  let summary = "Match a pattern against the rows in flight, keeping the rows it does not match";
+
+  let description = [{
+    Models Cypher's OPTIONAL MATCH: a left outer join of the rows in flight
+    against a pattern. A row the pattern matches fans out exactly as a MATCH
+    would; a row it matches not at all survives once, with the pattern's own
+    variables null. The pattern matches whole or not at all - a second hop that
+    finds nothing nulls the first hop's variables too - so it cannot be modelled
+    by making each traversal optional, and lives in a region of its own.
+
+    `input_columns` are the columns the pattern joins onto - every named column
+    the query holds at this point. The region's entry block takes one argument
+    per input column, so the pattern walks the rows in flight rather than the
+    whole graph, plus a trailing `!db.column<ui64>` row tag: the position of each
+    input row, carried through the pattern the way any other column is, so the
+    rows that matched are known once the pattern is walked. A query opening on
+    OPTIONAL MATCH has no input column and so no tag either - the rows it joins
+    onto are the single empty row Cypher starts from, which any match marks.
+
+      %p2, %e, %f = db.optional_match(%p) ({
+        ^bb0(%pIn: !db.column<!storage.node_id>, %tag: !db.column<ui64>):
+          %s, %e, %et, %t, %tag2 = db.get_out_edges(%pIn, {%tag}) : ...
+          db.optional_yield %tag2, {%s, %e, %t} : !db.column<ui64>, {...}
+      }) : (!db.column<!storage.node_id>) -> (...)
+
+    The db.optional_yield names the tag as the pattern left it, then the columns
+    the region contributes: one per input column first, in operand order - these
+    are the input rows as the pattern filtered and repeated them - then one per
+    variable the pattern binds of its own. The op's results line up with those
+    columns, so the results past the input count are the pattern's variables, and
+    those are the ones a row the pattern missed comes back with null. A null node
+    or edge is an invalid ID (`ID::isValid()`), which reads as null through a
+    property fetch and renders as null, so no column type changes here.
+
+    Reading the graph is deterministic, so the op is Pure.
+  }];
+
+  let arguments = (ins Variadic<Column>:$input_columns);
+
+  // One per column the region yields: the input columns as the pattern left
+  // them, then the variables the pattern binds.
+  let results = (outs Variadic<Column>:$results);
+
+  // Exactly one block, ending in a db.optional_yield.
+  let regions = (region SizedRegion<1>:$pattern);
+
+  let assemblyFormat = [{
+    `(` $input_columns `)` $pattern attr-dict `:` functional-type($input_columns, results)
+  }];
+
+  let hasVerifier = 1;
+}
+
+/**
+* OptionalYield
+*/
+def OptionalYield : TuringOp<"optional_yield", [Pure, Terminator, AttrSizedOperandSegments, HasParent<"OptionalMatch">]> {
+  let summary = "Name the row tag and the columns a db.optional_match's pattern contributes";
+
+  let description = [{
+    Terminates a db.optional_match's pattern region. `tag` is the row tag as the
+    pattern left it - the input row each matched row came from, absent when the
+    op has no input column - and `columns` are the columns the region
+    contributes, one per input column in operand order followed by the pattern's
+    own variables. The enclosing op's results are exactly those columns.
+  }];
+
+  let arguments = (ins Optional<ColumnRowTags>:$tag, Variadic<Column>:$columns);
+
+  // The tag's type is buildable and so left out; only the contributed column types
+  // are spelled, in braces as db.cross_product spells a factor's.
+  let assemblyFormat = [{
+    ($tag^ `,`)? `{` $columns `}` attr-dict `:` `{` qualified(type($columns)) `}`
+  }];
+}
+
 #endif //TURINGDB_OPS

--- a/query/ir/dialect/db/DBTypes.td
+++ b/query/ir/dialect/db/DBTypes.td
@@ -60,4 +60,15 @@ def ColumnOwnedStrings : ColumnOf<"::mlir::storage::OwnedStringType", "owned_str
 // so it rides the node ID column above.
 def ColumnDoubles : ColumnOf<"::mlir::Float64Type", "f64">;
 
+// The column an OPTIONAL MATCH's row tag rides on: the position of the input row
+// each matched row descends from. Unlike the ColumnOf constraints above it carries
+// a BuildableType recipe for its single concrete type, so db.optional_yield can
+// leave the tag's type out of its assembly and build it from here instead.
+def ColumnRowTags : Type<
+        CPred<"::llvm::isa<::mlir::db::ColumnType>($_self) && "
+              "::llvm::cast<::mlir::db::ColumnType>($_self).getType().isUnsignedInteger(64)">,
+        "column of row tags", "::mlir::db::ColumnType">,
+    BuildableType<"::mlir::db::ColumnType::get($_builder.getContext(), "
+                  "$_builder.getIntegerType(64, false))">;
+
 #endif // TURINGDB_TYPES

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -2259,4 +2259,102 @@ def ProcedureInit : NLOp<"procedure_init", [AttrSizedOperandSegments]> {
   }];
 }
 
+/**
+* OptionalBuffer
+*/
+// NOT Pure: it re-initializes the accumulator, so it must run exactly where it
+// sits - once per step of the rows the OPTIONAL MATCH joins onto - and must not
+// be hoisted, CSE'd or eliminated (like nl.sort_buffer).
+def OptionalBuffer : NLOp<"optional_buffer", [RowAlignedThroughOperands]> {
+  let summary = "Create (and reset) the accumulator for one OPTIONAL MATCH over this step's rows";
+  let description = [{
+    Sits at the top of the block whose step it covers - the innermost loop body
+    binding the columns the OPTIONAL MATCH joins onto - so the accumulator is
+    empty again at every step. It records this step's input chunks, clears the
+    matched flag of each of their rows, and produces the row tag: a chunk holding
+    each input row's position, which the pattern carries alongside the columns it
+    walks so nl.optional_collect knows which rows matched.
+
+      %state, %tag = nl.optional_buffer (%p) : {!nl.chunk<!storage.node_id>}
+
+    With no input columns - a query opening on OPTIONAL MATCH - the step is the
+    single empty row Cypher starts from, so the accumulator holds one flag and the
+    tag one row. The pattern has nothing to join onto there, so it never carries
+    that tag, which is why the op is row-aligned through its operands: a tag over
+    input rows holds exactly the rows those chunks do.
+  }];
+
+  // The chunks the OPTIONAL MATCH joins onto; the accumulator reads its row count
+  // from the first of them, and rebuilds the rows the pattern missed out of them.
+  let arguments = (ins Variadic<NLChunk>:$input_columns);
+
+  // The accumulator, then the row tag over this step's input rows.
+  let results = (outs NLOptionalState:$state, NLUInt64Chunk:$tag);
+
+  // The tag's type is buildable and so omitted; only the input chunk types are
+  // spelled, in braces as nl.cross_product spells a factor's.
+  let assemblyFormat = [{
+    `(` $input_columns `)` attr-dict `:` `{` qualified(type($input_columns)) `}`
+  }];
+}
+
+/**
+* OptionalCollect
+*/
+// NOT Pure: it appends the step's matched rows to the accumulator and marks the
+// input rows they came from, so it must run exactly where it sits (like
+// nl.sort_collect).
+def OptionalCollect : NLOp<"optional_collect", [AttrSizedOperandSegments]> {
+  let summary = "Append this step's matched rows to an OPTIONAL MATCH accumulator";
+  let description = [{
+    Runs in the pattern's innermost loop body, once per step. Appends the current
+    chunk of every column the pattern contributes to the accumulator's buffers,
+    and marks as matched each input row the tag names, so once the pattern is
+    walked the unmarked rows are exactly the ones it missed.
+
+      nl.optional_collect %state, %tag, (%p2, %e, %f)
+        : {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>}
+
+    The tag is absent when the accumulator has no input columns: the step is then
+    the single empty row, which any collected row marks.
+  }];
+
+  let arguments = (ins NLOptionalStateHandle:$state,
+                       Optional<NLUInt64Chunk>:$tag,
+                       Variadic<NLChunk>:$columns);
+
+  let assemblyFormat = [{
+    $state (`,` $tag^)? `,` `(` $columns `)` attr-dict `:` `{` qualified(type($columns)) `}`
+  }];
+}
+
+/**
+* OptionalDrain
+*/
+// Pure: given a filled accumulator it deterministically yields the same rows, and
+// produces no side effect of its own - the emission happens in the driving
+// nl.for. Mirrors nl.sort: a source op whose loop does the work.
+def OptionalDrain : NLOp<"optional_drain", [Pure]> {
+  let summary = "Create a database iterator over an OPTIONAL MATCH's matched rows, then its missed ones";
+  let description = [{
+    The emit phase of an OPTIONAL MATCH. Consumes a filled nl.optional_state and
+    produces an iterator whose steps yield first the rows the pattern matched, as
+    collected, and then one row per input row it missed: the input columns taken
+    from the step's own chunks and the pattern's own columns null - an invalid ID,
+    which reads as null through a property fetch.
+
+      %rows = nl.optional_drain(%state) : !nl.iter<!nl.chunk<!storage.node_id>, ...>
+      nl.for %p, %e, %f in %rows : !nl.iter<...> { ... }
+
+    Placing it after the pattern's loop nest, in the same block as the
+    nl.optional_buffer that opened the accumulator, is what guarantees the matched
+    rows are all in by the time it first steps.
+  }];
+
+  let arguments = (ins NLOptionalStateHandle:$state);
+  let results   = (outs NLIterator:$result);
+
+  let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
+}
+
 #endif //TURINGDB_NL_OPS

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -2346,9 +2346,9 @@ def OptionalDrain : NLOp<"optional_drain", [Pure]> {
       %rows = nl.optional_drain(%state) : !nl.iter<!nl.chunk<!storage.node_id>, ...>
       nl.for %p, %e, %f in %rows : !nl.iter<...> { ... }
 
-    Placing it after the pattern's loop nest, in the same block as the
-    nl.optional_buffer that opened the accumulator, is what guarantees the matched
-    rows are all in by the time it first steps.
+    Its first step must find every matched row already collected, so place it after
+    the pattern's loop nest, in the block holding the nl.optional_buffer that opened
+    the accumulator.
   }];
 
   let arguments = (ins NLOptionalStateHandle:$state);

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -108,6 +108,22 @@ def NLGroupAggregateState : NLType<"GroupAggregateState", "group_aggregate_state
     }];
 }
 
+def NLOptionalState : NLType<"OptionalState", "optional_state"> {
+    let summary = "An OPTIONAL MATCH accumulator handle";
+    let description = [{
+        Stands for one OPTIONAL MATCH's state over the current step of the rows it
+        joins onto: the input chunks themselves, a matched flag per input row, and
+        the row buffers the matched rows are collected into. Produced by
+        nl.optional_buffer at the top of the block whose step it covers - so it is
+        reset once per step of the rows in flight - appended to by
+        nl.optional_collect, and drained by the nl.for over nl.optional_drain, which
+        emits the collected rows and then one null-padded row per input row nothing
+        matched. The pattern sibling of !nl.sort_state: it accumulates rows to
+        re-emit them, but keeps the input chunks beside them so the rows it missed
+        can be rebuilt.
+    }];
+}
+
 def NLCollectState : NLType<"CollectState", "collect_state"> {
     let summary = "A per-group value-list accumulator handle for one collect";
     let description = [{
@@ -345,5 +361,26 @@ def NLProcedureStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::ProcedureStateType>($_self)">,
         "procedure state handle", "::mlir::nl::ProcedureStateType">,
     BuildableType<"::mlir::nl::ProcedureStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.optional_state handle, the same way
+// NLSortStateHandle constrains the sort handle. The single concrete type - there
+// is only ever !nl.optional_state - is what lets nl.optional_collect and
+// nl.optional_drain omit the handle's type in their assembly, building it from
+// this recipe instead.
+def NLOptionalStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::OptionalStateType>($_self)">,
+        "optional state handle", "::mlir::nl::OptionalStateType">,
+    BuildableType<"::mlir::nl::OptionalStateType::get($_builder.getContext())">;
+
+// Constrains an operand to a chunk of unsigned 64-bit counts, the way
+// NLNodeIDChunk constrains an ID chunk. It is what an OPTIONAL MATCH's row tag
+// rides on - the position of the input row each matched row descends from - and
+// the BuildableType recipe lets the ops naming it omit the type.
+def NLUInt64Chunk : Type<
+        CPred<"::llvm::isa<::mlir::nl::ChunkType>($_self) && "
+              "::llvm::cast<::mlir::nl::ChunkType>($_self).getElementType().isUnsignedInteger(64)">,
+        "chunk of unsigned 64-bit counts", "::mlir::nl::ChunkType">,
+    BuildableType<"::mlir::nl::ChunkType::get($_builder.getContext(), "
+                  "$_builder.getIntegerType(64, false))">;
 
 #endif // TURINGDB_NL_TYPES

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <numeric>
 #include <queue>
 #include <span>
 #include <string>
@@ -313,17 +314,21 @@ void functionVectorKernel(NLExecutionContext* context, Column* result, const Col
     bioassert(false, "Function operand has an unexpected column type.");
 }
 
+// A node or edge an OPTIONAL MATCH did not match is an invalid ID, so a function reading
+// one produces a null rather than reading the graph at an ID that is not in it. The
+// entity sibling of functionOptKernel: the input is a plain ID column, which carries its
+// null in the ID itself instead of in an optional.
 template <typename Functor>
-void functionOptKernel(NLExecutionContext* context, Column* result, const Column* input) {
+void functionEntityKernel(NLExecutionContext* context, Column* result, const Column* input) {
     using Arg = typename Functor::ArgType;
     using Res = typename Functor::ResultType;
     using JustRes = TypeUtils::unwrap_optional_t<Res>;
 
-    const auto* typedInput = dynamic_cast<const ColumnOptVector<Arg>*>(input);
+    const auto* typedInput = dynamic_cast<const ColumnVector<Arg>*>(input);
     bioassert(typedInput, "Function operand has an unexpected column type.");
     auto* output = static_cast<ColumnOptVector<JustRes>*>(result);
 
-    const auto& inputRaw = typedInput->getRaw();
+    const std::vector<Arg>& inputRaw = typedInput->getRaw();
     const size_t size = inputRaw.size();
 
     output->resize(size);
@@ -331,12 +336,57 @@ void functionOptKernel(NLExecutionContext* context, Column* result, const Column
 
     Functor functor = makeFunctor<Functor>(context);
     for (size_t row = 0; row < size; row++) {
+        if (inputRaw[row].isValid()) {
+            outputRaw[row] = functor(inputRaw[row]);
+        } else {
+            outputRaw[row] = std::nullopt;
+        }
+    }
+}
+
+template <typename Functor, typename Element>
+void applyFunctionOverOptVector(Functor& functor,
+                                const ColumnOptVector<Element>* input,
+                                ColumnOptVector<TypeUtils::unwrap_optional_t<typename Functor::ResultType>>* output) {
+    const auto& inputRaw = input->getRaw();
+    const size_t size = inputRaw.size();
+
+    output->resize(size);
+    auto& outputRaw = output->getRaw();
+
+    for (size_t row = 0; row < size; row++) {
         if (inputRaw[row].has_value()) {
             outputRaw[row] = functor(inputRaw[row].value());
         } else {
             outputRaw[row] = std::nullopt;
         }
     }
+}
+
+template <typename Functor>
+void functionOptKernel(NLExecutionContext* context, Column* result, const Column* input) {
+    using Arg = typename Functor::ArgType;
+    using Res = typename Functor::ResultType;
+    using JustRes = TypeUtils::unwrap_optional_t<Res>;
+
+    auto* output = static_cast<ColumnOptVector<JustRes>*>(result);
+    Functor functor = makeFunctor<Functor>(context);
+
+    if (const auto* typedInput = dynamic_cast<const ColumnOptVector<Arg>*>(input)) {
+        applyFunctionOverOptVector(functor, typedInput, output);
+        return;
+    }
+
+    // The same fallback functionVectorKernel keeps: a function taking a string may be
+    // handed a column of std::strings rather than of views
+    if constexpr (std::is_same_v<Arg, types::String::Primitive>) {
+        if (const auto* ownedInput = dynamic_cast<const ColumnOptVector<types::String::OwningPrimitive>*>(input)) {
+            applyFunctionOverOptVector(functor, ownedInput, output);
+            return;
+        }
+    }
+
+    bioassert(false, "Function operand has an unexpected column type.");
 }
 
 // Whether a column holds this element, in any of the shapes a chunk column takes: a plain
@@ -668,6 +718,16 @@ void gatherColumn(const Column* input,
     }
 }
 
+// Fill a chunk with a run of null rows. Every element type reads its own
+// default-constructed value as null: an ID defaults to the invalid ID that ID::isValid
+// rejects, which is how an entity an OPTIONAL MATCH did not match is spelled.
+template <typename ElementType>
+void fillNullColumn(Column* output, size_t rowCount) {
+    ColumnVector<ElementType>* typedOutput = static_cast<ColumnVector<ElementType>*>(output);
+
+    typedOutput->getRaw().assign(rowCount, ElementType {});
+}
+
 void collectMaskSurvivors(const Column* mask, ColumnVector<size_t>* indices) {
     const ColumnMask* typedMask = static_cast<const ColumnMask*>(mask);
     const std::vector<ColumnMask::Bool_t>& maskRaw = typedMask->getRaw();
@@ -898,6 +958,24 @@ void toNullableColumn(Column* result, const Column* operand) {
 
     nullables.resize(values.size());
     std::copy(values.begin(), values.end(), nullables.begin());
+}
+
+// Read an entity column as a nullable column of its IDs' integers: a node or an edge an
+// OPTIONAL MATCH did not match carries an invalid ID, which is the null. The entity
+// sibling of toNullableColumn, for the column family whose null is not an absent optional.
+template <typename ID>
+void entityToNullableColumn(Column* result, const Column* operand) {
+    const std::vector<ID>& ids = static_cast<const ColumnVector<ID>*>(operand)->getRaw();
+    auto& nullables = static_cast<ColumnOptVector<types::UInt64::Primitive>*>(result)->getRaw();
+
+    nullables.resize(ids.size());
+    for (size_t row = 0; row < ids.size(); row++) {
+        if (ids[row].isValid()) {
+            nullables[row] = ids[row].getValue();
+        } else {
+            nullables[row] = std::nullopt;
+        }
+    }
 }
 
 template <typename Primitive>
@@ -1177,6 +1255,17 @@ size_t countNonNullElementsColumn(const Column* column) {
     return std::count_if(raw.begin(), raw.end(), [](const ListElementView element) {
         return element.getTag() != ListBufferTypeTag::Null;
     });
+}
+
+// An entity an OPTIONAL MATCH did not match is an invalid ID, which is a null, so an ID
+// chunk charges only the rows holding a valid one - Cypher's count(x) counts the non-null
+// rows. The ID sibling of countPresentColumn, for the one column family whose null is not
+// a missing optional.
+template <typename ID>
+size_t countValidIDs(const Column* column) {
+    const std::vector<ID>& raw = static_cast<const ColumnVector<ID>*>(column)->getRaw();
+
+    return std::ranges::count_if(raw, [](const ID id) { return id.isValid(); });
 }
 
 // Count the present (non-null) values of a nullable value column - a
@@ -1721,8 +1810,26 @@ void groupFoldCountPresent(Column* accumulator,
     }
 }
 
-// Tally each group's distinct IDs (count(DISTINCT n) over a node/edge column): an ID
-// is never null, so every row is charged the first time its ID is seen in its group.
+// Tally each group's rows holding a valid ID (count(n) over a node/edge column): an
+// invalid ID is a null, so it is not charged - the ID sibling of groupFoldCountPresent.
+template <typename ID>
+void groupFoldCountValidID(Column* accumulator,
+                           std::vector<uint64_t>& counts,
+                           const Column* input,
+                           const std::vector<size_t>& groups,
+                           NLGroupDistinctTally& distinct) {
+    const std::vector<ID>& inputRaw = static_cast<const ColumnVector<ID>*>(input)->getRaw();
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (inputRaw[row].isValid()) {
+            counts[groups[row]]++;
+        }
+    }
+}
+
+// Tally each group's distinct IDs (count(DISTINCT n) over a node/edge column): an
+// invalid ID is a null, which count(DISTINCT x) does not charge, so only the valid ones
+// are keyed.
 template <typename ElementType>
 void groupFoldCountDistinctID(Column* accumulator,
                               std::vector<uint64_t>& counts,
@@ -1732,6 +1839,10 @@ void groupFoldCountDistinctID(Column* accumulator,
     const auto& inputRaw = static_cast<const ColumnVector<ElementType>*>(input)->getRaw();
 
     for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (!inputRaw[row].isValid()) {
+            continue;
+        }
+
         const size_t group = groups[row];
 
         distinct.beginKey(group);
@@ -3963,6 +4074,26 @@ NLUnaryFn NLExecutor::selectNot(const Column* operand, LocalMemory* memory, Colu
     return &applyNotOnMask;
 }
 
+NLUnaryFn NLExecutor::selectEntityToNullable(NLChunkKind kind, LocalMemory* memory, Column*& result) {
+    result = memory->alloc<ColumnOptVector<types::UInt64::Primitive>>();
+
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &entityToNullableColumn<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &entityToNullableColumn<EdgeID>;
+        break;
+
+        default:
+            throw IRException("Only a node or an edge column can be read as a nullable ID column");
+        break;
+    }
+
+    return nullptr;
+}
+
 NLUnaryFn NLExecutor::selectToNullable(ValueType valueType, const Column* operand, LocalMemory* memory, Column*& result) {
     switch (valueType) {
         case ValueType::Int64:
@@ -4034,6 +4165,13 @@ NLUnaryFunctionKernel NLExecutor::selectFunction(const Column* input, bool input
     if (inputNullable) {
         result = memory->alloc<ColumnOptVector<JustRes>>();
         return &functionOptKernel<Functor>;
+    }
+
+    // An entity column carries its null in the ID rather than in an optional, so it is
+    // read row by row for validity and its result is nullable all the same
+    if constexpr (TypedInternalID<typename Functor::ArgType>) {
+        result = memory->alloc<ColumnOptVector<JustRes>>();
+        return &functionEntityKernel<Functor>;
     }
 
     result = memory->alloc<ColumnVector<Res>>();
@@ -4127,6 +4265,96 @@ void NLExecutor::runSortLoop(NLExecutionContext* context, NLFunctionData* data) 
         for (size_t offset = 0; offset < totalRows; offset += chunkSize) {
             runIteration(offset);
         }
+    }
+}
+
+void NLExecutor::runOptionalReset(NLExecutionContext* context, NLFunctionData* data) {
+    NLOptionalResetData* reset = static_cast<NLOptionalResetData*>(data);
+    NLOptionalState* state = reset->getState();
+
+    state->reset();
+
+    // The tag holds each input row's position, so the pattern carries it the way it
+    // carries any other column and the collect reads the rows it matched off it.
+    std::vector<uint64_t>& tagRaw = reset->getTag()->getRaw();
+    tagRaw.resize(state->getRowCount());
+    std::iota(tagRaw.begin(), tagRaw.end(), uint64_t {0});
+}
+
+void NLExecutor::runOptionalCollect(NLExecutionContext* context, NLFunctionData* data) {
+    NLOptionalCollectData* collect = static_cast<NLOptionalCollectData*>(data);
+    NLOptionalState* state = collect->getState();
+
+    for (const NLOptionalCollectData::Append& append : collect->appends()) {
+        append._append(append._input, append._buffer);
+    }
+
+    const ColumnVector<uint64_t>* tag = collect->getTag();
+    if (!tag) {
+        // No input row to tag: the step is the single empty row, which this step's rows
+        // match - and a predicate that cut them all leaves nothing to match it.
+        const std::vector<NLOptionalCollectData::Append>& appends = collect->appends();
+        bioassert(!appends.empty(), "nl.optional_collect needs at least one column");
+
+        if (appends.front()._input->size() > 0) {
+            state->markMatched(0);
+        }
+
+        return;
+    }
+
+    for (const uint64_t row : tag->getRaw()) {
+        state->markMatched(row);
+    }
+}
+
+void NLExecutor::runOptionalDrainLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLOptionalDrainLoopData* loopData = static_cast<NLOptionalDrainLoopData*>(data);
+    NLOptionalState* state = loopData->getState();
+
+    const NLStmtContainer* loopBody = loopData->getStmts();
+    const size_t chunkSize = context->getChunkSize();
+    ColumnVector<size_t>* indices = loopData->getIndices();
+    std::vector<size_t>& indicesRaw = indices->getRaw();
+
+    const NLLimitState* limit = loopData->getLimit();
+    const auto budgetLeft = [&]() { return !limit || limit->getRemaining() > 0; };
+
+    // The rows the pattern matched, re-chunked out of the buffers the collect grew. A
+    // chunk never mixes them with the padded ones: the two are gathered from different
+    // columns, so each step reads one or the other.
+    const size_t matchedRows = state->getMatchedRowCount();
+    for (size_t offset = 0; offset < matchedRows && budgetLeft(); offset += chunkSize) {
+        const size_t stepRows = std::min(chunkSize, matchedRows - offset);
+
+        indicesRaw.resize(stepRows);
+        std::iota(indicesRaw.begin(), indicesRaw.end(), offset);
+
+        for (const NLOptionalDrainLoopData::DrainColumn& column : loopData->columns()) {
+            column._gather(column._buffer, indices, column._output);
+        }
+
+        runBody(context, loopBody);
+    }
+
+    // Then one row per input row nothing matched: its own values in the columns the
+    // pattern joined onto, and null in the ones the pattern binds.
+    const std::vector<size_t>& missedRaw = state->missedRows().getRaw();
+    const size_t missedRows = missedRaw.size();
+    for (size_t offset = 0; offset < missedRows && budgetLeft(); offset += chunkSize) {
+        const size_t stepRows = std::min(chunkSize, missedRows - offset);
+
+        indicesRaw.assign(missedRaw.begin() + offset, missedRaw.begin() + offset + stepRows);
+
+        for (const NLOptionalDrainLoopData::DrainColumn& column : loopData->columns()) {
+            if (column._input) {
+                column._gather(column._input, indices, column._output);
+            } else {
+                column._fillNull(column._output, stepRows);
+            }
+        }
+
+        runBody(context, loopBody);
     }
 }
 
@@ -4855,6 +5083,13 @@ void NLExecutor::runProcedureInitLoop(NLExecutionContext* context, NLFunctionDat
     runProcedureDrive(context, loopData, [state]() { state->execute(); });
 }
 
+NLFillNullFunction NLExecutor::selectFillNullFunction(NLChunkKind kind) {
+    NLFillNullFunction selected = nullptr;
+    dispatchChunkKind(kind, [&]<typename ElementType>() { selected = &fillNullColumn<ElementType>; });
+
+    return selected;
+}
+
 NLGatherFunction NLExecutor::selectGatherFunction(NLChunkKind kind) {
     NLGatherFunction selected = nullptr;
     dispatchChunkKind(kind, [&]<typename ElementType>() { selected = &gatherColumn<ElementType>; });
@@ -5004,6 +5239,38 @@ NLCopyFunction NLExecutor::selectConstCopyFunction() {
 
 // A nullable value chunk gathers the same way an ID chunk does - copy the indexed
 // rows - on the ColumnOptVector<Primitive> instantiation of the gather template.
+// The owned-string members of the nullable handler families. A nullable chunk of owned
+// strings wraps a value type of String, but its rows own their characters rather than
+// borrowing them from the graph, so it takes the std::string handlers where a property
+// column takes the std::string_view ones. Zero-argument, like the list-element family.
+NLGatherFunction NLExecutor::selectOptOwnedStringGather() {
+    return &gatherColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
+NLAppendFunction NLExecutor::selectOptOwnedStringAppend() {
+    return &appendColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
+NLCopyFunction NLExecutor::selectOptOwnedStringCopy() {
+    return &copyRangeColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
+NLGroupKeyGatherFunction NLExecutor::selectOptOwnedStringGroupKeyGather() {
+    return &groupGatherAppendColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
+NLCompareFunction NLExecutor::selectOptOwnedStringCompare() {
+    return &compareOptColumn<types::String::OwningPrimitive>;
+}
+
+NLKeyAppendFunction NLExecutor::selectOptOwnedStringKeyAppend() {
+    return &distinctKeyAppendOptColumn<types::String::OwningPrimitive>;
+}
+
+NLCountFunction NLExecutor::selectOptOwnedStringCount() {
+    return &countPresentColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
 NLGatherFunction NLExecutor::selectOptGatherFunction(ValueType valueType) {
     NLGatherFunction gather = nullptr;
     const auto select = [&]<SupportedType T>() {
@@ -5157,6 +5424,54 @@ NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) 
 // irrelevant here - the row count is just the column size.
 size_t NLExecutor::countAllRows(const Column* column) {
     return column->size();
+}
+
+// Selected per column from its kind, so count(n) tallies only the rows in which the node
+// or edge n is not null. A kind whose rows are never null - a label ID, or a scalar a
+// procedure yielded - has no invalid value to skip and gets no handle here.
+NLCountFunction NLExecutor::selectIDCountFunction(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &countValidIDs<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &countValidIDs<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &countValidIDs<EdgeTypeID>;
+        break;
+
+        default:
+            return nullptr;
+        break;
+    }
+
+    return nullptr;
+}
+
+// The grouped sibling of selectIDCountFunction, for count(n) inside a GROUP BY.
+NLGroupAggregateFoldFunction NLExecutor::selectGroupCountValidIDFold(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return &groupFoldCountValidID<NodeID>;
+        break;
+
+        case NLChunkKind::EdgeID:
+            return &groupFoldCountValidID<EdgeID>;
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return &groupFoldCountValidID<EdgeTypeID>;
+        break;
+
+        default:
+            return nullptr;
+        break;
+    }
+
+    return nullptr;
 }
 
 // Selected per column from its value type, so count(x) tallies only the rows in

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2037,7 +2037,20 @@ void collectValidIDFold(Column* values,
     auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
     const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
 
-    valuesRaw.reserve(valuesRaw.size() + inputRaw.size());
+    const size_t base = valuesRaw.size();
+    const auto isValid = [](const IDType id) { return id.isValid(); };
+
+    if (std::ranges::all_of(inputRaw, isValid)) {
+        valuesRaw.insert(valuesRaw.end(), inputRaw.begin(), inputRaw.end());
+
+        for (size_t row = 0; row < inputRaw.size(); row++) {
+            groupPositions[groups[row]].push_back(base + row);
+        }
+
+        return;
+    }
+
+    valuesRaw.reserve(base + inputRaw.size());
 
     for (size_t row = 0; row < inputRaw.size(); row++) {
         if (!inputRaw[row].isValid()) {
@@ -3231,7 +3244,14 @@ void NLExecutor::runDeleteNode(NLExecutionContext* context, NLFunctionData* data
 
     const auto& raw = nodes->getRaw();
 
+    // A node an OPTIONAL MATCH did not match is an invalid ID, which Cypher deletes nothing
+    // for. Staging it would tombstone an ID the graph never held, and the node count reads
+    // the tombstones off what it allocated: it would report one node too few.
     for (size_t row = 0; row < raw.size(); row++) {
+        if (!raw[row].isValid()) {
+            continue;
+        }
+
         const bool isPending = isPendingRow(pending, allPending, row);
         const CommitWriteBuffer::ExistingOrPendingNode node =
             resolveNode(nodes, row, isPending, firstPendingNodeID);
@@ -3279,6 +3299,10 @@ void NLExecutor::runDeleteEdge(NLExecutionContext* context, NLFunctionData* data
 
     const auto& raw = edges->getRaw();
     for (size_t row = 0; row < raw.size(); row++) {
+        if (!raw[row].isValid()) {
+            continue;
+        }
+
         if (isPendingRow(pending, allPending, row)) {
             writeBuffer->addDeletedPendingEdge(raw[row].getValue() - firstPendingEdgeID);
         } else {
@@ -4128,23 +4152,18 @@ NLUnaryFn NLExecutor::selectNot(const Column* operand, LocalMemory* memory, Colu
 }
 
 NLUnaryFn NLExecutor::selectEntityToNullable(NLChunkKind kind, LocalMemory* memory, Column*& result) {
-    result = memory->alloc<ColumnOptVector<types::UInt64::Primitive>>();
-
-    switch (kind) {
-        case NLChunkKind::NodeID:
-            return &entityToNullableColumn<NodeID>;
-        break;
-
-        case NLChunkKind::EdgeID:
-            return &entityToNullableColumn<EdgeID>;
-        break;
-
-        default:
-            throw IRException("Only a node or an edge column can be read as a nullable ID column");
-        break;
+    const bool readsIDs = kind == NLChunkKind::NodeID || kind == NLChunkKind::EdgeID;
+    if (!readsIDs) {
+        throw IRException("Only a node or an edge column can be read as a nullable ID column");
     }
 
-    return nullptr;
+    result = memory->alloc<ColumnOptVector<types::UInt64::Primitive>>();
+
+    if (kind == NLChunkKind::NodeID) {
+        return &entityToNullableColumn<NodeID>;
+    }
+
+    return &entityToNullableColumn<EdgeID>;
 }
 
 NLUnaryFn NLExecutor::selectToNullable(ValueType valueType, const Column* operand, LocalMemory* memory, Column*& result) {
@@ -5324,6 +5343,14 @@ NLCountFunction NLExecutor::selectOptOwnedStringCount() {
     return &countPresentColumn<std::optional<types::String::OwningPrimitive>>;
 }
 
+NLBroadcastFunction NLExecutor::selectOptOwnedStringBlockRepeat() {
+    return &blockRepeatColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
+NLBroadcastFunction NLExecutor::selectOptOwnedStringTile() {
+    return &tileColumn<std::optional<types::String::OwningPrimitive>>;
+}
+
 NLGatherFunction NLExecutor::selectOptGatherFunction(ValueType valueType) {
     NLGatherFunction gather = nullptr;
     const auto select = [&]<SupportedType T>() {
@@ -5480,8 +5507,8 @@ size_t NLExecutor::countAllRows(const Column* column) {
 }
 
 // Selected per column from its kind, so count(n) tallies only the rows in which the node
-// or edge n is not null. A kind whose rows are never null - a label ID, or a scalar a
-// procedure yielded - has no invalid value to skip and gets no handle here.
+// or edge n is not null. A kind whose rows are never null - a label or edge-type ID, or a
+// scalar a procedure yielded - has no invalid value to skip and gets no handle here.
 NLCountFunction NLExecutor::selectIDCountFunction(NLChunkKind kind) {
     switch (kind) {
         case NLChunkKind::NodeID:
@@ -5490,10 +5517,6 @@ NLCountFunction NLExecutor::selectIDCountFunction(NLChunkKind kind) {
 
         case NLChunkKind::EdgeID:
             return &countValidIDs<EdgeID>;
-        break;
-
-        case NLChunkKind::EdgeTypeID:
-            return &countValidIDs<EdgeTypeID>;
         break;
 
         default:
@@ -5513,10 +5536,6 @@ NLGroupAggregateFoldFunction NLExecutor::selectGroupCountValidIDFold(NLChunkKind
 
         case NLChunkKind::EdgeID:
             return &groupFoldCountValidID<EdgeID>;
-        break;
-
-        case NLChunkKind::EdgeTypeID:
-            return &groupFoldCountValidID<EdgeTypeID>;
         break;
 
         default:
@@ -6118,6 +6137,12 @@ NLKeyAppendFunction NLExecutor::selectOptMergeKeyAppendFunction(ValueType valueT
             return selectOptKeyAppendFunction(valueType);
         break;
     }
+}
+
+NLKeyAppendFunction NLExecutor::selectOptOwnedStringMergeKeyAppend(ValueType keyType) {
+    throwUnlessKeyedAsItsOwnType(ValueType::String, keyType);
+
+    return selectOptOwnedStringKeyAppend();
 }
 
 NLKeyAppendFunction NLExecutor::selectNullMergeKeyAppendFunction() {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2609,6 +2609,23 @@ const CommitWriteBuffer::SupportedTypeVariant* findEntityUpdate(const NLWrittenV
     }
 }
 
+// A node an OPTIONAL MATCH did not match is an invalid ID, and no edge can hang off one.
+// The whole column is read before anything is staged, so a CREATE naming a null endpoint
+// writes none of its edges rather than leaving the commit one it cannot resolve. A pending
+// endpoint is an offset into this change's new nodes rather than an ID, so only an existing
+// one can be null.
+void throwIfAnyNodeIsNull(const ColumnNodeIDs* column, bool isPending, std::string_view error) {
+    if (isPending) {
+        return;
+    }
+
+    for (const NodeID nodeID : column->getRaw()) {
+        if (!nodeID.isValid()) {
+            throw IRException(std::string(error));
+        }
+    }
+}
+
 void throwIfNodesHaveEdges(const GraphView& view, const ColumnNodeIDs* nodes) {
     const Tombstones& tombstones = view.tombstones();
 
@@ -3057,6 +3074,9 @@ void NLExecutor::runCreateEdge(NLExecutionContext* context, NLFunctionData* data
     const ColumnMask* srcPending = createData->getSrcPendingMask();
     const ColumnMask* tgtPending = createData->getTgtPendingMask();
 
+    throwIfAnyNodeIsNull(src, srcIsPending, "Cannot create an edge from a null node");
+    throwIfAnyNodeIsNull(tgt, tgtIsPending, "Cannot create an edge to a null node");
+
     const GraphView* view = context->getView();
     const size_t firstPendingNodeID = committedNodeCount(view);
 
@@ -3110,9 +3130,12 @@ void NLExecutor::runSetNodeProperty(NLExecutionContext* context, NLFunctionData*
 
     const size_t firstPendingNodeID = committedNodeCount(context->getView());
 
+    // A node an OPTIONAL MATCH did not match is an invalid ID, which Cypher writes nothing
+    // for: staging it would have the commit look the ID up among the nodes this change
+    // wrote, where it is not.
     const auto& raw = nodes->getRaw();
     for (size_t row = 0; row < rowCount; row++) {
-        if (!writeTouchesRow(rows, row)) {
+        if (!writeTouchesRow(rows, row) || !raw[row].isValid()) {
             continue;
         }
 
@@ -3146,7 +3169,7 @@ void NLExecutor::runSetEdgeProperty(NLExecutionContext* context, NLFunctionData*
 
     const auto& raw = edges->getRaw();
     for (size_t row = 0; row < rowCount; row++) {
-        if (!writeTouchesRow(rows, row)) {
+        if (!writeTouchesRow(rows, row) || !raw[row].isValid()) {
             continue;
         }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2006,16 +2006,16 @@ void collectFoldDistinct(Column* values,
     }
 }
 
-// The entity sibling of collectFold: an ID chunk has no null rows, so every row of the
-// input joins its group's list.
-template <typename IDType>
-void collectEntityFold(Column* values,
-                       const Column* input,
-                       const std::vector<size_t>& groups,
-                       std::vector<std::vector<size_t>>& groupPositions,
-                       NLGroupDistinctTally& distinct) {
-    auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
-    const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
+// The cell sibling of collectFold, for a chunk holding a value in every row: every row of
+// the input joins its group's list.
+template <typename Cell>
+void collectCellFold(Column* values,
+                     const Column* input,
+                     const std::vector<size_t>& groups,
+                     std::vector<std::vector<size_t>>& groupPositions,
+                     NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<Cell>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<Cell>*>(input)->getRaw();
 
     const size_t base = valuesRaw.size();
     valuesRaw.insert(valuesRaw.end(), inputRaw.begin(), inputRaw.end());
@@ -2025,18 +2025,48 @@ void collectEntityFold(Column* values,
     }
 }
 
-// The entity sibling of collectFoldDistinct: an entity repeated within its group joins
-// the list once, keyed by the ID's underlying integer.
+// The ID sibling of collectFold: an entity an OPTIONAL MATCH did not match is an invalid
+// ID, which is how a null entity is spelled, so it is dropped the way collectFold drops an
+// absent optional rather than collected as the value 2^64-1.
 template <typename IDType>
-void collectEntityFoldDistinct(Column* values,
-                               const Column* input,
-                               const std::vector<size_t>& groups,
-                               std::vector<std::vector<size_t>>& groupPositions,
-                               NLGroupDistinctTally& distinct) {
+void collectValidIDFold(Column* values,
+                        const Column* input,
+                        const std::vector<size_t>& groups,
+                        std::vector<std::vector<size_t>>& groupPositions,
+                        NLGroupDistinctTally& distinct) {
+    auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
+    const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
+
+    valuesRaw.reserve(valuesRaw.size() + inputRaw.size());
+
+    for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (!inputRaw[row].isValid()) {
+            continue;
+        }
+
+        const size_t position = valuesRaw.size();
+        valuesRaw.push_back(inputRaw[row]);
+        groupPositions[groups[row]].push_back(position);
+    }
+}
+
+// The ID sibling of collectFoldDistinct: an entity repeated within its group joins the
+// list once, keyed by the ID's underlying integer, and the null an unmatched pattern left
+// is no key of its own.
+template <typename IDType>
+void collectValidIDFoldDistinct(Column* values,
+                                const Column* input,
+                                const std::vector<size_t>& groups,
+                                std::vector<std::vector<size_t>>& groupPositions,
+                                NLGroupDistinctTally& distinct) {
     auto& valuesRaw = static_cast<ColumnVector<IDType>*>(values)->getRaw();
     const auto& inputRaw = static_cast<const ColumnVector<IDType>*>(input)->getRaw();
 
     for (size_t row = 0; row < inputRaw.size(); row++) {
+        if (!inputRaw[row].isValid()) {
+            continue;
+        }
+
         const size_t group = groups[row];
 
         distinct.beginKey(group);
@@ -2185,7 +2215,7 @@ void collectTaggedListEmit(const Column* values,
     }
 }
 
-// The list sibling of collectEntityFoldDistinct: two cells are the same value when their
+// The list sibling of collectValidIDFoldDistinct: two cells are the same value when their
 // elements are, so a cell keys by the list serialized element by element rather than by
 // the ListView's own span, which two equal lists never share.
 void collectListFoldDistinct(Column* values,
@@ -2268,7 +2298,7 @@ template <typename IDType>
 void selectCollectIDHandlers(bool distinctValues,
                              NLCollectFoldFunction& fold,
                              NLCollectListEmitFunction& listEmit) {
-    fold = distinctValues ? &collectEntityFoldDistinct<IDType> : &collectEntityFold<IDType>;
+    fold = distinctValues ? &collectValidIDFoldDistinct<IDType> : &collectValidIDFold<IDType>;
     listEmit = &collectListEmit<IDType>;
 }
 
@@ -4935,12 +4965,12 @@ void NLExecutor::selectCollectEntityHandlers(NLChunkKind kind,
     }
 }
 
-// A list cell is present in every row, so it folds the way an entity ID does; only the
-// dedup differs, keying on the elements rather than on the cell.
+// A list cell is present in every row, so it folds with no null to drop; only the dedup
+// differs, keying on the elements rather than on the cell.
 void NLExecutor::selectCollectListHandlers(bool distinctValues,
                                            NLCollectFoldFunction& fold,
                                            NLCollectListEmitFunction& listEmit) {
-    fold = distinctValues ? &collectListFoldDistinct : &collectEntityFold<ListView>;
+    fold = distinctValues ? &collectListFoldDistinct : &collectCellFold<ListView>;
     listEmit = &collectListEmit<ListView>;
 }
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -122,6 +122,19 @@ public:
     // variables and running the body (the nl.output) per chunk.
     static void runSortLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    // Empty the buffers and matched flags of an OPTIONAL MATCH accumulator and lay its row
+    // tag out over this step's input rows; runs each time its block runs.
+    static void runOptionalReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Append this step's chunk of every column the pattern contributes to its buffer, and
+    // mark as matched each input row the row tag names. The sole matched-flag mutator.
+    static void runOptionalCollect(NLExecutionContext* context, NLFunctionData* data);
+
+    // The emit phase of an OPTIONAL MATCH: re-chunk the collected rows, running the body
+    // per chunk, then sweep the matched flags and emit one null-padded row per input row
+    // the pattern missed.
+    static void runOptionalDrainLoop(NLExecutionContext* context, NLFunctionData* data);
+
     // Empty the seen-set of a DISTINCT; runs each time its block runs.
     static void runDistinctReset(NLExecutionContext* context, NLFunctionData* data);
 
@@ -234,6 +247,11 @@ public:
     static void runUnary(NLExecutionContext* context, NLFunctionData* data);
 
     static NLUnaryFn selectNot(const Column* operand, LocalMemory* memory, Column*& result);
+    // Read a node or edge column as a nullable column of its IDs' integers, an invalid ID
+    // - what an OPTIONAL MATCH leaves - reading as the null. The entity sibling of
+    // selectToNullable, which reads a scalar value column.
+    static NLUnaryFn selectEntityToNullable(NLChunkKind kind, LocalMemory* memory, Column*& result);
+
     static NLUnaryFn selectToNullable(ValueType valueType, const Column* operand, LocalMemory* memory, Column*& result);
 
     // Lay a constant chunk's single value out over the driving relation's rows
@@ -255,7 +273,22 @@ public:
     template <typename StringFunctor>
     static NLUnaryFunctionKernel selectConversion(const Column* input, bool inputNullable, LocalMemory* memory, Column*& result);
 
+    // The owned-string members of the nullable handler families, for the chunk kind
+    // labels() and edgeType() produce: a nullable value whose rows own their characters
+    // rather than borrowing them, so the value type alone does not pick the handler.
+    static NLGatherFunction selectOptOwnedStringGather();
+    static NLAppendFunction selectOptOwnedStringAppend();
+    static NLCopyFunction selectOptOwnedStringCopy();
+    static NLGroupKeyGatherFunction selectOptOwnedStringGroupKeyGather();
+    static NLCompareFunction selectOptOwnedStringCompare();
+    static NLKeyAppendFunction selectOptOwnedStringKeyAppend();
+    static NLCountFunction selectOptOwnedStringCount();
+
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
+
+    // The null fill for a chunk of this kind: an invalid ID for an ID chunk, which is how
+    // an entity an OPTIONAL MATCH did not match is spelled.
+    static NLFillNullFunction selectFillNullFunction(NLChunkKind kind);
 
     // Gather for a nullable value chunk of this value type (sort emit re-chunk).
     static NLGatherFunction selectOptGatherFunction(ValueType valueType);
@@ -390,6 +423,13 @@ public:
     // counts only its present values. Used by nl.count_update.
     static size_t countAllRows(const Column* column);
     static NLCountFunction selectOptCountFunction(ValueType valueType);
+
+    // Non-null row count for a COUNT over a node, edge or edge-type ID chunk, whose null
+    // is an invalid ID rather than a missing optional; null for a kind that has no such
+    // row, which then keeps countAllRows. The grouped sibling folds the same tally per
+    // group.
+    static NLCountFunction selectIDCountFunction(NLChunkKind kind);
+    static NLGroupAggregateFoldFunction selectGroupCountValidIDFold(NLChunkKind kind);
 
     // The reset / fold / emit handlers for one aggregate, selected from the
     // reduction and a value type (the accumulator's for reset/result, the input's

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -283,6 +283,8 @@ public:
     static NLCompareFunction selectOptOwnedStringCompare();
     static NLKeyAppendFunction selectOptOwnedStringKeyAppend();
     static NLCountFunction selectOptOwnedStringCount();
+    static NLBroadcastFunction selectOptOwnedStringBlockRepeat();
+    static NLBroadcastFunction selectOptOwnedStringTile();
 
     static NLGatherFunction selectGatherFunction(NLChunkKind kind);
 
@@ -339,6 +341,7 @@ public:
     static NLKeyAppendFunction selectPlainMergeKeyAppendFunction(NLChunkKind kind, ValueType keyType);
     static NLKeyAppendFunction selectConstMergeKeyAppendFunction(ValueType valueType, ValueType keyType);
     static NLKeyAppendFunction selectOptMergeKeyAppendFunction(ValueType valueType, ValueType keyType);
+    static NLKeyAppendFunction selectOptOwnedStringMergeKeyAppend(ValueType keyType);
     static NLKeyAppendFunction selectNullMergeKeyAppendFunction();
     static NLGroupKeyGatherFunction selectPlainGroupKeyGather(ValueType valueType);
 

--- a/query/ir/interpreter/NLMergeExecutor.cpp
+++ b/query/ir/interpreter/NLMergeExecutor.cpp
@@ -21,6 +21,7 @@
 #include "NLExecutionContext.h"
 #include "NLWriteProperties.h"
 
+#include "IRException.h"
 #include "BioAssert.h"
 
 using namespace db;
@@ -66,6 +67,22 @@ void fetchMergeEdgeProperty(const GraphView& view,
     ValueTypeDispatcher(property._propertyType._valueType).execute(fetch);
 }
 
+// A row an OPTIONAL MATCH did not match holds an invalid ID, which names no node of the
+// graph and none of the write buffer either: there is nothing to match the pattern against
+// and nothing to hang what it would write off
+void throwIfBoundNodeIsNull(const NLMergeData::Node& node, size_t rowCount) {
+    const ColumnNodeIDs* bound = node._boundColumn;
+    const ColumnMask* pending = node._boundPending;
+
+    for (size_t row = 0; row < rowCount; row++) {
+        const bool isPending = pending && (*pending)[row];
+
+        if (!isPending && !(*bound)[row].isValid()) {
+            throw IRException("Cannot merge a pattern on a null node");
+        }
+    }
+}
+
 }
 
 NLMergeExecutor::NLMergeExecutor(NLExecutionContext* context, NLMergeData* data)
@@ -93,6 +110,12 @@ void NLMergeExecutor::run() {
 
     clearResults();
     extractProperties(rowCount);
+
+    for (const NLMergeData::Node& node : _data->nodes()) {
+        if (node._boundColumn) {
+            throwIfBoundNodeIsNull(node, rowCount);
+        }
+    }
 
     _work->_candidates.resize(_data->nodes().size());
     _work->_candidateKeys.resize(_data->nodes().size());

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -143,6 +143,50 @@ size_t NLProcedureState::getInputRowCount() const {
     return 0;
 }
 
+size_t NLOptionalState::getRowCount() const {
+    if (_inputColumns.empty()) {
+        return 1;
+    }
+
+    return _inputColumns.front()->size();
+}
+
+size_t NLOptionalState::getMatchedRowCount() const {
+    if (_buffers.empty()) {
+        return 0;
+    }
+
+    return _buffers.front()->size();
+}
+
+void NLOptionalState::reset() {
+    for (Column* buffer : _buffers) {
+        buffer->clear();
+    }
+
+    _matched.assign(getRowCount(), false);
+
+    _missedRows.clear();
+    _swept = false;
+}
+
+const ColumnVector<size_t>& NLOptionalState::missedRows() {
+    if (_swept) {
+        return _missedRows;
+    }
+
+    std::vector<size_t>& missedRaw = _missedRows.getRaw();
+    for (size_t row = 0; row < _matched.size(); row++) {
+        if (!_matched[row]) {
+            missedRaw.push_back(row);
+        }
+    }
+
+    _swept = true;
+
+    return _missedRows;
+}
+
 void NLSortState::reset() {
     for (Column* buffer : _buffers) {
         buffer->clear();

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -2994,14 +2994,9 @@ private:
 using NLFillNullFunction = void (*)(Column* output, size_t rowCount);
 
 // Runtime state of one OPTIONAL MATCH over one step of the rows its pattern joins onto:
-// that step's own chunks, a matched flag per row of them, and the row buffers the matched
-// rows are collected into. nl.optional_buffer resets it once per step,
-// nl.optional_collect appends one chunk of every column the pattern contributes and marks
-// the input rows the row tag names, and the nl.for over nl.optional_drain reads the
-// collected rows back and then rebuilds the rows nothing matched out of the input chunks.
-// The pattern sibling of NLSortState: it accumulates rows to re-emit them, but keeps the
-// input chunks beside them, and covers one step rather than the whole relation - so the
-// memory it holds is one step's matches, not every row.
+// that step's own chunks, a matched flag per row of them, and the buffers the matched rows
+// are collected into. The sibling of NLSortState, except that it covers one step rather
+// than the whole relation, so the memory it holds is one step's matches.
 class NLOptionalState {
 public:
     // One chunk of the step the pattern joins onto, in the order the pattern yields them
@@ -3025,7 +3020,10 @@ public:
     // alone. Runs each time nl.optional_buffer's block runs.
     void reset();
 
-    void markMatched(size_t row) { _matched[row] = true; }
+    void markMatched(size_t row) {
+        bioassert(row < _matched.size(), "Row tag {} is outside the {} rows of the step", row, _matched.size());
+        _matched[row] = true;
+    }
 
     // The input rows nothing matched, in order. Computed on the first call of a step, so
     // the drain pays for the sweep once however many chunks it emits.

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -2988,6 +2988,155 @@ private:
     NLUnaryFunctionKernel _kernel {nullptr};
 };
 
+// Type of handle that fills a column with a run of null rows - for an ID column an
+// invalid ID, which is how an entity a pattern did not match is spelled. One per column
+// kind, selected during translation the way the gather and append families are.
+using NLFillNullFunction = void (*)(Column* output, size_t rowCount);
+
+// Runtime state of one OPTIONAL MATCH over one step of the rows its pattern joins onto:
+// that step's own chunks, a matched flag per row of them, and the row buffers the matched
+// rows are collected into. nl.optional_buffer resets it once per step,
+// nl.optional_collect appends one chunk of every column the pattern contributes and marks
+// the input rows the row tag names, and the nl.for over nl.optional_drain reads the
+// collected rows back and then rebuilds the rows nothing matched out of the input chunks.
+// The pattern sibling of NLSortState: it accumulates rows to re-emit them, but keeps the
+// input chunks beside them, and covers one step rather than the whole relation - so the
+// memory it holds is one step's matches, not every row.
+class NLOptionalState {
+public:
+    // One chunk of the step the pattern joins onto, in the order the pattern yields them
+    // back; borrowed, since they are the enclosing loop's own variables.
+    void addInputColumn(const Column* input) { _inputColumns.push_back(input); }
+
+    // One buffer per column the pattern contributes, in yield order.
+    void addMatchedBuffer(Column* buffer) { _buffers.push_back(buffer); }
+
+    const std::vector<const Column*>& inputColumns() const { return _inputColumns; }
+    const std::vector<Column*>& buffers() const { return _buffers; }
+
+    // The rows this step joins onto: the input chunks' row count, and one - the single
+    // empty row a query opening on OPTIONAL MATCH starts from - when there are none.
+    size_t getRowCount() const;
+
+    // The rows the pattern matched, read from the first buffer as a sort reads its own.
+    size_t getMatchedRowCount() const;
+
+    // Empty the buffers and clear every matched flag, so the accumulator covers this step
+    // alone. Runs each time nl.optional_buffer's block runs.
+    void reset();
+
+    void markMatched(size_t row) { _matched[row] = true; }
+
+    // The input rows nothing matched, in order. Computed on the first call of a step, so
+    // the drain pays for the sweep once however many chunks it emits.
+    const ColumnVector<size_t>& missedRows();
+
+private:
+    std::vector<const Column*> _inputColumns;
+    std::vector<Column*> _buffers;
+
+    // One flag per row of this step's input chunks, cleared by the reset and set by the
+    // collect through the row tag.
+    std::vector<bool> _matched;
+
+    ColumnVector<size_t> _missedRows;
+    bool _swept {false};
+};
+
+// nl.optional_buffer data: empties an accumulator and lays the row tag out over this
+// step's input rows, each time the block it lives in runs.
+class NLOptionalResetData : public NLFunctionData {
+public:
+    NLOptionalResetData(NLOptionalState* state, ColumnVector<uint64_t>* tag)
+        : _state(state),
+        _tag(tag)
+    {
+    }
+
+    NLOptionalState* getState() const { return _state; }
+    ColumnVector<uint64_t>* getTag() const { return _tag; }
+
+private:
+    NLOptionalState* _state {nullptr};
+    ColumnVector<uint64_t>* _tag {nullptr};
+};
+
+// nl.optional_collect data: appends the current chunk of every column the pattern
+// contributes to the matching buffer, and marks the input rows the tag names. Each entry
+// pairs the pattern's chunk with the buffer it grows and the append that copies one into
+// the other, as nl.sort_collect's do.
+class NLOptionalCollectData : public NLFunctionData {
+public:
+    struct Append {
+        const Column* _input {nullptr};
+        Column* _buffer {nullptr};
+        NLAppendFunction _append {nullptr};
+    };
+
+    NLOptionalCollectData(NLOptionalState* state)
+        : _state(state)
+    {
+    }
+
+    NLOptionalState* getState() const { return _state; }
+
+    // Null when the accumulator has no input column: the step is then the single empty
+    // row, which any collected row marks.
+    const ColumnVector<uint64_t>* getTag() const { return _tag; }
+    void setTag(const ColumnVector<uint64_t>* tag) { _tag = tag; }
+
+    const std::vector<Append>& appends() const { return _appends; }
+
+    void addAppend(const Append& append) { _appends.push_back(append); }
+
+private:
+    NLOptionalState* _state {nullptr};
+    const ColumnVector<uint64_t>* _tag {nullptr};
+    std::vector<Append> _appends;
+};
+
+// nl.for over nl.optional_drain data: the emit phase of an OPTIONAL MATCH. Holds the
+// accumulator and, per column, the buffer the matched rows are read from, the input chunk
+// a missed row's value is read from - null for a column the pattern binds, which a missed
+// row has no value for - the loop variable to fill, and the gather and null fill that
+// write it. The indices scratch holds the row slice of the current emit step.
+class NLOptionalDrainLoopData : public NLFunctionData {
+public:
+    struct DrainColumn {
+        const Column* _buffer {nullptr};
+        const Column* _input {nullptr};
+        Column* _output {nullptr};
+        NLGatherFunction _gather {nullptr};
+        NLFillNullFunction _fillNull {nullptr};
+    };
+
+    NLOptionalDrainLoopData(NLOptionalState* state)
+        : _state(state)
+    {
+    }
+
+    NLOptionalState* getState() const { return _state; }
+
+    const std::vector<DrainColumn>& columns() const { return _columns; }
+
+    void addColumn(const DrainColumn& column) { _columns.push_back(column); }
+
+    ColumnVector<size_t>* getIndices() { return &_indices; }
+
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
+private:
+    NLOptionalState* _state {nullptr};
+    NLLimitState* _limit {nullptr};
+    std::vector<DrainColumn> _columns;
+    ColumnVector<size_t> _indices;
+    NLStmtContainer _stmts;
+};
+
 class NLProgram {
 public:
     NLProgram();
@@ -3103,6 +3252,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one OPTIONAL MATCH's runtime accumulator, owned by the program; the reset,
+    // collect and drain statements that share it hold a borrowed pointer. The pattern
+    // sibling of allocSortState.
+    NLOptionalState* allocOptionalState() {
+        auto state = std::make_unique<NLOptionalState>();
+        NLOptionalState* statePtr = state.get();
+        _optionalStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     // The candidate index one chain-node signature already has, or a null pointer for a
     // signature no chain node of the program has reached yet. Two nodes of the same
     // labels and key properties look their candidates up in one index, so the label set
@@ -3150,6 +3309,7 @@ private:
     std::vector<std::unique_ptr<NLGroupAggregateState>> _groupAggregateStates;
     std::vector<std::unique_ptr<NLCollectState>> _collectStates;
     std::vector<std::unique_ptr<NLShortestPathState>> _shortestPathStates;
+    std::vector<std::unique_ptr<NLOptionalState>> _optionalStates;
     std::vector<std::unique_ptr<NLProcedureState>> _procedureStates;
     std::unordered_map<std::string, std::unique_ptr<NLMergeNodeIndex>> _mergeNodeIndexes;
     NLMergePendingEdges _mergePendingEdges;

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -364,6 +364,10 @@ ValueType valueTypeFromChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (mlir::isa<storage::OwnedStringType>(nullableType.getValueType())) {
+            return ValueType::String;
+        }
+
         return valueTypeFromElementType(nullableType.getValueType());
     }
 
@@ -2184,9 +2188,14 @@ void NLTranslator::addTruncateColumn(mlir::Value inputValue,
         output = _memory->allocSame(input);
         copyPrefix = NLExecutor::selectConstBlockRepeatFunction();
     } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
-        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
-        output = allocOptColumnForValueType(valueType);
-        copyPrefix = NLExecutor::selectOptBlockRepeatFunction(valueType);
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            output = allocOptOwnedStringColumn();
+            copyPrefix = NLExecutor::selectOptOwnedStringBlockRepeat();
+        } else {
+            const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+            output = allocOptColumnForValueType(valueType);
+            copyPrefix = NLExecutor::selectOptBlockRepeatFunction(valueType);
+        }
     } else if (isPlainValueElementType(elementType)) {
         const ValueType valueType = valueTypeFromElementType(elementType);
         output = allocPlainColumn(valueType);
@@ -2284,9 +2293,14 @@ void NLTranslator::addSkipColumn(mlir::Value inputValue,
         output = _memory->allocSame(input);
         copySuffix = NLExecutor::selectConstCopyFunction();
     } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
-        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
-        output = allocOptColumnForValueType(valueType);
-        copySuffix = NLExecutor::selectOptCopyFunction(valueType);
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            output = allocOptOwnedStringColumn();
+            copySuffix = NLExecutor::selectOptOwnedStringCopy();
+        } else {
+            const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+            output = allocOptColumnForValueType(valueType);
+            copySuffix = NLExecutor::selectOptCopyFunction(valueType);
+        }
     } else if (isPlainValueElementType(elementType)) {
         const ValueType valueType = valueTypeFromElementType(elementType);
         output = allocPlainColumn(valueType);
@@ -2794,14 +2808,15 @@ void NLTranslator::buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKin
                 // No row of a list chunk is null, so a group's tally is its whole row
                 // count, as it is for count(*).
                 aggregate._fold = NLExecutor::selectGroupCountAllFold();
-            } else {
-                // An ID chunk charges its valid rows, an invalid ID being the null an
-                // OPTIONAL MATCH leaves; every other non-nullable chunk holds no null
-                // to skip - a column a CALL yielded - so every row is charged.
+            } else if (isEntityIDElement(countElementType)) {
+                // An invalid ID is the null an OPTIONAL MATCH leaves, so a group charges
+                // its valid rows alone.
                 const NLChunkKind countKind = chunkKindFromElementType(countElementType);
-                const NLGroupAggregateFoldFunction idFold = NLExecutor::selectGroupCountValidIDFold(countKind);
-
-                aggregate._fold = idFold ? idFold : NLExecutor::selectGroupCountAllFold();
+                aggregate._fold = NLExecutor::selectGroupCountValidIDFold(countKind);
+            } else {
+                // Every other non-nullable chunk holds no null to skip - a column a CALL
+                // yielded - so every row of the group is charged.
+                aggregate._fold = NLExecutor::selectGroupCountAllFold();
             }
         }
         break;
@@ -3798,6 +3813,10 @@ NLKeyAppendFunction NLTranslator::selectMergeKeyAppend(mlir::Type chunkType,
     const mlir::Type elementType = mlir::cast<nl::ChunkType>(chunkType).getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringMergeKeyAppend(keyType);
+        }
+
         const ValueType nullableValueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptMergeKeyAppendFunction(nullableValueType, keyType);
     }
@@ -3855,9 +3874,10 @@ NLCountFunction NLTranslator::selectCountForChunkType(mlir::Type chunkType) {
     }
 
     // An entity an OPTIONAL MATCH did not match is an invalid ID, so an ID chunk counts
-    // its valid rows; every other plain chunk holds no null and counts them all.
-    if (const NLCountFunction idCount = NLExecutor::selectIDCountFunction(chunkKindFromElementType(elementType))) {
-        return idCount;
+    // its valid rows; every other plain chunk holds no null and counts them all, whether
+    // or not it is one chunkKindFromElementType has a kind for.
+    if (isEntityIDElement(elementType)) {
+        return NLExecutor::selectIDCountFunction(chunkKindFromElementType(elementType));
     }
 
     return &NLExecutor::countAllRows;
@@ -3916,6 +3936,10 @@ Column* NLTranslator::allocColumnForResultChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return allocOptOwnedStringColumn();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return allocOptColumnForValueType(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3992,10 +4016,16 @@ void NLTranslator::addCrossColumn(mlir::Value inputValue,
         output = _memory->allocSame(input);
         broadcast = NLExecutor::selectConstBlockRepeatFunction();
     } else if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
-        const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
-        output = allocOptColumnForValueType(valueType);
-        broadcast = isOuter ? NLExecutor::selectOptBlockRepeatFunction(valueType)
-                            : NLExecutor::selectOptTileFunction(valueType);
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            output = allocOptOwnedStringColumn();
+            broadcast = isOuter ? NLExecutor::selectOptOwnedStringBlockRepeat()
+                                : NLExecutor::selectOptOwnedStringTile();
+        } else {
+            const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
+            output = allocOptColumnForValueType(valueType);
+            broadcast = isOuter ? NLExecutor::selectOptBlockRepeatFunction(valueType)
+                                : NLExecutor::selectOptTileFunction(valueType);
+        }
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
         output = allocListElementColumn();
         broadcast = isOuter ? NLExecutor::selectListElementBlockRepeatFunction()
@@ -4082,6 +4112,10 @@ Column* NLTranslator::allocOptOwnedStringColumn() {
     column->reserve(_program->getChunkSize());
 
     return column;
+}
+
+bool NLTranslator::isEntityIDElement(mlir::Type elementType) {
+    return mlir::isa<storage::NodeIDType>(elementType) || mlir::isa<storage::EdgeIDType>(elementType);
 }
 
 bool NLTranslator::isPlainValueElementType(mlir::Type elementType) {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -587,6 +587,11 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             config._carriedColumns.assign(carriedColumns.begin(), carriedColumns.end());
 
             _iteratorConfigs[unwind.getResult()] = config;
+        } else if (nl::OptionalDrain optionalDrain = mlir::dyn_cast<nl::OptionalDrain>(operation)) {
+            IteratorConfig config;
+            config._kind = IteratorKind::OptionalDrain;
+            config._optionalState = optionalStateFor(optionalDrain.getState());
+            _iteratorConfigs[optionalDrain.getResult()] = config;
         } else if (nl::ProcedureInit procedureInit = mlir::dyn_cast<nl::ProcedureInit>(operation)) {
             IteratorConfig config;
             config._kind = IteratorKind::ProcedureInit;
@@ -723,6 +728,10 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateShortestPathBuffer(shortestPathBuffer, body);
         } else if (nl::ShortestPathUpdate shortestPathUpdate = mlir::dyn_cast<nl::ShortestPathUpdate>(operation)) {
             translateShortestPathUpdate(shortestPathUpdate, body);
+        } else if (nl::OptionalBuffer optionalBuffer = mlir::dyn_cast<nl::OptionalBuffer>(operation)) {
+            translateOptionalBuffer(optionalBuffer, body);
+        } else if (nl::OptionalCollect optionalCollect = mlir::dyn_cast<nl::OptionalCollect>(operation)) {
+            translateOptionalCollect(optionalCollect, body);
         } else if (nl::CreateNode createNode = mlir::dyn_cast<nl::CreateNode>(operation)) {
             translateCreateNode(createNode, body);
         } else if (nl::CreateEdge createEdge = mlir::dyn_cast<nl::CreateEdge>(operation)) {
@@ -807,6 +816,8 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         // An unwind expands the rows it is given rather than accumulating them, so - like
         // a hop - a downstream LIMIT can bound its loop through the ordinary early-exit.
         translateUnwindLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::OptionalDrain) {
+        translateOptionalDrainLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::ProcedureInit) {
         translateProcedureInitLoop(config, loopBody, limit, body);
     } else {
@@ -1924,14 +1935,23 @@ void NLTranslator::translateNot(nl::Not notOp, NLStmtContainer* body) {
 }
 
 void NLTranslator::translateToNullable(nl::ToNullable toNullable, NLStmtContainer* body) {
-    const Column* operand = getColumn(toNullable.getOperand());
+    const mlir::Value operandValue = toNullable.getOperand();
+    const Column* operand = getColumn(operandValue);
 
     const auto resultChunk = mlir::cast<nl::ChunkType>(toNullable.getResult().getType());
     const auto nullableType = mlir::cast<storage::NullableType>(resultChunk.getElementType());
     const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
 
+    // An entity column carries its null in the ID rather than in an optional, so it is
+    // read row by row for validity instead of copied straight across
+    const auto operandChunk = mlir::cast<nl::ChunkType>(operandValue.getType());
+    const mlir::Type operandElement = operandChunk.getElementType();
+    const bool readsAnEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(operandElement);
+
     Column* result = nullptr;
-    const NLUnaryFn fn = NLExecutor::selectToNullable(valueType, operand, _memory, result);
+    const NLUnaryFn fn = readsAnEntity
+        ? NLExecutor::selectEntityToNullable(chunkKindFromElementType(operandElement), _memory, result)
+        : NLExecutor::selectToNullable(valueType, operand, _memory, result);
     bioassert(result, "Failed to allocate the nullable column of nl.to_nullable.");
 
     _valueSlots[toNullable.getResult()] = result;
@@ -2427,6 +2447,113 @@ void NLTranslator::translateSortLoop(const IteratorConfig& config,
     translateBlock(loopBody, loopData->getStmts());
 }
 
+void NLTranslator::translateOptionalBuffer(nl::OptionalBuffer buffer, NLStmtContainer* body) {
+    NLOptionalState* state = _program->allocOptionalState();
+    _optionalStates[buffer.getState()] = state;
+
+    // This step's own chunks: the drain rebuilds the rows the pattern missed out of them,
+    // and their row count is how many matched flags the reset clears.
+    for (const mlir::Value column : buffer.getInputColumns()) {
+        state->addInputColumn(getColumn(column));
+    }
+
+    ColumnVector<uint64_t>* tag = static_cast<ColumnVector<uint64_t>*>(allocColumn(buffer.getTag()));
+
+    NLOptionalResetData* resetData = _program->allocFunctionData<NLOptionalResetData>(state, tag);
+    body->emplaceStmt(&NLExecutor::runOptionalReset, resetData);
+}
+
+void NLTranslator::translateOptionalCollect(nl::OptionalCollect collect, NLStmtContainer* body) {
+    NLOptionalState* state = optionalStateFor(collect.getState());
+
+    // The buffers are allocated once, by the single collect feeding an accumulator.
+    // Generated IR has exactly one collect per accumulator; a second would append to the
+    // same buffers and double the rows, so it is rejected here as a sort's is.
+    if (!state->buffers().empty()) {
+        throw IRException("an nl.optional_buffer must be fed by a single nl.optional_collect");
+    }
+
+    NLOptionalCollectData* data = _program->allocFunctionData<NLOptionalCollectData>(state);
+
+    if (const mlir::Value tag = collect.getTag()) {
+        data->setTag(static_cast<const ColumnVector<uint64_t>*>(getColumn(tag)));
+    }
+
+    // One growing buffer per column the pattern contributes, row-aligned. The buffer keeps
+    // the column's element type; the append copies a chunk's rows onto its tail.
+    for (const mlir::Value column : collect.getColumns()) {
+        Column* bufferColumn = allocColumnForChunkType(column.getType());
+        state->addMatchedBuffer(bufferColumn);
+
+        const NLOptionalCollectData::Append append {getColumn(column),
+                                                    bufferColumn,
+                                                    selectAppendForChunkType(column.getType())};
+        data->addAppend(append);
+    }
+
+    body->emplaceStmt(&NLExecutor::runOptionalCollect, data);
+}
+
+void NLTranslator::translateOptionalDrainLoop(const IteratorConfig& config,
+                                              mlir::Block& loopBody,
+                                              NLLimitState* limit,
+                                              NLStmtContainer* body) {
+    NLOptionalState* state = config._optionalState;
+    if (!state) {
+        throw IRException("nl.optional_drain iterator must carry an optional accumulator");
+    }
+
+    // For::verify binds one loop variable per iterator chunk, and the drain iterator's
+    // chunk types are the collected column types, so the loop must take one per buffer.
+    const size_t bufferCount = state->buffers().size();
+    if (loopBody.getNumArguments() != bufferCount) {
+        throw IRException("nl.optional_drain loop must bind one variable per collected column");
+    }
+
+    NLOptionalDrainLoopData* loopData = _program->allocFunctionData<NLOptionalDrainLoopData>(state);
+    loopData->setLimit(limit);
+
+    // Reserve the row-slice scratch so the per-step gather stays allocation-free, the same
+    // as the edge loop's indices column.
+    loopData->getIndices()->reserve(_program->getChunkSize());
+
+    // The columns the pattern joined onto come first, in the order it yielded them back,
+    // so the first inputColumns().size() of them are the ones a missed row is rebuilt from.
+    const std::vector<const Column*>& inputColumns = state->inputColumns();
+
+    for (size_t columnIndex = 0; columnIndex < bufferCount; columnIndex++) {
+        const mlir::Value loopVariable = loopBody.getArgument(static_cast<unsigned>(columnIndex));
+        const mlir::Type chunkType = loopVariable.getType();
+
+        Column* output = allocColumnForChunkType(chunkType);
+        _valueSlots[loopVariable] = output;
+
+        const bool joinedOnto = columnIndex < inputColumns.size();
+
+        NLOptionalDrainLoopData::DrainColumn column;
+        column._buffer = state->buffers()[columnIndex];
+        column._input = joinedOnto ? inputColumns[columnIndex] : nullptr;
+        column._output = output;
+        column._gather = selectGatherForChunkType(chunkType);
+        column._fillNull = joinedOnto ? nullptr : NLExecutor::selectFillNullFunction(getChunkKind(chunkType));
+
+        loopData->addColumn(column);
+    }
+
+    body->emplaceStmt(&NLExecutor::runOptionalDrainLoop, loopData);
+
+    translateBlock(loopBody, loopData->getStmts());
+}
+
+NLOptionalState* NLTranslator::optionalStateFor(mlir::Value handle) const {
+    const auto stateIt = _optionalStates.find(handle);
+    if (stateIt == _optionalStates.end()) {
+        throw IRException("optional handle must be produced by an nl.optional_buffer");
+    }
+
+    return stateIt->second;
+}
+
 NLSortState* NLTranslator::sortStateFor(mlir::Value handle) const {
     const auto stateIt = _sortStates.find(handle);
     if (stateIt == _sortStates.end()) {
@@ -2668,9 +2795,13 @@ void NLTranslator::buildGroupAggregate(mlir::storage::GroupAggregateKind mlirKin
                 // count, as it is for count(*).
                 aggregate._fold = NLExecutor::selectGroupCountAllFold();
             } else {
-                // A non-nullable chunk holds no null to skip - an ID chunk of
-                // count(*), or a column a CALL yielded - so every row is charged.
-                aggregate._fold = NLExecutor::selectGroupCountAllFold();
+                // An ID chunk charges its valid rows, an invalid ID being the null an
+                // OPTIONAL MATCH leaves; every other non-nullable chunk holds no null
+                // to skip - a column a CALL yielded - so every row is charged.
+                const NLChunkKind countKind = chunkKindFromElementType(countElementType);
+                const NLGroupAggregateFoldFunction idFold = NLExecutor::selectGroupCountValidIDFold(countKind);
+
+                aggregate._fold = idFold ? idFold : NLExecutor::selectGroupCountAllFold();
             }
         }
         break;
@@ -3554,6 +3685,10 @@ Column* NLTranslator::allocColumnForChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return allocOptOwnedStringColumn();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return allocOptColumnForValueType(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3576,6 +3711,10 @@ NLAppendFunction NLTranslator::selectAppendForChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringAppend();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptAppendFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3594,6 +3733,10 @@ NLGatherFunction NLTranslator::selectGatherForChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringGather();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptGatherFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3612,6 +3755,10 @@ NLCompareFunction NLTranslator::selectCompareForChunkType(mlir::Type chunkType) 
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringCompare();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptCompareFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3663,6 +3810,10 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringKeyAppend();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptKeyAppendFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3693,10 +3844,20 @@ NLCountFunction NLTranslator::selectCountForChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringCount();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptCountFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
         return NLExecutor::selectListElementCountFunction();
+    }
+
+    // An entity an OPTIONAL MATCH did not match is an invalid ID, so an ID chunk counts
+    // its valid rows; every other plain chunk holds no null and counts them all.
+    if (const NLCountFunction idCount = NLExecutor::selectIDCountFunction(chunkKindFromElementType(elementType))) {
+        return idCount;
     }
 
     return &NLExecutor::countAllRows;
@@ -3707,6 +3868,10 @@ NLGroupKeyGatherFunction NLTranslator::selectGroupKeyGatherForChunkType(mlir::Ty
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringGroupKeyGather();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptGroupKeyGather(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3725,6 +3890,10 @@ NLCopyFunction NLTranslator::selectCopyForChunkType(mlir::Type chunkType) {
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        if (isOwnedStringElement(nullableType.getValueType())) {
+            return NLExecutor::selectOptOwnedStringCopy();
+        }
+
         const ValueType valueType = valueTypeFromElementType(nullableType.getValueType());
         return NLExecutor::selectOptCopyFunction(valueType);
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
@@ -3901,6 +4070,20 @@ Column* NLTranslator::allocSingleRowOptColumnForValueType(ValueType valueType) {
 // tally is one (a ui64 that is never null) and so is an expression over it (a signed
 // i64, or an f64 once a double takes part). A width-1 integer is a mask, not one of
 // these, and an ID or list element is its own family.
+// A nullable chunk whose rows own their characters - what labels() and edgeType() produce
+// - rather than borrowing them from the graph, as a string property column does. Its value
+// type is String either way, so the handler families need this beside it.
+bool NLTranslator::isOwnedStringElement(mlir::Type elementType) {
+    return mlir::isa<storage::OwnedStringType>(elementType);
+}
+
+Column* NLTranslator::allocOptOwnedStringColumn() {
+    auto* column = _memory->alloc<ColumnOptVector<types::String::OwningPrimitive>>();
+    column->reserve(_program->getChunkSize());
+
+    return column;
+}
+
 bool NLTranslator::isPlainValueElementType(mlir::Type elementType) {
     if (mlir::isa<mlir::Float64Type>(elementType)) {
         return true;

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -61,6 +61,7 @@ private:
         VectorSearch,
         Unwind,
         ProcedureInit,
+        OptionalDrain,
     };
 
     // Settings of the iterators passed to each for loop
@@ -79,6 +80,9 @@ private:
         NLCollectState* _collectState {nullptr};
 
         NLShortestPathState* _shortestPathState {nullptr};
+
+        // The accumulator an OptionalDrain iterator drains; null for the other kinds.
+        NLOptionalState* _optionalState {nullptr};
 
         // The call a ProcedureInit iterator drives; null for the other kinds.
         NLProcedureState* _procedureState {nullptr};
@@ -195,6 +199,11 @@ private:
     llvm::DenseMap<mlir::Value, NLCollectState*> _collectStates;
 
     llvm::DenseMap<mlir::Value, NLShortestPathState*> _shortestPathStates;
+
+    // nl.optional_buffer handle SSA value -> the runtime accumulator it produces, so
+    // nl.optional_collect and the nl.for over nl.optional_drain find the same buffers and
+    // matched flags
+    llvm::DenseMap<mlir::Value, NLOptionalState*> _optionalStates;
 
     // nl.procedure handle SSA value -> the runtime call it produces, so every op that
     // names the handle - the nl.for over nl.procedure_init - drives the same procedure
@@ -471,6 +480,30 @@ private:
     // produced by an nl.collect_buffer translated earlier.
     NLCollectState* collectStateFor(mlir::Value handle) const;
 
+    // Translate an nl.optional_buffer: allocate the runtime accumulator, map the handle to
+    // it, record this step's input chunks and the row tag column, and record the reset
+    // statement (run each time the block runs). The row buffers are allocated by the
+    // collect, which knows their types, as nl.sort_collect allocates a sort's.
+    void translateOptionalBuffer(mlir::nl::OptionalBuffer buffer, NLStmtContainer* body);
+
+    // Translate an nl.optional_collect: allocate one growing buffer per column the pattern
+    // contributes with the append that grows it, wire the row tag, and record the per-step
+    // statement.
+    void translateOptionalCollect(mlir::nl::OptionalCollect collect, NLStmtContainer* body);
+
+    // Translate the nl.for over an nl.optional_drain iterator: allocate one loop variable
+    // per column, pair it with the buffer the matched rows come from and - for a column
+    // the pattern joined onto - the input chunk a missed row is rebuilt from, and record
+    // the emit-loop statement.
+    void translateOptionalDrainLoop(const IteratorConfig& config,
+                                    mlir::Block& loopBody,
+                                    NLLimitState* limit,
+                                    NLStmtContainer* body);
+
+    // The runtime accumulator an optional handle names. Throws if the handle was not
+    // produced by an nl.optional_buffer translated earlier.
+    NLOptionalState* optionalStateFor(mlir::Value handle) const;
+
     // Translate the nl.for over an nl.unwind_collect iterator: allocate one loop variable per
     // grouping key plus the element value, wire the key outputs and value output onto
     // the shared state, and record the per-element emit-loop statement.
@@ -698,6 +731,13 @@ private:
     // A count result is a ui64 tally, the pipeline's one non-nullable value chunk, so
     // it is neither an ID chunk nor a !storage.nullable<...> one and takes a plain
     // ColumnVector<uint64_t>.
+    // Whether a nullable chunk's value type is one whose rows own their characters, which
+    // the value type alone does not say: labels() and edgeType() format their own text
+    // where a string property column borrows the graph's
+    static bool isOwnedStringElement(mlir::Type elementType);
+
+    Column* allocOptOwnedStringColumn();
+
     static bool isPlainValueElementType(mlir::Type elementType);
     Column* allocPlainColumn(ValueType valueType);
     ColumnVector<uint64_t>* allocCountColumn();

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -738,6 +738,7 @@ private:
 
     Column* allocOptOwnedStringColumn();
 
+    static bool isEntityIDElement(mlir::Type elementType);
     static bool isPlainValueElementType(mlir::Type elementType);
     Column* allocPlainColumn(ValueType valueType);
     ColumnVector<uint64_t>* allocCountColumn();

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -2467,12 +2467,18 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
     const bool opensLoop = opensSourceLoop(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
 
-    // A pipeline breaker accumulates every row before emitting any, so the walk stops
-    // here; the limit budgets its emit loop instead, when it opens one.
     const bool emitsThroughLoop = mlir::isa<mlir::db::Sort,
                                             mlir::db::GroupAggregate,
                                             mlir::db::OptionalMatch>(definingOp);
-    const bool breaksPipeline = emitsThroughLoop || reducesToOneRow(definingOp);
+
+    // A sort or a grouped aggregate accumulates the whole relation before emitting any of
+    // it, so the loops feeding it have to see every row: the walk stops and the limit
+    // budgets the emit loop alone. An optional match accumulates one step of the rows it
+    // joins onto rather than the relation, and emits them in input order, so once the
+    // budget is spent no later step can contribute a row - the walk carries on and bounds
+    // the loops feeding it too.
+    const bool accumulatesTheRelation = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
+    const bool breaksPipeline = accumulatesTheRelation || reducesToOneRow(definingOp);
 
     bool reachedALoop = opensLoop || isCrossProduct || emitsThroughLoop;
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -353,6 +353,17 @@ bool isNullableChunk(mlir::Type chunkType) {
     return mlir::isa<storage::NullableType>(chunk.getElementType());
 }
 
+// A node or edge ID chunk: the one plain chunk whose rows can be null, an OPTIONAL MATCH
+// leaving an invalid ID where the pattern missed.
+bool isEntityChunk(mlir::Type chunkType) {
+    const nl::ChunkType chunk = mlir::dyn_cast<nl::ChunkType>(chunkType);
+    if (!chunk) {
+        return false;
+    }
+
+    return mlir::isa<storage::NodeIDType, storage::EdgeIDType>(chunk.getElementType());
+}
+
 bool isListChunk(mlir::Type chunkType) {
     const nl::ChunkType chunk = mlir::dyn_cast<nl::ChunkType>(chunkType);
     if (!chunk) {
@@ -1441,8 +1452,6 @@ void DBLowering::lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch) {
         }
     }
 
-    // The collect belongs where the pattern bound its columns together - the same block an
-    // nl.output over them would sit in.
     setInsertionInto(deepestOwnerBlock(matchedChunks, stepBlock));
     _builder.create<nl::OptionalCollect>(loc, state, matchedTag, matchedChunks);
 
@@ -1455,8 +1464,6 @@ void DBLowering::lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch) {
         chunkTypes.push_back(chunk.getType());
     }
 
-    // Placed after the pattern's nest in the block that opened the accumulator, so the
-    // matched rows are all in by the time it first steps.
     const nl::IteratorType iteratorType = nl::IteratorType::get(_builder.getContext(), chunkTypes);
     setInsertionInto(stepBlock);
     nl::OptionalDrain drain = _builder.create<nl::OptionalDrain>(loc, iteratorType, state);
@@ -3006,10 +3013,18 @@ void DBLowering::lowerBinaryOp(mlir::Operation& op, BinaryResultKind kind) {
     mlir::Value lhsChunk = mapValue(op.getOperand(0));
     mlir::Value rhsChunk = mapValue(op.getOperand(1));
 
+    const bool comparesTwoEntities = isEntityChunk(lhsChunk.getType()) && isEntityChunk(rhsChunk.getType());
+
     // x IS NULL over a plain scalar column meets kernels reading a nullable value column
     if (isUntypedNullChunk(rhsChunk.getType()) && !isNullableChunk(lhsChunk.getType())) {
         lhsChunk = nullableValueChunk(lhsChunk);
     } else if (isUntypedNullChunk(lhsChunk.getType()) && !isNullableChunk(rhsChunk.getType())) {
+        rhsChunk = nullableValueChunk(rhsChunk);
+    } else if (comparesTwoEntities) {
+        // Two entities are compared as the IDs they are, and an ID column carries its null
+        // in the ID: read raw, the invalid ID two missed matches hold compares equal to
+        // itself. Read as nullable ui64, a null compares as a null - which a WHERE drops.
+        lhsChunk = nullableValueChunk(lhsChunk);
         rhsChunk = nullableValueChunk(rhsChunk);
     }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1431,6 +1431,16 @@ void DBLowering::lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch) {
         throw IRException("db.optional_match pattern yields no column");
     }
 
+    // The drain rebuilds a missed row's carried columns out of this step's input chunks, so
+    // the two must be the same chunk type however the db types were spelled: a column a
+    // CALL yielded enters type-erased and comes back refined, and the chunk behind it is
+    // the same one either way.
+    for (size_t inputIndex = 0; inputIndex < inputChunks.size(); inputIndex++) {
+        if (matchedChunks[inputIndex].getType() != inputChunks[inputIndex].getType()) {
+            throw IRException("db.optional_match carries an input column back as another chunk type");
+        }
+    }
+
     // The collect belongs where the pattern bound its columns together - the same block an
     // nl.output over them would sit in.
     setInsertionInto(deepestOwnerBlock(matchedChunks, stepBlock));

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -109,8 +109,11 @@ struct UnaryFunctionLowering {
 };
 
 const std::unordered_map<std::string_view, UnaryFunctionLowering> unaryFunctionLowerings = {
-    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &ownedStringFunctionElement, ResultNullability::FollowsInput}},
-    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &ownedStringFunctionElement, ResultNullability::FollowsInput}},
+    // Both read an entity column, which carries its null in the ID an OPTIONAL MATCH left
+    // invalid rather than in an optional, so their result is nullable whatever the input
+    // chunk's own type says
+    {"db.labels",     {&emitNLUnaryFunction<nl::Labels>,    &ownedStringFunctionElement, ResultNullability::AlwaysNullable}},
+    {"db.edge_type",  {&emitNLUnaryFunction<nl::EdgeType>,  &ownedStringFunctionElement, ResultNullability::AlwaysNullable}},
     {"db.to_integer", {&emitNLUnaryFunction<nl::ToInteger>, &integerFunctionElement,     ResultNullability::AlwaysNullable}},
     {"db.to_float",   {&emitNLUnaryFunction<nl::ToFloat>,   &floatFunctionElement,       ResultNullability::AlwaysNullable}},
     {"db.to_boolean", {&emitNLUnaryFunction<nl::ToBoolean>, &booleanFunctionElement,     ResultNullability::AlwaysNullable}},
@@ -550,7 +553,10 @@ bool opensSourceLoop(mlir::Operation* operation) {
 // builds, and the emit loop a pipeline breaker opens over what it accumulated
 bool opensRowLoop(mlir::Operation* operation) {
     return opensSourceLoop(operation)
-        || mlir::isa<mlir::db::CrossProduct, mlir::db::Sort, mlir::db::GroupAggregate>(operation);
+        || mlir::isa<mlir::db::CrossProduct,
+                     mlir::db::Sort,
+                     mlir::db::GroupAggregate,
+                     mlir::db::OptionalMatch>(operation);
 }
 
 // A reduction emits its one row at function scope, so what follows it walks no rows of the
@@ -771,6 +777,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerDeleteEdge(deleteEdge);
     } else if (mlir::db::CrossProduct crossProduct = mlir::dyn_cast<mlir::db::CrossProduct>(operation)) {
         lowerCrossProduct(crossProduct);
+    } else if (mlir::db::OptionalMatch optionalMatch = mlir::dyn_cast<mlir::db::OptionalMatch>(operation)) {
+        lowerOptionalMatch(optionalMatch);
     } else if (mlir::db::Limit limit = mlir::dyn_cast<mlir::db::Limit>(operation)) {
         lowerLimit(limit);
     } else if (mlir::db::Skip skip = mlir::dyn_cast<mlir::db::Skip>(operation)) {
@@ -1344,6 +1352,108 @@ void DBLowering::lowerCheckEdgeTypeConstraint(mlir::db::CheckEdgeTypeConstraint 
     _valueMap[checkEdgeTypeConstraint.getResult()] = check.getResult();
 }
 
+mlir::Block* DBLowering::deepestOwnerBlock(llvm::ArrayRef<mlir::Value> chunks, mlir::Block* fallback) {
+    mlir::Block* deepest = fallback;
+    size_t deepestDepth = blockNestingDepth(fallback);
+
+    for (const mlir::Value chunk : chunks) {
+        mlir::Block* const owner = ownerBlock(chunk);
+        const size_t ownerDepth = blockNestingDepth(owner);
+
+        if (ownerDepth > deepestDepth) {
+            deepest = owner;
+            deepestDepth = ownerDepth;
+        }
+    }
+
+    return deepest;
+}
+
+void DBLowering::lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch) {
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    llvm::SmallVector<mlir::Value, 4> inputChunks;
+    for (const mlir::Value column : optionalMatch.getInputColumns()) {
+        inputChunks.push_back(mapValue(column));
+    }
+
+    // The step the accumulator covers is the one binding the columns the pattern joins
+    // onto, so it is emptied once per chunk of them - and the pattern's nest and the drain
+    // loop both go there, the drain after the nest.
+    mlir::Block* const stepBlock = deepestOwnerBlock(inputChunks, _rootBlock);
+
+    setInsertionInto(stepBlock);
+    nl::OptionalBuffer buffer = _builder.create<nl::OptionalBuffer>(loc, inputChunks);
+    const mlir::Value state = buffer.getState();
+
+    // The pattern reads this step's rows through its block arguments, and the row tag
+    // through the trailing one; a pattern with nothing to join onto has neither.
+    mlir::Block& patternBlock = optionalMatch.getPattern().front();
+    for (size_t inputIndex = 0; inputIndex < inputChunks.size(); inputIndex++) {
+        _valueMap[patternBlock.getArgument(static_cast<unsigned>(inputIndex))] = inputChunks[inputIndex];
+    }
+
+    if (!inputChunks.empty()) {
+        _valueMap[patternBlock.getArgument(static_cast<unsigned>(inputChunks.size()))] = buffer.getTag();
+    }
+
+    // A dataflow of its own, rooted where the accumulator sits so its loops nest inside
+    // this step; the caller's root and innermost loop are restored once it is lowered.
+    mlir::Block* const previousRoot = _rootBlock;
+    mlir::Block* const previousInnermostLoopBody = _innermostLoopBody;
+    const mlir::Value previousInnermostCardinality = _innermostCardinality;
+    _rootBlock = stepBlock;
+    _innermostLoopBody = nullptr;
+    _innermostCardinality = mlir::Value();
+
+    llvm::SmallVector<mlir::Value, 4> matchedChunks;
+    mlir::Value matchedTag;
+
+    for (mlir::Operation& operation : patternBlock) {
+        mlir::db::OptionalYield yield = mlir::dyn_cast<mlir::db::OptionalYield>(operation);
+        if (!yield) {
+            lowerOperation(operation);
+            continue;
+        }
+
+        for (const mlir::Value column : yield.getColumns()) {
+            matchedChunks.push_back(mapValue(column));
+        }
+
+        if (yield.getTag()) {
+            matchedTag = mapValue(yield.getTag());
+        }
+    }
+
+    // OptionalMatch::verify rejects a pattern yielding no column, so reaching this means
+    // unverified IR - a defensive backstop, as in lowerFactor and lowerSort.
+    if (matchedChunks.empty()) {
+        throw IRException("db.optional_match pattern yields no column");
+    }
+
+    // The collect belongs where the pattern bound its columns together - the same block an
+    // nl.output over them would sit in.
+    setInsertionInto(deepestOwnerBlock(matchedChunks, stepBlock));
+    _builder.create<nl::OptionalCollect>(loc, state, matchedTag, matchedChunks);
+
+    _rootBlock = previousRoot;
+    _innermostLoopBody = previousInnermostLoopBody;
+    _innermostCardinality = previousInnermostCardinality;
+
+    llvm::SmallVector<mlir::Type, 4> chunkTypes;
+    for (const mlir::Value chunk : matchedChunks) {
+        chunkTypes.push_back(chunk.getType());
+    }
+
+    // Placed after the pattern's nest in the block that opened the accumulator, so the
+    // matched rows are all in by the time it first steps.
+    const nl::IteratorType iteratorType = nl::IteratorType::get(_builder.getContext(), chunkTypes);
+    setInsertionInto(stepBlock);
+    nl::OptionalDrain drain = _builder.create<nl::OptionalDrain>(loc, iteratorType, state);
+
+    buildLoopForSource(drain.getResult(), optionalMatch.getOperation());
+}
+
 void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
     // The outer factor roots where this op would have - the entry block at top
     // level. The inner factor roots inside the outer factor's innermost loop
@@ -1429,17 +1539,7 @@ mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
     // root: the innermost loop body of a factor that walks a relation, and the root block
     // itself for one whose columns are a single row bound above every loop - a scalar
     // aggregate, or a constant laid out over the one row it is
-    mlir::Block* factorBody = rootBlock;
-    size_t deepestDepth = blockNestingDepth(rootBlock);
-    for (const mlir::Value chunk : yieldedChunks) {
-        mlir::Block* const owner = ownerBlock(chunk);
-        const size_t ownerDepth = blockNestingDepth(owner);
-
-        if (ownerDepth > deepestDepth) {
-            factorBody = owner;
-            deepestDepth = ownerDepth;
-        }
-    }
+    mlir::Block* const factorBody = deepestOwnerBlock(yieldedChunks, rootBlock);
 
     _rootBlock = previousRoot;
     _innermostLoopBody = previousInnermostLoopBody;
@@ -2369,7 +2469,9 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
 
     // A pipeline breaker accumulates every row before emitting any, so the walk stops
     // here; the limit budgets its emit loop instead, when it opens one.
-    const bool emitsThroughLoop = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
+    const bool emitsThroughLoop = mlir::isa<mlir::db::Sort,
+                                            mlir::db::GroupAggregate,
+                                            mlir::db::OptionalMatch>(definingOp);
     const bool breaksPipeline = emitsThroughLoop || reducesToOneRow(definingOp);
 
     bool reachedALoop = opensLoop || isCrossProduct || emitsThroughLoop;
@@ -3275,6 +3377,12 @@ mlir::Value DBLowering::nullableValueChunk(mlir::Value chunk) {
     mlir::Type valueElement = element;
     if (mlir::isa<storage::BoolType>(element)) {
         valueElement = _builder.getI1Type();
+    }
+
+    // A node or an edge reads as its ID's integer, absent where an OPTIONAL MATCH left the
+    // ID invalid: that is what makes n IS NULL the ordinary null test over a value column
+    if (mlir::isa<storage::NodeIDType, storage::EdgeIDType>(element)) {
+        valueElement = _builder.getIntegerType(64, /*isSigned=*/false);
     }
 
     const bool isString = mlir::isa<storage::StringType>(valueElement);

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -207,17 +207,10 @@ private:
     void lowerDeleteEdge(mlir::db::DeleteEdge deleteEdge);
     void lowerCrossProduct(mlir::db::CrossProduct product);
 
-    // Lower a db.optional_match: an nl.optional_buffer at the step of the block binding
-    // the columns the pattern joins onto - so the accumulator is emptied once per step -
-    // then the pattern's own loop nest rooted there (the shape lowerFactor gives a cross
-    // product's factor), an nl.optional_collect at its deepest point appending the matched
-    // rows and marking the input rows they came from, and - after that nest - an
-    // nl.optional_drain source plus its nl.for, which yields the matched rows and then one
-    // null-padded row per input row the pattern missed. db.optional_match's results map to
-    // that emit loop's variables, so what follows lowers into it, reading the rows the
-    // join kept. A pipeline breaker with an emit loop, like db.sort, but one whose
-    // accumulator lives inside the enclosing step rather than at function scope: the rows
-    // it must see before emitting any are one step's, not the whole relation's.
+    // Lower a db.optional_match into an nl.optional_buffer, the pattern's own loop nest,
+    // an nl.optional_collect at its deepest point and an nl.optional_drain loop yielding
+    // the matched rows then one null-padded row per input row the pattern missed. A
+    // pipeline breaker like db.sort, but its accumulator covers one step, not the relation.
     void lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch);
 
     // The most deeply nested block any of @param chunks is bound in, or @param fallback

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -207,6 +207,23 @@ private:
     void lowerDeleteEdge(mlir::db::DeleteEdge deleteEdge);
     void lowerCrossProduct(mlir::db::CrossProduct product);
 
+    // Lower a db.optional_match: an nl.optional_buffer at the step of the block binding
+    // the columns the pattern joins onto - so the accumulator is emptied once per step -
+    // then the pattern's own loop nest rooted there (the shape lowerFactor gives a cross
+    // product's factor), an nl.optional_collect at its deepest point appending the matched
+    // rows and marking the input rows they came from, and - after that nest - an
+    // nl.optional_drain source plus its nl.for, which yields the matched rows and then one
+    // null-padded row per input row the pattern missed. db.optional_match's results map to
+    // that emit loop's variables, so what follows lowers into it, reading the rows the
+    // join kept. A pipeline breaker with an emit loop, like db.sort, but one whose
+    // accumulator lives inside the enclosing step rather than at function scope: the rows
+    // it must see before emitting any are one step's, not the whole relation's.
+    void lowerOptionalMatch(mlir::db::OptionalMatch optionalMatch);
+
+    // The most deeply nested block any of @param chunks is bound in, or @param fallback
+    // when they are all bound at or above it: where an op reading them all belongs
+    static mlir::Block* deepestOwnerBlock(llvm::ArrayRef<mlir::Value> chunks, mlir::Block* fallback);
+
     // Lays the constant out over the rows of its driver, the layout rowAlignedChunk
     // performs for every consumer that reads a constant per row
     void lowerBroadcastConstant(mlir::db::BroadcastConstant broadcast);

--- a/query/plan/ReadStmtGenerator.cpp
+++ b/query/plan/ReadStmtGenerator.cpp
@@ -143,6 +143,10 @@ void ReadStmtGenerator::generateStmt(const Stmt* stmt) {
 void ReadStmtGenerator::generateMatchStmt(const MatchStmt* stmt) {
     const Pattern* pattern = stmt->getPattern();
 
+    if (stmt->isOptional()) {
+        throwError("OPTIONAL MATCH is only supported by the MLIR query engine.", stmt);
+    }
+
     if (stmt->hasOrderBy()) {
         throwError("MATCH ... ORDER BY ... is not supported yet. "
                    "Please use RETURN ... ORDER BY ... instead",

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -544,7 +544,8 @@ struct WriteProcessorPropertyTypes {
         std::optional<types::Bool::Primitive>,
         std::optional<types::Embedding::Primitive>,
 
-        std::string // For LOAD CSV inputs
+        std::string, // For LOAD CSV inputs
+        std::optional<std::string> // For labels() and edgeType(), which own their strings
     >>;
 
     // Used for specialised dispatching logic for only consts (shouldn't hold optional)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2086,3 +2086,25 @@ target_link_libraries(test_query_ir_similarity_guided_traversal PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_similarity_guided_traversal PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_owned_string_chunk OwnedStringChunkTest.cpp)
+target_link_libraries(test_query_ir_owned_string_chunk PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_owned_string_chunk PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_create_then_delete CreateThenDeleteTest.cpp)
+target_link_libraries(test_query_ir_create_then_delete PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_create_then_delete PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1324,6 +1324,20 @@ target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_aggregate_over_constant_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# OPTIONAL MATCH beside the clauses around it: a mandatory MATCH, another OPTIONAL MATCH, a
+# WITH barrier, an aggregation and a CALL. Reads its rows as text through StringRowSink,
+# since the projections range over IDs, properties and lists.
+add_turing_test(test_query_ir_optional_match_composition OptionalMatchCompositionTest.cpp)
+target_sources(test_query_ir_optional_match_composition PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_optional_match_composition PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_optional_match_composition PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_optional_match OptionalMatchTest.cpp)
 target_link_libraries(test_query_ir_optional_match PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1349,6 +1349,17 @@ target_link_libraries(test_query_ir_optional_match PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_optional_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_optional_match_write OptionalMatchWriteTest.cpp)
+target_link_libraries(test_query_ir_optional_match_write PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_optional_match_write PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with WithTest.cpp)
 target_link_libraries(test_query_ir_with PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1381,6 +1381,16 @@ target_link_libraries(test_query_ir_ldbc_bi11 PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_ldbc_bi11 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_ldbc_is7 LdbcIs7Test.cpp)
+target_link_libraries(test_query_ir_ldbc_is7 PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_ldbc_is7 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with_multi_part WithMultiPartTest.cpp)
 target_link_libraries(test_query_ir_with_multi_part PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1305,6 +1305,17 @@ target_link_libraries(test_query_ir_aggregate_over_constant_alias PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_aggregate_over_constant_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_optional_match OptionalMatchTest.cpp)
+target_link_libraries(test_query_ir_optional_match PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_optional_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_with WithTest.cpp)
 target_link_libraries(test_query_ir_with PRIVATE
         turing_db_s

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -739,6 +739,25 @@ target_link_libraries(test_query_ir_order_by_labels PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_order_by_labels PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_optional_match_cut OptionalMatchCutTest.cpp)
+target_link_libraries(test_query_ir_optional_match_cut PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_ast_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_frontend_cypher_s
+        turing_db_ir_codegen_s
+        turing_db_ir_interpreter_s
+        turing_db_ir_lowering_s
+        turing_db_ir_dbdialect_s
+        turing_db_ir_nldialect_s
+        turing_db_ir_common_s
+        MLIRParser)
+target_include_directories(test_query_ir_optional_match_cut PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_cross_product_cut CrossProductCutTest.cpp)
 target_link_libraries(test_query_ir_cross_product_cut PRIVATE
         turing_db_s

--- a/test/query/ir/CreateThenDeleteTest.cpp
+++ b/test/query/ir/CreateThenDeleteTest.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A CREATE and a DELETE in one query, over the entities a MATCH bound.
+class CreateThenDeleteTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    QueryStatus runWrite(std::string_view query, const ChangeID& changeID) {
+        NullSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+
+        return status;
+    }
+
+    void applyWrite(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        const QueryStatus status = runWrite(query, changeID);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed: " << submitStatus.getError();
+    }
+
+    void expectWriteRejected(std::string_view query, QueryStatus::Status stage) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        const QueryStatus status = runWrite(query, changeID);
+        ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
+
+        EXPECT_EQ(status.getStatus(), stage)
+            << "query: " << query
+            << "\nstage: " << QueryStatusDescription::value(status.getStatus())
+            << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// Both writes land: the Tag is created and Remy, who the MATCH bound, is gone with the
+// edges he walked
+TEST_F(CreateThenDeleteTest, createsANodeAndDetachDeletesAMatchedOne) {
+    applyWrite("MATCH (p:Person {name: 'Remy'}) CREATE (:Tag {name: 'x'}) DETACH DELETE p");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"x"}});
+    expectCounts("MATCH (p:Person) RETURN count(*)", {7});
+}
+
+// An edge a MATCH bound is deletable beside a CREATE the same way a node is
+TEST_F(CreateThenDeleteTest, createsANodeAndDeletesAMatchedEdge) {
+    applyWrite("MATCH (:Person {name: 'Adam'})-[e:INTERESTED_IN]->(:Interest {name: 'Bio'}) "
+               "CREATE (:Tag {name: 'x'}) DELETE e");
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"x"}});
+    expectRows("MATCH (:Person {name: 'Adam'})-[e:INTERESTED_IN]->(i) RETURN i.name",
+               {{"Cooking"}});
+}
+
+// The undetached delete of a connected node is turned away for what is wrong with it -
+// Remy's relationships - not for the CREATE standing beside it
+TEST_F(CreateThenDeleteTest, rejectsDeletingAConnectedNodeBesideACreate) {
+    expectWriteRejected("MATCH (p:Person {name: 'Remy'}) CREATE (:Tag {name: 'x'}) DELETE p",
+                        QueryStatus::Status::EXEC_ERROR);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -542,6 +542,33 @@ private:
     std::vector<bool> _values;
 };
 
+// Collects a nullable boolean column: what a comparison over an operand that can be null
+// emits, an entity column included - the invalid ID an OPTIONAL MATCH leaves is a null,
+// and a comparison against a null is one.
+class CollectingOptMaskSink : public NLOutputSink {
+public:
+    using OptBoolValues = std::vector<std::optional<bool>>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* values = dynamic_cast<const ColumnOptVector<CustomBool>*>(chunks[0]);
+        ASSERT_NE(values, nullptr);
+
+        const auto& raw = values->getRaw();
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            const std::optional<CustomBool>& value = raw[rowIndex];
+            _values.push_back(value ? std::optional<bool> {static_cast<bool>(*value)}
+                                    : std::optional<bool> {});
+        }
+    }
+
+    const OptBoolValues& getValues() const { return _values; }
+
+private:
+    OptBoolValues _values;
+};
+
 class CollectingNodeBoolSink : public NLOutputSink {
 public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
@@ -1970,6 +1997,18 @@ func.func @main() {
 }
 )mlir";
 
+// Counting a column of label-set IDs: a plain chunk whose element type is neither an
+// entity ID nor a nullable value. No row of it is null, so the tally is the node count.
+const char* const countLabelSetsProgram = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %ls = db.get_node_label_set(%a) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %n = db.count(%ls) : (!db.column<!storage.labelset_id>) -> !db.column<ui64>
+  db.output(%n) : !db.column<ui64>
+  return
+}
+)mlir";
+
 // MATCH (a) RETURN count(a.score): count the non-null scores. A node without the
 // property reads null, and count(a.score) does not charge those - so the tally is
 // fewer than the node count.
@@ -3073,12 +3112,13 @@ TEST_F(DBLoweringTest, eqNodeToItselfIsAllTrue) {
     const FrozenCommitTx transaction = graph->openTransaction();
     const GraphReader reader = transaction.readGraph();
 
-    CollectingMaskSink sink;
+    CollectingOptMaskSink sink;
     runLoweredProgram(eqSelfProgram, reader.getView(), sink);
 
-    // The diamond has four nodes, and every node equals itself.
-    const std::vector<bool> expected {true, true, true, true};
-    EXPECT_EQ(sink.values(), expected);
+    // The diamond has four nodes, and every node equals itself. The column is nullable
+    // because an entity column can carry one; none of these four rows does.
+    const CollectingOptMaskSink::OptBoolValues expected {true, true, true, true};
+    EXPECT_EQ(sink.getValues(), expected);
 }
 
 TEST_F(DBLoweringTest, eqNodePropertyToConstantBroadcasting) {
@@ -5492,6 +5532,20 @@ TEST_F(DBLoweringTest, countsNonNullScores) {
     runLoweredProgram(countScoresProgram, reader.getView(), sink);
 
     const std::vector<uint64_t> expected {2};
+    EXPECT_EQ(sink.getValues(), expected);
+}
+
+TEST_F(DBLoweringTest, countsEveryRowOfALabelSetColumn) {
+    auto graph = buildLabeledGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    // Five nodes, so five label sets. A tally over a plain chunk charges every row
+    // whether or not NLChunkKind names its element type.
+    CollectingCountSink sink;
+    runLoweredProgram(countLabelSetsProgram, reader.getView(), sink);
+
+    const std::vector<uint64_t> expected {5};
     EXPECT_EQ(sink.getValues(), expected);
 }
 

--- a/test/query/ir/IRTestRows.cpp
+++ b/test/query/ir/IRTestRows.cpp
@@ -29,6 +29,17 @@ using namespace turing::test;
 
 namespace {
 
+// An entity an OPTIONAL MATCH did not match is an invalid ID, which is a null
+template <typename ID>
+void renderEntityCell(ID id, std::string& out) {
+    if (!id.isValid()) {
+        out = "null";
+        return;
+    }
+
+    out = std::to_string(id.getValue());
+}
+
 void renderList(const ListView& list, std::string& out);
 
 void renderListElement(const ListElementView& element, std::string& out) {
@@ -145,11 +156,11 @@ bool renderValueCell(const Column* column, size_t row, std::string& out) {
 
 void turing::test::renderCell(const Column* column, size_t row, std::string& out) {
     if (const auto* nodeIDs = dynamic_cast<const ColumnNodeIDs*>(column)) {
-        out = std::to_string((*nodeIDs)[row].getValue());
+        renderEntityCell((*nodeIDs)[row], out);
     } else if (const auto* edgeIDs = dynamic_cast<const ColumnEdgeIDs*>(column)) {
-        out = std::to_string((*edgeIDs)[row].getValue());
+        renderEntityCell((*edgeIDs)[row], out);
     } else if (const auto* edgeTypes = dynamic_cast<const ColumnEdgeTypes*>(column)) {
-        out = std::to_string((*edgeTypes)[row].getValue());
+        renderEntityCell((*edgeTypes)[row], out);
     } else if (const auto* mask = dynamic_cast<const ColumnMask*>(column)) {
         out = (*mask)[row] ? "true" : "false";
     } else if (dynamic_cast<const ColumnConst<PropertyNull>*>(column)) {

--- a/test/query/ir/LdbcIs7Test.cpp
+++ b/test/query/ir/LdbcIs7Test.cpp
@@ -1,0 +1,160 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+#include "writers/GraphWriter.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The benchmark's query, verbatim but for the message id it is given and its CASE, which
+// the parser rejects as unimplemented. CASE r WHEN null THEN false ELSE true END asks
+// whether the OPTIONAL MATCH bound r, which is what r IS NOT NULL asks.
+std::string is7Query(int64_t messageId) {
+    return "MATCH (m:Message {id: " + std::to_string(messageId) + " })<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(p:Person) "
+           "    OPTIONAL MATCH (m)-[:HAS_CREATOR]->(a:Person)-[r:KNOWS]-(p) "
+           "    RETURN c.id AS commentId, "
+           "        c.content AS commentContent, "
+           "        c.creationDate AS commentCreationDate, "
+           "        p.id AS replyAuthorId, "
+           "        p.firstName AS replyAuthorFirstName, "
+           "        p.lastName AS replyAuthorLastName, "
+           "        r IS NOT NULL AS replyAuthorKnowsOriginalMessageAuthor "
+           "    ORDER BY commentCreationDate DESC, replyAuthorId";
+}
+
+}
+
+// LDBC SNB Interactive short read 7, "Replies of a message". The only query of the
+// benchmark whose OPTIONAL MATCH the engine can run: the other three reach for
+// variable-length paths, shortestPath, pattern predicates, size() or datetime().
+//
+// Its optional pattern closes onto two variables the mandatory match already bound - m and
+// p - so a reply whose author does not know the original author keeps its row with r null.
+class LdbcIs7Test : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        buildGraph(system.createGraph(_graphName));
+    }
+
+    // Alice posts message 100. Bob, Carol and Dan reply to it; Alice knows Bob alone, so
+    // Bob's row is the one the optional pattern matches. Erin replies to another message,
+    // which no row of the answer may reach.
+    void buildGraph(Graph* graph) {
+        JobSystem jobSystem;
+        jobSystem.init();
+
+        GraphWriter writer(graph, &jobSystem);
+
+        const auto addPerson = [&](int64_t id, std::string_view firstName, std::string_view lastName) {
+            const NodeID person = writer.addNode({"Person"});
+            writer.addNodeProperty<types::Int64>(person, "id", std::move(id));
+            writer.addNodeProperty<types::String>(person, "firstName", std::string_view(firstName));
+            writer.addNodeProperty<types::String>(person, "lastName", std::string_view(lastName));
+            return person;
+        };
+
+        const NodeID alice = addPerson(1, "Alice", "Adams");
+        const NodeID bob = addPerson(2, "Bob", "Brown");
+        const NodeID carol = addPerson(3, "Carol", "Clark");
+        const NodeID dan = addPerson(4, "Dan", "Davis");
+        const NodeID erin = addPerson(5, "Erin", "Evans");
+
+        const auto addMessage = [&](std::string_view kind, int64_t id, std::string_view content, int64_t creationDate) {
+            const NodeID message = writer.addNode({"Message", std::string(kind)});
+            writer.addNodeProperty<types::Int64>(message, "id", std::move(id));
+            writer.addNodeProperty<types::String>(message, "content", std::string_view(content));
+            writer.addNodeProperty<types::Int64>(message, "creationDate", std::move(creationDate));
+            return message;
+        };
+
+        const NodeID post = addMessage("Post", 100, "the original post", 1000);
+        writer.addEdge("HAS_CREATOR", post, alice);
+
+        const NodeID otherPost = addMessage("Post", 101, "an unrelated post", 1000);
+        writer.addEdge("HAS_CREATOR", otherPost, alice);
+
+        const auto reply = [&](int64_t id, std::string_view content, int64_t creationDate, NodeID author, NodeID target) {
+            const NodeID comment = addMessage("Comment", id, content, creationDate);
+            writer.addEdge("REPLY_OF", comment, target);
+            writer.addEdge("HAS_CREATOR", comment, author);
+        };
+
+        reply(201, "bob replies", 3000, bob, post);
+        reply(202, "carol replies", 2000, carol, post);
+        reply(203, "dan replies", 2000, dan, post);
+        reply(204, "erin replies elsewhere", 4000, erin, otherPost);
+
+        // KNOWS is symmetric in the benchmark and the query hops it undirected, so the one
+        // stored direction is matched from either end
+        writer.addEdge("KNOWS", alice, bob);
+        writer.addEdge("KNOWS", carol, dan);
+
+        writer.submit();
+        jobSystem.terminate();
+    }
+
+    void expectRowsInOrder(int64_t messageId, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              is7Query(messageId),
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << status.getError();
+
+        EXPECT_EQ(sink.rows(), expected);
+    }
+
+    const std::string _graphName = "ldbc";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// Bob knows Alice, so his row is the one the optional pattern matched; Carol and Dan know
+// each other but not Alice, and their rows come back with r null
+TEST_F(LdbcIs7Test, reportsWhichReplyAuthorsKnowTheMessageAuthor) {
+    expectRowsInOrder(100,
+                      {{"201", "bob replies", "3000", "2", "Bob", "Brown", "true"},
+                       {"202", "carol replies", "2000", "3", "Carol", "Clark", "false"},
+                       {"203", "dan replies", "2000", "4", "Dan", "Davis", "false"}});
+}
+
+// Only the replies of the message asked for: Erin's is the one reply of 101, and the three
+// replies of 100 are no rows of this answer
+TEST_F(LdbcIs7Test, reportsTheRepliesOfTheMessageAskedForAlone) {
+    expectRowsInOrder(101, {{"204", "erin replies elsewhere", "4000", "5", "Erin", "Evans", "false"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/MergeKeyTest.cpp
+++ b/test/query/ir/MergeKeyTest.cpp
@@ -51,6 +51,24 @@ TEST_F(MergeKeyTest, bindsAPendingNodeAnIntegerAndADoubleBothConstrain) {
     expectRows("MATCH (s:Score) RETURN count(s)", {{"2"}});
 }
 
+// labels() owns the characters of the string it hands back, where a property column
+// borrows them from the graph. That owned string is a merge key like any other value: the
+// one Person matched writes one Tag under its label set.
+TEST_F(MergeKeyTest, keysANodeOnTheLabelsOfAMatchedNode) {
+    expectWriteRowCount("MATCH (p:Person {name: 'Remy'}) MERGE (t:Tag {name: labels(p)})", 0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"Person, SoftwareEngineering, Founder"}});
+}
+
+// The edge sibling of the same key: edgeType() is owned the way labels() is
+TEST_F(MergeKeyTest, keysANodeOnTheTypeOfAMatchedEdge) {
+    expectWriteRowCount("MATCH (:Person {name: 'Remy'})-[e:KNOWS_WELL]->() "
+                        "MERGE (t:Tag {name: edgeType(e)})",
+                        0);
+
+    expectRows("MATCH (t:Tag) RETURN t.name", {{"KNOWS_WELL"}});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/MergeRejectionTest.cpp
+++ b/test/query/ir/MergeRejectionTest.cpp
@@ -110,6 +110,32 @@ TEST_F(MergeRejectionTest, rejectsAVariableLengthHop) {
         << status.getError();
 }
 
+// A node an OPTIONAL MATCH did not match is null, and a merge cannot hang an edge off a
+// node the graph does not hold: the six rows the pattern missed turn the query away where
+// it is written, the way a CREATE of the same edge is
+TEST_F(MergeRejectionTest, rejectsAnEdgeFromANodeAnOptionalMatchMissed) {
+    QueryStatus status;
+    runQuery("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+             "MERGE (f)-[:PROBE]->(t:Tag {name: 'x'})",
+             status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("Cannot merge a pattern on a null node"), std::string::npos)
+        << status.getError();
+}
+
+// The same null node standing on its own: a merge of a bound node alone has nothing to
+// match and nothing it may write, so it is turned away rather than merged as a node with
+// an invalid ID
+TEST_F(MergeRejectionTest, rejectsAPatternOnANodeAnOptionalMatchMissed) {
+    QueryStatus status;
+    runQuery("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) MERGE (f)", status);
+
+    EXPECT_FALSE(status.isOk()) << status.getError();
+    EXPECT_NE(status.getError().find("Cannot merge a pattern on a null node"), std::string::npos)
+        << status.getError();
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/OptionalMatchCompositionTest.cpp
+++ b/test/query/ir/OptionalMatchCompositionTest.cpp
@@ -1,0 +1,292 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = StringRowSink::Row;
+using Rows = std::vector<Row>;
+
+// simpledb's node IDs are stable and other tests already rely on them: Remy is 0, Adam 1,
+// Maxime 7. The CALL cases below name nodes by ID, which is what db.getNodes takes.
+constexpr const char* remyID = "0";
+constexpr const char* adamID = "1";
+constexpr const char* maximeID = "7";
+
+}
+
+// OPTIONAL MATCH composed with the clauses around it - a mandatory MATCH, another OPTIONAL
+// MATCH, a WITH barrier, an aggregation, a CALL - driven from Cypher text through the
+// analyzer, DBProgramGenerator, NL lowering and the NL interpreter.
+//
+// Each of these puts the join somewhere the padded rows have to survive a further stage:
+// a pattern walked from a variable that may be null, a barrier that republishes it, a
+// group that must not count it, a procedure whose rows are crossed with it.
+class OptionalMatchCompositionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    std::string _graphName {"simpledb"};
+};
+
+/**
+* A mandatory MATCH beside an OPTIONAL MATCH
+*/
+
+// Two mandatory patterns are walked together and the optional one joins onto what they
+// bound, so its single match repeats over each of their rows
+TEST_F(OptionalMatchCompositionTest, optionalJoinsOntoTwoMandatoryPatterns) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) MATCH (p)-[:INTERESTED_IN]->(i) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN i.name, f.name",
+               {{"Computers", "Adam"},
+                {"Eighties", "Adam"},
+                {"Ghosts", "Adam"}});
+}
+
+// The mandatory rows survive with the pattern null when it matches none of them
+TEST_F(OptionalMatchCompositionTest, mandatoryRowsSurviveAnUnmatchedOptional) {
+    expectRows("MATCH (p:Person {name: 'Martina'}) MATCH (p)-[:INTERESTED_IN]->(i) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN i.name, f.name",
+               {{"Cooking", "null"}});
+}
+
+// A comma-separated pattern is crossed before the join, and the optional pattern joins
+// onto one side of that product
+TEST_F(OptionalMatchCompositionTest, optionalJoinsOntoOneSideOfACrossProduct) {
+    expectRows("MATCH (p:Person {name: 'Remy'}), (q:Person {name: 'Adam'}) "
+               "OPTIONAL MATCH (q)-[:KNOWS_WELL]->(f) RETURN p.name, q.name, f.name",
+               {{"Remy", "Adam", "Remy"}});
+}
+
+/**
+* Patterns feeding each other
+*/
+
+// A second OPTIONAL MATCH walks from what the first bound: the rows it matched fan out,
+// and the ones it missed carry their null through
+TEST_F(OptionalMatchCompositionTest, optionalWalksFromAnotherOptionalsVariable) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "OPTIONAL MATCH (f)-[:INTERESTED_IN]->(i) RETURN p.name, f.name, i.name",
+               {{"Remy", "Adam", "Bio"},
+                {"Remy", "Adam", "Cooking"},
+                {"Adam", "Remy", "Ghosts"},
+                {"Adam", "Remy", "Computers"},
+                {"Adam", "Remy", "Eighties"},
+                {"Maxime", "null", "null"},
+                {"Luc", "null", "null"},
+                {"Martina", "null", "null"},
+                {"Suhas", "null", "null"},
+                {"Cyrus", "null", "null"},
+                {"Doruk", "null", "null"}});
+}
+
+// Walking from a variable the first pattern left null matches nothing rather than reading
+// the graph at an ID it holds no row for, so the second pattern nulls in turn
+TEST_F(OptionalMatchCompositionTest, optionalWalksFromANullVariable) {
+    expectRows("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "OPTIONAL MATCH (f)-[:INTERESTED_IN]->(i) RETURN p.name, f.name, i.name",
+               {{"Doruk", "null", "null"}});
+}
+
+// A mandatory MATCH walking from the optional pattern's own variable is mandatory again,
+// so the rows it left null are dropped
+TEST_F(OptionalMatchCompositionTest, mandatoryWalksFromTheOptionalsVariable) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "MATCH (f)-[:INTERESTED_IN]->(i) RETURN p.name, i.name",
+               {{"Remy", "Bio"},
+                {"Remy", "Cooking"},
+                {"Adam", "Ghosts"},
+                {"Adam", "Computers"},
+                {"Adam", "Eighties"}});
+}
+
+// A mandatory MATCH after the join reaching back to a variable the join carried, not to
+// the one it bound: the optional column rides along its rows
+TEST_F(OptionalMatchCompositionTest, mandatoryReachesBackPastTheJoin) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "MATCH (p)-[:INTERESTED_IN]->(i) RETURN f.name, i.name",
+               {{"Adam", "Computers"},
+                {"Adam", "Eighties"},
+                {"Adam", "Ghosts"}});
+}
+
+/**
+* A WITH barrier around the join
+*/
+
+// A barrier ahead of the join publishes the rows it joins onto
+TEST_F(OptionalMatchCompositionTest, barrierAheadOfTheJoin) {
+    expectRows("MATCH (p:Person) WITH p WHERE p.name = 'Doruk' "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN p.name, f.name",
+               {{"Doruk", "null"}});
+}
+
+// A cut at that barrier bounds what the join reads, not what it produced
+TEST_F(OptionalMatchCompositionTest, cutAtTheBarrierAheadOfTheJoin) {
+    expectRows("MATCH (p:Person) WITH p LIMIT 2 OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name",
+               {{"Remy", "Adam"}, {"Adam", "Remy"}});
+}
+
+// A barrier after the join republishes the padded rows, and a predicate over it reads the
+// null the join left - the anti-join Cypher writes as WHERE x IS NULL
+TEST_F(OptionalMatchCompositionTest, barrierAfterTheJoinKeepsTheNulls) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WITH p, f WHERE f IS NULL RETURN p.name",
+               {{"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
+}
+
+// DISTINCT past the barrier keys the padded rows on their null, so they collapse to one
+TEST_F(OptionalMatchCompositionTest, distinctPastTheBarrierCollapsesTheNulls) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) WITH DISTINCT f RETURN f",
+               {{remyID}, {adamID}, {"null"}});
+}
+
+/**
+* Aggregates over the joined rows
+*/
+
+// A grouped count charges the non-null rows of each group, so a group whose pattern missed
+// counts zero rather than the padded row it kept
+TEST_F(OptionalMatchCompositionTest, groupedCountIgnoresThePaddedRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN p.name, count(f)",
+               {{"Remy", "1"},
+                {"Adam", "1"},
+                {"Maxime", "0"},
+                {"Luc", "0"},
+                {"Martina", "0"},
+                {"Suhas", "0"},
+                {"Cyrus", "0"},
+                {"Doruk", "0"}});
+}
+
+// count(*) tallies every row the join kept, padded ones included, where count(x) does not
+TEST_F(OptionalMatchCompositionTest, groupedWildcardCountTalliesEveryRow) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, count(*)",
+               {{"Remy", "1"},
+                {"Adam", "1"},
+                {"Maxime", "1"},
+                {"Luc", "1"},
+                {"Martina", "1"},
+                {"Suhas", "1"},
+                {"Cyrus", "1"},
+                {"Doruk", "1"}});
+}
+
+// The padded rows share one null key, so a distinct count charges them nothing
+TEST_F(OptionalMatchCompositionTest, distinctCountIgnoresThePaddedRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN count(DISTINCT f)",
+               {{"2"}});
+}
+
+// A value reduction folds the non-null rows: the two KNOWS_WELL edges between Persons each
+// carry a duration of 20, and the six padded rows carry none
+TEST_F(OptionalMatchCompositionTest, valueReductionsFoldTheNonNullRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) RETURN sum(r.duration)",
+               {{"40"}});
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) RETURN avg(r.duration)",
+               {{"20"}});
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN min(r.duration), max(r.duration)",
+               {{"20", "20"}});
+}
+
+// A reduction over a pattern nothing matched folds no row at all: sum is Cypher's zero and
+// the extremes are null
+TEST_F(OptionalMatchCompositionTest, valueReductionsOverAWhollyUnmatchedPattern) {
+    expectRows("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN sum(r.duration), min(r.duration), max(r.duration)",
+               {{"0", "null", "null"}});
+}
+
+// collect gathers the non-null values, so a pattern nothing matched collects an empty list
+TEST_F(OptionalMatchCompositionTest, collectGathersTheNonNullValues) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN collect(f.name)",
+               {{"Adam, Remy"}});
+    expectRows("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN collect(f.name)",
+               {{""}});
+}
+
+/**
+* A CALL beside the join
+*/
+
+// A procedure's rows drive the join: what it yielded is the column the pattern walks from,
+// and the rows it left unmatched are padded like any other
+TEST_F(OptionalMatchCompositionTest, callDrivesTheJoin) {
+    expectRows("CALL db.getNodes([0, 7]) YIELD id AS p OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p, f",
+               {{remyID, adamID}, {maximeID, "null"}});
+}
+
+// The same when the procedure yields only rows the pattern misses
+TEST_F(OptionalMatchCompositionTest, callDrivesTheJoinWithNoMatch) {
+    expectRows("CALL db.getNodes([7]) YIELD id AS p OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p, f",
+               {{maximeID, "null"}});
+}
+
+// A call after the join reads none of its rows, so its own are crossed with them: nine
+// labels against the eight rows the join kept
+TEST_F(OptionalMatchCompositionTest, callAfterTheJoinCrossesItsRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "CALL db.labels() YIELD label RETURN count(label)",
+               {{"72"}});
+}

--- a/test/query/ir/OptionalMatchCompositionTest.cpp
+++ b/test/query/ir/OptionalMatchCompositionTest.cpp
@@ -290,3 +290,20 @@ TEST_F(OptionalMatchCompositionTest, callAfterTheJoinCrossesItsRows) {
                "CALL db.labels() YIELD label RETURN count(label)",
                {{"72"}});
 }
+
+// An aggregate the barrier published is one row standing for every row the join reads: the
+// eight Persons each carry the count of eight, and the six rows the pattern missed carry it
+// as much as the two it matched
+TEST_F(OptionalMatchCompositionTest, aggregateAheadOfTheJoinIsCarriedByEveryRow) {
+    expectRows("MATCH (a:Person) WITH count(a) AS people "
+               "MATCH (x:Person) OPTIONAL MATCH (x)-[:KNOWS_WELL]->(f) "
+               "RETURN people, x.name, f.name",
+               {{"8", "Remy", "Adam"},
+                {"8", "Adam", "Remy"},
+                {"8", "Maxime", "null"},
+                {"8", "Luc", "null"},
+                {"8", "Martina", "null"},
+                {"8", "Suhas", "null"},
+                {"8", "Cyrus", "null"},
+                {"8", "Doruk", "null"}});
+}

--- a/test/query/ir/OptionalMatchCutTest.cpp
+++ b/test/query/ir/OptionalMatchCutTest.cpp
@@ -210,6 +210,10 @@ protected:
         return Rows(rows.begin(), rows.begin() + count);
     }
 
+    static Rows suffix(const Rows& rows, size_t count) {
+        return Rows(rows.begin() + count, rows.end());
+    }
+
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
     Graph* _graph {nullptr};
@@ -284,4 +288,40 @@ TEST_F(OptionalMatchCutTest, leavesTheScanUnboundedUnderASort) {
                nlModule);
 
     EXPECT_FALSE(loopOverIsBounded<mlir::nl::ScanNodesByLabel>(*nlModule));
+}
+
+// The cut a query writes on the OPTIONAL MATCH itself rather than on the projection behind
+// it. The sort reads the rows the join kept, matched and padded alike: the two rows f
+// matched carry a name to order on, and the six it missed carry a null, which sorts last.
+TEST_F(OptionalMatchCutTest, sortsTheRowsTheJoinKept) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) ORDER BY f.name, p.name "
+               "RETURN p.name, f.name",
+               {{"Remy", "Adam"},
+                {"Adam", "Remy"},
+                {"Cyrus", "null"},
+                {"Doruk", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Maxime", "null"},
+                {"Suhas", "null"}});
+}
+
+TEST_F(OptionalMatchCutTest, limitsTheRowsTheJoinKeptOnTheMatch) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) LIMIT 2 "
+               "RETURN p.name, f.name",
+               prefix(friendRows, 2));
+}
+
+TEST_F(OptionalMatchCutTest, skipsTheRowsTheJoinKeptOnTheMatch) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) SKIP 2 "
+               "RETURN p.name, f.name",
+               suffix(friendRows, 2));
+}
+
+// The mirror of those three: a cut the mandatory MATCH ahead of the join carries bounds
+// what the join reads, so it is generated where that MATCH is and not behind the op
+TEST_F(OptionalMatchCutTest, limitsTheRowsTheJoinReads) {
+    expectRows("MATCH (p:Person) LIMIT 2 OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name",
+               prefix(friendRows, 2));
 }

--- a/test/query/ir/OptionalMatchCutTest.cpp
+++ b/test/query/ir/OptionalMatchCutTest.cpp
@@ -1,0 +1,287 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+#include "DBDialect.h"
+#include "DBDialectInterpreter.h"
+#include "DBLowering.h"
+#include "DBProgramGenerator.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLOps.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "CypherAST.h"
+#include "CypherAnalyzer.h"
+#include "CypherParser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
+#include "iterators/ChunkConfig.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "TuringException.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Row = std::vector<std::string>;
+using Rows = std::vector<Row>;
+
+// The eight Person nodes of simpledb, in the order a label scan walks them. Only Remy and
+// Adam have a KNOWS_WELL out-edge, so a pattern over it leaves the other six null and the
+// rows come out in this order.
+const Rows friendRows = {
+    {"Remy", "Adam"},
+    {"Adam", "Remy"},
+    {"Maxime", "null"},
+    {"Luc", "null"},
+    {"Martina", "null"},
+    {"Suhas", "null"},
+    {"Cyrus", "null"},
+    {"Doruk", "null"},
+};
+
+class NameRowSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
+            Row& row = _rows.emplace_back();
+            for (const Column* const column : chunks) {
+                const auto* names = dynamic_cast<const ColumnOptVector<std::string_view>*>(column);
+                if (!names) {
+                    throw TuringException("OptionalMatchCutTest: expected a string property column");
+                }
+
+                const std::optional<std::string_view>& name = (*names)[rowIndex];
+                row.push_back(name ? std::string(*name) : "null");
+            }
+        }
+    }
+
+    const Rows& rows() const { return _rows; }
+
+private:
+    Rows _rows;
+};
+
+}
+
+// LIMIT over an OPTIONAL MATCH, through the MLIR frontend: each query is parsed, analyzed,
+// generated into the db dialect, then lowered and interpreted.
+//
+// An optional match accumulates one step of the rows it joins onto rather than the whole
+// relation, so - unlike a sort - the loops feeding it can stop as soon as the budget is
+// spent. The tests below pin both halves of that: the rows a cut returns, and that the
+// budget actually reaches the scan driving the join.
+class OptionalMatchCutTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        _graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(_graph);
+    }
+
+    // Parses and analyzes a query, generates the db dialect and lowers it into nlModule,
+    // whose ops the loop assertions below walk
+    void lowerQuery(std::string_view query,
+                    mlir::MLIRContext& context,
+                    mlir::OwningOpRef<mlir::ModuleOp>& nlModule) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = dbModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        const mlir::func::FuncOp dbFunction = module.lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        nlModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+    }
+
+    void runQuery(std::string_view query, Rows& rows, size_t chunkSize) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const ProcedureManager* procedures = system.getProcedures();
+
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphView view = transaction.viewGraph();
+
+        CypherAST ast(procedures, query);
+
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module);
+        generator.generate(&ast);
+
+        NameRowSink sink;
+        LocalMemory memory;
+        DBDialectInterpreter interpreter(module, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+
+        rows = sink.rows();
+    }
+
+    void expectRows(std::string_view query,
+                    const Rows& expected,
+                    size_t chunkSize = ChunkConfig::CHUNK_SIZE) {
+        Rows actual;
+        runQuery(query, actual, chunkSize);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    // Whether the loop over an iterator of this kind carries a limit handle. Fails the
+    // test when no such loop was lowered, so a query whose shape changed is not read as a
+    // silent pass.
+    template <typename IteratorOp>
+    bool loopOverIsBounded(mlir::ModuleOp nlModule) {
+        std::optional<bool> bounded;
+
+        nlModule.walk([&](mlir::nl::For forLoop) {
+            if (forLoop.getIterator().getDefiningOp<IteratorOp>()) {
+                bounded = forLoop.getLimit() != nullptr;
+            }
+        });
+
+        EXPECT_TRUE(bounded.has_value()) << "no loop over the expected iterator was lowered";
+
+        return bounded.value_or(false);
+    }
+
+    static Rows prefix(const Rows& rows, size_t count) {
+        return Rows(rows.begin(), rows.begin() + count);
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    Graph* _graph {nullptr};
+};
+
+TEST_F(OptionalMatchCutTest, emitsEveryRowUncut) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN p.name, f.name",
+               friendRows);
+}
+
+TEST_F(OptionalMatchCutTest, limitsToTheMatchedRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name LIMIT 2",
+               prefix(friendRows, 2));
+}
+
+// Reaching past the matched rows takes padded ones, which are drained after them
+TEST_F(OptionalMatchCutTest, limitsPastTheMatchedRowsIntoThePaddedOnes) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name LIMIT 5",
+               prefix(friendRows, 5));
+}
+
+// A chunk of one puts every row in a step of its own, so the cut lands between steps
+// rather than inside one
+TEST_F(OptionalMatchCutTest, limitsOneRowPerStep) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name LIMIT 5",
+               prefix(friendRows, 5),
+               /*chunkSize=*/1);
+}
+
+TEST_F(OptionalMatchCutTest, limitsBeyondTheRowsEmitsThemAll) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name LIMIT 20",
+               friendRows);
+}
+
+// The budget reaches the scan driving the join, not just the loop draining it: the scan
+// stops taking steps once the cut is spent rather than walking every remaining node and
+// re-running the pattern for each
+TEST_F(OptionalMatchCutTest, boundsTheScanDrivingTheJoin) {
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule;
+    lowerQuery("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name LIMIT 3",
+               context,
+               nlModule);
+
+    EXPECT_TRUE(loopOverIsBounded<mlir::nl::ScanNodesByLabel>(*nlModule));
+    EXPECT_TRUE(loopOverIsBounded<mlir::nl::OptionalDrain>(*nlModule));
+}
+
+// A sort between the cut and the join is a pipeline breaker of the whole relation, so the
+// scan must still see every row: the budget stops at the sort's emit loop
+TEST_F(OptionalMatchCutTest, leavesTheScanUnboundedUnderASort) {
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::storage::Storage>();
+    context.getOrLoadDialect<mlir::db::DB>();
+    context.getOrLoadDialect<mlir::nl::NL>();
+
+    mlir::OwningOpRef<mlir::ModuleOp> nlModule;
+    lowerQuery("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f.name ORDER BY p.name LIMIT 3",
+               context,
+               nlModule);
+
+    EXPECT_FALSE(loopOverIsBounded<mlir::nl::ScanNodesByLabel>(*nlModule));
+}

--- a/test/query/ir/OptionalMatchTest.cpp
+++ b/test/query/ir/OptionalMatchTest.cpp
@@ -292,3 +292,33 @@ TEST_F(OptionalMatchTest, DistinctCollapsesThePaddedRows) {
     expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN DISTINCT f.name",
                {{"Adam"}, {"Remy"}, {"null"}});
 }
+
+// A group whose rows the pattern all missed collects an empty list, and keeps its row
+// rather than dropping out of the result
+TEST_F(OptionalMatchTest, CollectsAnEmptyListForAnUnmatchedOptional) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, collect(f.name)",
+               {{"Remy", "[Adam]"},
+                {"Adam", "[Remy]"},
+                {"Maxime", "[]"},
+                {"Luc", "[]"},
+                {"Martina", "[]"},
+                {"Suhas", "[]"},
+                {"Cyrus", "[]"},
+                {"Doruk", "[]"}});
+}
+
+// A reduction beside the collected list charges the same groups: a group the pattern
+// missed counts none of its padded rows
+TEST_F(OptionalMatchTest, CountsBesideACollectedListOverPaddedRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, collect(f.name), count(f)",
+               {{"Remy", "[Adam]", "1"},
+                {"Adam", "[Remy]", "1"},
+                {"Maxime", "[]", "0"},
+                {"Luc", "[]", "0"},
+                {"Martina", "[]", "0"},
+                {"Suhas", "[]", "0"},
+                {"Cyrus", "[]", "0"},
+                {"Doruk", "[]", "0"}});
+}

--- a/test/query/ir/OptionalMatchTest.cpp
+++ b/test/query/ir/OptionalMatchTest.cpp
@@ -243,6 +243,22 @@ TEST_F(OptionalMatchTest, IsNullKeepsTheRowsThePatternMissed) {
                {{"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
 }
 
+// A WHERE on the OPTIONAL MATCH is part of the pattern, not a filter over the rows it
+// produced: the predicate failing discards the match, so the row comes back padded rather
+// than dropped. Remy and Adam match a friend, fail the test, and are kept null like the rest.
+TEST_F(OptionalMatchTest, WhereOnTheOptionalMatchNullsTheMatchInsteadOfFiltering) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WHERE f IS NULL RETURN p.name, f.name",
+               {{"Remy", "null"},
+                {"Adam", "null"},
+                {"Maxime", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Suhas", "null"},
+                {"Cyrus", "null"},
+                {"Doruk", "null"}});
+}
+
 // And IS NOT NULL keeps the ones it matched
 TEST_F(OptionalMatchTest, IsNotNullKeepsTheRowsThePatternMatched) {
     expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "

--- a/test/query/ir/OptionalMatchTest.cpp
+++ b/test/query/ir/OptionalMatchTest.cpp
@@ -322,3 +322,32 @@ TEST_F(OptionalMatchTest, CountsBesideACollectedListOverPaddedRows) {
                 {"Cyrus", "[]", "0"},
                 {"Doruk", "[]", "0"}});
 }
+
+// collect() drops a null, and an entity the pattern missed is one, so the group of a row
+// it padded collects an empty list rather than the invalid ID standing for the null
+TEST_F(OptionalMatchTest, CollectsAnEmptyListOfEntitiesForAnUnmatchedOptional) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, collect(f)",
+               {{"Remy", "[1]"},
+                {"Adam", "[0]"},
+                {"Maxime", "[]"},
+                {"Luc", "[]"},
+                {"Martina", "[]"},
+                {"Suhas", "[]"},
+                {"Cyrus", "[]"},
+                {"Doruk", "[]"}});
+}
+
+// The edge sibling: an unmatched relationship is a null too
+TEST_F(OptionalMatchTest, CollectsAnEmptyListOfEdgesForAnUnmatchedOptional) {
+    expectRows("MATCH (p:Person {name: 'Luc'}) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN p.name, collect(r)",
+               {{"Luc", "[]"}});
+}
+
+// collect(DISTINCT n) keys on the ID, and the null the pattern left is no key of its own
+TEST_F(OptionalMatchTest, CollectsDistinctEntitiesWithoutTheUnmatchedNull) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN collect(DISTINCT f)",
+               {{"[1, 0]"}});
+}

--- a/test/query/ir/OptionalMatchTest.cpp
+++ b/test/query/ir/OptionalMatchTest.cpp
@@ -1,0 +1,294 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// OPTIONAL MATCH, driven from Cypher text through the analyzer, DBProgramGenerator,
+// NL lowering and the NL interpreter.
+class OptionalMatchTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    // The rows in the order the query emits them, for the ORDER BY case
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query;
+    }
+
+    void expectRowCount(std::string_view query, size_t expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.rows().size(), expected) << "query: " << query;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    std::string _graphName {"simpledb"};
+};
+
+// The unmatched rows of the left are kept, with the pattern's own variables null
+TEST_F(OptionalMatchTest, UnmatchedRowsAreNullPadded) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN p.name, f.name",
+               {{"Remy", "Adam"},
+                {"Adam", "Remy"},
+                {"Maxime", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Suhas", "null"},
+                {"Cyrus", "null"},
+                {"Doruk", "null"}});
+}
+
+// A pattern every left row matches adds no null row, and fans out exactly as a MATCH does
+TEST_F(OptionalMatchTest, FullyMatchedPatternFansOutLikeMatch) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:INTERESTED_IN]->(i) RETURN p.name, i.name",
+               {{"Remy", "Ghosts"},
+                {"Remy", "Computers"},
+                {"Remy", "Eighties"},
+                {"Adam", "Bio"},
+                {"Adam", "Cooking"},
+                {"Maxime", "Bio"},
+                {"Maxime", "Padel"},
+                {"Luc", "Animals"},
+                {"Luc", "Computers"},
+                {"Martina", "Cooking"},
+                {"Suhas", "Gym"},
+                {"Suhas", "JiuJitsu"},
+                {"Cyrus", "Gym"},
+                {"Cyrus", "Travel"},
+                {"Doruk", "Gym"}});
+}
+
+// The whole pattern matches or none of it does: a second hop that finds nothing nulls the
+// first hop's variables too, and leaves one row - not one per partial match
+TEST_F(OptionalMatchTest, PartialMatchNullsTheWholePattern) {
+    expectRows("MATCH (p:Person {name: 'Adam'}) "
+               "OPTIONAL MATCH (p)-[:INTERESTED_IN]->(i)-[:INTERESTED_IN]->(j) "
+               "RETURN p.name, i.name, j.name",
+               {{"Adam", "null", "null"}});
+}
+
+// The pattern's WHERE is part of the match: a left row whose every match the predicate
+// cuts is null-padded, not dropped
+TEST_F(OptionalMatchTest, PatternWhereIsPartOfTheMatch) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:INTERESTED_IN]->(i) "
+               "WHERE i.name = 'Gym' RETURN p.name, i.name",
+               {{"Remy", "null"},
+                {"Adam", "null"},
+                {"Maxime", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Suhas", "Gym"},
+                {"Cyrus", "Gym"},
+                {"Doruk", "Gym"}});
+}
+
+// An unmatched edge variable is null too, and so is every property read off it
+TEST_F(OptionalMatchTest, UnmatchedEdgeAndItsPropertiesAreNull) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) RETURN p.name, r.name",
+               {{"Remy", "Remy -> Adam"},
+                {"Adam", "Adam -> Remy"},
+                {"Maxime", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Suhas", "null"},
+                {"Cyrus", "null"},
+                {"Doruk", "null"}});
+}
+
+// A null node projected whole renders as null rather than as an out-of-range ID
+TEST_F(OptionalMatchTest, UnmatchedNodeProjectsAsNull) {
+    expectRows("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, f",
+               {{"Doruk", "null"}});
+}
+
+// count(x) charges the non-null rows, so the padded rows are not counted; count(*) tallies
+// every row the OPTIONAL MATCH kept
+TEST_F(OptionalMatchTest, CountIgnoresThePaddedRows) {
+    expectCounts("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN count(f)", {2});
+    expectCounts("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN count(*)", {8});
+}
+
+// Two OPTIONAL MATCHes chain: the second joins onto the rows the first left behind
+TEST_F(OptionalMatchTest, ChainedOptionalMatches) {
+    expectRows("MATCH (p:Person {name: 'Martina'}) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "OPTIONAL MATCH (p)-[:INTERESTED_IN]->(i) "
+               "RETURN p.name, f.name, i.name",
+               {{"Martina", "null", "Cooking"}});
+}
+
+// A MATCH after an OPTIONAL MATCH is mandatory again, so it drops the padded rows
+TEST_F(OptionalMatchTest, MandatoryMatchAfterOptionalDropsPaddedRows) {
+    expectRows("MATCH (p:Person) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "MATCH (f)-[:INTERESTED_IN]->(i) "
+               "RETURN p.name, i.name",
+               {{"Remy", "Bio"},
+                {"Remy", "Cooking"},
+                {"Adam", "Ghosts"},
+                {"Adam", "Computers"},
+                {"Adam", "Eighties"}});
+}
+
+// A WITH barrier carries the padded rows through unchanged
+TEST_F(OptionalMatchTest, PaddedRowsSurviveABarrier) {
+    expectRows("MATCH (p:Person {name: 'Luc'}) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WITH p.name AS person, f AS friend "
+               "RETURN person, friend",
+               {{"Luc", "null"}});
+}
+
+// A query opening on OPTIONAL MATCH joins onto the single empty row it starts from, so a
+// pattern that matches behaves as a MATCH does
+TEST_F(OptionalMatchTest, LeadingOptionalMatchThatMatches) {
+    expectRows("OPTIONAL MATCH (p:Person {name: 'Remy'}) RETURN p.name", {{"Remy"}});
+}
+
+// And one that matches nothing leaves that row behind, with the pattern null
+TEST_F(OptionalMatchTest, LeadingOptionalMatchThatMissesKeepsOneRow) {
+    expectRows("OPTIONAL MATCH (p:Person {name: 'Nobody'}) RETURN p.name", {{"null"}});
+}
+
+// A pattern sharing no variable with the rows it joins onto crosses them, as a
+// comma-separated MATCH does
+TEST_F(OptionalMatchTest, DisconnectedPatternCrossesTheRows) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) OPTIONAL MATCH (i:Interest {name: 'Gym'}) "
+               "RETURN p.name, i.name",
+               {{"Remy", "Gym"}});
+}
+
+// The anti-join: keeping the rows whose pattern missed is what IS NULL over the pattern's
+// own variable asks for
+TEST_F(OptionalMatchTest, IsNullKeepsTheRowsThePatternMissed) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WITH p, f WHERE f IS NULL RETURN p.name",
+               {{"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
+}
+
+// And IS NOT NULL keeps the ones it matched
+TEST_F(OptionalMatchTest, IsNotNullKeepsTheRowsThePatternMatched) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WITH p, f WHERE f IS NOT NULL RETURN p.name",
+               {{"Remy"}, {"Adam"}});
+}
+
+// A property of a null entity is null, so the test reads the same through an alias
+TEST_F(OptionalMatchTest, IsNullOverAPropertyOfANullEntity) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "WITH p.name AS person, f.name AS friend WHERE friend IS NULL RETURN person",
+               {{"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
+}
+
+// A function reading a null entity reads a null rather than the graph at an ID it holds no
+// row for
+TEST_F(OptionalMatchTest, LabelsOfANullNodeIsNull) {
+    expectRows("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN labels(f)",
+               {{"null"}});
+}
+
+// An ORDER BY reads the padded rows as any other: a null sorts after every value, so the
+// rows the pattern missed come last
+TEST_F(OptionalMatchTest, OrderByOverPaddedRows) {
+    expectRowsInOrder("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+                      "RETURN p.name, f.name ORDER BY f.name, p.name",
+                      {{"Remy", "Adam"},
+                       {"Adam", "Remy"},
+                       {"Cyrus", "null"},
+                       {"Doruk", "null"},
+                       {"Luc", "null"},
+                       {"Martina", "null"},
+                       {"Maxime", "null"},
+                       {"Suhas", "null"}});
+}
+
+// A LIMIT cuts the drained rows, matched and padded alike
+TEST_F(OptionalMatchTest, LimitCutsTheDrainedRows) {
+    expectRowCount("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+                   "RETURN p.name, f.name LIMIT 3",
+                   3);
+}
+
+// DISTINCT keys the padded rows on their null, so they collapse together
+TEST_F(OptionalMatchTest, DistinctCollapsesThePaddedRows) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) RETURN DISTINCT f.name",
+               {{"Adam"}, {"Remy"}, {"null"}});
+}

--- a/test/query/ir/OptionalMatchTest.cpp
+++ b/test/query/ir/OptionalMatchTest.cpp
@@ -273,6 +273,35 @@ TEST_F(OptionalMatchTest, IsNullOverAPropertyOfANullEntity) {
                {{"Maxime"}, {"Luc"}, {"Martina"}, {"Suhas"}, {"Cyrus"}, {"Doruk"}});
 }
 
+// Two nulls are not equal: a null compared to anything is a null, and a WHERE keeps only
+// what is true. Doruk and Maxime both walk no KNOWS_WELL edge, so f and g are both null
+// and the one row the two crosses make goes.
+TEST_F(OptionalMatchTest, TwoNullEntitiesDoNotCompareEqual) {
+    expectRowCount("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+                   "MATCH (q:Person {name: 'Maxime'}) OPTIONAL MATCH (q)-[:KNOWS_WELL]->(g) "
+                   "WITH p, q, f, g WHERE f = g RETURN p.name, q.name",
+                   0);
+}
+
+// Of the 64 pairs the two crosses make, the ones equality keeps are the two whose patterns
+// both matched the same friend: Remy walks to Adam on both sides, Adam to Remy
+TEST_F(OptionalMatchTest, EqualityKeepsThePairsBothPatternsMatched) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "MATCH (q:Person) OPTIONAL MATCH (q)-[:KNOWS_WELL]->(g) "
+               "WITH p, q, f, g WHERE f = g RETURN p.name, q.name",
+               {{"Remy", "Remy"}, {"Adam", "Adam"}});
+}
+
+// A null is not unequal either, so the same two pairs are all <> has to work with: Remy's
+// Adam against Adam's Remy, either way round. A row holding a null names no second entity
+// for the friend it did match to differ from.
+TEST_F(OptionalMatchTest, InequalityKeepsThePairsBothPatternsMatched) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "MATCH (q:Person) OPTIONAL MATCH (q)-[:KNOWS_WELL]->(g) "
+               "WITH p, q, f, g WHERE f <> g RETURN p.name, q.name",
+               {{"Remy", "Adam"}, {"Adam", "Remy"}});
+}
+
 // A function reading a null entity reads a null rather than the graph at an ID it holds no
 // row for
 TEST_F(OptionalMatchTest, LabelsOfANullNodeIsNull) {
@@ -366,4 +395,30 @@ TEST_F(OptionalMatchTest, CollectsDistinctEntitiesWithoutTheUnmatchedNull) {
     expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
                "RETURN collect(DISTINCT f)",
                {{"[1, 0]"}});
+}
+
+// The row tag the join carries is named under a spelling of the engine's own. A
+// backtick-quoted identifier can hold anything but a backtick, so a variable written that
+// way is the query's own and resolves to the node the pattern bound.
+TEST_F(OptionalMatchTest, EscapedVariableSpelledLikeTheRowTag) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) "
+               "OPTIONAL MATCH (p)-[:KNOWS_WELL]->(`'optional_tag`) "
+               "RETURN p.name, `'optional_tag`.name",
+               {{"Remy", "Adam"}});
+}
+
+// A pattern the query names - `q = (a)-->(b)` - is unimplemented across both engines, so
+// it is turned away where it is written. The op verifier's rule that every pattern
+// variable is a node or an edge ID column is a backstop behind that, never a user's error.
+TEST_F(OptionalMatchTest, RejectsANamedPathWithoutAnInternalError) {
+    RowSink sink;
+    const QueryStatus status = runQuery("MATCH (a:Person) "
+                                        "OPTIONAL MATCH q = (a)-[:KNOWS_WELL]->(b) RETURN q",
+                                        &sink);
+
+    ASSERT_FALSE(status.isOk());
+
+    const std::string& error = status.getError();
+    EXPECT_EQ(error.find("Internal Error"), std::string::npos) << error;
+    EXPECT_EQ(error.find("must be a node or an edge ID column"), std::string::npos) << error;
 }

--- a/test/query/ir/OptionalMatchWriteTest.cpp
+++ b/test/query/ir/OptionalMatchWriteTest.cpp
@@ -1,0 +1,258 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "QueryConfig.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "TuringDB.h"
+#include "dataframe/Dataframe.h"
+#include "versioning/Change.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// The writes a query part performs behind an OPTIONAL MATCH. Two families of column reach
+// them: the ones the join carried, which every row it kept holds - the padded ones as much
+// as the matched ones - and the pattern's own variables, which a row it missed holds null.
+// A null entity is written nothing, so the second family must reach the matched rows alone.
+class OptionalMatchWriteTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void openChange(ChangeID& changeID) {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        const auto res = system.newChange(_graphName);
+        ASSERT_TRUE(res);
+
+        changeID = res.value()->id();
+    }
+
+    QueryStatus runWrite(std::string_view query, const ChangeID& changeID) {
+        NullSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              changeID,
+                              &_env->getMem(),
+                              &sink);
+
+        return status;
+    }
+
+    // Runs a writing query in its own change and submits it, so a following read sees it
+    void applyWrite(std::string_view query) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        const QueryStatus status = runWrite(query, changeID);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        QueryCallbacks callbacks;
+        callbacks.setOnOutputData([](const Dataframe*) {});
+
+        const QueryState submitState(_graphName,
+                                     &_env->getMem(),
+                                     &_queryConfig,
+                                     &callbacks,
+                                     CommitHash::head(),
+                                     changeID);
+        const QueryStatus submitStatus = _env->getDB().query("CHANGE SUBMIT", submitState);
+        ASSERT_TRUE(submitStatus.isOk()) << "CHANGE SUBMIT failed: " << submitStatus.getError();
+    }
+
+    // A write the engine turns away has to name what is wrong with the query, at the
+    // statement that is wrong - rather than stage it and trip an internal error at the
+    // commit
+    void expectWriteRejected(std::string_view query, QueryStatus::Status stage) {
+        ChangeID changeID;
+        openChange(changeID);
+
+        const QueryStatus status = runWrite(query, changeID);
+        ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
+
+        const std::string& error = status.getError();
+
+        EXPECT_EQ(status.getStatus(), stage)
+            << "query: " << query
+            << "\nstage: " << QueryStatusDescription::value(status.getStatus())
+            << "\nerror: " << error;
+
+        EXPECT_EQ(error.find("Unexpected exception"), std::string::npos)
+            << "query: " << query << "\nerror: " << error;
+        EXPECT_EQ(error.find("Internal Error"), std::string::npos)
+            << "query: " << query << "\nerror: " << error;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    QueryConfig _queryConfig;
+};
+
+// p is bound ahead of the join, so all eight Persons are written - only Remy and Adam walk
+// a KNOWS_WELL edge, and the six the pattern missed carry their own p through
+TEST_F(OptionalMatchWriteTest, setsAPropertyOnEveryRowTheJoinKept) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) SET p.dob = '02/02'");
+
+    expectCounts("MATCH (p:Person {dob: '02/02'}) RETURN count(*)", {8});
+}
+
+// One node per row the join kept, carrying the value that row holds
+TEST_F(OptionalMatchWriteTest, createsANodePerRowTheJoinKept) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "CREATE (:Tag {name: p.name})");
+
+    expectRows("MATCH (t:Tag) RETURN t.name",
+               {{"Remy"},
+                {"Adam"},
+                {"Maxime"},
+                {"Luc"},
+                {"Martina"},
+                {"Suhas"},
+                {"Cyrus"},
+                {"Doruk"}});
+}
+
+// The two KNOWS_WELL edges between Persons are the ones the pattern matched; the one out of
+// Ghosts, which no Person walks, stays
+TEST_F(OptionalMatchWriteTest, deletesTheEdgesThePatternMatched) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[e:KNOWS_WELL]->(f) DELETE e");
+
+    expectRows("MATCH ()-[e:KNOWS_WELL]->() RETURN e.name", {{"Ghosts -> Remy"}});
+}
+
+// f is Remy on Adam's row and Adam on Remy's, so the two of them go and six Persons remain
+TEST_F(OptionalMatchWriteTest, detachDeletesTheNodesThePatternMatched) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) DETACH DELETE f");
+
+    expectCounts("MATCH (p:Person) RETURN count(*)", {6});
+}
+
+// Doruk walks no KNOWS_WELL edge, so f is null on the one row the join kept and the delete
+// has nothing to read
+TEST_F(OptionalMatchWriteTest, deletesNothingWhenThePatternMatchedNoRow) {
+    applyWrite("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "DETACH DELETE f");
+
+    expectCounts("MATCH (p:Person) RETURN count(*)", {8});
+}
+
+// Remy and Adam both carry further edges, so what the engine turns away is the undetached
+// delete of a connected node - not the padded rows beside them
+TEST_F(OptionalMatchWriteTest, rejectsDeletingAConnectedNodeThePatternMatched) {
+    expectWriteRejected("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) DELETE f",
+                        QueryStatus::Status::EXEC_ERROR);
+}
+
+TEST_F(OptionalMatchWriteTest, createsAnEdgeWhenEveryRowMatched) {
+    applyWrite("MATCH (p:Person {name: 'Remy'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "CREATE (p)-[:PROBE]->(f)");
+
+    expectRows("MATCH (a:Person)-[:PROBE]->(b) RETURN a.name, b.name", {{"Remy", "Adam"}});
+}
+
+// f is the pattern's own variable: the two rows it matched hold Adam and Remy, and the six
+// it missed hold a null, which is written nothing
+TEST_F(OptionalMatchWriteTest, setsAPropertyOnTheRowsThePatternMatched) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) SET f.dob = '02/02'");
+
+    expectRows("MATCH (p:Person {dob: '02/02'}) RETURN p.name", {{"Remy"}, {"Adam"}});
+}
+
+// Every row the join kept is a padded one, so the SET reads a column of nulls alone
+TEST_F(OptionalMatchWriteTest, setsNoPropertyWhenThePatternMatchedNoRow) {
+    applyWrite("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "SET f.dob = '02/02'");
+
+    expectCounts("MATCH (p:Person {dob: '02/02'}) RETURN count(*)", {0});
+}
+
+// An edge variable a row the pattern missed holds is null the way a node one is, so the
+// same two edges are written and the third keeps the duration it had
+TEST_F(OptionalMatchWriteTest, setsAPropertyOnTheEdgesThePatternMatched) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[e:KNOWS_WELL]->(f) SET e.duration = 99");
+
+    expectRows("MATCH ()-[e:KNOWS_WELL]->() RETURN e.name, e.duration",
+               {{"Remy -> Adam", "99"},
+                {"Adam -> Remy", "99"},
+                {"Ghosts -> Remy", "200"}});
+}
+
+// An edge cannot hang off a node that is null, so the six padded rows name no edge to
+// create: the query is turned away where it is written, not staged and tripped over at the
+// commit
+TEST_F(OptionalMatchWriteTest, rejectsCreatingAnEdgeToANullEndpoint) {
+    expectWriteRejected("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+                        "CREATE (p)-[:PROBE]->(f)",
+                        QueryStatus::Status::EXEC_ERROR);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/OptionalMatchWriteTest.cpp
+++ b/test/query/ir/OptionalMatchWriteTest.cpp
@@ -16,9 +16,11 @@
 #include "SystemManager.h"
 #include "TuringDB.h"
 #include "dataframe/Dataframe.h"
+#include "reader/GraphReader.h"
 #include "versioning/Change.h"
 #include "versioning/ChangeID.h"
 #include "versioning/CommitHash.h"
+#include "versioning/Transaction.h"
 
 #include "IRTestRows.h"
 #include "TuringTest.h"
@@ -149,6 +151,22 @@ protected:
         EXPECT_EQ(actual, expected) << "query: " << query;
     }
 
+    // What the graph itself holds, rather than what a scan of one label finds: the counts
+    // read the tombstones a delete left, so an ID that was never in the graph shows up here
+    size_t graphNodeCount() {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.getGraph(_graphName);
+
+        return graph->openTransaction().readGraph().getNodeCount();
+    }
+
+    size_t graphEdgeCount() {
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.getGraph(_graphName);
+
+        return graph->openTransaction().readGraph().getEdgeCount();
+    }
+
     const std::string _graphName = "simpledb";
     std::unique_ptr<TuringTestEnv> _env;
     std::unique_ptr<QueryInterpreterV3> _interpreter;
@@ -242,6 +260,33 @@ TEST_F(OptionalMatchWriteTest, setsAPropertyOnTheEdgesThePatternMatched) {
                {{"Remy -> Adam", "99"},
                 {"Adam -> Remy", "99"},
                 {"Ghosts -> Remy", "200"}});
+}
+
+// simpledb holds 18 nodes and 18 edges. Remy and Adam are the two f matched, and the six
+// padded rows name no node, so the graph is left with 16 nodes - and the 8 edges the two
+// of them walked are the only ones the detach takes.
+TEST_F(OptionalMatchWriteTest, detachDeleteTombstonesTheNodesThePatternMatched) {
+    applyWrite("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) DETACH DELETE f");
+
+    EXPECT_EQ(graphNodeCount(), 16u);
+}
+
+// Doruk walks no KNOWS_WELL edge, so f is null on every row the join kept: there is no
+// node to tombstone, and the invalid ID the null carries is not one
+TEST_F(OptionalMatchWriteTest, detachDeleteOverANullNodeTombstonesNothing) {
+    applyWrite("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "DETACH DELETE f");
+
+    EXPECT_EQ(graphNodeCount(), 18u);
+    EXPECT_EQ(graphEdgeCount(), 18u);
+}
+
+// The edge variable of a row the pattern missed is null the way a node one is
+TEST_F(OptionalMatchWriteTest, deleteOverANullEdgeTombstonesNothing) {
+    applyWrite("MATCH (p:Person {name: 'Doruk'}) OPTIONAL MATCH (p)-[e:KNOWS_WELL]->(f) "
+               "DELETE e");
+
+    EXPECT_EQ(graphEdgeCount(), 18u);
 }
 
 // An edge cannot hang off a node that is null, so the six padded rows name no edge to

--- a/test/query/ir/OrderByLabelsTest.cpp
+++ b/test/query/ir/OrderByLabelsTest.cpp
@@ -31,6 +31,7 @@
 #include "SimpleGraph.h"
 #include "SystemAccessor.h"
 #include "SystemManager.h"
+#include "columns/ColumnOptVector.h"
 #include "columns/ColumnVector.h"
 #include "versioning/Transaction.h"
 #include "views/GraphView.h"
@@ -48,12 +49,13 @@ public:
     void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
         ASSERT_EQ(chunks.size(), 1u);
 
-        const auto* strings = dynamic_cast<const ColumnVector<std::string>*>(chunks[0]);
+        const auto* strings = dynamic_cast<const ColumnOptVector<std::string>*>(chunks[0]);
         ASSERT_NE(strings, nullptr);
 
         const auto& raw = strings->getRaw();
         for (size_t rowIndex = offset; rowIndex < offset + rowCount; rowIndex++) {
-            _values.push_back(raw[rowIndex]);
+            ASSERT_TRUE(raw[rowIndex].has_value());
+            _values.push_back(*raw[rowIndex]);
         }
     }
 

--- a/test/query/ir/OwnedStringChunkTest.cpp
+++ b/test/query/ir/OwnedStringChunkTest.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// labels() and edgeType() are the two functions whose rows own the characters they hold,
+// where a string property column borrows them from the graph. That makes their chunk a
+// nullable of owned strings, an element type every step carrying a chunk on has to know:
+// a limit, a skip, a grouping key, a cross product.
+class OwnedStringChunkTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRowCount(std::string_view query, size_t expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        EXPECT_EQ(sink.rows().size(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// simpledb holds 18 nodes and 18 edges
+TEST_F(OwnedStringChunkTest, limitsAColumnOfLabels) {
+    expectRowCount("MATCH (n) RETURN labels(n) LIMIT 3", 3);
+}
+
+TEST_F(OwnedStringChunkTest, skipsAColumnOfLabels) {
+    expectRowCount("MATCH (n) RETURN labels(n) SKIP 1", 17);
+}
+
+TEST_F(OwnedStringChunkTest, skipsAColumnOfEdgeTypes) {
+    expectRowCount("MATCH ()-[e]->() RETURN edgeType(e) SKIP 2", 16);
+}
+
+TEST_F(OwnedStringChunkTest, dedupsAColumnOfLabels) {
+    expectRows("MATCH (p:Person) RETURN DISTINCT labels(p)",
+               {{"Person, SoftwareEngineering, Founder"},
+                {"Person, Founder, Bioinformatics"},
+                {"Person, Bioinformatics"},
+                {"Person, SoftwareEngineering"},
+                {"Person, Sales"}});
+}
+
+// The eight Persons carry five label sets between them: three write software, two do
+// bioinformatics, and the two founders and Doruk stand alone
+TEST_F(OwnedStringChunkTest, groupsOnAColumnOfLabels) {
+    expectRows("MATCH (p:Person) RETURN labels(p), count(*)",
+               {{"Person, SoftwareEngineering, Founder", "1"},
+                {"Person, Founder, Bioinformatics", "1"},
+                {"Person, Bioinformatics", "2"},
+                {"Person, SoftwareEngineering", "3"},
+                {"Person, Sales", "1"}});
+}
+
+// Remy's labels crossed with the ten interests: the one row the WITH published is repeated
+// once per interest, carrying its string along
+TEST_F(OwnedStringChunkTest, carriesAColumnOfLabelsAcrossACrossProduct) {
+    expectRows("MATCH (p:Person {name: 'Remy'}) WITH labels(p) AS tags "
+               "MATCH (i:Interest) RETURN tags, i.name",
+               {{"Person, SoftwareEngineering, Founder", "Animals"},
+                {"Person, SoftwareEngineering, Founder", "Bio"},
+                {"Person, SoftwareEngineering, Founder", "Computers"},
+                {"Person, SoftwareEngineering, Founder", "Cooking"},
+                {"Person, SoftwareEngineering, Founder", "Eighties"},
+                {"Person, SoftwareEngineering, Founder", "Ghosts"},
+                {"Person, SoftwareEngineering, Founder", "Gym"},
+                {"Person, SoftwareEngineering, Founder", "JiuJitsu"},
+                {"Person, SoftwareEngineering, Founder", "Padel"},
+                {"Person, SoftwareEngineering, Founder", "Travel"}});
+}
+
+
+// An edge the pattern missed is null, so the grouping key it holds is one too: the two
+// edges Remy and Adam walk form the named group, the six padded rows the null one
+TEST_F(OwnedStringChunkTest, groupsOnTheEdgeTypeOfAnOptionalMatch) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[e:KNOWS_WELL]->(f) "
+               "RETURN edgeType(e), count(*)",
+               {{"KNOWS_WELL", "2"}, {"null", "6"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/StringRowSink.cpp
+++ b/test/query/ir/StringRowSink.cpp
@@ -20,6 +20,7 @@ using namespace turing::test;
 
 namespace {
 
+// An entity an OPTIONAL MATCH did not match is an invalid ID, which reads as null
 template <typename IDType>
 bool textOfID(const Column* chunk, size_t rowIndex, std::string& text) {
     const auto* column = dynamic_cast<const ColumnVector<IDType>*>(chunk);
@@ -27,7 +28,9 @@ bool textOfID(const Column* chunk, size_t rowIndex, std::string& text) {
         return false;
     }
 
-    text = fmt::format("{}", column->getRaw()[rowIndex].getValue());
+    const IDType id = column->getRaw()[rowIndex];
+    text = id.isValid() ? fmt::format("{}", id.getValue()) : "null";
+
     return true;
 }
 

--- a/test/query/ir/StringRowSink.cpp
+++ b/test/query/ir/StringRowSink.cpp
@@ -216,6 +216,8 @@ std::string StringRowSink::cellText(const Column* chunk, size_t rowIndex) {
         return text;
     } else if (textOfOptional<std::string_view>(chunk, rowIndex, text)) {
         return text;
+    } else if (textOfOptional<std::string>(chunk, rowIndex, text)) {
+        return text;
     } else if (textOfListElement(chunk, rowIndex, text)) {
         return text;
     } else if (textOfList(chunk, rowIndex, text)) {

--- a/test/tools/ShellCompletionTest.cpp
+++ b/test/tools/ShellCompletionTest.cpp
@@ -89,6 +89,14 @@ TEST_F(ShellCompletionTest, BackspaceDeletesBothSides) {
     EXPECT_EQ(typeKey(_completion, backspaceKey, "MATCH (n)|"), "MATCH (n|");
 }
 
+// Two of the same character are not a pair: the one before the cursor goes, the one
+// after it stays. It is the doubled letters of ordinary Cypher that this protects.
+TEST_F(ShellCompletionTest, BackspaceLeavesADoubledCharacterAlone) {
+    EXPECT_EQ(typeKey(_completion, backspaceKey, "MATCH (n|n)"), "MATCH (|n)");
+    EXPECT_EQ(typeKey(_completion, backspaceKey, "MATCH (a)-[:FOL|LOWS]->()"), "MATCH (a)-[:FO|LOWS]->()");
+    EXPECT_EQ(typeKey(_completion, backspaceKey, "MATCH (a)-|-(b)"), "MATCH (a)|-(b)");
+}
+
 TEST_F(ShellCompletionTest, DashCompletesToArrows) {
     EXPECT_EQ(firstCompletion(_completion, "MATCH (a)-"), "MATCH (a)-->|");
     EXPECT_EQ(firstCompletion(_completion, "MATCH (a)<-"), "MATCH (a)<--|");

--- a/tools/turingdb/ShellCompletion.cpp
+++ b/tools/turingdb/ShellCompletion.cpp
@@ -344,7 +344,18 @@ bool ShellCompletion::deletePair(std::string_view line, size_t cursor, Edit& edi
         return false;
     }
 
-    const size_t runLength = closingRunLength(line[cursor - 1], line, cursor);
+    // closerFor hands back any other character unchanged, so without this only an opener
+    // or a quote is read as one half of a pair - a doubled letter is two characters that
+    // happen to be equal
+    const char opener = line[cursor - 1];
+    const bool opensAPair = openerChars.find(opener) != std::string_view::npos
+                            || quoteChars.find(opener) != std::string_view::npos;
+
+    if (!opensAPair) {
+        return false;
+    }
+
+    const size_t runLength = closingRunLength(opener, line, cursor);
     if (runLength == 0) {
         return false;
     }

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -523,6 +523,17 @@ void asString(std::string& out, const PropertyNull) {
     out += "null";
 }
 
+// An entity an OPTIONAL MATCH did not match is an invalid ID, which reads as null
+template <db::IntegralType T, int Tag>
+void asString(std::string& out, const db::ID<T, Tag>& id) {
+    if (!id.isValid()) {
+        out += "null";
+        return;
+    }
+
+    out += fmt::format("{}", id.getValue());
+}
+
 void asString(std::string& out, std::span<const float> embedding) {
     out += "[";
 


### PR DESCRIPTION
Implement OPTIONAL MATCH.

```Cypher
MATCH (p:Person)
OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f)
RETURN p.name, f.name

MATCH (p:Person)
OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f)
MATCH (f)-[:INTERESTED_IN]->(i)
RETURN p.name, i.name

MATCH (p:Person)
OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f)
WITH p, f WHERE f IS NULL
RETURN p.name

MATCH (p:Person)
OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f)
RETURN p.name, collect(f)

MATCH (p:Person)
OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f)
SET f.dob = '02/02'
```

- Unmatched rows are kept, with the pattern's variables being null. The first query returns all 8 people, 6 of them with a null friend because they don't have a :KNOWS edge.

- A null node or edge is an invalid ID, not an empty optional. So a pattern variable must be an ID column, and `db.optional_match` checks it.

- An optional match pattern is built into its own MLIR region

```
  %0 = db.scan_nodes_by_label(["Person"]) 
  %1:3 = db.optional_match(%0) {
  ^bb0(%arg0: !db.column<!storage.node_id>, %arg1: !db.column<ui64>):
    %4, %5, %6, %7, %8 = db.get_out_edges_by_type(%arg0, "KNOWS_WELL", {%arg1})
    db.optional_yield %8, {%4, %7, %5}
  }
  %2 = db.get_node_properties(%1#0, "name")
  %3 = db.get_node_properties(%1#1, "name")
  db.output(%2, %3) names ["p.name", "f.name"] 
```

- A MATCH, which is mandatory again, drops the rows that have been padded with null for the pattern variables when not found.

- `labels(n)` and `edgeType(e)` are nullable now, since the node or edge can be null.

- Aggregates skip the null. `count(f)` is 0 for an unmatched group, `collect(f)` is `[]`.

- `SET f.dob` skips the null rows. `CREATE (p)-[:PROBE]->(f)` is rejected: an edge cannot have a null endpoint.
