### PR TITLE
MLIR: sink a predicate past the filters between it and its anchor

### DIFF
--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -147,7 +147,10 @@ Operation::operand_range factorYieldColumns(mlir::Region& factor) {
 }
 
 // Walk op chain until we reach a node/edge source or something we can't push down to
-Value climbToLineageAnchor(Value column) {
+// The column its variable was bound at, following every op that passes the column through.
+// Sets crossedProducer when one of those builds the rows - a hop or a cross product - as
+// opposed to a filter, which only drops them.
+Value climbToLineageAnchor(Value column, bool& crossedProducer) {
     for (;;) {
         Operation* const def = column.getDefiningOp();
         if (!def) {
@@ -158,10 +161,11 @@ Value climbToLineageAnchor(Value column) {
             return column;
         }
 
-        if (isa<FilterOp>(def)) {
-            // A filter passes each column through unchanged, so its result is the same
-            // variable one step on - a valid boundary to sit a further filter right after.
-            return column;
+        if (FilterOp filter = dyn_cast<FilterOp>(def)) {
+            const size_t resultIndex = cast<OpResult>(column).getResultNumber();
+            column = filter.getColumnsToFilter()[resultIndex];
+
+            continue;
         }
 
         if (CrossProduct product = dyn_cast<CrossProduct>(def)) {
@@ -180,6 +184,8 @@ Value climbToLineageAnchor(Value column) {
                 column = rightColumns[resultIndex - leftCount];
             }
 
+            crossedProducer = true;
+
             continue;
         }
 
@@ -196,9 +202,11 @@ Value climbToLineageAnchor(Value column) {
 
             if (resultIndex == inputResultIndex) {
                 column = def->getOperand(0);
+                crossedProducer = true;
             } else if (resultIndex >= hopFixedResultCount) {
                 // Carried columns follow input_nodes (operand 0) in operand order.
                 column = def->getOperand(1 + (resultIndex - hopFixedResultCount));
+                crossedProducer = true;
             } else {
                 return column;
             }
@@ -270,9 +278,9 @@ bool matchPushablePredicate(FilterOp filter, PushablePredicate& pushable) {
         return false;
     }
 
-    bool reachedAnchor = true;
+    bool crossedProducer = false;
     for (const Value input : pushable._cone._inputs) {
-        const Value inputAnchor = climbToLineageAnchor(input);
+        const Value inputAnchor = climbToLineageAnchor(input, crossedProducer);
         if (!inputAnchor) {
             return false;
         }
@@ -283,14 +291,12 @@ bool matchPushablePredicate(FilterOp filter, PushablePredicate& pushable) {
             // More than one lineage feeds the mask: not a single-variable predicate.
             return false;
         }
-
-        if (input != inputAnchor) {
-            reachedAnchor = false;
-        }
     }
 
-    // Filter already maximally pushed down
-    return !reachedAnchor;
+    // Crossing only filters leaves the predicate over the rows the anchor produced already:
+    // moving it would swap two filters over the same rows, or step between a constraint
+    // filter and the op that is about to absorb it.
+    return crossedProducer;
 }
 
 void pushDownPredicate(FilterOp filter, const PushablePredicate& pushable, mlir::OpBuilder& builder) {

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -370,3 +370,87 @@ TEST_F(PushDownFilterTest, sinksRootPredicateWithConstantPowExpression) {
     ASSERT_EQ(reads.size(), 1u);
     EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
 }
+
+// MATCH (a:Reaction {stId: 'R-HSA-177934'})-->(b:Complex) RETURN b
+const char* const rootPredicateBehindLabelFilter = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes_by_label(["Reaction"]) : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %ls = db.get_node_label_set(%t1) : (!db.column<!storage.node_id>) -> !db.column<!storage.labelset_id>
+  %ok = db.check_label_constraint(%ls, ["Complex"]) : (!db.column<!storage.labelset_id>) -> !db.column<!storage.bool>
+  %bl, %al = db.filter(%ok, {%t1, %s1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %id = db.get_node_properties(%al, "stId") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %k = db.constant("R-HSA-177934" : !storage.string)
+  %mask = db.eq %id, %k : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %bf = db.filter(%mask, {%bl}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%bf) names ["b"] : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, sinksRootPredicatePastAnInterveningFilter) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(rootPredicateBehindLabelFilter);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+    mlir::db::GetOutEdges hop = hops.front();
+
+    // The label filter stays where it is; the root predicate climbs past it to the scan.
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+    mlir::db::FilterOp seedFilter = filters.front();
+    mlir::db::FilterOp labelFilter = filters.back();
+
+    EXPECT_TRUE(seedFilter.getOperation()->isBeforeInBlock(hop.getOperation()));
+    EXPECT_TRUE(hop.getOperation()->isBeforeInBlock(labelFilter.getOperation()));
+
+    ASSERT_EQ(seedFilter.getColumnsToFilter().size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodesByLabel>(seedFilter.getColumnsToFilter().front().getDefiningOp()));
+    EXPECT_EQ(hop.getInputNodes().getDefiningOp(), seedFilter.getOperation());
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodesByLabel>(reads.front().getInputNodes().getDefiningOp()));
+}
+
+// MATCH (a:Complex {stId: 'R-HSA-8867037'})-[:hasComponent]->(b)-->(c) RETURN c
+const char* const rootPredicateBehindFilterAndHop = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes_by_label(["Complex"]) : !db.column<!storage.node_id>
+  %s1, %e1, %et1, %t1 = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %ok = db.check_edge_type_constraint(%et1, ["hasComponent"]) : (!db.column<!storage.edge_type_id>) -> !db.column<!storage.bool>
+  %bl, %al = db.filter(%ok, {%t1, %s1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %ac = db.get_out_edges(%bl, {%al}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %id = db.get_node_properties(%ac, "stId") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %k = db.constant("R-HSA-8867037" : !storage.string)
+  %mask = db.eq %id, %k : (!db.column<none>, !db.column<!storage.string>) -> !db.column<!storage.bool>
+  %cf = db.filter(%mask, {%t2}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%cf) names ["c"] : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, sinksRootPredicatePastAFilterAndASecondHop) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(rootPredicateBehindFilterAndHop);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 2u);
+    mlir::db::GetOutEdges firstHop = hops.front();
+
+    llvm::SmallVector<mlir::db::FilterOp> filters = collect<mlir::db::FilterOp>(*module);
+    ASSERT_EQ(filters.size(), 2u);
+    mlir::db::FilterOp seedFilter = filters.front();
+
+    EXPECT_TRUE(seedFilter.getOperation()->isBeforeInBlock(firstHop.getOperation()));
+    EXPECT_EQ(firstHop.getInputNodes().getDefiningOp(), seedFilter.getOperation());
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodesByLabel>(reads.front().getInputNodes().getDefiningOp()));
+}


### PR DESCRIPTION
Sink a predicate past unrelated filters.

For a query with a label filter on the target, such as `MATCH (a:Reaction {stId: 'R-HSA-177934'})-->(b:Complex)` the predicate on the stId property is emitted after the label filter for b:Complex but the predicate pushdown pass was stopping at that first filter and was not able to push the stId predicate down to the a scan.

Before:

```mlir
// MATCH (a:Reaction {stId: 'R-HSA-177934'})-->(b:Complex) RETURN b
%a  = db.scan_nodes_by_label(["Reaction"])
%s1, %e1, %et1, %t1 = db.get_out_edges(%a, {})
%ls = db.get_node_label_set(%t1)
%ok = db.check_label_constraint(%ls, ["Complex"])
%bl, %al = db.filter(%ok, {%t1, %s1})
%id = db.get_node_properties(%al, "stId")
%k  = db.constant("R-HSA-177934")
%mask = db.eq %id, %k
%bf = db.filter(%mask, {%bl})
db.output(%bf) names ["b"]
```

After:

```mlir
// MATCH (a:Reaction {stId: 'R-HSA-177934'})-->(b:Complex) RETURN b
%a  = db.scan_nodes_by_label(["Reaction"])
%id = db.get_node_properties(%a, "stId")
%k  = db.constant("R-HSA-177934")
%mask = db.eq %id, %k
%af = db.filter(%mask, {%a})
%s1, %e1, %et1, %t1 = db.get_out_edges(%af, {})
%ls = db.get_node_label_set(%t1)
%ok = db.check_label_constraint(%ls, ["Complex"])
%bl, %al = db.filter(%ok, {%t1, %s1})
db.output(%bl) names ["b"]
```
