### PR TITLE
MLIR: Fix reads (e.g. `labels(n)`) on a `CREATE`d variable

### DIFF
--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2811,6 +2811,7 @@ void DBProgramGenerator::generateCrossedCall(std::string_view procedureName,
 void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
                                               mlir::Value column,
                                               llvm::ArrayRef<llvm::StringRef> labelNames,
+                                              llvm::StringRef edgeType,
                                               llvm::ArrayRef<llvm::StringRef> propNames,
                                               llvm::ArrayRef<mlir::Value> propValues) {
     bioassert(propNames.size() == propValues.size(), "One value per created property expected");
@@ -2823,6 +2824,8 @@ void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
     for (const llvm::StringRef labelName : labelNames) {
         created._labels.emplace_back(labelName.data(), labelName.size());
     }
+
+    created._edgeType.assign(edgeType.begin(), edgeType.end());
 
     for (size_t index = 0; index < propNames.size(); index++) {
         const llvm::StringRef propName = propNames[index];
@@ -2908,7 +2911,7 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
 
         if (decl) {
             knownVars[decl] = nodeValue;
-            publishCreatedEntity(decl, nodeValue, labelNames, propNames, propValues);
+            publishCreatedEntity(decl, nodeValue, labelNames, {}, propNames, propValues);
         }
 
         return nodeValue;
@@ -2966,7 +2969,12 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
 
                 const VarDecl* edgeDecl = edge->getDecl();
                 if (edgeDecl && !edgeDecl->isUnnamed()) {
-                    publishCreatedEntity(edgeDecl, createEdge.getResult(), {}, propNames, propValues);
+                    publishCreatedEntity(edgeDecl,
+                                         createEdge.getResult(),
+                                         {},
+                                         llvm::StringRef {edgeType.data(), edgeType.size()},
+                                         propNames,
+                                         propValues);
                 }
 
                 lhsValue = rhsValue;
@@ -4219,6 +4227,14 @@ mlir::Value DBProgramGenerator::nullConstantColumn() {
     return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), resultType, valueAttr).getResult();
 }
 
+mlir::Value DBProgramGenerator::constantString(llvm::StringRef value) {
+    const mlir::Type stringType = mlir::storage::StringType::get(_mlirCtxt);
+    const mlir::TypedAttr valueAttr = mlir::StringAttr::get(value, stringType);
+    const mlir::db::ColumnType resultType = allocColumnType(stringType);
+
+    return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), resultType, valueAttr).getResult();
+}
+
 mlir::Value DBProgramGenerator::constantLabelString(llvm::ArrayRef<std::string> labels) {
     static constexpr std::string_view labelSeparator = ", ";
 
@@ -4231,11 +4247,7 @@ mlir::Value DBProgramGenerator::constantLabelString(llvm::ArrayRef<std::string> 
         joined += labels[index];
     }
 
-    const mlir::Type stringType = mlir::storage::StringType::get(_mlirCtxt);
-    const mlir::TypedAttr valueAttr = mlir::StringAttr::get(joined, stringType);
-    const mlir::db::ColumnType resultType = allocColumnType(stringType);
-
-    return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), resultType, valueAttr).getResult();
+    return constantString(joined);
 }
 
 mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propExpr) {
@@ -4374,7 +4386,7 @@ mlir::Value DBProgramGenerator::translateArg(const Expr* argExpr) {
     return _part._exprMap.at(argExpr);
 }
 
-mlir::Value DBProgramGenerator::translateCreatedLabels(const Expr* argExpr) {
+mlir::Value DBProgramGenerator::translateCreatedMetadata(std::string_view funcName, const Expr* argExpr) {
     if (argExpr->getKind() != Expr::Kind::SYMBOL) {
         return {};
     }
@@ -4387,7 +4399,15 @@ mlir::Value DBProgramGenerator::translateCreatedLabels(const Expr* argExpr) {
         return {};
     }
 
-    return constantLabelString(createdIt->second._labels);
+    const PartScope::CreatedEntity& created = createdIt->second;
+
+    if (funcName == "labels") {
+        return constantLabelString(created._labels);
+    } else if (funcName == "edgeType") {
+        return constantString(created._edgeType);
+    } else {
+        return {};
+    }
 }
 
 void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
@@ -4398,10 +4418,11 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
     const mlir::Location loc = _opBuilder.getUnknownLoc();
     const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
 
-    if (funcName == "labels" && args && args->size() == 1) {
-        const mlir::Value createdLabels = translateCreatedLabels(args->front());
-        if (createdLabels) {
-            _part._exprMap[expr] = createdLabels;
+    const bool isEntityMetadata = funcName == "labels" || funcName == "edgeType";
+    if (isEntityMetadata && args && args->size() == 1) {
+        const mlir::Value createdMetadata = translateCreatedMetadata(funcName, args->front());
+        if (createdMetadata) {
+            _part._exprMap[expr] = createdMetadata;
             return;
         }
     }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -2810,12 +2810,19 @@ void DBProgramGenerator::generateCrossedCall(std::string_view procedureName,
 
 void DBProgramGenerator::publishCreatedEntity(const VarDecl* decl,
                                               mlir::Value column,
+                                              llvm::ArrayRef<llvm::StringRef> labelNames,
                                               llvm::ArrayRef<llvm::StringRef> propNames,
                                               llvm::ArrayRef<mlir::Value> propValues) {
     bioassert(propNames.size() == propValues.size(), "One value per created property expected");
 
     PartScope::CreatedEntity& created = _part._createdEntities[decl];
     created._column = column;
+
+    created._labels.clear();
+    created._labels.reserve(labelNames.size());
+    for (const llvm::StringRef labelName : labelNames) {
+        created._labels.emplace_back(labelName.data(), labelName.size());
+    }
 
     for (size_t index = 0; index < propNames.size(); index++) {
         const llvm::StringRef propName = propNames[index];
@@ -2901,7 +2908,7 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
 
         if (decl) {
             knownVars[decl] = nodeValue;
-            publishCreatedEntity(decl, nodeValue, propNames, propValues);
+            publishCreatedEntity(decl, nodeValue, labelNames, propNames, propValues);
         }
 
         return nodeValue;
@@ -2959,7 +2966,7 @@ void DBProgramGenerator::generateCreate(const SinglePartQuery* query) {
 
                 const VarDecl* edgeDecl = edge->getDecl();
                 if (edgeDecl && !edgeDecl->isUnnamed()) {
-                    publishCreatedEntity(edgeDecl, createEdge.getResult(), propNames, propValues);
+                    publishCreatedEntity(edgeDecl, createEdge.getResult(), {}, propNames, propValues);
                 }
 
                 lhsValue = rhsValue;
@@ -4212,6 +4219,25 @@ mlir::Value DBProgramGenerator::nullConstantColumn() {
     return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), resultType, valueAttr).getResult();
 }
 
+mlir::Value DBProgramGenerator::constantLabelString(llvm::ArrayRef<std::string> labels) {
+    static constexpr std::string_view labelSeparator = ", ";
+
+    std::string joined;
+    for (size_t index = 0; index < labels.size(); index++) {
+        if (index > 0) {
+            joined += labelSeparator;
+        }
+
+        joined += labels[index];
+    }
+
+    const mlir::Type stringType = mlir::storage::StringType::get(_mlirCtxt);
+    const mlir::TypedAttr valueAttr = mlir::StringAttr::get(joined, stringType);
+    const mlir::db::ColumnType resultType = allocColumnType(stringType);
+
+    return _opBuilder.create<mlir::db::ConstantOp>(_opBuilder.getUnknownLoc(), resultType, valueAttr).getResult();
+}
+
 mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propExpr) {
     const VarDecl* entityDecl = propExpr->getEntityVarDecl();
     const std::string_view varName = entityDecl->getName();
@@ -4348,6 +4374,22 @@ mlir::Value DBProgramGenerator::translateArg(const Expr* argExpr) {
     return _part._exprMap.at(argExpr);
 }
 
+mlir::Value DBProgramGenerator::translateCreatedLabels(const Expr* argExpr) {
+    if (argExpr->getKind() != Expr::Kind::SYMBOL) {
+        return {};
+    }
+
+    const SymbolExpr* symbolExpr = static_cast<const SymbolExpr*>(argExpr);
+    const VarDecl* decl = symbolExpr->getDecl();
+
+    const auto createdIt = _part._createdEntities.find(decl);
+    if (createdIt == end(_part._createdEntities)) {
+        return {};
+    }
+
+    return constantLabelString(createdIt->second._labels);
+}
+
 void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
                                                const FunctionInvocation* invocation) {
     const std::string_view funcName = invocation->getSignature()->getFullName();
@@ -4355,6 +4397,14 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
 
     const mlir::Location loc = _opBuilder.getUnknownLoc();
     const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
+
+    if (funcName == "labels" && args && args->size() == 1) {
+        const mlir::Value createdLabels = translateCreatedLabels(args->front());
+        if (createdLabels) {
+            _part._exprMap[expr] = createdLabels;
+            return;
+        }
+    }
 
     const auto unaryIt = unaryFunctionEmitters.find(funcName);
     if (unaryIt != end(unaryFunctionEmitters)) {

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -143,14 +143,15 @@ private:
         std::vector<YieldedColumn> _yieldedColumns;
 
         // What a CREATE wrote for one of its named pattern entities: the column of
-        // provisional IDs, the value column of every property it set, and the labels it
-        // wrote. A created entity is in no pattern the traversal walked, so it is no VDG
-        // variable, and its rows are not in the graph a fetch would read - all come from
-        // here instead
+        // provisional IDs, the value column of every property it set, and the labels or
+        // edge type it wrote. A created entity is in no pattern the traversal walked, so it
+        // is no VDG variable, and its rows are not in the graph a fetch would read - all
+        // come from here instead
         struct CreatedEntity {
             mlir::Value _column;
             std::unordered_map<std::string_view, mlir::Value> _properties;
             std::vector<std::string> _labels;
+            std::string _edgeType;
         };
 
         std::unordered_map<const VarDecl*, CreatedEntity> _createdEntities;
@@ -307,6 +308,7 @@ private:
     void publishCreatedEntity(const VarDecl* decl,
                               mlir::Value column,
                               llvm::ArrayRef<llvm::StringRef> labelNames,
+                              llvm::StringRef edgeType,
                               llvm::ArrayRef<llvm::StringRef> propNames,
                               llvm::ArrayRef<mlir::Value> propValues);
 
@@ -503,6 +505,7 @@ private:
 
     mlir::Value nullConstantColumn();
 
+    mlir::Value constantString(llvm::StringRef value);
     mlir::Value constantLabelString(llvm::ArrayRef<std::string> labels);
 
     // Taken in the order the query declares its variables, so the choice is the query's
@@ -560,10 +563,11 @@ private:
     mlir::Value translatePropertyExpr(const PropertyExpr* propExpr);
     mlir::Value translateEntityTypeExpr(const EntityTypeExpr* typeExpr);
 
-    // The labels of a node the CREATE wrote, as the constant string labels() reads: its
-    // provisional ID is in no committed graph a db.labels read would consult. Null when
-    // the argument is not a created entity, so a matched node falls through to db.labels.
-    mlir::Value translateCreatedLabels(const Expr* argExpr);
+    // labels() / edgeType() of an entity the CREATE wrote, as the constant string it reads:
+    // its provisional ID is in no committed graph the runtime read would consult. Null when
+    // the argument is not a created entity, so a matched entity falls through to db.labels /
+    // db.edge_type.
+    mlir::Value translateCreatedMetadata(std::string_view funcName, const Expr* argExpr);
 
     // The attribute carrying a scalar literal's value and type, or a null attribute for
     // any other literal kind

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -143,12 +143,14 @@ private:
         std::vector<YieldedColumn> _yieldedColumns;
 
         // What a CREATE wrote for one of its named pattern entities: the column of
-        // provisional IDs, and the value column of every property it set. A created entity
-        // is in no pattern the traversal walked, so it is no VDG variable, and its rows are
-        // not in the graph a fetch would read - both come from here instead
+        // provisional IDs, the value column of every property it set, and the labels it
+        // wrote. A created entity is in no pattern the traversal walked, so it is no VDG
+        // variable, and its rows are not in the graph a fetch would read - all come from
+        // here instead
         struct CreatedEntity {
             mlir::Value _column;
             std::unordered_map<std::string_view, mlir::Value> _properties;
+            std::vector<std::string> _labels;
         };
 
         std::unordered_map<const VarDecl*, CreatedEntity> _createdEntities;
@@ -304,6 +306,7 @@ private:
     // reads that back rather than fetching an ID the graph does not hold yet
     void publishCreatedEntity(const VarDecl* decl,
                               mlir::Value column,
+                              llvm::ArrayRef<llvm::StringRef> labelNames,
                               llvm::ArrayRef<llvm::StringRef> propNames,
                               llvm::ArrayRef<mlir::Value> propValues);
 
@@ -500,6 +503,8 @@ private:
 
     mlir::Value nullConstantColumn();
 
+    mlir::Value constantLabelString(llvm::ArrayRef<std::string> labels);
+
     // Taken in the order the query declares its variables, so the choice is the query's
     // and not the addresses'
     mlir::Value resolveColumnInScope(ColumnPredicate accept) const;
@@ -554,6 +559,11 @@ private:
     mlir::Value translateLiteralExpr(const Literal* literal);
     mlir::Value translatePropertyExpr(const PropertyExpr* propExpr);
     mlir::Value translateEntityTypeExpr(const EntityTypeExpr* typeExpr);
+
+    // The labels of a node the CREATE wrote, as the constant string labels() reads: its
+    // provisional ID is in no committed graph a db.labels read would consult. Null when
+    // the argument is not a created entity, so a matched node falls through to db.labels.
+    mlir::Value translateCreatedLabels(const Expr* argExpr);
 
     // The attribute carrying a scalar literal's value and type, or a null attribute for
     // any other literal kind

--- a/storage/columns/Functions.cpp
+++ b/storage/columns/Functions.cpp
@@ -17,7 +17,15 @@ namespace rv = rg::views;
 
 void LabelsFunction::getLabelString(std::string& out, GraphView view, NodeID n) {
     out.clear();
-    const LabelSetHandle lblset = view.read().getNodeLabelSet(n);
+    const GraphReader reader = view.read();
+
+    const bool exists = reader.graphHasNode(n);
+    if (!exists) {
+        out = "null";
+        return;
+    }
+
+    const LabelSetHandle lblset = reader.getNodeLabelSet(n);
 
     std::vector<LabelID> labels;
     lblset.decompose(labels);

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -174,6 +174,13 @@ TEST_F(CreateReturnTest, returnsLabelsOncePerMatchedRow) {
                      {"Clone"}, {"Clone"}, {"Clone"}, {"Clone"}});
 }
 
+// edgeType() reads the type the CREATE wrote, not a db.edge_type of the provisional ID:
+// that edge is in no committed graph the read would consult
+TEST_F(CreateReturnTest, returnsEdgeTypeAndLabelsOfThePatternItCreated) {
+    expectWriteRows("CREATE (n:S)-[e:E]->(m:T) RETURN labels(n), edgeType(e), labels(m)",
+                    {{"S", "E", "T"}});
+}
+
 // One Tag per Person, each carrying that Person's name
 TEST_F(CreateReturnTest, returnsANodePerMatchedRow) {
     expectWriteRows("MATCH (p:Person) CREATE (t:Tag {name: p.name}) RETURN t.name",

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -158,6 +158,22 @@ TEST_F(CreateReturnTest, returnsNullForAPropertyTheCreateDidNotWrite) {
     expectWriteRows("CREATE (n:Tag {name: 'x'}) RETURN n.age", {{"null"}});
 }
 
+// labels() reads the labels the CREATE wrote, not a db.labels of the provisional ID: that
+// node is in no committed graph the read would consult
+TEST_F(CreateReturnTest, returnsLabelsOfTheNodeItCreated) {
+    expectWriteRows("CREATE (n:Tag) RETURN labels(n)", {{"Tag"}});
+}
+
+TEST_F(CreateReturnTest, returnsEveryLabelOfTheNodeItCreated) {
+    expectWriteRows("CREATE (n:Person:Officer) RETURN labels(n)", {{"Person, Officer"}});
+}
+
+TEST_F(CreateReturnTest, returnsLabelsOncePerMatchedRow) {
+    expectWriteRows("MATCH (p:Person) CREATE (m:Clone) RETURN labels(m)",
+                    {{"Clone"}, {"Clone"}, {"Clone"}, {"Clone"},
+                     {"Clone"}, {"Clone"}, {"Clone"}, {"Clone"}});
+}
+
 // One Tag per Person, each carrying that Person's name
 TEST_F(CreateReturnTest, returnsANodePerMatchedRow) {
     expectWriteRows("MATCH (p:Person) CREATE (t:Tag {name: p.name}) RETURN t.name",


### PR DESCRIPTION
Populates a created entity in the MLIR executor to store the labels and edge types (as strings) such that they can be returned by the `labels()` and `edgeType()` functions, respectively.