### PR TITLE
MLIR: implement hash join and optimise cartesian product

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -40,7 +40,7 @@
 
 ## Build
 - Always build from `build/` directory: `make -j8`
-- Regression tests: `make run_regress`
+- Regression tests: `make run_regress` (classic pipeline only -- proves nothing about v3/MLIR work)
 - Unit tests: `ctest` or `ctest --output-on-failure`
 
 ## Code Style Feedback
@@ -101,3 +101,4 @@
 - @reference_no_string_predicates.md — no CONTAINS / STARTS WITH / ENDS WITH; StringOperator existing in the AST does NOT imply support
 - @reference_v3_cross_product_chunked.md — v3 nl.cross_product is an iterator driving its own nl.for; one chunk of pairs per step, like v2's cursor
 - @reference_change_visibility.md — within a change MATCH sees the COMMITted tip (read-your-own-writes works after COMMIT); after SUBMIT the change is gone, checkout head to see committed data
+- @reference_regress_not_v3.md — regress does not exercise the v3 MLIR engine; verify v3 work with ctest, not run_regress

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -99,4 +99,5 @@
 - @reference_bioassert_throws.md — bioassert throws a catchable FatalException (TuringException); the abort() is dead code
 - @reference_gcc_maybe_uninit_sort.md — sort an index permutation to dodge GCC's -Wmaybe-uninitialized; a call-site pragma can't suppress it
 - @reference_no_string_predicates.md — no CONTAINS / STARTS WITH / ENDS WITH; StringOperator existing in the AST does NOT imply support
+- @reference_v3_cross_product_chunked.md — v3 nl.cross_product is an iterator driving its own nl.for; one chunk of pairs per step, like v2's cursor
 - @reference_change_visibility.md — within a change MATCH sees the COMMITted tip (read-your-own-writes works after COMMIT); after SUBMIT the change is gone, checkout head to see committed data

--- a/.claude/memory/reference_v3_cross_product_chunked.md
+++ b/.claude/memory/reference_v3_cross_product_chunked.md
@@ -1,0 +1,39 @@
+---
+name: reference-v3-cross-product-chunked
+description: v3's nl.cross_product is an iterator that drives its own nl.for, emitting one chunk of pairs per step; both engines hold one chunk whatever the sides measure
+metadata:
+  type: reference
+---
+
+The cross product is the one operator whose result outgrows its inputs, so in v3 it is
+an **iterator**, not a straight-line op: `nl.cross_product {outer} {inner}` returns
+`!nl.iter<...>` and `DBLowering::lowerCrossProduct` drives it with `buildLoopForSource`,
+exactly as a scan is driven. That loop is a third level below the two the factors open,
+and it is where the consumer (the lowered `db.output`) goes:
+
+    nl.for %a in %scanA { nl.for %b in %scanB {
+      %pairs = nl.cross_product {%a} {%b}
+      nl.for %ra, %rb in %pairs { nl.output(%ra, %rb) }
+    } }
+
+`NLExecutor::runCrossProductLoop` walks the N*M pairs with a single `position` cursor,
+emitting `min(chunkSize, remaining pairs)` per step - the v2 `CartesianProductProcessor`
+design, whose cursor is `_lhsPtr`/`_rhsPtr`. The broadcasts take that slice: pair p is
+outer row `p / M` (`blockRepeatColumn`) with inner row `p % M` (`tileColumn`), so a step
+may start and end mid-block or mid-tile. `factor` is M for **both** directions.
+
+Consequences worth knowing:
+- **Peak memory is one chunk per product**, not the product. A three-way MATCH nests two
+  products, each with its own loop, so it is O(depth * chunkSize).
+- A `LIMIT` bounds it through the ordinary loop early-exit (`nl.for ... limit %h`), like
+  a scan's; the op carries no limit operand of its own.
+- Every column of a side must be row-aligned with that side's first column - that is what
+  lets one position slice them all.
+
+Before 2026-09-09 the op was straight-line and laid out the whole chunk-against-chunk
+product in one step, so two 64Ki-row sides meant 4.29e9 rows - 64 GiB for two id columns,
+and reliable OOM kills. Measured after the change on reactome: `MATCH (a:Reaction),
+(b:Reaction) RETURN a, b` (6.97e9 rows) runs in 1.76 s holding 1.9 MiB, against 3.8 s /
+8.3 GiB for the 542M-row `Pathway x Pathway` before it. `samples/cartesian_bench/`
+benchmarks v2 against v3 and guards the product size; `test/query/ir/
+CrossProductChunkedTest.cpp` pins that no chunk exceeds the chunk size.

--- a/docs/join_cartesian_improvements.md
+++ b/docs/join_cartesian_improvements.md
@@ -74,8 +74,8 @@ emitting them costs one dependent load per row where a contiguous array would pr
 Materialising each group as a contiguous run after the build completes, as DuckDB does,
 would remove that, at the price of a finalise step between the last collect and the first
 probe. No measurement points at it today, so it is speculative: the chunked probe already
-brought the reactome species join, whose single group of roughly 6300 rows emits 40 million
-pairs, to 2.8x faster than the linked walk it replaced.
+brought the reactome species join, whose largest species group of roughly 6300 pathways
+emits 39.7 of its 40.2 million pairs, to 2.8x faster than the linked walk it replaced.
 
 **A sorted side with a branchless search.** Sorting one side and searching it answers `<`,
 `<=`, ranges and the complement of an equality from one build, where a hash table answers
@@ -99,3 +99,125 @@ that workload.
 **Parallel build and probe.** The build side is read once and the probe streams chunks, so
 both phases parallelise over chunks with a shared read-only index after the build. This
 depends on the same morsel machinery as the product.
+
+**A pattern that revisits a node should be a join, not a traversal.** These two queries ask
+one question and return the same 40,244,478 rows, the first through a value equality and the
+second through a pattern that passes back out of the species node:
+
+    MATCH (p1:Pathway)-[:species]->(s1:Species), (p2:Pathway)-[:species]->(s2:Species)
+    WHERE s1.dbId = s2.dbId RETURN count(*)
+
+    MATCH (p1:Pathway)-[:species]->(s:Species)<-[:species]-(p2:Pathway) RETURN count(*)
+
+The first fuses into `db.hash_join` and runs in 128 ms. The second contains no
+`db.hash_join` at all - its plan is `scan_nodes_by_label`, `get_out_edges_by_type`, a label
+check, `get_in_edges_by_type`, a second label check, `count` - and runs in 17,322 ms, 135
+times slower.
+
+The cost is an intermediate blow-up, not a slow traversal. `p2` is restricted to `:Pathway`
+only *after* the in-edge expansion, so the plan expands every species in-edge whatever its
+source type. Dropping that one label makes the query return 1,325,916,617 rows in 2,168 ms,
+against 40,244,478 rows in 14,465 ms with it: the same expansion either way, 1.33 billion
+intermediate rows, of which the label check keeps 3% and for which it charges about 9 ns
+each. The bare expansion runs at 1.6 ns per row, so the traversal itself is not the problem.
+The join form never expands anything unqualified, because each factor restricts itself to
+pathways at 23,290 rows before a single pair is made.
+
+What is missing is that the second shape is a join on `s` and is never considered as one.
+`FuseHashJoin` only matches a `db.cross_product` cut by an equality (`matchEqualityCross`),
+and a single connected pattern never becomes a product, so the pass never sees it.
+
+The fix is to recognise a node reached by two hops within one pattern as a join key: emit
+the two halves as factors of a product carrying an equality on that node, which the
+existing pass then fuses, or add a pass rewriting the hop-out/hop-in pair directly into
+`db.hash_join`. It has to be cost-based, not unconditional. Traversal streams and needs no
+buffer, so it wins whenever the fan-out is small; the join wins when the revisited node has
+many edges, which is exactly when the traversal form pays a random in-edge lookup per row.
+
+Ladybug (a Kùzu fork, `~/lbbench`, one thread) runs the pattern in 697 ms, 25x faster than
+we do, and its `EXPLAIN` shows precisely the plan proposed above:
+
+    SCAN_NODE_TABLE -> FILTER isPathway -> SCAN_REL_TABLE (p2)-[]->(s) -> FLATTEN -> HASH_JOIN_BUILD
+    SCAN_NODE_TABLE -> FILTER isPathway -> FLATTEN -> HASH_JOIN_BUILD
+    SCAN_NODE_TABLE -> FILTER isSpecies -> SCAN_REL_TABLE (s)<-[]-(p1) -> SEMI_MASKER
+    -> HASH_JOIN_PROBE -> HASH_JOIN_PROBE -> AGGREGATE
+
+Both pathway sides are filtered before their relationship scan, so no unqualified edge is
+ever expanded, and the shared node becomes two hash joins with a semi-mask - the paper's
+ASP-Join sideways information passing. The `FLATTEN` operators mark where it gives up its
+factorized representation.
+
+It prefers the opposite phrasing to ours, 697 ms for the pattern against 1039 ms for the
+value equality, since adjacency-list joins over CSR indices are what its storage exists to
+serve. Each engine is between 5 and 135 times slower on the other's phrasing of one
+question. Comparing each at its own best form, v3 leads on the join by 5.4x - so the engine
+is not the gap here, the plan for this phrasing is.
+
+## Work above a row-multiplying operator
+
+A cross product and a join both emit more rows than they consume, so every operator placed
+above one is charged per output row instead of per input row. This is one root cause with
+several faces, and on the species join it costs more than everything else in the query
+combined.
+
+**Sink a projection's property read into the factor.** The join above costs 128 ms for
+`count(*)`. The same join projecting three properties costs 1161 ms:
+
+| query | median |
+|---|---|
+| `RETURN count(*)` | 128 ms |
+| `RETURN p1, p2, s1` | 158 ms |
+| `RETURN p1.displayName` | 428 ms |
+| `RETURN p1.displayName, p2.displayName, s1.displayName` | 1142 ms |
+
+The three property reads are about 984 ms of that - the difference between projecting the
+three node ids and projecting their properties - near 8.2 ns per value over 120 million
+reads, and 86% of the query. They are that expensive only because of where they sit.
+The plan shows all three `db.get_node_properties` ops above the join, over its 40 million
+output rows, while the factors that produced `p1` and `s1` hold 23,290 rows between them.
+Reading `displayName` inside the factor and letting the join carry the column would turn 120
+million random property lookups into 70 thousand, leaving only a gather from a
+cache-resident buffer - which the id-only row above measures at about 10 ms per column. That
+puts the whole query near 220 ms rather than 1142 ms.
+
+The machinery already exists and is already used for exactly this, one level up:
+`sinkKeyIntoFactor` clones the key's property read into each factor so the join can index
+it, which is why `db.get_node_properties(s1, "dbId")` appears inside both factors of the
+plan. What is missing is applying the same move to a read that only the projection consumes.
+Like the item above it must be cost-based: sinking pays off when the join multiplies rows,
+and costs when the join is selective enough that its output is smaller than its inputs.
+
+**The same problem wears other hats.** In the traversal plan above, the label check
+establishing `p2:Pathway` (`get_node_label_set`, then `check_label_constraint`, then
+`filter`) runs over all 1.33 billion expanded rows and discards 97% of them, at about 9 ns
+each: some 12 of the query's 14.5 seconds. `get_node_label_set` is a random gather per row
+into `NodeContainer::_nodes`, whose `NodeRecord` is one `LabelSetHandle` - a 4-byte id plus
+an 8-byte pointer - so roughly 48 MB across reactome's 2.98 million nodes, past any cache.
+The join form never pays any of it, because both sides check their labels at 23,290 rows and
+the join only pairs rows that already qualified. Any predicate, conversion or fetch that
+depends on one side alone belongs below the operator that multiplies rows.
+
+**Factorization is the general form of this, and the state of the art does not reach it
+either.** Kùzu's CIDR 2023 paper makes it design goal (i): "Intermediate relations of m-n
+joins should be factorized, i.e., represented as Cartesian products instead of flat tuples",
+and it notes that aggregations "cannot blindly assume that each factorized tuple represents
+one tuple, and may need to check multiplicities to produce correct outputs" - so counting a
+property over a factorized result should read one value per distinct value, not one per
+output row. The paper is also candid about the limit: "S-Join achieves our two goals only if
+the build side contains a good factorization structure in which the join key is flat...
+sometimes the good factorization structure of a sub-query may contain an unflat join keys, so
+joining requires flattening the join key values and losing the factorization structure."
+
+Measured, that limit bites. Ladybug pays about 1.3 s for the three property reads in both
+phrasings, 1961 ms against its 1039 ms baseline for the value equality and 2009 ms against
+its 697 ms baseline for the pattern, so it flattens before the reads rather than exploiting
+multiplicity even in the shape its factorization targets. Both engines therefore pay per
+output row for properties, which is why v3's 8.1x lead on `count(*)` shrinks to 1.7x once
+three properties are projected. Sinking the read into the factor is the cheap way to take
+most of that back without rebuilding the chunk model; full factorized vectors, which would
+also subsume the selection-vector item in the cross product section, is the thorough one.
+
+Ladybug numbers here come from `~/lbbench` on the same reactome dump, pinned to one thread,
+with the query translated to its schema: one `Node` table with the labels as boolean columns,
+and "the same species" expressed as `s1.id = s2.id` on the primary key, since the conversion
+carried `stId`, `displayName`, `schemaClass` and `speciesName` but not `dbId`.

--- a/docs/join_cartesian_improvements.md
+++ b/docs/join_cartesian_improvements.md
@@ -1,0 +1,101 @@
+# Cross product and hash join improvements
+
+Work not yet done on the v3 (MLIR) cross product and hash join, with where each piece
+lands in the code and what it is expected to buy. Measurements quoted here were taken on
+reactome, single node, through `samples/cartesian_bench` and `samples/hash_join_bench`.
+
+## Where the two operators stand today
+
+The cross product is a block nested loop that materialises every pair. `nl.cross_product`
+is an iterator driving its own `nl.for`, so one step lays out `min(chunkSize, remaining)`
+pairs and peak memory is one chunk per product rather than the whole product
+(`NLExecutor::runCrossProductLoop`, `blockRepeatColumn` and `tileColumn`). Each step
+physically writes every carried column of both sides, and a residual predicate above it
+gathers the survivors into fresh columns.
+
+The hash join buffers its build side once, then probes it. Keys are hashed and compared in
+place, never serialised, and the rows carrying one key form a group so a probe confirms a
+key once and then emits that group's rows with no further comparison (`NLHashJoinIndex`).
+`nl.hash_join_probe` is an iterator driving its own `nl.for`, as the cross product is, so a
+step emits one chunk of pairs and may start and end partway through one probe row's matches
+(`DBLowering::lowerHashJoin`, `NLExecutor::runHashJoinCollect` and `runHashJoinProbeLoop`).
+
+The optimiser turns a product cut by one equality into `db.hash_join`, pushes
+single-variable predicates into the factors, reuses property reads and trims unread columns
+(`dbPassPipeline` in `DBProgramGenerator.cpp`).
+
+## Cross product
+
+**Zero-copy pair chunks.** Instead of laying out repeated values, pair one row of the
+smaller side, exposed as a `ColumnConst`, with a whole chunk of the larger side, exposed as
+the input chunk itself with no copy. Materialisation drops from one write per column per
+pair to nothing, and steps stay chunk-sized because the referenced side is always the
+larger one. The foundations are already in place: constant columns flow into the product,
+the filter has a constant-mask fast path, and the output sink takes a window over columns.
+The work is making every consumer accept a constant column where it now expects a vector.
+Note that pair order changes when the sides swap, so any test pinning output order without
+`ORDER BY` needs checking. This is the DuckDB and Velox cross product design.
+
+**Buffer the smaller factor once.** The inner factor's scans, property reads and hops
+re-execute for every outer chunk, because `lowerCrossProduct` roots the inner factor inside
+the outer factor's innermost loop. A keyless buffer plus the existing cardinality estimate
+to pick the side turns the product into "spool the small side, stream the large one". The
+machinery exists as `nl.hash_join_buffer` and `nl.hash_join_collect` minus the key, and
+memory is bounded by the smaller factor, which the graph already holds.
+
+**Selection vectors and late materialisation.** A residual predicate such as `a.x < b.y`
+currently gathers every carried column. Carrying a selection vector beside a chunk defers
+all copying to the output, and combined with zero-copy pair chunks it makes product plus
+filter copy-free until the sink. This is an engine-wide change to the chunk model rather
+than a product-local one, so it is the largest of these items.
+
+**Better algorithms for non-equality predicates.** For a single inequality or a band
+predicate, sort one side and binary-search or merge instead of generating and discarding
+pairs. `nl.sort_buffer` and `nl.sort_collect` already accumulate a side. See DuckDB's
+piecewise merge join and the IEJoin paper.
+
+**Morsel-driven parallelism.** Once the inner side is buffered, outer chunks are
+independent work units. Splitting them across threads with per-thread sinks is the HyPer
+design and is the largest wall-clock win available for a pure product.
+
+**Native code through MLIR.** Lowering the `nl` loop nest to LLVM makes pairs plain loop
+indices that never become columns. It is the end state the MLIR design points at, though
+the constant-column form above captures most of the benefit at interpreter cost.
+
+**Algebraic shortcuts.** An unfiltered product under `count(*)` is the product of the two
+counts and needs no loop at all. For very large results, run-end encoding the repeated side
+ships the answer in linear rather than quadratic space, which is where the remaining time
+goes once the engine itself is cheap.
+
+## Hash join
+
+**Contiguous per-group runs.** A group's rows are chained through a linked list, so
+emitting them costs one dependent load per row where a contiguous array would prefetch.
+Materialising each group as a contiguous run after the build completes, as DuckDB does,
+would remove that, at the price of a finalise step between the last collect and the first
+probe. No measurement points at it today, so it is speculative: the chunked probe already
+brought the reactome species join, whose single group of roughly 6300 rows emits 40 million
+pairs, to 2.8x faster than the linked walk it replaced.
+
+**A sorted side with a branchless search.** Sorting one side and searching it answers `<`,
+`<=`, ranges and the complement of an equality from one build, where a hash table answers
+equality only. Make the search branchless, or lay the side out in Eytzinger order
+(Khuong and Morin), since a textbook binary search mispredicts at every level. Sorting the
+probe chunk too lets each search gallop from the previous hit rather than restart at the
+root, which degrades toward a merge as the probe chunk gets denser.
+
+**Node IDs come out range by range.** A label scan walks a range per label set per data
+part (`ScanNodesByLabelIterator` over `NodeRange`), so each range is ascending and a join
+whose key is node identity can merge the ranges rather than sort a side or build a table at
+all. Worth confirming how the ranges of several label sets and data parts order against
+each other before relying on it.
+
+**An ordered property index.** The only property index today is a prefix trie for
+approximate string matching (`StringPropertyIndexer`), so a sorted or hashed side must be
+built per query. A per-data-part ordered property index turns a repeated join on the same
+key into an index nested loop join with no build cost, which is the standard answer for
+that workload.
+
+**Parallel build and probe.** The build side is read once and the probe streams chunks, so
+both phases parallelise over chunks with a shared read-only index after the build. This
+depends on the same morsel machinery as the product.

--- a/net/decoders/DecodeContext.h
+++ b/net/decoders/DecodeContext.h
@@ -35,12 +35,17 @@ struct DecodeContext {
     // Entry count of the EntityList row being decoded. The count and actual data can be
     // split across chunks so we need to store state here.
     std::optional<size_t> _entityListEntryCount;
+    // Set once a constant list column's header has been read and its space reserved, so a
+    // resumed pass drains elements rather than reading the header again. An optional
+    // constant spends _rowIndex on its has-value flag, so the two cannot share it.
+    bool _constListStarted {false};
 
     void reset() {
         _columnIndex = 0;
         _rowIndex = 0;
         _bufferState.reset();
         _entityListEntryCount.reset();
+        _constListStarted = false;
     }
 };
 

--- a/net/decoders/Decoders.h
+++ b/net/decoders/Decoders.h
@@ -477,6 +477,40 @@ struct OptionalVectorColumnDecoder {
 };
 
 template <ProtoDecodeSink Sink>
+struct OptionalVectorColumnDecoder<SinkListElementView<Sink>, Sink> {
+    using T = SinkListElementView<Sink>;
+
+    static bool decode(DecodeContext* context,
+                       Sink* sink,
+                       SinkColumnOptVector<T, Sink>* typedColumn,
+                       ProtoColumnState* columnState) {
+        // One element per column row, as in the non-optional case, wire-encoded as
+        // [listByteSize] followed by the elements. Which rows hold one is read off the mask,
+        // not off the tag: a row holding a null out of a list carries the very same tag.
+        if (context->_rowIndex == 0) {
+            if (context->_inBuf->readable() < sizeof(WireSize)) {
+                return false;
+            }
+
+            WireSize listByteSize = 0;
+            context->_inBuf->readData(&listByteSize, sizeof(listByteSize));
+
+            sink->beginList(columnState->getNumRows(), listByteSize);
+            context->_rowIndex = 1;
+        }
+
+        const ProtoColumnState::BitMask& mask = columnState->getBitMask();
+        auto onTopLevelElement = [typedColumn, &mask](size_t index, const SinkListElementView<Sink>& view) {
+            if (mask.test(index)) {
+                typedColumn->data()[index] = view;
+            }
+        };
+
+        return drainListStack(context, sink, onTopLevelElement);
+    }
+};
+
+template <ProtoDecodeSink Sink>
 struct OptionalVectorColumnDecoder<db::types::String::Primitive, Sink> {
     using T = db::types::String::Primitive;
 
@@ -664,10 +698,11 @@ struct ConstColumnDecoder<SinkListView<Sink>, Sink> {
 
     template <ConstColumnOf<T, Sink> Column>
     static bool decode(DecodeContext* context, Sink* sink, Column* typedColumn) {
-        // Const columns have no row dimension, so reuse _rowIndex as a 0/1 "list started"
-        // marker (the driver resets it to 0 before this column). 1 means we have read the
-        // header, reserved the space, and set the (initially unfilled) ListView on the column.
-        if (context->_rowIndex == 0) {
+        // Const columns have no row dimension, so _constListStarted carries the "list
+        // started" state (the driver clears it before this column). Set means we have read
+        // the header, reserved the space, and set the (initially unfilled) ListView on the
+        // column.
+        if (!context->_constListStarted) {
             if (context->_inBuf->readable() < 2 * sizeof(WireSize)) {
                 return false;
             }
@@ -678,7 +713,7 @@ struct ConstColumnDecoder<SinkListView<Sink>, Sink> {
             context->_inBuf->readData(&listByteSize, sizeof(listByteSize));
 
             typedColumn->set(sink->beginList(elementCount, listByteSize));
-            context->_rowIndex = 1;
+            context->_constListStarted = true;
         }
         auto onTopLevelElement = [](size_t, const SinkListElementView<Sink>&) {};
         return drainListStack(context, sink, onTopLevelElement);
@@ -694,7 +729,7 @@ struct ConstColumnDecoder<SinkListElementView<Sink>, Sink> {
         // A constant ListElementView is a single element, wire-encoded as [listByteSize] + one
         // element. Stream it onto the list buffer and set the column to its view.
 
-        if (context->_rowIndex == 0) {
+        if (!context->_constListStarted) {
             if (context->_inBuf->readable() < sizeof(WireSize)) {
                 return false;
             }
@@ -703,7 +738,7 @@ struct ConstColumnDecoder<SinkListElementView<Sink>, Sink> {
             context->_inBuf->readData(&listByteSize, sizeof(listByteSize));
 
             sink->beginList(1, listByteSize);
-            context->_rowIndex = 1;
+            context->_constListStarted = true;
         }
 
         // The constant is the single top-level element; store its view on the column.

--- a/net/decoders/TuringProtoDecoder.h
+++ b/net/decoders/TuringProtoDecoder.h
@@ -330,6 +330,7 @@ void TuringProtoDecoder<Sink>::decodeIncomingData(SinkColumnContainer<Sink>* con
 
         ++_context._columnIndex;
         _context._rowIndex = 0;
+        _context._constListStarted = false;
     }
 }
 

--- a/net/decoders/TuringProtoDecoderConcepts.h
+++ b/net/decoders/TuringProtoDecoderConcepts.h
@@ -50,6 +50,7 @@ concept SupportedColumnOptVectorTypes = std::is_same_v<T, db::types::UInt64::Pri
 || std::is_same_v<T, db::types::Double::Primitive>
 || std::is_same_v<T, db::types::Bool::Primitive>
 || std::is_same_v<T, db::types::Embedding::Primitive>
+|| std::is_same_v<T, typename Sink::ListElementView>
 || std::is_same_v<T, db::types::String::Primitive>;
 
 template <typename T, typename Sink>
@@ -69,6 +70,7 @@ concept SupportedColumnOptConstTypes = std::is_same_v<T, db::types::UInt64::Prim
 || std::is_same_v<T, db::types::Double::Primitive>
 || std::is_same_v<T, db::types::Bool::Primitive>
 || std::is_same_v<T, db::types::Embedding::Primitive>
+|| std::is_same_v<T, typename Sink::ListElementView>
 || std::is_same_v<T, db::types::String::Primitive>;
 
 }

--- a/net/encoders/TuringProtoEncoder.h
+++ b/net/encoders/TuringProtoEncoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <span>
 #include <stack>
 #include <type_traits>
@@ -49,6 +50,26 @@ inline WireSize computeListByteSize(std::span<const db::ListElementView> element
     for (const auto& elem : elements) {
         db::ListTagDispatcher dispatcher {elem.getTag()};
         totalSize += dispatcher.execute(sizeVisitor, elem);
+    }
+
+    bioassert(totalSize <= MAX_WIRE_SIZE, "List length exceeds maximum wire size");
+    return static_cast<WireSize>(totalSize);
+}
+
+// The same for an optional column's elements, counting a row that holds no element as the
+// null it is written as.
+inline WireSize computeOptionalListByteSize(std::span<const std::optional<db::ListElementView>> elements) {
+    const ListElementByteSizeVisitor sizeVisitor;
+
+    size_t totalSize = 0;
+    for (const std::optional<db::ListElementView>& element : elements) {
+        if (!element.has_value()) {
+            totalSize += sizeof(db::PropertyNull);
+            continue;
+        }
+
+        db::ListTagDispatcher dispatcher {element->getTag()};
+        totalSize += dispatcher.execute(sizeVisitor, *element);
     }
 
     bioassert(totalSize <= MAX_WIRE_SIZE, "List length exceeds maximum wire size");
@@ -334,9 +355,7 @@ public:
             // is diagnosed eagerly by pre-P2593 compilers even when discarded.
             static_assert(sizeof(T) == 0, "Sending ColumnOptVector<EntityList> not supported");
         } else if constexpr (db::IsListElement<T>) {
-            // The element decoders read a contiguous run of scalars, wire format has no
-            // framing for null
-            throw FatalException("ColumnOptVector<ListElementView> is not supported");
+            writeOptionalListElements(col->getRaw());
         } else if constexpr (db::IsNull<T>) {
             // Don't send anything for property null
         } else {
@@ -425,8 +444,8 @@ public:
             // Dependent condition (see the ColumnOptVector<EntityList> branch above).
             static_assert(sizeof(T) == 0, "ColumnOptConst<EntityList> is not supported");
         } else if constexpr (db::IsListElement<T>) {
-            // See the ColumnOptVector<ListElementView> branch above.
-            throw FatalException("ColumnOptConst<ListElementView> is not supported");
+            const db::ListElementView element = *opt;
+            writeListElements(std::span<const db::ListElementView>(&element, 1));
         } else if constexpr (db::IsNull<T>) {
             // Don't send anything for property null
         } else {
@@ -492,6 +511,35 @@ private:
         _outBuf->copyFixedLenData(&listByteSize, sizeof(listByteSize));
 
         writeListElementValues(elements);
+    }
+
+    // The same for an optional column. A row holding no element is written as a null one so
+    // the elements stay one per row; the column's null mask, already on the wire, is what
+    // tells such a row from one holding a null read out of a list.
+    void writeOptionalListElements(std::span<const std::optional<db::ListElementView>> elements) {
+        const WireSize listByteSize = computeOptionalListByteSize(elements);
+
+        _outBuf->checkRemainingAndFlush(sizeof(listByteSize));
+        _outBuf->copyFixedLenData(&listByteSize, sizeof(listByteSize));
+
+        for (const std::optional<db::ListElementView>& element : elements) {
+            if (!element.has_value()) {
+                writeNullListElement();
+                continue;
+            }
+
+            writeListElementValues(std::span<const db::ListElementView>(&element.value(), 1));
+        }
+    }
+
+    void writeNullListElement() {
+        constexpr size_t tagSize = sizeof(db::ListBufferTypeTag);
+        constexpr db::ListBufferTypeTag tag = db::TypeToListBufferTag<db::PropertyNull>::Tag;
+        const db::PropertyNull value {};
+
+        _outBuf->checkRemainingAndFlush(tagSize + sizeof(value));
+        _outBuf->copyFixedLenData(&tag, tagSize);
+        _outBuf->copyFixedLenData(&value, sizeof(value));
     }
 
     net::proto::TuringProtoOutBuf* _outBuf {nullptr};

--- a/query/AST/CypherASTDumper.cpp
+++ b/query/AST/CypherASTDumper.cpp
@@ -934,6 +934,12 @@ void CypherASTDumper::dump(std::ostream& out, const BinaryExpr* expr) {
         case BinaryOperator::In:
             out << "        Operator IN\n";
             break;
+        case BinaryOperator::IsNull:
+            out << "        Operator IS_NULL\n";
+            break;
+        case BinaryOperator::IsNotNull:
+            out << "        Operator IS_NOT_NULL\n";
+            break;
         default:
             throw CompilerException("Unknown binary operator");
             break;

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -338,10 +338,7 @@ void ExprAnalyzer::analyzeBinaryExpr(BinaryExpr* expr) {
             // Ordering a value against a null is null, the same as comparing it against
             // one. Only the MLIR engine answers such a comparison: the legacy planner
             // hands the operator a null column no ordering kernel reads
-            const bool ordersAgainstNull =
-                pair == TypePairBitset(EvaluatedType::Null, EvaluatedType::Null)
-                || pair == TypePairBitset(EvaluatedType::Integer, EvaluatedType::Null)
-                || pair == TypePairBitset(EvaluatedType::Double, EvaluatedType::Null);
+            const bool ordersAgainstNull = a == EvaluatedType::Null || b == EvaluatedType::Null;
 
             if (_isV3 && ordersAgainstNull) {
                 break;

--- a/query/common/CardinalityEstimation.cpp
+++ b/query/common/CardinalityEstimation.cpp
@@ -19,6 +19,12 @@ size_t CardinalityEstimation::estimateNodeCount(const LabelSet& labelset) const 
     return reader.getNodeCountMatchingLabelset(labelset.handle());
 }
 
+size_t CardinalityEstimation::estimateEdgeCount() const {
+    GraphReader reader(_graphView);
+
+    return reader.getEdgeCount();
+}
+
 bool CardinalityEstimation::shouldPreferCartesian(const LabelSet& left, const LabelSet& right, size_t queryLimit) const {
     const size_t leftCount = estimateNodeCount(left);
     const size_t rightCount = estimateNodeCount(right);

--- a/query/common/CardinalityEstimation.h
+++ b/query/common/CardinalityEstimation.h
@@ -21,6 +21,11 @@ public:
     // Returns total node count if labelset is empty.
     size_t estimateNodeCount(const LabelSet& labelset) const;
 
+    // Estimate the number of edges a scan of them selects. The graph keeps no per-type
+    // tally, so an edge type narrows the scan without narrowing this: the whole edge
+    // count is what a by-type scan is read at, an upper bound on its rows.
+    size_t estimateEdgeCount() const;
+
     // Returns true when cartesian product + filter is likely cheaper
     // than value hash join, either because the product is small or
     // because a small LIMIT makes early-termination effective.

--- a/query/interpreter/QueryInterpreterV3.cpp
+++ b/query/interpreter/QueryInterpreterV3.cpp
@@ -178,7 +178,9 @@ void QueryInterpreterV3::executeImpl(QueryStatus& status,
     mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
     mlir::ModuleOp module = owningModule.get();
 
-    DBProgramGenerator generator(&module, explain);
+    const mlir::db::DBPassContext passContext {&view, _forcesValueHashJoin, _usesValueHashJoin};
+
+    DBProgramGenerator generator(&module, explain, passContext);
     try {
         generator.generate(&ast);
     } catch (const CompilerException& e) {

--- a/query/interpreter/QueryInterpreterV3.h
+++ b/query/interpreter/QueryInterpreterV3.h
@@ -31,8 +31,17 @@ public:
                  LocalMemory* mem,
                  NLOutputSink* sink);
 
+    // The overrides of the join cost model, which otherwise leaves a cross product cut by
+    // an equality as it stands whenever it estimates the product the cheaper of the two.
+    // The v3 siblings of PlanGenConfig's flags, and they mean what those mean: forcing
+    // fuses every cut the pass matches, and clearing use fuses none.
+    void setForceValueHashJoin(bool force) { _forcesValueHashJoin = force; }
+    void setUseValueHashJoin(bool use) { _usesValueHashJoin = use; }
+
 private:
     SystemManager* _sysMan {nullptr};
+    bool _forcesValueHashJoin {false};
+    bool _usesValueHashJoin {true};
 
     void executeImpl(QueryStatus& status,
                      std::string_view query,

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -145,24 +145,26 @@ mlir::ArrayAttr strArrayAttr(mlir::OpBuilder& builder, std::span<const std::stri
     return builder.getStrArrayAttr(refs);
 }
 
-using DBPassFactory = std::unique_ptr<mlir::Pass> (*)();
+using DBPassFactory = std::unique_ptr<mlir::Pass> (*)(const mlir::db::DBPassContext&);
 
 // The optimisation pipeline every query runs through, in order. An EXPLAIN prefix
 // reporting on a pass walks the same table one pass at a time, which is what keeps the
-// pipeline it reports on and the pipeline that runs the same one.
+// pipeline it reports on and the pipeline that runs the same one. Every factory is handed
+// the context; only the join's cost model reads it, the rewrites beside it answering off
+// the IR alone.
 const std::array<DBPassFactory, 12> dbPassPipeline = {
-    &mlir::db::createFuseScanByLabel,
-    &mlir::db::createPushDownFilters,
-    &mlir::db::createTrimUnreadColumns,
-    &mlir::db::createFuseUnwindEquality,
-    &mlir::db::createFuseScanByNodeIDs,
-    &mlir::db::createFuseScanByPropertyValue,
-    &mlir::db::createFuseScanEdges,
-    &mlir::db::createFuseEdgesByType,
-    &mlir::db::createFuseScanEdgesByType,
-    &mlir::db::createReusePropertyReads,
-    &mlir::db::createFuseHashJoin,
-    &mlir::db::createTrimUnreadColumns,
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseScanByLabel(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createPushDownFilters(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createTrimUnreadColumns(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseUnwindEquality(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseScanByNodeIDs(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseScanByPropertyValue(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseScanEdges(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseEdgesByType(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createFuseScanEdgesByType(); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createReusePropertyReads(); },
+    [](const mlir::db::DBPassContext& context) { return mlir::db::createFuseHashJoin(context); },
+    [](const mlir::db::DBPassContext&) { return mlir::db::createTrimUnreadColumns(); },
 };
 
 // The stage a dump of one pass is reported under: "after fuse_scan_edges", or "after
@@ -178,8 +180,9 @@ void makePassLabel(std::string_view selector, std::string_view passName, size_t 
 }
 
 void fillPipelinePassNames(std::vector<std::string_view>& passNames) {
+    const mlir::db::DBPassContext context;
     for (const DBPassFactory factory : dbPassPipeline) {
-        const std::unique_ptr<mlir::Pass> pass = factory();
+        const std::unique_ptr<mlir::Pass> pass = factory(context);
         passNames.push_back(toStringView(pass->getArgument()));
     }
 }
@@ -614,11 +617,14 @@ void collectDistinctValueIndices(llvm::ArrayRef<const FunctionInvocationExpr*> c
 
 }
 
-DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule, ExplainReport* explain)
+DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule,
+                                       ExplainReport* explain,
+                                       const mlir::db::DBPassContext& passContext)
     : _module(mainModule),
     _mlirCtxt(_module->getContext()),
     _opBuilder(_module->getBodyRegion()),
-    _explain(explain)
+    _explain(explain),
+    _passContext(passContext)
 {
 }
 
@@ -1188,7 +1194,7 @@ void DBProgramGenerator::runPasses() {
     mlir::PassManager passManager(_mlirCtxt);
     passManager.enableVerifier(false);
     for (const DBPassFactory factory : dbPassPipeline) {
-        passManager.addPass(factory());
+        passManager.addPass(factory(_passContext));
     }
 
     if (mlir::failed(passManager.run(*_module))) {
@@ -1216,7 +1222,7 @@ void DBProgramGenerator::runExplainedPasses() {
     ExplainReport::renderModule(*_module, module);
 
     for (size_t passIndex = 0; passIndex < dbPassPipeline.size(); passIndex++) {
-        std::unique_ptr<mlir::Pass> pass = dbPassPipeline[passIndex]();
+        std::unique_ptr<mlir::Pass> pass = dbPassPipeline[passIndex](_passContext);
         const std::string_view passName = pipelinePasses[passIndex];
         const size_t run = passRunNumber(pipelinePasses, passIndex);
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1234,6 +1234,7 @@ void DBProgramGenerator::runExplainedPasses() {
         }
 
         mlir::PassManager passManager(_mlirCtxt);
+        passManager.enableVerifier(false);
         passManager.addPass(std::move(pass));
 
         if (mlir::failed(passManager.run(*_module))) {

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -150,7 +150,7 @@ using DBPassFactory = std::unique_ptr<mlir::Pass> (*)();
 // The optimisation pipeline every query runs through, in order. An EXPLAIN prefix
 // reporting on a pass walks the same table one pass at a time, which is what keeps the
 // pipeline it reports on and the pipeline that runs the same one.
-const std::array<DBPassFactory, 11> dbPassPipeline = {
+const std::array<DBPassFactory, 12> dbPassPipeline = {
     &mlir::db::createFuseScanByLabel,
     &mlir::db::createPushDownFilters,
     &mlir::db::createTrimUnreadColumns,
@@ -161,6 +161,7 @@ const std::array<DBPassFactory, 11> dbPassPipeline = {
     &mlir::db::createFuseEdgesByType,
     &mlir::db::createFuseScanEdgesByType,
     &mlir::db::createReusePropertyReads,
+    &mlir::db::createFuseHashJoin,
     &mlir::db::createTrimUnreadColumns,
 };
 

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/Value.h"
 
 #include "DBOps.h"
+#include "DBPasses.h"
 #include "DBTypes.h"
 #include "expr/CaseExpr.h"
 
@@ -111,7 +112,12 @@ public:
 
     // A null report is a query to run: nothing is dumped and the compilation is the
     // one an unprefixed query gets
-    explicit DBProgramGenerator(mlir::ModuleOp* mainModule, ExplainReport* explain = nullptr);
+    // The pass context carries what the optimisation pipeline reads from outside the IR:
+    // the graph the join cost model estimates from, and its overrides. Its default holds
+    // no graph, which leaves every cut the join pass matches fused.
+    explicit DBProgramGenerator(mlir::ModuleOp* mainModule,
+                                ExplainReport* explain = nullptr,
+                                const mlir::db::DBPassContext& passContext = mlir::db::DBPassContext {});
     ~DBProgramGenerator();
 
     void generate(const CypherAST* ast);
@@ -126,6 +132,7 @@ private:
     mlir::OpBuilder _opBuilder;
 
     ExplainReport* _explain {nullptr};
+    mlir::db::DBPassContext _passContext;
 
     // How many query parts have had their dependency graph dumped, which numbers the
     // graphs a multi-part query reports

--- a/query/ir/dialect/db/CMakeLists.txt
+++ b/query/ir/dialect/db/CMakeLists.txt
@@ -46,6 +46,10 @@ add_mlir_library(turing_db_ir_dbdialect_s
   MLIRBuiltinToLLVMIRTranslation
   turing_db_ir_storagedialect_s
   turing_db_ir_common_s
+
+  # The join cost model estimates each side from the graph's node counts, which is what
+  # the v2 planner reads it from too
+  turing_db_query_common_s
 )
 
 # Ensure we have MLIR and LLVM includes, as well as the headers in current dir

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -27,6 +27,9 @@ namespace {
 // `db.cross_product factor { ... } factor { ... }`.
 const char* const factorKeyword = "factor";
 
+// The keyword db.hash_join spells its two key column indices after.
+const char* const keysKeyword = "on";
+
 // The db.yield that terminates a factor region, or a null Yield if the region
 // is empty or does not end with one. A factor's yield names the columns that
 // factor contributes to the product.
@@ -50,7 +53,7 @@ ParseResult appendFactorYieldTypes(OpAsmParser& parser,
     Yield yield = getFactorYield(factor);
     if (!yield) {
         return parser.emitError(parser.getCurrentLocation(),
-                                "cross_product factor must end with a db.yield");
+                                "factor must end with a db.yield");
     }
 
     for (const Type columnType : yield.getColumns().getTypes()) {
@@ -70,6 +73,49 @@ ParseResult parseFactorRegion(OpAsmParser& parser, OperationState& result) {
 
     Region* factor = result.addRegion();
     return parser.parseRegion(*factor, {});
+}
+
+// The results of a two-factor op - db.cross_product, db.hash_join - must be exactly the
+// columns the two factors yield: the left factor's yielded columns followed by the right
+// factor's. The yields drive the result types during parsing, so this guards the
+// programmatic builder path and re-checks parsed IR. Shared by both verifiers.
+LogicalResult verifyFactorResults(Operation* op, Region& leftFactor, Region& rightFactor) {
+    Yield leftYield = getFactorYield(leftFactor);
+    Yield rightYield = getFactorYield(rightFactor);
+    if (!leftYield || !rightYield) {
+        return op->emitOpError("each factor region must end with a db.yield");
+    }
+
+    // Each factor must contribute at least one column. A side's row count is read
+    // from its first yielded column during lowering, so a factor that surfaces no
+    // column (an empty db.yield) cannot be sized - reject it here at the db level.
+    if (leftYield.getColumns().empty() || rightYield.getColumns().empty()) {
+        return op->emitOpError("each factor must yield at least one column");
+    }
+
+    llvm::SmallVector<Type> expectedResultTypes;
+    for (const Type columnType : leftYield.getColumns().getTypes()) {
+        expectedResultTypes.push_back(columnType);
+    }
+    for (const Type columnType : rightYield.getColumns().getTypes()) {
+        expectedResultTypes.push_back(columnType);
+    }
+
+    const Operation::result_type_range resultTypes = op->getResultTypes();
+    if (resultTypes.size() != expectedResultTypes.size()) {
+        return op->emitOpError("expects ") << expectedResultTypes.size()
+                                           << " results, the columns yielded by the two factors, but has "
+                                           << resultTypes.size();
+    }
+
+    for (size_t resultIndex = 0; resultIndex < expectedResultTypes.size(); resultIndex++) {
+        if (resultTypes[resultIndex] != expectedResultTypes[resultIndex]) {
+            return op->emitOpError("result ") << resultIndex << " must be the yielded column type "
+                                              << expectedResultTypes[resultIndex];
+        }
+    }
+
+    return success();
 }
 
 // A literal list typed as homogeneous - db.unwind_const's typed column, db.const_list's
@@ -231,44 +277,104 @@ void CrossProduct::print(OpAsmPrinter& printer) {
     printer.printOptionalAttrDict((*this)->getAttrs());
 }
 
-// The results must be exactly the columns yielded by the two factors: the left
-// factor's yielded columns followed by the right factor's. The yields drive the
-// result types during parsing, so this guards the programmatic builder path and
-// re-checks parsed IR.
 LogicalResult CrossProduct::verify() {
-    Yield leftYield = getFactorYield(getLeftFactor());
-    Yield rightYield = getFactorYield(getRightFactor());
-    if (!leftYield || !rightYield) {
-        return emitOpError("each factor region must end with a db.yield");
+    return verifyFactorResults(getOperation(), getLeftFactor(), getRightFactor());
+}
+
+// Builds the op from the result types - the left factor's yielded columns followed
+// by the right factor's - and the two key column indices, and creates the two empty
+// factor blocks. The cross product's sibling builder, with the join keys added.
+void HashJoin::build(OpBuilder& builder,
+                     OperationState& state,
+                     TypeRange resultTypes,
+                     uint64_t leftKey,
+                     uint64_t rightKey) {
+    const OpBuilder::InsertionGuard guard(builder);
+
+    state.addTypes(resultTypes);
+
+    const Type keyIndexType = builder.getIntegerType(64, /*isSigned=*/false);
+    state.addAttribute(getLeftKeyAttrName(state.name), builder.getIntegerAttr(keyIndexType, leftKey));
+    state.addAttribute(getRightKeyAttrName(state.name), builder.getIntegerAttr(keyIndexType, rightKey));
+
+    Region* leftFactor = state.addRegion();
+    builder.createBlock(leftFactor);
+
+    Region* rightFactor = state.addRegion();
+    builder.createBlock(rightFactor);
+}
+
+// Custom syntax, the cross product's with the join keys spelled after the regions:
+//
+//   %a, %ka, %b, %kb = db.hash_join factor { ... db.yield %x, %k : ... }
+//                                   factor { ... db.yield %y, %k : ... } on 1, 1
+//
+// The result types are recovered from the two factors' yields, exactly as
+// db.cross_product recovers them.
+ParseResult HashJoin::parse(OpAsmParser& parser, OperationState& result) {
+    if (parseFactorRegion(parser, result) || parseFactorRegion(parser, result)) {
+        return failure();
     }
 
-    // Each factor must contribute at least one column. A side's row count is read
-    // from its first yielded column during lowering, so a factor that surfaces no
-    // column (an empty db.yield) cannot be sized - reject it here at the db level.
-    if (leftYield.getColumns().empty() || rightYield.getColumns().empty()) {
-        return emitOpError("each factor must yield at least one column");
+    uint64_t leftKey = 0;
+    uint64_t rightKey = 0;
+    const bool keysFailed = parser.parseKeyword(keysKeyword)
+                            || parser.parseInteger(leftKey)
+                            || parser.parseComma()
+                            || parser.parseInteger(rightKey);
+    if (keysFailed) {
+        return failure();
     }
 
-    llvm::SmallVector<Type> expectedResultTypes;
-    for (const Type columnType : leftYield.getColumns().getTypes()) {
-        expectedResultTypes.push_back(columnType);
-    }
-    for (const Type columnType : rightYield.getColumns().getTypes()) {
-        expectedResultTypes.push_back(columnType);
+    if (parser.parseOptionalAttrDict(result.attributes)) {
+        return failure();
     }
 
-    const Operation::result_type_range resultTypes = getOperation()->getResultTypes();
-    if (resultTypes.size() != expectedResultTypes.size()) {
-        return emitOpError("expects ") << expectedResultTypes.size()
-                                       << " results, the columns yielded by the two factors, but has "
-                                       << resultTypes.size();
+    const Type keyIndexType = parser.getBuilder().getIntegerType(64, /*isSigned=*/false);
+    result.addAttribute(getLeftKeyAttrName(result.name), IntegerAttr::get(keyIndexType, leftKey));
+    result.addAttribute(getRightKeyAttrName(result.name), IntegerAttr::get(keyIndexType, rightKey));
+
+    Region& leftFactor = *result.regions[0];
+    Region& rightFactor = *result.regions[1];
+    if (appendFactorYieldTypes(parser, leftFactor, result.types)
+        || appendFactorYieldTypes(parser, rightFactor, result.types)) {
+        return failure();
     }
 
-    for (size_t resultIndex = 0; resultIndex < expectedResultTypes.size(); resultIndex++) {
-        if (resultTypes[resultIndex] != expectedResultTypes[resultIndex]) {
-            return emitOpError("result ") << resultIndex << " must be the yielded column type "
-                                          << expectedResultTypes[resultIndex];
-        }
+    return success();
+}
+
+void HashJoin::print(OpAsmPrinter& printer) {
+    printer << " " << factorKeyword << " ";
+    printer.printRegion(getLeftFactor());
+
+    printer << " " << factorKeyword << " ";
+    printer.printRegion(getRightFactor());
+
+    printer << " " << keysKeyword << " " << getLeftKey() << ", " << getRightKey();
+
+    printer.printOptionalAttrDict((*this)->getAttrs(), {getLeftKeyAttrName(), getRightKeyAttrName()});
+}
+
+// The results line up with the two factors' yields exactly as a cross product's do, and
+// each key index has to name a column of its own factor's yield - it is what the join
+// matches on, so a key past the end names no column to read.
+LogicalResult HashJoin::verify() {
+    if (failed(verifyFactorResults(getOperation(), getLeftFactor(), getRightFactor()))) {
+        return failure();
+    }
+
+    const size_t leftCount = getFactorYield(getLeftFactor()).getColumns().size();
+    const size_t rightCount = getFactorYield(getRightFactor()).getColumns().size();
+
+    if (getLeftKey() >= leftCount) {
+        return emitOpError("left key column ") << getLeftKey() << " is past the "
+                                               << leftCount << " columns the left factor yields";
+    }
+
+    if (getRightKey() >= rightCount) {
+        return emitOpError("right key column ") << getRightKey() << " is past the "
+                                                << rightCount << " columns the right factor yields";
     }
 
     return success();

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -898,8 +898,13 @@ def HashJoin : TuringOp<"hash_join", [Pure]> {
     `=` against a null gives null and the filter keeps only the true rows.
 
     The right factor is the built side and the left the probed one, so a left
-    row's matches come out together and in right-factor order - the order the
-    nested loop this replaces emitted the surviving rows in.
+    row's matches come out together and in right-factor order, however either
+    side was chunked. That is not the order the product and its filter emitted
+    the surviving rows in: the product re-runs its right factor once per chunk
+    of the left, so a right side spanning several chunks interleaves them. Row
+    order is what an ORDER BY is for, so the fusion is free to change it - but
+    a LIMIT with no ORDER BY over a join can keep other rows than the same
+    LIMIT over the product.
 
     As on db.cross_product the result types are not spelled after the regions;
     the parser recovers them from the two yields and the verifier checks they line

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -869,17 +869,80 @@ def CrossProduct : TuringOp<"cross_product", [Pure]> {
 }
 
 /**
-* Yield
+* HashJoin
 */
-def Yield : TuringOp<"yield", [Pure, Terminator, HasParent<"CrossProduct">]> {
-  let summary = "Name the columns a cross_product factor contributes to the result";
+def HashJoin : TuringOp<"hash_join", [Pure]> {
+  let summary = "Cross two column dataflows, keeping the rows their key columns agree on";
 
   let description = [{
-    Terminates a db.cross_product factor region, naming the columns that factor
-    contributes to the product. The cross_product's results are the left
+    The fused form of a db.cross_product whose product one db.filter cuts by a
+    single db.eq between a column of each factor - an inner equi-join. It holds
+    each side the way the product does, in its own region ending in a db.yield,
+    and its results are the left factor's yielded columns followed by the right
+    factor's.
+
+      %a, %ka, %b, %kb = db.hash_join factor {
+        %x = db.scan_nodes() : !db.column<!storage.node_id>
+        %k = db.get_node_properties(%x, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+        db.yield %x, %k : !db.column<!storage.node_id>, !db.column<none>
+      } factor {
+        %y = db.scan_nodes() : !db.column<!storage.node_id>
+        %k = db.get_node_properties(%y, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+        db.yield %y, %k : !db.column<!storage.node_id>, !db.column<none>
+      } on 1, 1
+
+    `on` names the key column of each side as an index into that factor's
+    db.yield - the left factor's first, the right factor's second. A result row
+    pairs a left row with a right row whose keys hold the same value. A row whose
+    key is null joins with nothing, which is what the equality it replaces did:
+    `=` against a null gives null and the filter keeps only the true rows.
+
+    The right factor is the built side and the left the probed one, so a left
+    row's matches come out together and in right-factor order - the order the
+    nested loop this replaces emitted the surviving rows in.
+
+    As on db.cross_product the result types are not spelled after the regions;
+    the parser recovers them from the two yields and the verifier checks they line
+    up. Reading the graph is deterministic, so the op is Pure.
+  }];
+
+  // Which column of each factor's yield carries the join key: the left factor's,
+  // then the right factor's.
+  let arguments = (ins UI64Attr:$leftKey, UI64Attr:$rightKey);
+
+  // The results are the concatenation of the two factors' yielded columns; the
+  // count and types are recovered from the yields, never spelled out.
+  let results = (outs Variadic<Column>:$results);
+
+  // Each factor is exactly one block: a self-contained dataflow ending in a
+  // db.yield, with no operands and no block arguments.
+  let regions = (region SizedRegion<1>:$leftFactor, SizedRegion<1>:$rightFactor);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  // The only builder takes the result types and the two key indices and creates
+  // the two empty factor blocks; the caller fills each region and terminates it
+  // with a db.yield whose operands match the result types contributed by that
+  // factor.
+  let skipDefaultBuilders = 1;
+  let builders = [
+      OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "uint64_t":$leftKey, "uint64_t":$rightKey)>
+  ];
+}
+
+/**
+* Yield
+*/
+def Yield : TuringOp<"yield", [Pure, Terminator, ParentOneOf<["CrossProduct", "HashJoin"]>]> {
+  let summary = "Name the columns a factor contributes to the result of the op holding it";
+
+  let description = [{
+    Terminates a factor region of a db.cross_product or a db.hash_join, naming
+    the columns that factor contributes. Either op's results are the left
     factor's yielded columns followed by the right factor's. A factor must yield
-    at least one column - the cross_product verifier rejects an empty yield,
-    since a side's row count is read from its first yielded column.
+    at least one column - the holder's verifier rejects an empty yield, since a
+    side's row count is read from its first yielded column.
   }];
 
   let arguments = (ins Variadic<Column>:$columns);
@@ -887,8 +950,8 @@ def Yield : TuringOp<"yield", [Pure, Terminator, HasParent<"CrossProduct">]> {
   // The yielded column types vary from query to query and cannot be built from
   // a recipe, so - when present - they are spelled after the colon, as in
   // db.output. The optional group, anchored on the operands, keeps the syntax
-  // total: an empty yield (`db.yield`) still parses, then the cross_product
-  // verifier rejects it with a clear db-level diagnostic.
+  // total: an empty yield (`db.yield`) still parses, then the holder's verifier
+  // rejects it with a clear db-level diagnostic.
   let assemblyFormat = "( $columns^ `:` qualified(type($columns)) )? attr-dict";
 }
 

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2036,12 +2036,15 @@ StringAttr conePropertyName(const MaskCone& cone) {
 // key against a probe key by the bytes each serializes to, so two columns that could
 // serialize differently - an integer property against a string one, a node against a
 // number - would answer a comparison the equality did not. A db column type is concrete
-// only for the entity and metadata columns; a property column is typed none until
-// lowering resolves the name against the schema, so for those the name is what the two
-// sides have to share.
+// only for the entity and metadata columns; a column typed none carries no type at all
+// until lowering resolves it, so two of those are only provably alike when both are read
+// from one property name.
 bool keysShareAColumnType(const JoinKeySide& left, const JoinKeySide& right) {
     if (left._cone._ops.empty() && right._cone._ops.empty()) {
-        return left._key.getType() == right._key.getType();
+        const Type leftType = left._key.getType();
+        const bool typeIsResolved = !isa<mlir::NoneType>(cast<ColumnType>(leftType).getType());
+
+        return typeIsResolved && leftType == right._key.getType();
     }
 
     const StringAttr leftProperty = conePropertyName(left._cone);

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1,6 +1,7 @@
 #include "DBPasses.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
@@ -2161,6 +2162,19 @@ bool factorHoldsAProduct(Region& factor) {
     return walked.wasInterrupted();
 }
 
+// The label set a scan's label names stand for, resolved against the schema.
+void collectScanLabels(ArrayAttr labelNames, const ::db::GraphMetadata& metadata, ::db::LabelSet& labels) {
+    const ::db::LabelMap& labelMap = metadata.labels();
+    for (const Attribute labelAttr : labelNames) {
+        const llvm::StringRef name = cast<StringAttr>(labelAttr).getValue();
+        const std::optional<::db::LabelID> label = labelMap.get(std::string_view(name.data(), name.size()));
+
+        if (label) {
+            labels.set(*label);
+        }
+    }
+}
+
 // The label set the rows of one side are scanned under, when the db level knows one: the
 // labels of a by-label node scan, and none at all otherwise - every node of the graph,
 // which is what the v2 planner estimates a variable with no label constraint at.
@@ -2176,15 +2190,7 @@ void keySideLabels(const JoinKeySide& side,
         return;
     }
 
-    const ::db::LabelMap& labelMap = metadata.labels();
-    for (const Attribute labelAttr : scan.getLabels()) {
-        const llvm::StringRef name = cast<StringAttr>(labelAttr).getValue();
-        const std::optional<::db::LabelID> label = labelMap.get(std::string_view(name.data(), name.size()));
-
-        if (label) {
-            labels.set(*label);
-        }
-    }
+    collectScanLabels(scan.getLabels(), metadata, labels);
 }
 
 // The row budget a limit downstream of the cut puts on the rows the join would emit, and
@@ -2251,6 +2257,84 @@ bool prefersTheProduct(const EqualityCross& match, const DBPassContext& context)
     return estimation.shouldPreferCartesian(leftLabels, rightLabels, limitOverTheCut(match._filter));
 }
 
+// Whether an op seeds a factor with a row per node it selects.
+bool isNodeScan(Operation* op) {
+    return isa<ScanNodes, ScanNodesByLabel, ConstScanNodes, ScanNodesByPropertyValue>(op);
+}
+
+// The rows a node scan selects, as the graph says. A listed set of IDs is its own count; a
+// by-label scan is what the graph holds under those labels, which is also all a property
+// scan can be read at - selectivity is not something the db level knows.
+size_t estimateScanRows(Operation* scan,
+                        const ::db::GraphMetadata& metadata,
+                        const ::db::CardinalityEstimation& estimation) {
+    if (ConstScanNodes constScan = dyn_cast<ConstScanNodes>(scan)) {
+        return constScan.getNodeIDs().size();
+    }
+
+    ::db::LabelSet labels;
+    if (ScanNodesByLabel byLabel = dyn_cast<ScanNodesByLabel>(scan)) {
+        collectScanLabels(byLabel.getLabels(), metadata, labels);
+    }
+
+    return estimation.estimateNodeCount(labels);
+}
+
+// The rows a factor makes: the product of the node counts its scans select, a factor
+// crossing two of them holding a row per pair. A factor seeded from somewhere the db level
+// cannot count - a procedure, a load, an edge scan - counts as the ten rows the v2 planner
+// reads a yielded item at.
+size_t estimateFactorRows(Region& factor,
+                          const ::db::GraphMetadata& metadata,
+                          const ::db::CardinalityEstimation& estimation) {
+    constexpr size_t uncountedSourceRows = 10;
+    constexpr size_t rowCeiling = std::numeric_limits<size_t>::max();
+
+    bool countedAScan = false;
+    size_t rows = 1;
+
+    factor.walk([&](Operation* op) {
+        if (!isNodeScan(op)) {
+            return;
+        }
+
+        const size_t scanned = estimateScanRows(op, metadata, estimation);
+        countedAScan = true;
+        rows = (scanned != 0 && rows > rowCeiling / scanned) ? rowCeiling : rows * scanned;
+    });
+
+    return countedAScan ? rows : uncountedSourceRows;
+}
+
+// Which way round the two sides go into the join, whose right factor is the built one. The
+// built side is buffered whole and indexed while the probed side streams a chunk at a
+// time, so the side to build is the smaller - and the side never to build is one holding a
+// product, whose rows multiply where a scan's are linear, whatever either side counts.
+bool buildsTheLeftFactor(const EqualityCross& match, const DBPassContext& context) {
+    CrossProduct product = match._product;
+    Region& leftFactor = product.getLeftFactor();
+    Region& rightFactor = product.getRightFactor();
+
+    const bool leftHoldsAProduct = factorHoldsAProduct(leftFactor);
+    const bool rightHoldsAProduct = factorHoldsAProduct(rightFactor);
+    if (leftHoldsAProduct != rightHoldsAProduct) {
+        return rightHoldsAProduct;
+    }
+
+    // Alike that far and no graph to count them against, so the right factor is built, the
+    // way db.hash_join reads its two regions.
+    if (!context._view) {
+        return false;
+    }
+
+    const ::db::GraphView& view = *context._view;
+    const ::db::GraphMetadata& metadata = view.metadata();
+    const ::db::CardinalityEstimation estimation(view);
+
+    return estimateFactorRows(leftFactor, metadata, estimation)
+         < estimateFactorRows(rightFactor, metadata, estimation);
+}
+
 bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
     EqOp equality = filter.getMask().getDefiningOp<EqOp>();
     if (!equality || !equality.getResult().hasOneUse()) {
@@ -2303,20 +2387,7 @@ bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
         return false;
     }
 
-    const bool carriesProductColumns = carriesProductColumnsOnly(filter, product);
-    const bool rowsReachOnlyTheCut = productRowsReachOnly(product, match);
-    if (!carriesProductColumns || !rowsReachOnlyTheCut) {
-        return false;
-    }
-
-    // With neither side or both holding a product there is nothing to tell them apart -
-    // no cardinality is known here - so the right factor is built, the way db.hash_join
-    // reads its two regions.
-    const bool leftHoldsAProduct = factorHoldsAProduct(product.getLeftFactor());
-    const bool rightHoldsAProduct = factorHoldsAProduct(product.getRightFactor());
-    match._buildsTheLeftFactor = rightHoldsAProduct && !leftHoldsAProduct;
-
-    return true;
+    return carriesProductColumnsOnly(filter, product) && productRowsReachOnly(product, match);
 }
 
 // Sinks the ops rebuilding a side's key into its factor, so the key becomes a column the
@@ -2432,9 +2503,12 @@ struct FuseHashJoin : public impl::FuseHashJoinBase<FuseHashJoin> {
         llvm::SmallVector<EqualityCross, 2> matches;
         root->walk([&matches, &context](FilterOp filter) {
             EqualityCross match;
-            if (matchEqualityCross(filter, match) && !prefersTheProduct(match, context)) {
-                matches.push_back(match);
+            if (!matchEqualityCross(filter, match) || prefersTheProduct(match, context)) {
+                return;
             }
+
+            match._buildsTheLeftFactor = buildsTheLeftFactor(match, context);
+            matches.push_back(match);
         });
 
         mlir::OpBuilder builder(&getContext());

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2326,17 +2326,10 @@ struct FuseHashJoin : public impl::FuseHashJoinBase<FuseHashJoin> {
         Operation* const root = getOperation();
 
         // Collect the matches first: fusing erases ops, which would invalidate the walk.
-        // Fusing a product leaves nothing for a second filter over the same rows to match,
-        // so the first filter to reach a product is the one that takes it.
         llvm::SmallVector<EqualityCross, 2> matches;
-        llvm::SmallPtrSet<Operation*, 4> matchedProducts;
-        root->walk([&matches, &matchedProducts](FilterOp filter) {
+        root->walk([&matches](FilterOp filter) {
             EqualityCross match;
-            if (!matchEqualityCross(filter, match)) {
-                return;
-            }
-
-            if (matchedProducts.insert(match._product.getOperation()).second) {
+            if (matchEqualityCross(filter, match)) {
                 matches.push_back(match);
             }
         });

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -15,6 +15,11 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include "CardinalityEstimation.h"
+#include "metadata/GraphMetadata.h"
+#include "metadata/LabelSet.h"
+#include "views/GraphView.h"
+
 #include "IRConstantColumn.h"
 #include "PropertyScanLiteral.h"
 #include "DBOps.h"
@@ -2156,6 +2161,96 @@ bool factorHoldsAProduct(Region& factor) {
     return walked.wasInterrupted();
 }
 
+// The label set the rows of one side are scanned under, when the db level knows one: the
+// labels of a by-label node scan, and none at all otherwise - every node of the graph,
+// which is what the v2 planner estimates a variable with no label constraint at.
+void keySideLabels(const JoinKeySide& side,
+                   size_t factorFirstResult,
+                   const ::db::GraphMetadata& metadata,
+                   ::db::LabelSet& labels) {
+    Yield yield = cast<Yield>(side._factor->front().getTerminator());
+    const size_t columnIndex = cast<OpResult>(side._column).getResultNumber() - factorFirstResult;
+
+    ScanNodesByLabel scan = yield.getColumns()[columnIndex].getDefiningOp<ScanNodesByLabel>();
+    if (!scan) {
+        return;
+    }
+
+    const ::db::LabelMap& labelMap = metadata.labels();
+    for (const Attribute labelAttr : scan.getLabels()) {
+        const llvm::StringRef name = cast<StringAttr>(labelAttr).getValue();
+        const std::optional<::db::LabelID> label = labelMap.get(std::string_view(name.data(), name.size()));
+
+        if (label) {
+            labels.set(*label);
+        }
+    }
+}
+
+// The row budget a limit downstream of the cut puts on the rows the join would emit, and
+// zero when none governs them. A product stops as soon as the budget is met, where the
+// join reads its whole build side before it can emit a row, which is what tips a small
+// budget back towards the product.
+uint64_t limitOverTheCut(FilterOp filter) {
+    llvm::SmallVector<Operation*, 8> pending;
+    llvm::SmallPtrSet<Operation*, 8> visited;
+    for (const Value column : filter.getFilteredColumns()) {
+        for (Operation* const user : column.getUsers()) {
+            if (visited.insert(user).second) {
+                pending.push_back(user);
+            }
+        }
+    }
+
+    while (!pending.empty()) {
+        Operation* const op = pending.pop_back_val();
+        if (Limit limit = dyn_cast<Limit>(op)) {
+            return limit.getCount();
+        }
+
+        for (const Value result : op->getResults()) {
+            for (Operation* const user : result.getUsers()) {
+                if (visited.insert(user).second) {
+                    pending.push_back(user);
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+// Whether the cut is better left as the product it stands as. The join reads its build
+// side whole before emitting a row and indexes every key it holds, which a small product
+// - or a small limit over a large one - never repays, so the shape alone does not settle
+// which form to run: this is the v2 planner's verdict (ReadStmtGenerator::
+// shouldPlaceValueHashJoin), answered by the same CardinalityEstimation over the node
+// counts of each side's labels.
+bool prefersTheProduct(const EqualityCross& match, const DBPassContext& context) {
+    if (context._forcesHashJoin) {
+        return false;
+    } else if (!context._usesHashJoin) {
+        return true;
+    } else if (!context._view) {
+        return false;
+    }
+
+    const ::db::GraphView& view = *context._view;
+    const ::db::GraphMetadata& metadata = view.metadata();
+
+    CrossProduct product = match._product;
+    const size_t leftFactorColumns = factorYieldColumns(product.getLeftFactor()).size();
+
+    ::db::LabelSet leftLabels;
+    ::db::LabelSet rightLabels;
+    keySideLabels(match._left, 0, metadata, leftLabels);
+    keySideLabels(match._right, leftFactorColumns, metadata, rightLabels);
+
+    const ::db::CardinalityEstimation estimation(view);
+
+    return estimation.shouldPreferCartesian(leftLabels, rightLabels, limitOverTheCut(match._filter));
+}
+
 bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
     EqOp equality = filter.getMask().getDefiningOp<EqOp>();
     if (!equality || !equality.getResult().hasOneUse()) {
@@ -2322,14 +2417,22 @@ void fuseHashJoin(EqualityCross& match, mlir::OpBuilder& builder) {
 }
 
 struct FuseHashJoin : public impl::FuseHashJoinBase<FuseHashJoin> {
+    FuseHashJoin() {}
+
+    FuseHashJoin(const DBPassContext& context)
+        : _context(context)
+    {
+    }
+
     void runOnOperation() override {
         Operation* const root = getOperation();
 
         // Collect the matches first: fusing erases ops, which would invalidate the walk.
+        const DBPassContext& context = _context;
         llvm::SmallVector<EqualityCross, 2> matches;
-        root->walk([&matches](FilterOp filter) {
+        root->walk([&matches, &context](FilterOp filter) {
             EqualityCross match;
-            if (matchEqualityCross(filter, match)) {
+            if (matchEqualityCross(filter, match) && !prefersTheProduct(match, context)) {
                 matches.push_back(match);
             }
         });
@@ -2339,8 +2442,15 @@ struct FuseHashJoin : public impl::FuseHashJoinBase<FuseHashJoin> {
             fuseHashJoin(match, builder);
         }
     }
+
+private:
+    DBPassContext _context;
 };
 
+}
+
+std::unique_ptr<Pass> createFuseHashJoin(const DBPassContext& context) {
+    return std::make_unique<FuseHashJoin>(context);
 }
 
 }

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2281,27 +2281,66 @@ std::optional<size_t> estimateSourceRows(Operation* op,
     return std::nullopt;
 }
 
+// The ratio an op multiplies the rows it reads by, and nothing when it hands them on as
+// they come. A hop makes the graph's average degree of rows per row it reads - all the db
+// level can say of a hop out of a node it cannot name - and an undirected one walks both
+// directions, so twice that. It is a ratio rather than a count because a graph with fewer
+// edges than nodes has a hop shrink its input rather than grow it.
+struct RowMultiplier {
+    size_t _numerator {1};
+    size_t _denominator {1};
+};
+
+std::optional<RowMultiplier> estimateRowMultiplier(Operation* op, const ::db::CardinalityEstimation& estimation) {
+    const bool walksOneDirection = isa<GetOutEdges, GetInEdges, GetOutEdgesByType, GetInEdgesByType>(op);
+    const bool walksBoth = isa<GetEdges>(op);
+    if (!walksOneDirection && !walksBoth) {
+        return std::nullopt;
+    }
+
+    const size_t nodeCount = estimation.estimateNodeCount(::db::LabelSet {});
+    if (nodeCount == 0) {
+        return std::nullopt;
+    }
+
+    const size_t edgeCount = estimation.estimateEdgeCount();
+
+    return RowMultiplier {walksBoth ? 2 * edgeCount : edgeCount, nodeCount};
+}
+
+size_t multiplySaturating(size_t rows, size_t factor) {
+    constexpr size_t rowCeiling = std::numeric_limits<size_t>::max();
+    if (factor != 0 && rows > rowCeiling / factor) {
+        return rowCeiling;
+    }
+
+    return rows * factor;
+}
+
 // The rows a factor makes: the product of what its sources seed it with, a factor crossing
-// two of them holding a row per pair. A factor seeded from somewhere the db level cannot
-// count - a procedure, a load - counts as the ten rows the v2 planner reads a yielded item
-// at.
+// two of them holding a row per pair, grown or shrunk by every hop walked from one. A
+// factor seeded from somewhere the db level cannot count - a procedure, a load - counts as
+// the ten rows the v2 planner reads a yielded item at.
 size_t estimateFactorRows(Region& factor,
                           const ::db::GraphMetadata& metadata,
                           const ::db::CardinalityEstimation& estimation) {
     constexpr size_t uncountedSourceRows = 10;
-    constexpr size_t rowCeiling = std::numeric_limits<size_t>::max();
 
     bool countedASource = false;
     size_t rows = 1;
 
     factor.walk([&](Operation* op) {
         const std::optional<size_t> seeded = estimateSourceRows(op, metadata, estimation);
-        if (!seeded) {
+        if (seeded) {
+            countedASource = true;
+            rows = multiplySaturating(rows, *seeded);
             return;
         }
 
-        countedASource = true;
-        rows = (*seeded != 0 && rows > rowCeiling / *seeded) ? rowCeiling : rows * *seeded;
+        const std::optional<RowMultiplier> multiplier = estimateRowMultiplier(op, estimation);
+        if (multiplier) {
+            rows = multiplySaturating(rows, multiplier->_numerator) / multiplier->_denominator;
+        }
     });
 
     return countedASource ? rows : uncountedSourceRows;

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2005,13 +2005,15 @@ struct JoinKeySide {
 };
 
 // A cross product cut by one equality between a column of each factor, and the filter
-// applying it: what a hash join is made of.
+// applying it: what a hash join is made of. _buildsTheLeftFactor says which way round the
+// two go into the join, whose right factor is the built side.
 struct EqualityCross {
     CrossProduct _product {nullptr};
     EqOp _equality {nullptr};
     FilterOp _filter {nullptr};
     JoinKeySide _left;
     JoinKeySide _right;
+    bool _buildsTheLeftFactor {false};
 };
 
 // The property a one-op key cone reads, null for any other cone. A property column's
@@ -2138,6 +2140,22 @@ bool carriesProductColumnsOnly(FilterOp filter, CrossProduct product) {
     return true;
 }
 
+// Whether a factor's rows are the product of two relations'. The built side is buffered
+// whole while the probed side streams a chunk at a time, so a factor holding a product -
+// which is where the cascade of a comma pattern puts one - is the side to probe: its rows
+// multiply where a scan or a traversal contributes them linearly.
+bool factorHoldsAProduct(Region& factor) {
+    const WalkResult walked = factor.walk([](Operation* op) {
+        if (isa<CrossProduct, HashJoin>(op)) {
+            return WalkResult::interrupt();
+        }
+
+        return WalkResult::advance();
+    });
+
+    return walked.wasInterrupted();
+}
+
 bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
     EqOp equality = filter.getMask().getDefiningOp<EqOp>();
     if (!equality || !equality.getResult().hasOneUse()) {
@@ -2190,7 +2208,20 @@ bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
         return false;
     }
 
-    return carriesProductColumnsOnly(filter, product) && productRowsReachOnly(product, match);
+    const bool carriesProductColumns = carriesProductColumnsOnly(filter, product);
+    const bool rowsReachOnlyTheCut = productRowsReachOnly(product, match);
+    if (!carriesProductColumns || !rowsReachOnlyTheCut) {
+        return false;
+    }
+
+    // With neither side or both holding a product there is nothing to tell them apart -
+    // no cardinality is known here - so the right factor is built, the way db.hash_join
+    // reads its two regions.
+    const bool leftHoldsAProduct = factorHoldsAProduct(product.getLeftFactor());
+    const bool rightHoldsAProduct = factorHoldsAProduct(product.getRightFactor());
+    match._buildsTheLeftFactor = rightHoldsAProduct && !leftHoldsAProduct;
+
+    return true;
 }
 
 // Sinks the ops rebuilding a side's key into its factor, so the key becomes a column the
@@ -2230,24 +2261,38 @@ void fuseHashJoin(EqualityCross& match, mlir::OpBuilder& builder) {
     const size_t leftKey = sinkKeyIntoFactor(match._left, 0, builder);
     const size_t rightKey = sinkKeyIntoFactor(match._right, leftCount, builder);
 
+    // The join probes its left factor and builds its right, so the two sides go in the
+    // way round the match chose rather than the way round the product held them.
+    const bool buildsTheLeftFactor = match._buildsTheLeftFactor;
+    Yield probeYield = buildsTheLeftFactor ? rightYield : leftYield;
+    Yield buildYield = buildsTheLeftFactor ? leftYield : rightYield;
+    Region& probeFactor = buildsTheLeftFactor ? product.getRightFactor() : product.getLeftFactor();
+    Region& buildFactor = buildsTheLeftFactor ? product.getLeftFactor() : product.getRightFactor();
+
     llvm::SmallVector<Type> resultTypes;
-    llvm::append_range(resultTypes, leftYield.getColumns().getTypes());
-    llvm::append_range(resultTypes, rightYield.getColumns().getTypes());
+    llvm::append_range(resultTypes, probeYield.getColumns().getTypes());
+    llvm::append_range(resultTypes, buildYield.getColumns().getTypes());
+
+    const size_t probeKey = buildsTheLeftFactor ? rightKey : leftKey;
+    const size_t buildKey = buildsTheLeftFactor ? leftKey : rightKey;
 
     builder.setInsertionPoint(product);
-    HashJoin join = builder.create<HashJoin>(product.getLoc(), resultTypes, leftKey, rightKey);
-    join.getLeftFactor().takeBody(product.getLeftFactor());
-    join.getRightFactor().takeBody(product.getRightFactor());
+    HashJoin join = builder.create<HashJoin>(product.getLoc(), resultTypes, probeKey, buildKey);
+    join.getLeftFactor().takeBody(probeFactor);
+    join.getRightFactor().takeBody(buildFactor);
 
-    // Sinking a key widens that factor's yield, so a right-factor column sits further
-    // along in the join's results than it did in the product's.
-    const size_t joinLeftCount = leftYield.getNumOperands();
+    // Sinking a key widens that factor's yield, so a column of the side the join reads
+    // second sits further along in its results than it did in the product's.
+    const size_t joinProbeCount = probeYield.getNumOperands();
+    const size_t leftFirstResult = buildsTheLeftFactor ? joinProbeCount : 0;
+    const size_t rightFirstResult = buildsTheLeftFactor ? 0 : joinProbeCount;
+
     llvm::SmallVector<Value> joinColumns;
     for (size_t columnIndex = 0; columnIndex < leftCount; columnIndex++) {
-        joinColumns.push_back(join.getResult(columnIndex));
+        joinColumns.push_back(join.getResult(leftFirstResult + columnIndex));
     }
     for (size_t columnIndex = 0; columnIndex < rightCount; columnIndex++) {
-        joinColumns.push_back(join.getResult(joinLeftCount + columnIndex));
+        joinColumns.push_back(join.getResult(rightFirstResult + columnIndex));
     }
 
     // The join keeps only the rows the equality held on, so what the filter handed

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2086,17 +2086,28 @@ bool matchKeySide(Value key, JoinKeySide& side, CrossProduct& product) {
 }
 
 // Whether nothing but the equality reads the ops rebuilding a key. The cone is sunk into
-// the factor and dropped from here, so a reader left behind would lose its operand.
-bool keyConeIsPrivateTo(const MaskCone& cone, EqOp equality) {
+// the factor and dropped from here, so a reader left behind would lose its operand - the
+// exception being the filter carrying the key itself, which the join yields among its own
+// columns and hands to that reader instead.
+bool keyConeIsPrivateTo(const JoinKeySide& side, EqOp equality, FilterOp filter) {
     llvm::SmallPtrSet<Operation*, 8> coneOps;
-    for (Operation* const coneOp : cone._ops) {
+    for (Operation* const coneOp : side._cone._ops) {
         coneOps.insert(coneOp);
     }
 
     Operation* const equalityOp = equality.getOperation();
-    for (Operation* const coneOp : cone._ops) {
+    Operation* const filterOp = filter.getOperation();
+    Operation* const keyOp = side._key.getDefiningOp();
+
+    for (Operation* const coneOp : side._cone._ops) {
+        const bool holdsTheKey = coneOp == keyOp;
+
         for (Operation* const user : coneOp->getUsers()) {
-            if (user != equalityOp && !coneOps.contains(user)) {
+            const bool isTheEquality = user == equalityOp;
+            const bool isAnotherConeOp = coneOps.contains(user);
+            const bool carriesTheKey = holdsTheKey && user == filterOp;
+
+            if (!isTheEquality && !isAnotherConeOp && !carriesTheKey) {
                 return false;
             }
         }
@@ -2134,12 +2145,16 @@ bool productRowsReachOnly(CrossProduct product, const EqualityCross& match) {
     return true;
 }
 
-// Whether every column the filter carries is a column of the product. The join hands each
-// of them back as a result of its own, which it can only do for a column the product made:
-// one computed from them outside was computed over the rows the join no longer produces.
-bool carriesProductColumnsOnly(FilterOp filter, CrossProduct product) {
+// Whether every column the filter carries is one the join hands back as a result of its
+// own: a column the product made, or a key, which the join yields beside the columns its
+// factor already had. One computed from them outside was computed over the rows the join
+// no longer produces.
+bool carriesJoinColumnsOnly(FilterOp filter, const EqualityCross& match) {
     for (const Value carried : filter.getColumnsToFilter()) {
-        if (carried.getDefiningOp<CrossProduct>() != product) {
+        const bool isAProductColumn = carried.getDefiningOp<CrossProduct>() == match._product;
+        const bool isAKey = carried == match._left._key || carried == match._right._key;
+
+        if (!isAProductColumn && !isAKey) {
             return false;
         }
     }
@@ -2431,13 +2446,13 @@ bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
         return false;
     }
 
-    const bool conesArePrivate = keyConeIsPrivateTo(match._left._cone, equality)
-                                 && keyConeIsPrivateTo(match._right._cone, equality);
+    const bool conesArePrivate = keyConeIsPrivateTo(match._left, equality, filter)
+                                 && keyConeIsPrivateTo(match._right, equality, filter);
     if (!conesArePrivate) {
         return false;
     }
 
-    return carriesProductColumnsOnly(filter, product) && productRowsReachOnly(product, match);
+    return carriesJoinColumnsOnly(filter, match) && productRowsReachOnly(product, match);
 }
 
 // Sinks the ops rebuilding a side's key into its factor, so the key becomes a column the
@@ -2511,13 +2526,26 @@ void fuseHashJoin(EqualityCross& match, mlir::OpBuilder& builder) {
         joinColumns.push_back(join.getResult(rightFirstResult + columnIndex));
     }
 
+    // A sunk key sits past the columns its factor already yielded, so it is none of those.
+    const Value leftKeyColumn = join.getResult(leftFirstResult + leftKey);
+    const Value rightKeyColumn = join.getResult(rightFirstResult + rightKey);
+
     // The join keeps only the rows the equality held on, so what the filter handed
-    // downstream now comes from the join directly.
+    // downstream now comes from the join directly - a carried key from the column the
+    // join yields for it, which is that key over the joined rows.
     const Operation::operand_range carried = match._filter.getColumnsToFilter();
     const ResultRange filtered = match._filter.getFilteredColumns();
     for (size_t columnIndex = 0; columnIndex < carried.size(); columnIndex++) {
-        const unsigned productIndex = cast<OpResult>(carried[columnIndex]).getResultNumber();
-        filtered[columnIndex].replaceAllUsesWith(joinColumns[productIndex]);
+        const Value carriedColumn = carried[columnIndex];
+
+        if (carriedColumn == match._left._key) {
+            filtered[columnIndex].replaceAllUsesWith(leftKeyColumn);
+        } else if (carriedColumn == match._right._key) {
+            filtered[columnIndex].replaceAllUsesWith(rightKeyColumn);
+        } else {
+            const unsigned productIndex = cast<OpResult>(carriedColumn).getResultNumber();
+            filtered[columnIndex].replaceAllUsesWith(joinColumns[productIndex]);
+        }
     }
 
     for (size_t columnIndex = 0; columnIndex < joinColumns.size(); columnIndex++) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
@@ -2257,53 +2258,53 @@ bool prefersTheProduct(const EqualityCross& match, const DBPassContext& context)
     return estimation.shouldPreferCartesian(leftLabels, rightLabels, limitOverTheCut(match._filter));
 }
 
-// Whether an op seeds a factor with a row per node it selects.
-bool isNodeScan(Operation* op) {
-    return isa<ScanNodes, ScanNodesByLabel, ConstScanNodes, ScanNodesByPropertyValue>(op);
-}
-
-// The rows a node scan selects, as the graph says. A listed set of IDs is its own count; a
-// by-label scan is what the graph holds under those labels, which is also all a property
-// scan can be read at - selectivity is not something the db level knows.
-size_t estimateScanRows(Operation* scan,
-                        const ::db::GraphMetadata& metadata,
-                        const ::db::CardinalityEstimation& estimation) {
-    if (ConstScanNodes constScan = dyn_cast<ConstScanNodes>(scan)) {
+// The rows an op seeds a factor with, and nothing at all when it seeds none - a fetch, a
+// filter or a hop reads a column rather than making one. A listed set of IDs is its own
+// count, a by-label scan is what the graph holds under those labels, and a property scan
+// is read at the whole node count: selectivity is not something the db level knows.
+std::optional<size_t> estimateSourceRows(Operation* op,
+                                         const ::db::GraphMetadata& metadata,
+                                         const ::db::CardinalityEstimation& estimation) {
+    if (ConstScanNodes constScan = dyn_cast<ConstScanNodes>(op)) {
         return constScan.getNodeIDs().size();
-    }
-
-    ::db::LabelSet labels;
-    if (ScanNodesByLabel byLabel = dyn_cast<ScanNodesByLabel>(scan)) {
+    } else if (ScanNodesByLabel byLabel = dyn_cast<ScanNodesByLabel>(op)) {
+        ::db::LabelSet labels;
         collectScanLabels(byLabel.getLabels(), metadata, labels);
+
+        return estimation.estimateNodeCount(labels);
+    } else if (isa<ScanNodes, ScanNodesByPropertyValue>(op)) {
+        return estimation.estimateNodeCount(::db::LabelSet {});
+    } else if (isa<ScanEdges, ScanEdgesByType>(op)) {
+        return estimation.estimateEdgeCount();
     }
 
-    return estimation.estimateNodeCount(labels);
+    return std::nullopt;
 }
 
-// The rows a factor makes: the product of the node counts its scans select, a factor
-// crossing two of them holding a row per pair. A factor seeded from somewhere the db level
-// cannot count - a procedure, a load, an edge scan - counts as the ten rows the v2 planner
-// reads a yielded item at.
+// The rows a factor makes: the product of what its sources seed it with, a factor crossing
+// two of them holding a row per pair. A factor seeded from somewhere the db level cannot
+// count - a procedure, a load - counts as the ten rows the v2 planner reads a yielded item
+// at.
 size_t estimateFactorRows(Region& factor,
                           const ::db::GraphMetadata& metadata,
                           const ::db::CardinalityEstimation& estimation) {
     constexpr size_t uncountedSourceRows = 10;
     constexpr size_t rowCeiling = std::numeric_limits<size_t>::max();
 
-    bool countedAScan = false;
+    bool countedASource = false;
     size_t rows = 1;
 
     factor.walk([&](Operation* op) {
-        if (!isNodeScan(op)) {
+        const std::optional<size_t> seeded = estimateSourceRows(op, metadata, estimation);
+        if (!seeded) {
             return;
         }
 
-        const size_t scanned = estimateScanRows(op, metadata, estimation);
-        countedAScan = true;
-        rows = (scanned != 0 && rows > rowCeiling / scanned) ? rowCeiling : rows * scanned;
+        countedASource = true;
+        rows = (*seeded != 0 && rows > rowCeiling / *seeded) ? rowCeiling : rows * *seeded;
     });
 
-    return countedAScan ? rows : uncountedSourceRows;
+    return countedASource ? rows : uncountedSourceRows;
 }
 
 // Which way round the two sides go into the join, whose right factor is the built one. The

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -2258,15 +2258,22 @@ bool prefersTheProduct(const EqualityCross& match, const DBPassContext& context)
     return estimation.shouldPreferCartesian(leftLabels, rightLabels, limitOverTheCut(match._filter));
 }
 
+// What the db level puts on rows it cannot count - the figure the v2 planner reads a
+// yielded item at.
+constexpr size_t uncountableRows = 10;
+
 // The rows an op seeds a factor with, and nothing at all when it seeds none - a fetch, a
 // filter or a hop reads a column rather than making one. A listed set of IDs is its own
-// count, a by-label scan is what the graph holds under those labels, and a property scan
-// is read at the whole node count: selectivity is not something the db level knows.
+// count, a literal list one row per element, a by-label scan what the graph holds under
+// those labels, and a property scan the whole node count: selectivity is not something
+// the db level knows.
 std::optional<size_t> estimateSourceRows(Operation* op,
                                          const ::db::GraphMetadata& metadata,
                                          const ::db::CardinalityEstimation& estimation) {
     if (ConstScanNodes constScan = dyn_cast<ConstScanNodes>(op)) {
         return constScan.getNodeIDs().size();
+    } else if (UnwindConst unwind = dyn_cast<UnwindConst>(op)) {
+        return unwind.getElements().size();
     } else if (ScanNodesByLabel byLabel = dyn_cast<ScanNodesByLabel>(op)) {
         ::db::LabelSet labels;
         collectScanLabels(byLabel.getLabels(), metadata, labels);
@@ -2285,13 +2292,20 @@ std::optional<size_t> estimateSourceRows(Operation* op,
 // they come. A hop makes the graph's average degree of rows per row it reads - all the db
 // level can say of a hop out of a node it cannot name - and an undirected one walks both
 // directions, so twice that. It is a ratio rather than a count because a graph with fewer
-// edges than nodes has a hop shrink its input rather than grow it.
+// edges than nodes has a hop shrink its input rather than grow it. An unwind makes a row
+// per element of each row's list, whose length is a property of the rows themselves: no
+// statistic of the graph measures it, so it reads at the figure an uncountable source
+// does - where a literal list, whose elements are in the IR, is counted exactly instead.
 struct RowMultiplier {
     size_t _numerator {1};
     size_t _denominator {1};
 };
 
 std::optional<RowMultiplier> estimateRowMultiplier(Operation* op, const ::db::CardinalityEstimation& estimation) {
+    if (isa<Unwind>(op)) {
+        return RowMultiplier {uncountableRows, 1};
+    }
+
     const bool walksOneDirection = isa<GetOutEdges, GetInEdges, GetOutEdgesByType, GetInEdgesByType>(op);
     const bool walksBoth = isa<GetEdges>(op);
     if (!walksOneDirection && !walksBoth) {
@@ -2318,14 +2332,12 @@ size_t multiplySaturating(size_t rows, size_t factor) {
 }
 
 // The rows a factor makes: the product of what its sources seed it with, a factor crossing
-// two of them holding a row per pair, grown or shrunk by every hop walked from one. A
-// factor seeded from somewhere the db level cannot count - a procedure, a load - counts as
-// the ten rows the v2 planner reads a yielded item at.
+// two of them holding a row per pair, grown or shrunk by every hop and unwind reading from
+// one. A factor seeded from somewhere the db level cannot count - a procedure, a load -
+// counts as an uncountable source's rows.
 size_t estimateFactorRows(Region& factor,
                           const ::db::GraphMetadata& metadata,
                           const ::db::CardinalityEstimation& estimation) {
-    constexpr size_t uncountedSourceRows = 10;
-
     bool countedASource = false;
     size_t rows = 1;
 
@@ -2343,28 +2355,26 @@ size_t estimateFactorRows(Region& factor,
         }
     });
 
-    return countedASource ? rows : uncountedSourceRows;
+    return countedASource ? rows : uncountableRows;
 }
 
 // Which way round the two sides go into the join, whose right factor is the built one. The
 // built side is buffered whole and indexed while the probed side streams a chunk at a
-// time, so the side to build is the smaller - and the side never to build is one holding a
-// product, whose rows multiply where a scan's are linear, whatever either side counts.
+// time, so the side to build is the one making the fewer rows.
 bool buildsTheLeftFactor(const EqualityCross& match, const DBPassContext& context) {
     CrossProduct product = match._product;
     Region& leftFactor = product.getLeftFactor();
     Region& rightFactor = product.getRightFactor();
 
-    const bool leftHoldsAProduct = factorHoldsAProduct(leftFactor);
-    const bool rightHoldsAProduct = factorHoldsAProduct(rightFactor);
-    if (leftHoldsAProduct != rightHoldsAProduct) {
-        return rightHoldsAProduct;
-    }
-
-    // Alike that far and no graph to count them against, so the right factor is built, the
-    // way db.hash_join reads its two regions.
+    // With no graph to count either side against, a factor holding a product of its own is
+    // the one to probe - its rows multiply where a scan's are linear - and with neither or
+    // both holding one the right factor is built, the way db.hash_join reads its regions.
+    // The estimate needs no such proxy: it multiplies through the product itself.
     if (!context._view) {
-        return false;
+        const bool leftHoldsAProduct = factorHoldsAProduct(leftFactor);
+        const bool rightHoldsAProduct = factorHoldsAProduct(rightFactor);
+
+        return rightHoldsAProduct && !leftHoldsAProduct;
     }
 
     const ::db::GraphView& view = *context._view;

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -32,6 +32,7 @@ namespace mlir::db {
 #define GEN_PASS_DEF_FUSEEDGESBYTYPE
 #define GEN_PASS_DEF_FUSESCANEDGESBYTYPE
 #define GEN_PASS_DEF_REUSEPROPERTYREADS
+#define GEN_PASS_DEF_FUSEHASHJOIN
 #define GEN_PASS_DEF_TRIMUNREADCOLUMNS
 #include "DBPasses.h.inc"
 
@@ -1242,7 +1243,7 @@ bool matchCarrySetLayout(Operation* op, CarrySetLayout& layout) {
 bool trimsColumns(Operation* op) {
     CarrySetLayout layout;
 
-    return matchCarrySetLayout(op, layout) || isa<CrossProduct>(op);
+    return matchCarrySetLayout(op, layout) || isa<CrossProduct, HashJoin>(op);
 }
 
 size_t carriedCount(Operation* op, const CarrySetLayout& layout) {
@@ -1458,52 +1459,134 @@ void eraseUnkeptYields(Yield yield, const llvm::SmallBitVector& keep, size_t fir
     yield->eraseOperands(erased);
 }
 
-// A product's results are the columns its two factors yield; a result nobody reads leaves
-// the yield, and each factor keeps a row-carrying column to be sized by.
-void trimCrossProduct(CrossProduct product, mlir::OpBuilder& builder) {
-    Yield leftYield = cast<Yield>(product.getLeftFactor().front().getTerminator());
-    Yield rightYield = cast<Yield>(product.getRightFactor().front().getTerminator());
+// The db.yield ending a factor region of a two-factor op - db.cross_product, db.hash_join.
+Yield factorYield(Operation* op, unsigned factorIndex) {
+    return cast<Yield>(op->getRegion(factorIndex).front().getTerminator());
+}
+
+// The results a two-factor op has to keep: the ones something reads, the ones the op
+// itself matches on, and - since lowering sizes each side by a column of it - one
+// row-carrying column per factor. False when that is every result, so the caller leaves
+// the op alone.
+bool selectKeptFactorColumns(Operation* op, llvm::SmallBitVector& keep) {
+    Yield leftYield = factorYield(op, 0);
+    Yield rightYield = factorYield(op, 1);
     const size_t leftCount = leftYield.getNumOperands();
 
-    const Operation::result_range results = product.getResults();
+    const Operation::result_range results = op->getResults();
 
-    llvm::SmallBitVector keep(results.size());
+    keep.resize(results.size());
     for (size_t resultIndex = 0; resultIndex < results.size(); resultIndex++) {
         if (!results[resultIndex].use_empty()) {
             keep.set(resultIndex);
         }
     }
 
+    // A join reads its two key columns to match on whether or not anything downstream
+    // reads them, the way a sort orders by its keys.
+    if (HashJoin join = dyn_cast<HashJoin>(op)) {
+        keep.set(join.getLeftKey());
+        keep.set(leftCount + join.getRightKey());
+    }
+
     keepRowCarryingColumn(leftYield.getColumns(), 0, keep);
     keepRowCarryingColumn(rightYield.getColumns(), leftCount, keep);
 
-    if (keep.all()) {
-        return;
-    }
+    return !keep.all();
+}
 
-    llvm::SmallVector<Type> trimmedTypes;
+void keptResultTypes(Operation* op, const llvm::SmallBitVector& keep, llvm::SmallVectorImpl<Type>& types) {
+    const Operation::result_range results = op->getResults();
     for (size_t resultIndex = 0; resultIndex < results.size(); resultIndex++) {
         if (keep[resultIndex]) {
-            trimmedTypes.push_back(results[resultIndex].getType());
+            types.push_back(results[resultIndex].getType());
+        }
+    }
+}
+
+// Where a factor's key column lands once that factor's unkept columns are gone: the kept
+// columns of the factor ahead of it. firstIndex is where the factor's columns start among
+// the op's results.
+size_t trimmedKeyColumn(const llvm::SmallBitVector& keep, size_t firstIndex, size_t keyColumn) {
+    size_t trimmed = 0;
+    for (size_t columnIndex = 0; columnIndex < keyColumn; columnIndex++) {
+        if (keep[firstIndex + columnIndex]) {
+            trimmed++;
         }
     }
 
-    builder.setInsertionPoint(product);
-    CrossProduct trimmed = builder.create<CrossProduct>(product.getLoc(), trimmedTypes);
-    trimmed.getLeftFactor().takeBody(product.getLeftFactor());
-    trimmed.getRightFactor().takeBody(product.getRightFactor());
+    return trimmed;
+}
+
+// Hands the two factors to the op built in its place, drops the columns their yields no
+// longer name, and rewires every kept result. Shared by the cross product and the hash
+// join, which differ only in the op the caller built.
+void replaceWithTrimmedFactors(Operation* op,
+                               Operation* trimmed,
+                               const llvm::SmallBitVector& keep,
+                               size_t leftCount) {
+    Yield leftYield = factorYield(op, 0);
+    Yield rightYield = factorYield(op, 1);
+
+    trimmed->getRegion(0).takeBody(op->getRegion(0));
+    trimmed->getRegion(1).takeBody(op->getRegion(1));
 
     eraseUnkeptYields(leftYield, keep, 0);
     eraseUnkeptYields(rightYield, keep, leftCount);
 
+    const Operation::result_range results = op->getResults();
     size_t trimmedIndex = 0;
     for (size_t resultIndex = 0; resultIndex < results.size(); resultIndex++) {
         if (keep[resultIndex]) {
-            results[resultIndex].replaceAllUsesWith(trimmed.getResult(trimmedIndex++));
+            results[resultIndex].replaceAllUsesWith(trimmed->getResult(trimmedIndex++));
         }
     }
 
-    product.erase();
+    op->erase();
+}
+
+// A product's results are the columns its two factors yield; a result nobody reads leaves
+// the yield, and each factor keeps a row-carrying column to be sized by.
+void trimCrossProduct(CrossProduct product, mlir::OpBuilder& builder) {
+    Operation* const productOp = product.getOperation();
+
+    llvm::SmallBitVector keep;
+    if (!selectKeptFactorColumns(productOp, keep)) {
+        return;
+    }
+
+    const size_t leftCount = factorYield(productOp, 0).getNumOperands();
+
+    llvm::SmallVector<Type> trimmedTypes;
+    keptResultTypes(productOp, keep, trimmedTypes);
+
+    builder.setInsertionPoint(product);
+    CrossProduct trimmed = builder.create<CrossProduct>(product.getLoc(), trimmedTypes);
+
+    replaceWithTrimmedFactors(productOp, trimmed.getOperation(), keep, leftCount);
+}
+
+// The product's sibling, with the two key columns kept on top of what is read and each
+// renumbered into the yield the trim leaves behind.
+void trimHashJoin(HashJoin join, mlir::OpBuilder& builder) {
+    Operation* const joinOp = join.getOperation();
+
+    llvm::SmallBitVector keep;
+    if (!selectKeptFactorColumns(joinOp, keep)) {
+        return;
+    }
+
+    const size_t leftCount = factorYield(joinOp, 0).getNumOperands();
+    const size_t leftKey = trimmedKeyColumn(keep, 0, join.getLeftKey());
+    const size_t rightKey = trimmedKeyColumn(keep, leftCount, join.getRightKey());
+
+    llvm::SmallVector<Type> trimmedTypes;
+    keptResultTypes(joinOp, keep, trimmedTypes);
+
+    builder.setInsertionPoint(join);
+    HashJoin trimmed = builder.create<HashJoin>(join.getLoc(), trimmedTypes, leftKey, rightKey);
+
+    replaceWithTrimmedFactors(joinOp, trimmed.getOperation(), keep, leftCount);
 }
 
 struct TrimUnreadColumns : public impl::TrimUnreadColumnsBase<TrimUnreadColumns> {
@@ -1524,11 +1607,14 @@ struct TrimUnreadColumns : public impl::TrimUnreadColumnsBase<TrimUnreadColumns>
             if (CrossProduct product = dyn_cast<CrossProduct>(op)) {
                 trimCrossProduct(product, builder);
                 continue;
+            } else if (HashJoin join = dyn_cast<HashJoin>(op)) {
+                trimHashJoin(join, builder);
+                continue;
             }
 
             CarrySetLayout layout;
             const bool carries = matchCarrySetLayout(op, layout);
-            bioassert(carries, "A trimming op that is not a cross product has a carry set");
+            bioassert(carries, "A trimming op that is neither a cross product nor a join has a carry set");
 
             llvm::SmallVector<size_t> kept;
             selectKeptCarriedColumns(op, layout, kept);
@@ -1904,6 +1990,312 @@ struct ReusePropertyReads : public impl::ReusePropertyReadsBase<ReusePropertyRea
 
             read->getResult(0).replaceAllUsesWith(reused);
             read->erase();
+        }
+    }
+};
+
+// One side of a join: the factor supplying its key, the product column the key is read
+// from, the ops computing one from the other, and - once sunk - where the key sits in the
+// factor's yield.
+struct JoinKeySide {
+    Region* _factor {nullptr};
+    Value _key;
+    Value _column;
+    MaskCone _cone;
+};
+
+// A cross product cut by one equality between a column of each factor, and the filter
+// applying it: what a hash join is made of.
+struct EqualityCross {
+    CrossProduct _product {nullptr};
+    EqOp _equality {nullptr};
+    FilterOp _filter {nullptr};
+    JoinKeySide _left;
+    JoinKeySide _right;
+};
+
+// The property a one-op key cone reads, null for any other cone. A property column's
+// value type is resolved from the name during lowering, so two keys read from one name
+// are two columns of one type.
+StringAttr conePropertyName(const MaskCone& cone) {
+    if (cone._ops.size() != 1) {
+        return nullptr;
+    }
+
+    Operation* const read = cone._ops.front();
+    if (GetNodeProperties nodeRead = dyn_cast<GetNodeProperties>(read)) {
+        return nodeRead.getPropertyAttr();
+    } else if (GetEdgeProperties edgeRead = dyn_cast<GetEdgeProperties>(read)) {
+        return edgeRead.getPropertyAttr();
+    }
+
+    return nullptr;
+}
+
+// Whether the two sides' keys are provably columns of one type. The join matches a build
+// key against a probe key by the bytes each serializes to, so two columns that could
+// serialize differently - an integer property against a string one, a node against a
+// number - would answer a comparison the equality did not. A db column type is concrete
+// only for the entity and metadata columns; a property column is typed none until
+// lowering resolves the name against the schema, so for those the name is what the two
+// sides have to share.
+bool keysShareAColumnType(const JoinKeySide& left, const JoinKeySide& right) {
+    if (left._cone._ops.empty() && right._cone._ops.empty()) {
+        return left._key.getType() == right._key.getType();
+    }
+
+    const StringAttr leftProperty = conePropertyName(left._cone);
+
+    return leftProperty && leftProperty == conePropertyName(right._cone);
+}
+
+// Reads into side the one product column a key is computed over, along with the ops
+// computing one from the other. False when the key reads no column, more than one, or one
+// a different cross product made - product names the one already matched, null for the
+// first side, and is set to the one this side found.
+bool matchKeySide(Value key, JoinKeySide& side, CrossProduct& product) {
+    side._key = key;
+    side._cone = collectMaskCone(key);
+
+    if (side._cone._inputs.size() != 1) {
+        return false;
+    }
+
+    side._column = side._cone._inputs.front();
+
+    CrossProduct keyProduct = side._column.getDefiningOp<CrossProduct>();
+    if (!keyProduct || (product && keyProduct != product)) {
+        return false;
+    }
+
+    product = keyProduct;
+
+    return true;
+}
+
+// Whether nothing but the equality reads the ops rebuilding a key. The cone is sunk into
+// the factor and dropped from here, so a reader left behind would lose its operand.
+bool keyConeIsPrivateTo(const MaskCone& cone, EqOp equality) {
+    llvm::SmallPtrSet<Operation*, 8> coneOps;
+    for (Operation* const coneOp : cone._ops) {
+        coneOps.insert(coneOp);
+    }
+
+    Operation* const equalityOp = equality.getOperation();
+    for (Operation* const coneOp : cone._ops) {
+        for (Operation* const user : coneOp->getUsers()) {
+            if (user != equalityOp && !coneOps.contains(user)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// Whether the product's rows reach nothing but the equality and the filter it masks. The
+// join emits the rows the filter kept, so a reader of the product's own rows would go
+// from seeing every pair to seeing only the matching ones.
+bool productRowsReachOnly(CrossProduct product, const EqualityCross& match) {
+    EqOp equality = match._equality;
+    FilterOp filter = match._filter;
+
+    llvm::SmallPtrSet<Operation*, 8> readers;
+    readers.insert(equality.getOperation());
+    readers.insert(filter.getOperation());
+
+    const JoinKeySide* const sides[] = {&match._left, &match._right};
+    for (const JoinKeySide* const side : sides) {
+        for (Operation* const coneOp : side->_cone._ops) {
+            readers.insert(coneOp);
+        }
+    }
+
+    for (const Value column : product.getResults()) {
+        for (Operation* const user : column.getUsers()) {
+            if (!readers.contains(user)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// Whether every column the filter carries is a column of the product. The join hands each
+// of them back as a result of its own, which it can only do for a column the product made:
+// one computed from them outside was computed over the rows the join no longer produces.
+bool carriesProductColumnsOnly(FilterOp filter, CrossProduct product) {
+    for (const Value carried : filter.getColumnsToFilter()) {
+        if (carried.getDefiningOp<CrossProduct>() != product) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool matchEqualityCross(FilterOp filter, EqualityCross& match) {
+    EqOp equality = filter.getMask().getDefiningOp<EqOp>();
+    if (!equality || !equality.getResult().hasOneUse()) {
+        return false;
+    }
+
+    match._filter = filter;
+    match._equality = equality;
+
+    // Either operand may name either factor, so the two sides are told apart by the
+    // factor each key's column belongs to rather than by the order they are written in.
+    CrossProduct product;
+    JoinKeySide first;
+    JoinKeySide second;
+    if (!matchKeySide(equality.getLhs(), first, product)
+        || !matchKeySide(equality.getRhs(), second, product)) {
+        return false;
+    }
+
+    if (product->getBlock() != filter->getBlock()) {
+        return false;
+    }
+
+    match._product = product;
+
+    const size_t leftCount = factorYieldColumns(product.getLeftFactor()).size();
+    const auto yieldedByTheLeftFactor = [leftCount](const JoinKeySide& side) {
+        return cast<OpResult>(side._column).getResultNumber() < leftCount;
+    };
+
+    // One key on each side is what makes this a join; two keys of one factor are a
+    // single-variable predicate, which the filter applies where it already stands.
+    if (yieldedByTheLeftFactor(first) == yieldedByTheLeftFactor(second)) {
+        return false;
+    }
+
+    const bool firstIsOnTheLeft = yieldedByTheLeftFactor(first);
+    match._left = firstIsOnTheLeft ? first : second;
+    match._right = firstIsOnTheLeft ? second : first;
+    match._left._factor = &product.getLeftFactor();
+    match._right._factor = &product.getRightFactor();
+
+    if (!keysShareAColumnType(match._left, match._right)) {
+        return false;
+    }
+
+    const bool conesArePrivate = keyConeIsPrivateTo(match._left._cone, equality)
+                                 && keyConeIsPrivateTo(match._right._cone, equality);
+    if (!conesArePrivate) {
+        return false;
+    }
+
+    return carriesProductColumnsOnly(filter, product) && productRowsReachOnly(product, match);
+}
+
+// Sinks the ops rebuilding a side's key into its factor, so the key becomes a column the
+// factor yields and the join can index it as that side is read. Answers where the key
+// lands in the yield: the column's own place when the key is that column, a fresh last
+// place when it is computed from it.
+size_t sinkKeyIntoFactor(JoinKeySide& side, size_t factorFirstResult, mlir::OpBuilder& builder) {
+    Yield yield = cast<Yield>(side._factor->front().getTerminator());
+    const size_t columnIndex = cast<OpResult>(side._column).getResultNumber() - factorFirstResult;
+
+    if (side._cone._ops.empty()) {
+        return columnIndex;
+    }
+
+    mlir::IRMapping mapping;
+    mapping.map(side._column, yield.getColumns()[columnIndex]);
+
+    builder.setInsertionPoint(yield);
+    for (Operation* const coneOp : side._cone._ops) {
+        builder.clone(*coneOp, mapping);
+    }
+
+    const size_t keyColumn = yield.getNumOperands();
+    yield->insertOperands(static_cast<unsigned>(keyColumn), mapping.lookup(side._key));
+
+    return keyColumn;
+}
+
+void fuseHashJoin(EqualityCross& match, mlir::OpBuilder& builder) {
+    CrossProduct product = match._product;
+
+    Yield leftYield = cast<Yield>(product.getLeftFactor().front().getTerminator());
+    Yield rightYield = cast<Yield>(product.getRightFactor().front().getTerminator());
+    const size_t leftCount = leftYield.getNumOperands();
+    const size_t rightCount = rightYield.getNumOperands();
+
+    const size_t leftKey = sinkKeyIntoFactor(match._left, 0, builder);
+    const size_t rightKey = sinkKeyIntoFactor(match._right, leftCount, builder);
+
+    llvm::SmallVector<Type> resultTypes;
+    llvm::append_range(resultTypes, leftYield.getColumns().getTypes());
+    llvm::append_range(resultTypes, rightYield.getColumns().getTypes());
+
+    builder.setInsertionPoint(product);
+    HashJoin join = builder.create<HashJoin>(product.getLoc(), resultTypes, leftKey, rightKey);
+    join.getLeftFactor().takeBody(product.getLeftFactor());
+    join.getRightFactor().takeBody(product.getRightFactor());
+
+    // Sinking a key widens that factor's yield, so a right-factor column sits further
+    // along in the join's results than it did in the product's.
+    const size_t joinLeftCount = leftYield.getNumOperands();
+    llvm::SmallVector<Value> joinColumns;
+    for (size_t columnIndex = 0; columnIndex < leftCount; columnIndex++) {
+        joinColumns.push_back(join.getResult(columnIndex));
+    }
+    for (size_t columnIndex = 0; columnIndex < rightCount; columnIndex++) {
+        joinColumns.push_back(join.getResult(joinLeftCount + columnIndex));
+    }
+
+    // The join keeps only the rows the equality held on, so what the filter handed
+    // downstream now comes from the join directly.
+    const Operation::operand_range carried = match._filter.getColumnsToFilter();
+    const ResultRange filtered = match._filter.getFilteredColumns();
+    for (size_t columnIndex = 0; columnIndex < carried.size(); columnIndex++) {
+        const unsigned productIndex = cast<OpResult>(carried[columnIndex]).getResultNumber();
+        filtered[columnIndex].replaceAllUsesWith(joinColumns[productIndex]);
+    }
+
+    for (size_t columnIndex = 0; columnIndex < joinColumns.size(); columnIndex++) {
+        product.getResult(columnIndex).replaceAllUsesWith(joinColumns[columnIndex]);
+    }
+
+    match._filter.erase();
+    match._equality.erase();
+
+    const JoinKeySide* const sides[] = {&match._left, &match._right};
+    for (const JoinKeySide* const side : sides) {
+        for (Operation* const coneOp : llvm::reverse(side->_cone._ops)) {
+            eraseIfUnused(coneOp);
+        }
+    }
+
+    product.erase();
+}
+
+struct FuseHashJoin : public impl::FuseHashJoinBase<FuseHashJoin> {
+    void runOnOperation() override {
+        Operation* const root = getOperation();
+
+        // Collect the matches first: fusing erases ops, which would invalidate the walk.
+        // Fusing a product leaves nothing for a second filter over the same rows to match,
+        // so the first filter to reach a product is the one that takes it.
+        llvm::SmallVector<EqualityCross, 2> matches;
+        llvm::SmallPtrSet<Operation*, 4> matchedProducts;
+        root->walk([&matches, &matchedProducts](FilterOp filter) {
+            EqualityCross match;
+            if (!matchEqualityCross(filter, match)) {
+                return;
+            }
+
+            if (matchedProducts.insert(match._product.getOperation()).second) {
+                matches.push_back(match);
+            }
+        });
+
+        mlir::OpBuilder builder(&getContext());
+        for (EqualityCross& match : matches) {
+            fuseHashJoin(match, builder);
         }
     }
 };

--- a/query/ir/dialect/db/DBPasses.h
+++ b/query/ir/dialect/db/DBPasses.h
@@ -4,6 +4,10 @@
 
 #include "DBDialect.h"
 
+namespace db {
+class GraphView;
+}
+
 namespace mlir::db {
 
 #define GEN_PASS_DECL
@@ -11,5 +15,19 @@ namespace mlir::db {
 
 #define GEN_PASS_REGISTRATION
 #include "DBPasses.h.inc"
+
+// What a pass reads from outside the IR. Only fuse_hash_join does: a cross product cut by
+// an equality is not always dearer than the join that replaces it, and which one wins
+// depends on the graph rather than on the program, so the cost model needs the graph the
+// query reads. _forcesHashJoin fuses every cut the pass matches whatever it estimates, and
+// clearing _usesHashJoin fuses none - the two overrides the v2 planner carries as well.
+// With no graph there is nothing to estimate, so every match fuses.
+struct DBPassContext {
+    const ::db::GraphView* _view {nullptr};
+    bool _forcesHashJoin {false};
+    bool _usesHashJoin {true};
+};
+
+std::unique_ptr<Pass> createFuseHashJoin(const DBPassContext& context);
 
 }

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -48,6 +48,11 @@ def ReusePropertyReads : Pass<"reuse_property_reads"> {
     let dependentDialects = ["mlir::db::DB"];
 }
 
+def FuseHashJoin : Pass<"fuse_hash_join"> {
+    let summary = "Fuse a cross product and the equality filter over it into a hash_join";
+    let dependentDialects = ["mlir::db::DB"];
+}
+
 def TrimUnreadColumns : Pass<"trim_unread_columns"> {
     let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products, grouping ops and calls";
     let dependentDialects = ["mlir::db::DB"];

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -378,17 +378,18 @@ LogicalResult HashJoinProbe::verify() {
         return emitOpError("requires at least one column to probe with");
     }
 
-    const ResultRange results = getResults();
-    if (results.size() < columns.size()) {
-        return emitOpError("expects a result per probe column and per build column, but has ")
-               << results.size() << " results for " << columns.size() << " probe columns";
+    const auto iteratorType = cast<IteratorType>(getResult().getType());
+    const ArrayRef<Type> chunkTypes = iteratorType.getChunkTypes();
+    if (chunkTypes.size() < columns.size()) {
+        return emitOpError("expects a chunk per probe column and per build column, but has ")
+               << chunkTypes.size() << " chunks for " << columns.size() << " probe columns";
     }
 
     for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
-        if (columns[columnIndex].getType() != results[columnIndex].getType()) {
-            return emitOpError("result ") << columnIndex
-                                          << " must have the same type as probe column "
-                                          << columnIndex;
+        if (columns[columnIndex].getType() != chunkTypes[columnIndex]) {
+            return emitOpError("chunk ") << columnIndex
+                                         << " must have the same type as probe column "
+                                         << columnIndex;
         }
     }
 

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -354,6 +354,43 @@ LogicalResult SortCollect::verify() {
     return success();
 }
 
+// An nl.hash_join_collect must append at least one column: the build side's row
+// count is read from the first buffer, and one of the columns is the key the
+// buffer op names.
+LogicalResult HashJoinCollect::verify() {
+    if (getColumns().empty()) {
+        return emitOpError("requires at least one column to collect");
+    }
+
+    return success();
+}
+
+// An nl.hash_join_probe reads at least one probe column - one of them is the key -
+// and emits the probe columns unchanged followed by the build ones, so it has at
+// least as many results as columns and the first of them keep the probe types.
+LogicalResult HashJoinProbe::verify() {
+    if (getColumns().empty()) {
+        return emitOpError("requires at least one column to probe with");
+    }
+
+    const OperandRange columns = getColumns();
+    const ResultRange results = getResults();
+    if (results.size() < columns.size()) {
+        return emitOpError("expects a result per probe column and per build column, but has ")
+               << results.size() << " results for " << columns.size() << " probe columns";
+    }
+
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        if (columns[columnIndex].getType() != results[columnIndex].getType()) {
+            return emitOpError("result ") << columnIndex
+                                          << " must have the same type as probe column "
+                                          << columnIndex;
+        }
+    }
+
+    return success();
+}
+
 // A distinct filter passes its columns through unchanged - only duplicate rows
 // are removed - so each result keeps its input column's chunk type, the same as
 // nl.limit_truncate.

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -369,11 +369,11 @@ LogicalResult HashJoinCollect::verify() {
 // and emits the probe columns unchanged followed by the build ones, so it has at
 // least as many results as columns and the first of them keep the probe types.
 LogicalResult HashJoinProbe::verify() {
-    if (getColumns().empty()) {
+    const OperandRange columns = getColumns();
+    if (columns.empty()) {
         return emitOpError("requires at least one column to probe with");
     }
 
-    const OperandRange columns = getColumns();
     const ResultRange results = getResults();
     if (results.size() < columns.size()) {
         return emitOpError("expects a result per probe column and per build column, but has ")

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -251,13 +251,17 @@ LogicalResult CrossProduct::inferReturnTypes(MLIRContext* context,
                                              std::optional<Location> location,
                                              CrossProduct::Adaptor adaptor,
                                              SmallVectorImpl<Type>& inferredReturnTypes) {
+    SmallVector<Type, 8> chunkTypes;
+
     for (const Type columnType : adaptor.getOuterColumns().getTypes()) {
-        inferredReturnTypes.push_back(columnType);
+        chunkTypes.push_back(columnType);
     }
 
     for (const Type columnType : adaptor.getInnerColumns().getTypes()) {
-        inferredReturnTypes.push_back(columnType);
+        chunkTypes.push_back(columnType);
     }
+
+    inferredReturnTypes.push_back(IteratorType::get(context, chunkTypes));
 
     return success();
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1214,9 +1214,11 @@ def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
 
     The results are the probe columns followed by the build columns, so they line
     up with the db.hash_join results this lowers from: the left (probed) factor's
-    yielded columns followed by the right (built) factor's. A probe row's matches
-    come out together and in build order, so the rows arrive in the order the
-    nested loop this replaces produced them in.
+    yielded columns followed by the right (built) factor's. The whole build side
+    is indexed before any probing, so a probe row's matches come out together and
+    in build order at any chunk size - where nl.cross_product, re-running the
+    inner nest per outer chunk, interleaves a multi-chunk inner side. Neither
+    order is one an ORDER BY constrains, so they may differ under a LIMIT.
 
     The build columns are not operands - they live in the handle - so their chunk
     types cannot be inferred and the whole result signature is spelled out, the

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1174,8 +1174,9 @@ def HashJoinCollect : NLOp<"hash_join_collect", []> {
     build column to the matching buffer of the handle and records where each row's
     key lands, so that by the time the build loop is exhausted the buffers hold
     every build row and the index answers any probe key. The columns are taken
-    together so the buffers stay row-aligned. A row whose key is null is buffered
-    like any other but left out of the index: null matches nothing.
+    together so the buffers stay row-aligned. A row whose key can match nothing is
+    buffered like any other but left out of the index: a null matches nothing, and
+    so does a NaN, or an embedding holding one, which no `=` calls equal.
 
       nl.hash_join_collect %state, (%b, %name) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
 

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -707,54 +707,55 @@ def Yield : NLOp<"yield", [Pure, Terminator, HasParent<"For">]> {
 * CrossProduct
 */
 def CrossProduct : NLOp<"cross_product", [Pure, InferTypeOpAdaptor, AttrSizedOperandSegments]> {
-  let summary = "Cross every row of one loop's chunks with every row of another";
+  let summary = "Create an iterator over every pair of one loop's chunk rows with another's";
 
   let description = [{
-    Given an outer chunk of N rows and an inner chunk of M rows it produces N*M
-    rows: each outer column is block-repeated x M (outer row i becomes M
-    consecutive rows) and each inner column is tiled x N (the whole inner chunk
-    repeated N times), so result row k pairs outer row k/M with inner row k%M -
-    every outer row against every inner row.
+    Given an outer chunk of N rows and an inner chunk of M rows the product has
+    N*M rows: pair k is outer row k/M with inner row k%M, so every outer row meets
+    every inner row. Each step of an enclosing nl.for fills one chunk of that
+    sequence - each outer column block-repeated and each inner column tiled over
+    the pairs the step covers:
 
-      %a, %b = nl.cross_product {%a} {%b}
+      %pairs = nl.cross_product {%a} {%b}
                  : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.for %ra, %rb in %pairs : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        ...
+      }
+
+    The product is the one operator whose result outgrows its inputs, so it is an
+    iterator rather than a straight-line op: laying all N*M rows out at once would
+    mean a chunk of 64Ki rows crossed with another holding 4.29e9 rows - 64 GiB for
+    two id columns. Chunked, a step holds the chunk size whatever the sides measure,
+    which is what the v2 CartesianProductProcessor does with its own cursor.
 
     The two brace groups are the columns each factor contributes, in db.yield
-    order; the op's results are the outer columns followed by the inner, each
-    result chunk keeping its input's element type - only the row count changes.
+    order; the iterator's chunk types are the outer columns' followed by the
+    inner's, each keeping its input's element type - only the row count changes.
     N and M are read from the first column of each group, so each group must be
-    non-empty.
+    non-empty, and every column of a group must be row-aligned with that first one.
 
-    An optional `limit` operand carries an !nl.limit_state handle. When present,
-    the product is built only up to limit.getRemaining() rows: rows are laid out in
-    (outer, inner) order, so the product's prefix is exactly the prefix the
-    following nl.limit_update/nl.output can emit this step, and building the rest
-    would be wasted work. Absent, the whole N*M product is built.
-
-      %a, %b = nl.cross_product {%a} {%b} limit %h
-                 : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+    A `limit` on the enclosing nl.for bounds the product the way it bounds a scan:
+    the loop stops once the budget is spent, and - since the pairs come out in
+    (outer, inner) order - a step lays out only the prefix the following
+    nl.limit_update/nl.output can still emit.
   }];
 
-  // The outer and inner column groups to cross, plus the optional limit handle.
-  // Three operand groups of independent size need AttrSizedOperandSegments to
-  // record each group's size.
+  // The outer and inner column groups to cross. Two operand groups of independent
+  // size need AttrSizedOperandSegments to record each group's size.
   let arguments = (ins Variadic<NLChunk>:$outer_columns,
-                       Variadic<NLChunk>:$inner_columns,
-                       Optional<NLLimitStateHandle>:$limit);
+                       Variadic<NLChunk>:$inner_columns);
 
-  // One result per crossed column, outer group then inner group; inferred from
-  // the operands since the broadcast keeps each chunk's element type.
-  let results = (outs Variadic<NLChunk>:$results);
+  // An iterator over the crossed columns, outer group then inner group; inferred
+  // from the operands since the broadcast keeps each chunk's element type.
+  let results = (outs NLIterator:$result);
 
-  // The two SSA brace groups mirror the two factors. The result types are
-  // inferred, so only the operand chunk types are spelled - the same two
-  // groups, each in braces, after the colon (as nl.output spells its chunk
-  // types). The optional limit handle, when present, prints after a `limit`
-  // keyword (its type is buildable and so omitted, as on nl.output). The
+  // The two SSA brace groups mirror the two factors. The result type is inferred,
+  // so only the operand chunk types are spelled - the same two groups, each in
+  // braces, after the colon (as nl.output spells its chunk types). The
   // operandSegmentSizes attribute is populated and elided automatically by the
   // generated parser/printer.
   let assemblyFormat = [{
-    `{` $outer_columns `}` `{` $inner_columns `}` (`limit` $limit^)? attr-dict `:`
+    `{` $outer_columns `}` `{` $inner_columns `}` attr-dict `:`
     `{` qualified(type($outer_columns)) `}` `{` qualified(type($inner_columns)) `}`
   }];
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1200,8 +1200,6 @@ def HashJoinCollect : NLOp<"hash_join_collect", []> {
 */
 // Pure: given a filled build side it deterministically produces the same matched
 // rows from the same probe chunk, and it writes only its own result chunks.
-// AttrSizedOperandSegments: the probe columns and the optional limit handle are two
-// operand groups of independent size, as on nl.cross_product.
 def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
   let summary = "Create an iterator over each probe row paired with the build rows its key matches";
   let description = [{

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1202,52 +1202,56 @@ def HashJoinCollect : NLOp<"hash_join_collect", []> {
 // rows from the same probe chunk, and it writes only its own result chunks.
 // AttrSizedOperandSegments: the probe columns and the optional limit handle are two
 // operand groups of independent size, as on nl.cross_product.
-def HashJoinProbe : NLOp<"hash_join_probe", [Pure, AttrSizedOperandSegments]> {
-  let summary = "Emit each probe row paired with the build rows its key matches";
+def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
+  let summary = "Create an iterator over each probe row paired with the build rows its key matches";
   let description = [{
-    Runs in the probe loop body, once per step, and stands where nl.cross_product
-    stands in a nested loop: it is what makes the join's rows. For each row of the
-    probe chunk it looks the row's key up in the handle's index and emits one row
-    per build row that matches - the probe row's columns repeated once per match,
+    Runs in the probe loop body and stands where nl.cross_product stands in a
+    nested loop: it is what makes the join's rows. For each row of the probe chunk
+    it looks the row's key up in the handle's index and pairs the row with every
+    build row that matches - the probe row's columns repeated once per match,
     beside the matched build row's columns read back from the buffers. A probe row
-    whose key is null, or whose key matches nothing, emits no row.
+    whose key is null, or whose key matches nothing, pairs with nothing.
 
-      %n, %name, %m = nl.hash_join_probe %state, (%arg0, %key)
+      %pairs = nl.hash_join_probe %state, (%arg0, %key)
           : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
-         -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>)
+         -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>>
+      nl.for %n, %name, %m in %pairs
+          : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>> {
+        ...
+      }
 
-    The results are the probe columns followed by the build columns, so they line
-    up with the db.hash_join results this lowers from: the left (probed) factor's
-    yielded columns followed by the right (built) factor's. The whole build side
-    is indexed before any probing, so a probe row's matches come out together and
-    in build order at any chunk size - where nl.cross_product, re-running the
-    inner nest per outer chunk, interleaves a multi-chunk inner side. Neither
-    order is one an ORDER BY constrains, so they may differ under a LIMIT.
+    A key that many build rows carry makes more pairs than either side holds, so -
+    like the cross product - this is an iterator rather than a straight-line op:
+    pairing a whole probe chunk at once means a side of 6345 rows sharing one key
+    lays out 40e6 rows in a single step. Chunked, a step holds the chunk size
+    whatever the fan-out measures, so a step may start and end partway through one
+    probe row's matches.
 
-    The build columns are not operands - they live in the handle - so their chunk
-    types cannot be inferred and the whole result signature is spelled out, the
-    way nl.sort spells its iterator's.
+    The iterator's chunks are the probe columns followed by the build columns, so
+    they line up with the db.hash_join results this lowers from: the left (probed)
+    factor's yielded columns followed by the right (built) factor's. The build
+    columns are not operands - they live in the handle - so their chunk types
+    cannot be inferred and the iterator type is spelled out, the way nl.sort
+    spells its own.
 
-    An optional `limit` operand carries an !nl.limit_state handle. When present,
-    only the first limit.getRemaining() matched pairs of this step are laid out:
-    the rows come out probe-row-major, so that prefix is exactly the prefix the
-    following nl.limit_update/nl.output can emit, and pairing the rest would be
-    wasted work. Absent, every match of the chunk is laid out. The bounded sibling
-    of nl.cross_product's own limit operand.
+    The whole build side is indexed before any probing, so a probe row's matches
+    come out together and in build order at any chunk size - where
+    nl.cross_product, re-running the inner nest per outer chunk, interleaves a
+    multi-chunk inner side. Neither order is one an ORDER BY constrains, so they
+    may differ under a LIMIT.
 
-      %n, %name, %m = nl.hash_join_probe %state, (%arg0, %key) limit %h
-          : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
-         -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>)
+    A `limit` on the enclosing nl.for bounds the pairing the way it bounds a
+    product: the loop stops once the budget is spent, and a step lays out only the
+    prefix the following nl.limit_update/nl.output can still emit.
   }];
 
   let arguments = (ins NLHashJoinStateHandle:$state,
-                       Variadic<NLChunk>:$columns,
-                       Optional<NLLimitStateHandle>:$limit);
-  let results   = (outs Variadic<NLChunk>:$results);
+                       Variadic<NLChunk>:$columns);
+  let results   = (outs NLIterator:$result);
 
   let assemblyFormat = [{
-    $state `,` `(` $columns `)` (`limit` $limit^)? attr-dict `:`
-    `(` qualified(type($columns)) `)` `->` `(` qualified(type($results)) `)`
+    $state `,` `(` $columns `)` attr-dict `:`
+    `(` qualified(type($columns)) `)` `->` qualified(type($result))
   }];
   let hasVerifier = 1;
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1131,6 +1131,108 @@ def Sort : NLOp<"sort", [Pure]> {
   let assemblyFormat = "`(` $state `)` attr-dict `:` qualified(type($result))";
 }
 
+/**
+* HashJoinBuffer
+*/
+// NOT Pure: each nl.hash_join_buffer is a distinct build side, so two must never
+// be CSE'd into one, and an unread one must not be DCE'd - resetting its buffers
+// and its key index is a side effect (like nl.sort_buffer).
+def HashJoinBuffer : NLOp<"hash_join_buffer", []> {
+  let summary = "Create (and reset) the build side of one hash join";
+  let description = [{
+    Sits at the top of the block the join's two loop nests are rooted in - the
+    entry block for a top-level join, the enclosing loop body for one nested in a
+    factor - so the build side is emptied once per entry into that block, before
+    the build loop refills it. Produces the !nl.hash_join_state handle that
+    nl.hash_join_collect fills and nl.hash_join_probe reads.
+
+    `build_key` and `probe_key` are the column indices the two sides match on:
+    `build_key` indexes the columns nl.hash_join_collect appends, `probe_key` the
+    columns nl.hash_join_probe reads. The buffers' column types are not spelled
+    here - they are recovered from the collect that feeds the same handle - so
+    only the key spec appears. The result type is buildable and omitted.
+
+      %state = nl.hash_join_buffer build_key 1 probe_key 1
+  }];
+
+  let arguments = (ins UI64Attr:$buildKey, UI64Attr:$probeKey);
+  let results   = (outs NLHashJoinState:$state);
+
+  let assemblyFormat = "`build_key` $buildKey `probe_key` $probeKey attr-dict";
+}
+
+/**
+* HashJoinCollect
+*/
+// NOT Pure: it appends the current chunk's rows to the handle's buffers and
+// indexes their keys, so it must run exactly where it sits, once per build-loop
+// step, and must not be hoisted, CSE'd or eliminated.
+def HashJoinCollect : NLOp<"hash_join_collect", []> {
+  let summary = "Append this step's chunk of every build column to a hash join";
+  let description = [{
+    Runs in the build loop body, once per step. Appends the current chunk of each
+    build column to the matching buffer of the handle and records where each row's
+    key lands, so that by the time the build loop is exhausted the buffers hold
+    every build row and the index answers any probe key. The columns are taken
+    together so the buffers stay row-aligned. A row whose key is null is buffered
+    like any other but left out of the index: null matches nothing.
+
+      nl.hash_join_collect %state, (%b, %name) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+
+    The build side's sibling of nl.sort_collect.
+  }];
+
+  // The build handle, then the columns to append. The column chunk types are
+  // spelled after the colon (as nl.sort_collect spells its own), since the
+  // buffers' element types are recovered from them.
+  let arguments = (ins NLHashJoinStateHandle:$state, Variadic<NLChunk>:$columns);
+
+  let assemblyFormat = [{
+    $state `,` `(` $columns `)` attr-dict `:` qualified(type($columns))
+  }];
+  let hasVerifier = 1;
+}
+
+/**
+* HashJoinProbe
+*/
+// Pure: given a filled build side it deterministically produces the same matched
+// rows from the same probe chunk, and it writes only its own result chunks.
+def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
+  let summary = "Emit each probe row paired with the build rows its key matches";
+  let description = [{
+    Runs in the probe loop body, once per step, and stands where nl.cross_product
+    stands in a nested loop: it is what makes the join's rows. For each row of the
+    probe chunk it looks the row's key up in the handle's index and emits one row
+    per build row that matches - the probe row's columns repeated once per match,
+    beside the matched build row's columns read back from the buffers. A probe row
+    whose key is null, or whose key matches nothing, emits no row.
+
+      %n, %name, %m = nl.hash_join_probe %state, (%arg0, %key)
+          : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
+         -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>)
+
+    The results are the probe columns followed by the build columns, so they line
+    up with the db.hash_join results this lowers from: the left (probed) factor's
+    yielded columns followed by the right (built) factor's. A probe row's matches
+    come out together and in build order, so the rows arrive in the order the
+    nested loop this replaces produced them in.
+
+    The build columns are not operands - they live in the handle - so their chunk
+    types cannot be inferred and the whole result signature is spelled out, the
+    way nl.sort spells its iterator's.
+  }];
+
+  let arguments = (ins NLHashJoinStateHandle:$state, Variadic<NLChunk>:$columns);
+  let results   = (outs Variadic<NLChunk>:$results);
+
+  let assemblyFormat = [{
+    $state `,` `(` $columns `)` attr-dict `:`
+    `(` qualified(type($columns)) `)` `->` `(` qualified(type($results)) `)`
+  }];
+  let hasVerifier = 1;
+}
+
 // NOT Pure: resetting the seen-set is a side effect, and two seen-sets must never
 // be CSE'd into one (like nl.limit / nl.sort_buffer).
 def Distinct : NLOp<"distinct", []> {

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1198,7 +1198,9 @@ def HashJoinCollect : NLOp<"hash_join_collect", []> {
 */
 // Pure: given a filled build side it deterministically produces the same matched
 // rows from the same probe chunk, and it writes only its own result chunks.
-def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
+// AttrSizedOperandSegments: the probe columns and the optional limit handle are two
+// operand groups of independent size, as on nl.cross_product.
+def HashJoinProbe : NLOp<"hash_join_probe", [Pure, AttrSizedOperandSegments]> {
   let summary = "Emit each probe row paired with the build rows its key matches";
   let description = [{
     Runs in the probe loop body, once per step, and stands where nl.cross_product
@@ -1223,13 +1225,26 @@ def HashJoinProbe : NLOp<"hash_join_probe", [Pure]> {
     The build columns are not operands - they live in the handle - so their chunk
     types cannot be inferred and the whole result signature is spelled out, the
     way nl.sort spells its iterator's.
+
+    An optional `limit` operand carries an !nl.limit_state handle. When present,
+    only the first limit.getRemaining() matched pairs of this step are laid out:
+    the rows come out probe-row-major, so that prefix is exactly the prefix the
+    following nl.limit_update/nl.output can emit, and pairing the rest would be
+    wasted work. Absent, every match of the chunk is laid out. The bounded sibling
+    of nl.cross_product's own limit operand.
+
+      %n, %name, %m = nl.hash_join_probe %state, (%arg0, %key) limit %h
+          : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
+         -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>)
   }];
 
-  let arguments = (ins NLHashJoinStateHandle:$state, Variadic<NLChunk>:$columns);
+  let arguments = (ins NLHashJoinStateHandle:$state,
+                       Variadic<NLChunk>:$columns,
+                       Optional<NLLimitStateHandle>:$limit);
   let results   = (outs Variadic<NLChunk>:$results);
 
   let assemblyFormat = [{
-    $state `,` `(` $columns `)` attr-dict `:`
+    $state `,` `(` $columns `)` (`limit` $limit^)? attr-dict `:`
     `(` qualified(type($columns)) `)` `->` `(` qualified(type($results)) `)`
   }];
   let hasVerifier = 1;

--- a/query/ir/dialect/nl/NLTypes.td
+++ b/query/ir/dialect/nl/NLTypes.td
@@ -47,6 +47,21 @@ def NLSortState : NLType<"SortState", "sort_state"> {
     }];
 }
 
+def NLHashJoinState : NLType<"HashJoinState", "hash_join_state"> {
+    let summary = "A hash join build side handle";
+    let description = [{
+        Stands for one equi-join's built side: the rows of the build factor,
+        materialized column by column, and the index from a row's serialized key
+        to the rows carrying it. Produced by nl.hash_join_buffer, filled by
+        nl.hash_join_collect once per build-loop step, and read by
+        nl.hash_join_probe once per probe-loop step. It is a handle, not a chunk:
+        it owns the growing per-column buffers and the key index, not a single
+        chunk of values. The joining sibling of !nl.sort_state - it indexes the
+        rows it accumulates rather than ordering them, and the rows come back out
+        through the probe rather than through an nl.for of its own.
+    }];
+}
+
 def NLDistinctState : NLType<"DistinctState", "distinct_state"> {
     let summary = "A DISTINCT seen-set handle";
     let description = [{
@@ -308,6 +323,16 @@ def NLSortStateHandle : Type<
         CPred<"::llvm::isa<::mlir::nl::SortStateType>($_self)">,
         "sort state handle", "::mlir::nl::SortStateType">,
     BuildableType<"::mlir::nl::SortStateType::get($_builder.getContext())">;
+
+// Constrains an operand to an !nl.hash_join_state handle, the same way
+// NLSortStateHandle constrains the sort handle. The single concrete type - there
+// is only ever !nl.hash_join_state - is what lets nl.hash_join_collect and
+// nl.hash_join_probe omit the handle's type in their assembly, building it from
+// this recipe instead.
+def NLHashJoinStateHandle : Type<
+        CPred<"::llvm::isa<::mlir::nl::HashJoinStateType>($_self)">,
+        "hash join state handle", "::mlir::nl::HashJoinStateType">,
+    BuildableType<"::mlir::nl::HashJoinStateType::get($_builder.getContext())">;
 
 // Constrains an operand to an !nl.distinct_state handle, the same way
 // NLSortStateHandle constrains the sort handle. The single concrete type - there

--- a/query/ir/interpreter/CMakeLists.txt
+++ b/query/ir/interpreter/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ir_interpreter_sources
     NLProgram.cpp
+    NLHashJoinIndex.cpp
     NLOutputSink.cpp
     NLExecutionContext.cpp
     NLWriteProperties.cpp

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1418,6 +1418,38 @@ bool plainDoubleColumnRowMatchable(const Column* column, size_t row) {
     return !std::isnan(raw[row]);
 }
 
+// Whether one row of a nullable embedding column carries a key a join can match. A null
+// does not, and neither does a vector holding a NaN: TuringEqual compares two embeddings
+// element by element, so such a row equals nothing - not even itself.
+bool optEmbeddingColumnRowMatchable(const Column* column, size_t row) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<types::Embedding::Primitive>>*>(column)->getRaw();
+    const std::optional<types::Embedding::Primitive>& embedding = raw[row];
+    if (!embedding.has_value()) {
+        return false;
+    }
+
+    const auto isNaN = [](float value) { return std::isnan(value); };
+
+    return std::none_of(embedding->begin(), embedding->end(), isNaN);
+}
+
+// Serialize one row of a nullable embedding column into the row key, as the vector's
+// length then its floats. TuringEqual holds when two embeddings carry the same floats in
+// the same order, which is byte equality once the sign of a zero is canonicalized; a NaN
+// never reaches here, the match gate having kept those rows out of the join.
+void joinKeyAppendOptEmbeddingColumn(const Column* column, size_t row, std::string& key) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<types::Embedding::Primitive>>*>(column)->getRaw();
+    const types::Embedding::Primitive& embedding = *raw[row];
+
+    const size_t length = embedding.size();
+    key.append(reinterpret_cast<const char*>(&length), sizeof(length));
+
+    for (const float value : embedding) {
+        const float normalized = (value == 0.0f) ? 0.0f : value;
+        key.append(reinterpret_cast<const char*>(&normalized), sizeof(normalized));
+    }
+}
+
 // Whether one row of a type-erased column of tagged scalars carries a matchable key - the
 // cell's own tag says whether it is null, where a nullable column has a present flag.
 bool listElementColumnRowMatchable(const Column* column, size_t row) {
@@ -6212,12 +6244,14 @@ NLKeyIsMatchableFunction NLExecutor::everyKeyMatchable() {
     return &everyRowMatchable;
 }
 
-// Selected per column from its value type. Every value type carries a present flag, so -
-// unlike selectOptKeyAppendFunction - an embedding dispatches fine here; a key column of
-// one is rejected by the serializer, not by this.
+// Selected per column from its value type. A double and an embedding answer their own way,
+// since neither a NaN nor a vector holding one equals itself; every other value type
+// matches on any present row.
 NLKeyIsMatchableFunction NLExecutor::selectOptKeyMatchableFunction(ValueType valueType) {
     if (valueType == ValueType::Double) {
         return &optDoubleColumnRowMatchable;
+    } else if (valueType == ValueType::Embedding) {
+        return &optEmbeddingColumnRowMatchable;
     }
 
     NLKeyIsMatchableFunction isMatchable = nullptr;
@@ -6241,6 +6275,10 @@ NLKeyIsMatchableFunction NLExecutor::selectPlainKeyMatchableFunction(ValueType v
 
 NLKeyIsMatchableFunction NLExecutor::selectListElementKeyMatchableFunction() {
     return &listElementColumnRowMatchable;
+}
+
+NLKeyAppendFunction NLExecutor::selectOptEmbeddingKeyAppendFunction() {
+    return &joinKeyAppendOptEmbeddingColumn;
 }
 
 // An ID chunk (node/edge/edge-type IDs) has no null rows, so every row counts,

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -2,7 +2,9 @@
 
 #include <stdint.h>
 #include <algorithm>
+#include <bit>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <numeric>
 #include <queue>
@@ -1441,23 +1443,6 @@ bool optEmbeddingColumnRowMatchable(const Column* column, size_t row) {
     return std::none_of(embedding->begin(), embedding->end(), isNaN);
 }
 
-// Serialize one row of a nullable embedding column into the row key, as the vector's
-// length then its floats. TuringEqual holds when two embeddings carry the same floats in
-// the same order, which is byte equality once the sign of a zero is canonicalized; a NaN
-// never reaches here, the match gate having kept those rows out of the join.
-void joinKeyAppendOptEmbeddingColumn(const Column* column, size_t row, std::string& key) {
-    const auto& raw = static_cast<const ColumnVector<std::optional<types::Embedding::Primitive>>*>(column)->getRaw();
-    const types::Embedding::Primitive& embedding = *raw[row];
-
-    const size_t length = embedding.size();
-    key.append(reinterpret_cast<const char*>(&length), sizeof(length));
-
-    for (const float value : embedding) {
-        const float normalized = (value == 0.0f) ? 0.0f : value;
-        key.append(reinterpret_cast<const char*>(&normalized), sizeof(normalized));
-    }
-}
-
 // Whether one row of a type-erased column of tagged scalars carries a matchable key - the
 // cell's own tag says whether it is null, where a nullable column has a present flag.
 bool listElementColumnRowMatchable(const Column* column, size_t row) {
@@ -1490,6 +1475,158 @@ void distinctKeyAppendOptListElementColumn(const Column* column, size_t row, std
 void distinctKeyAppendListColumn(const Column* column, size_t row, std::string& key) {
     const auto& raw = static_cast<const ColumnVector<ListView>*>(column)->getRaw();
     distinctAppendListBytes(key, raw[row]);
+}
+
+// The 64-bit finalizer of MurmurHash3, so a key's bits spread over every bucket
+uint64_t mixKeyBits(uint64_t bits) {
+    bits ^= bits >> 33;
+    bits *= 0xff51afd7ed558ccdULL;
+    bits ^= bits >> 33;
+    bits *= 0xc4ceb9fe1a85ec53ULL;
+    bits ^= bits >> 33;
+
+    return bits;
+}
+
+template <typename Integral>
+    requires std::is_integral_v<Integral> || std::is_enum_v<Integral>
+uint64_t hashKeyValue(Integral value) {
+    return mixKeyBits(static_cast<uint64_t>(value));
+}
+
+template <IntegralType T, int I>
+uint64_t hashKeyValue(ID<T, I> id) {
+    return hashKeyValue(id.getValue());
+}
+
+uint64_t hashKeyValue(CustomBool value) {
+    return mixKeyBits(value._boolean);
+}
+
+// -0.0 hashes as +0.0, the one value it equals; a NaN never reaches a lookup
+uint64_t hashKeyValue(double value) {
+    const double normalized = (value == 0.0) ? 0.0 : value;
+    return mixKeyBits(std::bit_cast<uint64_t>(normalized));
+}
+
+uint64_t hashKeyValue(std::string_view value) {
+    return std::hash<std::string_view> {}(value);
+}
+
+uint64_t hashKeyValue(const std::string& value) {
+    return hashKeyValue(std::string_view(value));
+}
+
+uint64_t hashKeyValue(types::Embedding::Primitive embedding) {
+    uint64_t hash = mixKeyBits(embedding.size());
+
+    for (const float value : embedding) {
+        const float normalized = (value == 0.0f) ? 0.0f : value;
+        hash = mixKeyBits(hash ^ std::bit_cast<uint32_t>(normalized));
+    }
+
+    return hash;
+}
+
+template <typename ElementType>
+void hashKeyColumn(const Column* column, std::vector<uint64_t>& hashes) {
+    const auto& raw = static_cast<const ColumnVector<ElementType>*>(column)->getRaw();
+    hashes.resize(raw.size());
+
+    std::transform(raw.begin(), raw.end(), hashes.begin(), [](const ElementType& value) {
+        return hashKeyValue(value);
+    });
+}
+
+template <typename Primitive>
+void hashOptKeyColumn(const Column* column, std::vector<uint64_t>& hashes) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
+    hashes.resize(raw.size());
+
+    std::transform(raw.begin(), raw.end(), hashes.begin(), [](const std::optional<Primitive>& value) {
+        return value.has_value() ? hashKeyValue(*value) : uint64_t {0};
+    });
+}
+
+// A tagged scalar hashes through the bytes DISTINCT keys it by, so an integer and a float
+// holding one value hash alike, as they compare equal
+void hashListElementKeyColumn(const Column* column, std::vector<uint64_t>& hashes) {
+    const auto& raw = static_cast<const ColumnVector<ListElementView>*>(column)->getRaw();
+    hashes.resize(raw.size());
+
+    std::string bytes;
+    std::transform(raw.begin(), raw.end(), hashes.begin(), [&bytes](const ListElementView element) {
+        bytes.clear();
+        distinctAppendElementBytes(bytes, element);
+        return hashKeyValue(std::string_view(bytes));
+    });
+}
+
+void hashListKeyColumn(const Column* column, std::vector<uint64_t>& hashes) {
+    const auto& raw = static_cast<const ColumnVector<ListView>*>(column)->getRaw();
+    hashes.resize(raw.size());
+
+    std::string bytes;
+    std::transform(raw.begin(), raw.end(), hashes.begin(), [&bytes](const ListView list) {
+        bytes.clear();
+        distinctAppendListBytes(bytes, list);
+        return hashKeyValue(std::string_view(bytes));
+    });
+}
+
+template <typename ElementType>
+bool keyValuesEqual(const ElementType& probe, const ElementType& build) {
+    return probe == build;
+}
+
+bool keyValuesEqual(types::Embedding::Primitive probe, types::Embedding::Primitive build) {
+    return EmbeddingEqual {}(probe, build);
+}
+
+template <typename ElementType>
+bool keyEqualColumn(const Column* probe, size_t probeRow, const Column* build, size_t buildRow) {
+    const auto& probeRaw = static_cast<const ColumnVector<ElementType>*>(probe)->getRaw();
+    const auto& buildRaw = static_cast<const ColumnVector<ElementType>*>(build)->getRaw();
+
+    return keyValuesEqual(probeRaw[probeRow], buildRaw[buildRow]);
+}
+
+template <typename Primitive>
+bool keyEqualOptColumn(const Column* probe, size_t probeRow, const Column* build, size_t buildRow) {
+    const auto& probeRaw = static_cast<const ColumnVector<std::optional<Primitive>>*>(probe)->getRaw();
+    const auto& buildRaw = static_cast<const ColumnVector<std::optional<Primitive>>*>(build)->getRaw();
+
+    return keyValuesEqual(*probeRaw[probeRow], *buildRaw[buildRow]);
+}
+
+template <typename ElementType>
+NLJoinKeyFunctions joinKeyFunctions() {
+    return {&hashKeyColumn<ElementType>, &keyEqualColumn<ElementType>};
+}
+
+template <typename Primitive>
+NLJoinKeyFunctions optJoinKeyFunctions() {
+    return {&hashOptKeyColumn<Primitive>, &keyEqualOptColumn<Primitive>};
+}
+
+// The group of build rows carrying a key, or noRow when no indexed row carries it. One
+// bucket chains the groups of every key that falls in it, so a group's key is confirmed
+// by hash and then by value.
+size_t findKeyGroup(const NLHashJoinIndex& index,
+                    uint64_t hash,
+                    const Column* probeKey,
+                    size_t probeRow,
+                    const Column* buildKey,
+                    NLKeyEqualFunction keyEqual) {
+    for (size_t group = index.getFirstGroup(hash); group != NLHashJoinIndex::noRow; group = index.getNextGroup(group)) {
+        const bool sameHash = index.getHash(group) == hash;
+
+        if (sameHash && keyEqual(probeKey, probeRow, buildKey, group)) {
+            return group;
+        }
+    }
+
+    return NLHashJoinIndex::noRow;
 }
 
 // Count the non-null cells of a type-erased column of tagged scalars, so count(x) over a
@@ -5067,45 +5204,62 @@ void NLExecutor::runHashJoinReset(NLExecutionContext* context, NLFunctionData* d
 void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData* data) {
     NLHashJoinCollectData* collect = static_cast<NLHashJoinCollectData*>(data);
     NLHashJoinState* state = collect->getState();
+    NLHashJoinIndex& index = state->getIndex();
 
     const Column* key = collect->getKeyColumn();
     const size_t rowCount = key->size();
-    const size_t firstRow = state->getRowCount();
+    const size_t firstRow = index.getRowCount();
+
+    const NLKeyHashFunction hashKeys = collect->getKeyHash();
+    std::vector<uint64_t>& hashes = *collect->getHashScratch();
+    hashKeys(key, hashes);
+
+    // Appending before indexing puts every row a key could join with in the buffer, so a
+    // new row's key is compared against one already indexed through that buffer alone.
+    for (const NLSortCollectData::Append& append : collect->appends()) {
+        append._append(append._input, append._buffer);
+    }
+
+    index.addRows(rowCount);
+
+    const Column* buildKey = collect->getBuildKeyColumn();
+    const NLKeyEqualFunction keyEqual = collect->getKeyEqual();
+    const NLKeyIsMatchableFunction keyIsMatchable = collect->getKeyIsMatchable();
 
     // A key no probe key can match - a null, a NaN - is indexed under nothing, so no probe
     // row reaches it.
-    const NLKeyAppendFunction keyAppend = collect->getKeyAppend();
-    const NLKeyIsMatchableFunction keyIsMatchable = collect->getKeyIsMatchable();
-    std::string* keyScratch = collect->getKeyScratch();
-
     for (size_t row = 0; row < rowCount; row++) {
         if (!keyIsMatchable(key, row)) {
             continue;
         }
 
-        keyScratch->clear();
-        keyAppend(key, row, *keyScratch);
+        const uint64_t hash = hashes[row];
+        const size_t bufferRow = firstRow + row;
+        const size_t group = findKeyGroup(index, hash, buildKey, bufferRow, buildKey, keyEqual);
 
-        state->indexRow(*keyScratch, firstRow + row);
+        if (group == NLHashJoinIndex::noRow) {
+            index.openGroup(bufferRow, hash);
+        } else {
+            index.addToGroup(group, bufferRow);
+        }
     }
-
-    for (const NLSortCollectData::Append& append : collect->appends()) {
-        append._append(append._input, append._buffer);
-    }
-
-    state->addRows(rowCount);
 }
 
 void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* data) {
     NLHashJoinProbeData* probe = static_cast<NLHashJoinProbeData*>(data);
     const NLHashJoinState* state = probe->getState();
+    const NLHashJoinIndex& index = state->getIndex();
 
     const Column* key = probe->getKeyColumn();
+    const Column* buildKey = probe->getBuildKeyColumn();
     const size_t rowCount = key->size();
 
-    const NLKeyAppendFunction keyAppend = probe->getKeyAppend();
+    const NLKeyHashFunction hashKeys = probe->getKeyHash();
+    const NLKeyEqualFunction keyEqual = probe->getKeyEqual();
     const NLKeyIsMatchableFunction keyIsMatchable = probe->getKeyIsMatchable();
-    std::string* keyScratch = probe->getKeyScratch();
+
+    std::vector<uint64_t>& hashes = *probe->getHashScratch();
+    hashKeys(key, hashes);
 
     ColumnVector<size_t>* probeIndices = probe->getProbeIndices();
     ColumnVector<size_t>* buildIndices = probe->getBuildIndices();
@@ -5126,16 +5280,15 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
             continue;
         }
 
-        keyScratch->clear();
-        keyAppend(key, row, *keyScratch);
+        const size_t group = findKeyGroup(index, hashes[row], key, row, buildKey, keyEqual);
 
-        for (const size_t buildRow : state->rowsFor(*keyScratch)) {
+        // Every row of the group carries the key the probe row matched, so the group is
+        // walked without comparing again.
+        for (size_t match = group;
+             match != NLHashJoinIndex::noRow && probeRaw.size() < pairBudget;
+             match = index.getNextInGroup(match)) {
             probeRaw.push_back(row);
-            buildRaw.push_back(buildRow);
-
-            if (probeRaw.size() == pairBudget) {
-                break;
-            }
+            buildRaw.push_back(match);
         }
     }
 
@@ -6303,8 +6456,101 @@ NLKeyIsMatchableFunction NLExecutor::selectListElementKeyMatchableFunction() {
     return &listElementColumnRowMatchable;
 }
 
-NLKeyAppendFunction NLExecutor::selectOptEmbeddingKeyAppendFunction() {
-    return &joinKeyAppendOptEmbeddingColumn;
+NLJoinKeyFunctions NLExecutor::selectJoinKeyFunctions(NLChunkKind kind) {
+    switch (kind) {
+        case NLChunkKind::NodeID:
+            return joinKeyFunctions<NodeID>();
+        break;
+
+        case NLChunkKind::EdgeID:
+            return joinKeyFunctions<EdgeID>();
+        break;
+
+        case NLChunkKind::EdgeTypeID:
+            return joinKeyFunctions<EdgeTypeID>();
+        break;
+
+        case NLChunkKind::LabelID:
+            return joinKeyFunctions<LabelID>();
+        break;
+
+        case NLChunkKind::PropertyTypeID:
+            return joinKeyFunctions<PropertyTypeID>();
+        break;
+
+        case NLChunkKind::ValueTypeCode:
+            return joinKeyFunctions<ValueType>();
+        break;
+
+        case NLChunkKind::UInt64:
+            return joinKeyFunctions<types::UInt64::Primitive>();
+        break;
+
+        case NLChunkKind::Int64:
+            return joinKeyFunctions<types::Int64::Primitive>();
+        break;
+
+        case NLChunkKind::Double:
+            return joinKeyFunctions<types::Double::Primitive>();
+        break;
+
+        case NLChunkKind::Bool:
+            return joinKeyFunctions<types::Bool::Primitive>();
+        break;
+
+        case NLChunkKind::String:
+            return joinKeyFunctions<types::String::Primitive>();
+        break;
+
+        case NLChunkKind::OwnedString:
+            return joinKeyFunctions<std::string>();
+        break;
+
+        case NLChunkKind::List:
+            return {&hashListKeyColumn, &keyEqualColumn<ListView>};
+        break;
+
+        case NLChunkKind::Path:
+            throw IRException("A path column cannot be a join key: a path has no scalar value to key on");
+        break;
+    }
+
+    bioassert(false, "Unknown NLChunkKind");
+    return {};
+}
+
+NLJoinKeyFunctions NLExecutor::selectOptJoinKeyFunctions(ValueType valueType) {
+    NLJoinKeyFunctions functions;
+    const auto select = [&]<SupportedType T>() {
+        functions = optJoinKeyFunctions<typename T::Primitive>();
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return functions;
+}
+
+NLJoinKeyFunctions NLExecutor::selectPlainJoinKeyFunctions(ValueType valueType) {
+    switch (valueType) {
+        case ValueType::Int64:
+            return joinKeyFunctions<types::Int64::Primitive>();
+        break;
+
+        case ValueType::UInt64:
+            return joinKeyFunctions<types::UInt64::Primitive>();
+        break;
+
+        case ValueType::Double:
+            return joinKeyFunctions<types::Double::Primitive>();
+        break;
+
+        default:
+            throw IRException("a plain value column must be numeric");
+        break;
+    }
+}
+
+NLJoinKeyFunctions NLExecutor::selectListElementJoinKeyFunctions() {
+    return {&hashListElementKeyColumn, &keyEqualColumn<ListElementView>};
 }
 
 // An ID chunk (node/edge/edge-type IDs) has no null rows, so every row counts,

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -832,60 +832,68 @@ void applyNotOnConst(Column* result, const Column* operand) {
 void applyNotOnNullConst(Column*, const Column*) {
 }
 
-// Block-repeat: each input row is emitted `factor` times in a row, so input row
-// i lands at output indices [i*factor, (i+1)*factor). This lays out an outer
-// column of a cross product, where each outer row pairs with the whole inner
-// chunk. The fill stops at `outputRowCount` rows (min(N*factor, remaining) under
-// a limit), so the last block may be partial and later input rows are skipped.
+// Block-repeat: the outer column of a cross product, where each outer row pairs
+// with the whole inner chunk, so pair p takes input row p/factor. Fills the
+// `rowCount` pairs from `position` on, which may start partway into one input
+// row's block and end partway into another's.
 template <typename ElementType, typename ColumnType = ColumnVector<ElementType>>
-void blockRepeatColumn(const Column* input, size_t factor, size_t outputRowCount, Column* output) {
+void blockRepeatColumn(const Column* input, size_t factor, size_t position, size_t rowCount, Column* output) {
     const ColumnType* typedInput = static_cast<const ColumnType*>(input);
     ColumnType* typedOutput = static_cast<ColumnType*>(output);
 
     const auto& inputRaw = typedInput->getRaw();
     auto& outputRaw = typedOutput->getRaw();
-    outputRaw.resize(outputRowCount);
+    outputRaw.resize(rowCount);
 
     auto outputIt = outputRaw.begin();
-    size_t rowsLeft = outputRowCount;
-    for (const ElementType& value : inputRaw) {
-        if (rowsLeft == 0) {
-            break;
-        }
+    size_t rowsLeft = rowCount;
+    size_t inputIndex = position / factor;
+    size_t doneInBlock = position % factor;
 
-        const size_t count = std::min(factor, rowsLeft);
-        std::fill_n(outputIt, count, value);
+    while (rowsLeft > 0 && inputIndex < inputRaw.size()) {
+        const size_t count = std::min(factor - doneInBlock, rowsLeft);
+        std::fill_n(outputIt, count, inputRaw[inputIndex]);
+
         outputIt += count;
         rowsLeft -= count;
+        inputIndex++;
+        doneInBlock = 0;
     }
 }
 
-void blockRepeatConstColumn(const Column* input, size_t factor, size_t outputRowCount, Column* output) {
-    output->assignFromLine(input, 0, outputRowCount);
+void blockRepeatConstColumn(const Column* input, size_t factor, size_t position, size_t rowCount, Column* output) {
+    output->assignFromLine(input, 0, rowCount);
 }
 
-// Tile: the whole input chunk is emitted back to back, so input row j lands at
-// output indices j, j+M, j+2M, ... This lays out an inner column of a cross
-// product, where the inner chunk repeats once per outer row. The fill stops at
-// `outputRowCount` rows (min(M*N, remaining) under a limit), which alone bounds
-// the repeats, so the row count drives it rather than the `factor` (N) the outer
-// side uses. The last tile may be partial.
+// Tile: the inner column of a cross product, where the inner chunk repeats once
+// per outer row, so pair p takes input row p % M. Fills the `rowCount` pairs from
+// `position` on, which may start partway into one tile and end partway into
+// another. M is the tile's own length, which is what the enclosing product passes
+// as the factor.
 template <typename ElementType, typename ColumnType = ColumnVector<ElementType>>
-void tileColumn(const Column* input, size_t factor, size_t outputRowCount, Column* output) {
+void tileColumn(const Column* input, size_t factor, size_t position, size_t rowCount, Column* output) {
     const ColumnType* typedInput = static_cast<const ColumnType*>(input);
     ColumnType* typedOutput = static_cast<ColumnType*>(output);
 
     const auto& inputRaw = typedInput->getRaw();
     auto& outputRaw = typedOutput->getRaw();
-    outputRaw.resize(outputRowCount);
+    outputRaw.resize(rowCount);
 
     const size_t tileLength = inputRaw.size();
+    if (tileLength == 0) {
+        return;
+    }
+
     auto outputIt = outputRaw.begin();
-    size_t rowsLeft = outputRowCount;
+    size_t rowsLeft = rowCount;
+    size_t inputIndex = position % tileLength;
+
     while (rowsLeft > 0) {
-        const size_t count = std::min(tileLength, rowsLeft);
-        outputIt = std::copy(inputRaw.begin(), inputRaw.begin() + count, outputIt);
+        const size_t count = std::min(tileLength - inputIndex, rowsLeft);
+        outputIt = std::copy(inputRaw.begin() + inputIndex, inputRaw.begin() + inputIndex + count, outputIt);
+
         rowsLeft -= count;
+        inputIndex = 0;
     }
 }
 
@@ -4388,34 +4396,52 @@ void NLExecutor::runGetInEdgesByTypeLoop(NLExecutionContext* context, NLFunction
     runEdgeLoopSteps(context, loopData, &chunkWriter, loopData->getTargets());
 }
 
-void NLExecutor::runCrossProduct(NLExecutionContext* context, NLFunctionData* data) {
-    NLCrossProductData* cross = static_cast<NLCrossProductData*>(data);
+void NLExecutor::runCrossProductLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLCrossProductLoopData* loopData = static_cast<NLCrossProductLoopData*>(data);
 
-    const NLCrossProductData::Columns& outerColumns = cross->outerColumns();
-    const NLCrossProductData::Columns& innerColumns = cross->innerColumns();
+    const NLCrossProductLoopData::Columns& outerColumns = loopData->outerColumns();
+    const NLCrossProductLoopData::Columns& innerColumns = loopData->innerColumns();
     bioassert(!outerColumns.empty() && !innerColumns.empty(),
               "nl.cross_product needs a column on each side to size the product");
 
-    // N outer rows crossed with M inner rows: each outer column is
-    // block-repeated x M and each inner column tiled x N, so every outer row
-    // pairs with every inner row. The counts come from the first column of each
-    // side; all columns of a side are row-aligned, so any one measures it.
+    // N outer rows crossed with M inner rows make N*M pairs. The counts come from
+    // the first column of each side; every column of a side is row-aligned with
+    // that first one, which is what lets one position slice them all.
     const size_t outerRowCount = outerColumns.front().getInput()->size();
     const size_t innerRowCount = innerColumns.front().getInput()->size();
 
-    const NLLimitState* limit = cross->getLimit();
     const size_t productRowCount = outerRowCount * innerRowCount;
-    const size_t remaining = limit ? limit->getRemaining() : productRowCount;
-    const size_t outputRowCount = std::min(productRowCount, remaining);
+    const size_t chunkSize = context->getChunkSize();
+    const NLLimitState* limit = loopData->getLimit();
+    const NLStmtContainer* loopBody = loopData->getStmts();
 
-    for (const NLCrossColumn& column : outerColumns) {
-        const NLBroadcastFunction broadcast = column.getBroadcast();
-        broadcast(column.getInput(), innerRowCount, outputRowCount, column.getOutput());
-    }
+    // Walk the pairs a chunk at a time. Under a limit the step is cut to what the
+    // budget can still emit - the pairs come out in (outer, inner) order, so the
+    // step's prefix is exactly what the nl.limit_update/nl.output below can take,
+    // and the loop stops once the budget is spent, as a scan's loop does.
+    size_t position = 0;
+    while (position < productRowCount) {
+        const size_t remaining = limit ? limit->getRemaining() : productRowCount;
+        if (remaining == 0) {
+            return;
+        }
 
-    for (const NLCrossColumn& column : innerColumns) {
-        const NLBroadcastFunction broadcast = column.getBroadcast();
-        broadcast(column.getInput(), outerRowCount, outputRowCount, column.getOutput());
+        const size_t chunkRowCount = std::min(chunkSize, productRowCount - position);
+        const size_t rowCount = std::min(chunkRowCount, remaining);
+
+        for (const NLCrossColumn& column : outerColumns) {
+            const NLBroadcastFunction broadcast = column.getBroadcast();
+            broadcast(column.getInput(), innerRowCount, position, rowCount, column.getOutput());
+        }
+
+        for (const NLCrossColumn& column : innerColumns) {
+            const NLBroadcastFunction broadcast = column.getBroadcast();
+            broadcast(column.getInput(), innerRowCount, position, rowCount, column.getOutput());
+        }
+
+        runBody(context, loopBody);
+
+        position += rowCount;
     }
 }
 
@@ -4439,7 +4465,7 @@ void NLExecutor::runLimitTruncate(NLExecutionContext* context, NLFunctionData* d
     // nl.limit_update); never mutates the counter.
     for (const NLCrossColumn& column : truncate->columns()) {
         const NLBroadcastFunction copyPrefix = column.getBroadcast();
-        copyPrefix(column.getInput(), 1, emitThisStep, column.getOutput());
+        copyPrefix(column.getInput(), 1, 0, emitThisStep, column.getOutput());
     }
 }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1384,27 +1384,46 @@ void distinctAppendElementBytes(std::string& key, const ListElementView element)
     bioassert(false, "Unknown ListBufferTypeTag");
 }
 
-// A chunk of this kind holds no null row - an ID column, a plainly-held value - so every
-// row of it carries a key a join can match on.
-bool neverNullColumn(const Column* column, size_t row) {
-    return false;
+// A chunk of this kind holds neither a null nor a NaN - an ID column, a plainly-held
+// value of any other type - so every row of it carries a key a join can match on.
+bool everyRowMatchable(const Column* column, size_t row) {
+    return true;
 }
 
-// Whether one row of a nullable value column is null, which keeps it out of a join: `=`
-// against a null gives null, and the filter this join replaces kept only the true rows.
+// Whether one row of a nullable value column carries a key a join can match. A null does
+// not: `=` against a null gives null, and the filter this join replaces kept only the
+// true rows.
 template <typename Primitive>
-bool optColumnIsNull(const Column* column, size_t row) {
+bool optColumnRowMatchable(const Column* column, size_t row) {
     const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
 
-    return !raw[row].has_value();
+    return raw[row].has_value();
 }
 
-// Whether one row of a type-erased column of tagged scalars is null - the cell's own tag
-// says so, where a nullable column has a present flag.
-bool listElementColumnIsNull(const Column* column, size_t row) {
+// The double sibling, which rejects a NaN as well: NaN = NaN is false, so a NaN key
+// matches nothing - not even another NaN. The key bytes cannot say so, since the
+// serializer maps every NaN payload to one canonical NaN so that DISTINCT groups them.
+bool optDoubleColumnRowMatchable(const Column* column, size_t row) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<types::Double::Primitive>>*>(column)->getRaw();
+    const std::optional<types::Double::Primitive>& value = raw[row];
+
+    return value.has_value() && !std::isnan(*value);
+}
+
+// The plainly-held double sibling: no row of such a column is null, so only a NaN keeps
+// one out of the join.
+bool plainDoubleColumnRowMatchable(const Column* column, size_t row) {
+    const auto& raw = static_cast<const ColumnVector<types::Double::Primitive>*>(column)->getRaw();
+
+    return !std::isnan(raw[row]);
+}
+
+// Whether one row of a type-erased column of tagged scalars carries a matchable key - the
+// cell's own tag says whether it is null, where a nullable column has a present flag.
+bool listElementColumnRowMatchable(const Column* column, size_t row) {
     const auto& raw = static_cast<const ColumnVector<ListElementView>*>(column)->getRaw();
 
-    return raw[row].getTag() == ListBufferTypeTag::Null;
+    return raw[row].getTag() != ListBufferTypeTag::Null;
 }
 
 // Serialize one row of a type-erased column of tagged scalars into the row key.
@@ -4996,14 +5015,14 @@ void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData*
     const size_t firstRow = state->getRowCount();
 
     // Row r of this chunk becomes build row firstRow + r, which is what the buffers will
-    // hold it at once appended. A null key is indexed under nothing, so no probe row can
-    // match it.
+    // hold it at once appended. A key no probe key can match - a null, a NaN - is indexed
+    // under nothing, so no probe row reaches it.
     const NLKeyAppendFunction keyAppend = collect->getKeyAppend();
-    const NLIsNullFunction keyIsNull = collect->getKeyIsNull();
+    const NLKeyIsMatchableFunction keyIsMatchable = collect->getKeyIsMatchable();
     std::string* keyScratch = collect->getKeyScratch();
 
     for (size_t row = 0; row < rowCount; row++) {
-        if (keyIsNull(key, row)) {
+        if (!keyIsMatchable(key, row)) {
             continue;
         }
 
@@ -5030,7 +5049,7 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
     const size_t rowCount = key->size();
 
     const NLKeyAppendFunction keyAppend = probe->getKeyAppend();
-    const NLIsNullFunction keyIsNull = probe->getKeyIsNull();
+    const NLKeyIsMatchableFunction keyIsMatchable = probe->getKeyIsMatchable();
     std::string* keyScratch = probe->getKeyScratch();
 
     ColumnVector<size_t>* probeIndices = probe->getProbeIndices();
@@ -5041,10 +5060,10 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
     buildRaw.clear();
 
     // One output row per matched pair, the probe rows walked in order and each row's
-    // matches taken in build order - the order the nested loop this replaces emitted the
-    // surviving pairs in. A null key matches nothing, as the equality it replaces did.
+    // matches taken in build order. A key nothing can match - a null, a NaN - emits no
+    // row, as the equality this replaces kept none.
     for (size_t row = 0; row < rowCount; row++) {
-        if (keyIsNull(key, row)) {
+        if (!keyIsMatchable(key, row)) {
             continue;
         }
 
@@ -6186,25 +6205,39 @@ NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) 
     return nullptr;
 }
 
-NLIsNullFunction NLExecutor::neverNull() {
-    return &neverNullColumn;
+NLKeyIsMatchableFunction NLExecutor::everyKeyMatchable() {
+    return &everyRowMatchable;
 }
 
 // Selected per column from its value type. Every value type carries a present flag, so -
 // unlike selectOptKeyAppendFunction - an embedding dispatches fine here; a key column of
 // one is rejected by the serializer, not by this.
-NLIsNullFunction NLExecutor::selectOptIsNullFunction(ValueType valueType) {
-    NLIsNullFunction isNull = nullptr;
+NLKeyIsMatchableFunction NLExecutor::selectOptKeyMatchableFunction(ValueType valueType) {
+    if (valueType == ValueType::Double) {
+        return &optDoubleColumnRowMatchable;
+    }
+
+    NLKeyIsMatchableFunction isMatchable = nullptr;
     const auto select = [&]<SupportedType T>() {
-        isNull = &optColumnIsNull<typename T::Primitive>;
+        isMatchable = &optColumnRowMatchable<typename T::Primitive>;
     };
     ValueTypeDispatcher(valueType).execute(select);
 
-    return isNull;
+    return isMatchable;
 }
 
-NLIsNullFunction NLExecutor::selectListElementIsNullFunction() {
-    return &listElementColumnIsNull;
+// A plainly-held value carries no present flag, so a double is the only such column with
+// a row a join cannot match on.
+NLKeyIsMatchableFunction NLExecutor::selectPlainKeyMatchableFunction(ValueType valueType) {
+    if (valueType == ValueType::Double) {
+        return &plainDoubleColumnRowMatchable;
+    }
+
+    return &everyRowMatchable;
+}
+
+NLKeyIsMatchableFunction NLExecutor::selectListElementKeyMatchableFunction() {
+    return &listElementColumnRowMatchable;
 }
 
 // An ID chunk (node/edge/edge-type IDs) has no null rows, so every row counts,

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -5014,9 +5014,8 @@ void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData*
     const size_t rowCount = key->size();
     const size_t firstRow = state->getRowCount();
 
-    // Row r of this chunk becomes build row firstRow + r, which is what the buffers will
-    // hold it at once appended. A key no probe key can match - a null, a NaN - is indexed
-    // under nothing, so no probe row reaches it.
+    // A key no probe key can match - a null, a NaN - is indexed under nothing, so no probe
+    // row reaches it.
     const NLKeyAppendFunction keyAppend = collect->getKeyAppend();
     const NLKeyIsMatchableFunction keyIsMatchable = collect->getKeyIsMatchable();
     std::string* keyScratch = collect->getKeyScratch();
@@ -5032,8 +5031,6 @@ void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData*
         state->indexRow(*keyScratch, firstRow + row);
     }
 
-    // The columns are appended together, so the buffers stay row-aligned with each other
-    // and with the rows just indexed.
     for (const NLSortCollectData::Append& append : collect->appends()) {
         append._append(append._input, append._buffer);
     }
@@ -5084,8 +5081,6 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
         }
     }
 
-    // The probe side reads its own chunk, the build side the buffers; both gather by the
-    // matched pairs, so every output column is row-aligned with the joined rows.
     for (const NLCarriedColumn& column : probe->probeColumns()) {
         const NLGatherFunction gather = column.getGatherFunc();
         gather(column.getInput(), probeIndices, column.getOutput());

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -5061,8 +5061,12 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
 
     // One output row per matched pair, the probe rows walked in order and each row's
     // matches taken in build order. A key nothing can match - a null, a NaN - emits no
-    // row, as the equality this replaces kept none.
-    for (size_t row = 0; row < rowCount; row++) {
+    // row, as the equality this replaces kept none. A limit caps the pairs at the prefix
+    // it can emit this step, since the rows come out in the order they are paired in.
+    const NLLimitState* limit = probe->getLimit();
+    const size_t pairBudget = limit ? limit->getRemaining() : std::numeric_limits<size_t>::max();
+
+    for (size_t row = 0; row < rowCount && probeRaw.size() < pairBudget; row++) {
         if (!keyIsMatchable(key, row)) {
             continue;
         }
@@ -5073,6 +5077,10 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
         for (const size_t buildRow : state->rowsFor(*keyScratch)) {
             probeRaw.push_back(row);
             buildRaw.push_back(buildRow);
+
+            if (probeRaw.size() == pairBudget) {
+                break;
+            }
         }
     }
 

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1384,6 +1384,29 @@ void distinctAppendElementBytes(std::string& key, const ListElementView element)
     bioassert(false, "Unknown ListBufferTypeTag");
 }
 
+// A chunk of this kind holds no null row - an ID column, a plainly-held value - so every
+// row of it carries a key a join can match on.
+bool neverNullColumn(const Column* column, size_t row) {
+    return false;
+}
+
+// Whether one row of a nullable value column is null, which keeps it out of a join: `=`
+// against a null gives null, and the filter this join replaces kept only the true rows.
+template <typename Primitive>
+bool optColumnIsNull(const Column* column, size_t row) {
+    const auto& raw = static_cast<const ColumnVector<std::optional<Primitive>>*>(column)->getRaw();
+
+    return !raw[row].has_value();
+}
+
+// Whether one row of a type-erased column of tagged scalars is null - the cell's own tag
+// says so, where a nullable column has a present flag.
+bool listElementColumnIsNull(const Column* column, size_t row) {
+    const auto& raw = static_cast<const ColumnVector<ListElementView>*>(column)->getRaw();
+
+    return raw[row].getTag() == ListBufferTypeTag::Null;
+}
+
 // Serialize one row of a type-erased column of tagged scalars into the row key.
 void distinctKeyAppendListElementColumn(const Column* column, size_t row, std::string& key) {
     const auto& raw = static_cast<const ColumnVector<ListElementView>*>(column)->getRaw();
@@ -4959,6 +4982,94 @@ void NLExecutor::runDistinctFilter(NLExecutionContext* context, NLFunctionData* 
     }
 }
 
+void NLExecutor::runHashJoinReset(NLExecutionContext* context, NLFunctionData* data) {
+    const NLHashJoinResetData* reset = static_cast<NLHashJoinResetData*>(data);
+    reset->getState()->reset();
+}
+
+void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData* data) {
+    NLHashJoinCollectData* collect = static_cast<NLHashJoinCollectData*>(data);
+    NLHashJoinState* state = collect->getState();
+
+    const Column* key = collect->getKeyColumn();
+    const size_t rowCount = key->size();
+    const size_t firstRow = state->getRowCount();
+
+    // Row r of this chunk becomes build row firstRow + r, which is what the buffers will
+    // hold it at once appended. A null key is indexed under nothing, so no probe row can
+    // match it.
+    const NLKeyAppendFunction keyAppend = collect->getKeyAppend();
+    const NLIsNullFunction keyIsNull = collect->getKeyIsNull();
+    std::string* keyScratch = collect->getKeyScratch();
+
+    for (size_t row = 0; row < rowCount; row++) {
+        if (keyIsNull(key, row)) {
+            continue;
+        }
+
+        keyScratch->clear();
+        keyAppend(key, row, *keyScratch);
+
+        state->indexRow(*keyScratch, firstRow + row);
+    }
+
+    // The columns are appended together, so the buffers stay row-aligned with each other
+    // and with the rows just indexed.
+    for (const NLSortCollectData::Append& append : collect->appends()) {
+        append._append(append._input, append._buffer);
+    }
+
+    state->addRows(rowCount);
+}
+
+void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* data) {
+    NLHashJoinProbeData* probe = static_cast<NLHashJoinProbeData*>(data);
+    const NLHashJoinState* state = probe->getState();
+
+    const Column* key = probe->getKeyColumn();
+    const size_t rowCount = key->size();
+
+    const NLKeyAppendFunction keyAppend = probe->getKeyAppend();
+    const NLIsNullFunction keyIsNull = probe->getKeyIsNull();
+    std::string* keyScratch = probe->getKeyScratch();
+
+    ColumnVector<size_t>* probeIndices = probe->getProbeIndices();
+    ColumnVector<size_t>* buildIndices = probe->getBuildIndices();
+    std::vector<size_t>& probeRaw = probeIndices->getRaw();
+    std::vector<size_t>& buildRaw = buildIndices->getRaw();
+    probeRaw.clear();
+    buildRaw.clear();
+
+    // One output row per matched pair, the probe rows walked in order and each row's
+    // matches taken in build order - the order the nested loop this replaces emitted the
+    // surviving pairs in. A null key matches nothing, as the equality it replaces did.
+    for (size_t row = 0; row < rowCount; row++) {
+        if (keyIsNull(key, row)) {
+            continue;
+        }
+
+        keyScratch->clear();
+        keyAppend(key, row, *keyScratch);
+
+        for (const size_t buildRow : state->rowsFor(*keyScratch)) {
+            probeRaw.push_back(row);
+            buildRaw.push_back(buildRow);
+        }
+    }
+
+    // The probe side reads its own chunk, the build side the buffers; both gather by the
+    // matched pairs, so every output column is row-aligned with the joined rows.
+    for (const NLCarriedColumn& column : probe->probeColumns()) {
+        const NLGatherFunction gather = column.getGatherFunc();
+        gather(column.getInput(), probeIndices, column.getOutput());
+    }
+
+    for (const NLCarriedColumn& column : probe->buildColumns()) {
+        const NLGatherFunction gather = column.getGatherFunc();
+        gather(column.getInput(), buildIndices, column.getOutput());
+    }
+}
+
 void NLExecutor::runFilter(NLExecutionContext* context, NLFunctionData* data) {
     NLFilterData* filter = static_cast<NLFilterData*>(data);
 
@@ -6073,6 +6184,27 @@ NLKeyAppendFunction NLExecutor::selectOptKeyAppendFunction(ValueType valueType) 
 
     bioassert(false, "Unhandled value type");
     return nullptr;
+}
+
+NLIsNullFunction NLExecutor::neverNull() {
+    return &neverNullColumn;
+}
+
+// Selected per column from its value type. Every value type carries a present flag, so -
+// unlike selectOptKeyAppendFunction - an embedding dispatches fine here; a key column of
+// one is rejected by the serializer, not by this.
+NLIsNullFunction NLExecutor::selectOptIsNullFunction(ValueType valueType) {
+    NLIsNullFunction isNull = nullptr;
+    const auto select = [&]<SupportedType T>() {
+        isNull = &optColumnIsNull<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return isNull;
+}
+
+NLIsNullFunction NLExecutor::selectListElementIsNullFunction() {
+    return &listElementColumnIsNull;
 }
 
 // An ID chunk (node/edge/edge-type IDs) has no null rows, so every row counts,

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -5245,8 +5245,8 @@ void NLExecutor::runHashJoinCollect(NLExecutionContext* context, NLFunctionData*
     }
 }
 
-void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* data) {
-    NLHashJoinProbeData* probe = static_cast<NLHashJoinProbeData*>(data);
+void NLExecutor::runHashJoinProbeLoop(NLExecutionContext* context, NLFunctionData* data) {
+    NLHashJoinProbeLoopData* probe = static_cast<NLHashJoinProbeLoopData*>(data);
     const NLHashJoinState* state = probe->getState();
     const NLHashJoinIndex& index = state->getIndex();
 
@@ -5265,41 +5265,70 @@ void NLExecutor::runHashJoinProbe(NLExecutionContext* context, NLFunctionData* d
     ColumnVector<size_t>* buildIndices = probe->getBuildIndices();
     std::vector<size_t>& probeRaw = probeIndices->getRaw();
     std::vector<size_t>& buildRaw = buildIndices->getRaw();
-    probeRaw.clear();
-    buildRaw.clear();
 
-    // One output row per matched pair, the probe rows walked in order and each row's
-    // matches taken in build order. A key nothing can match - a null, a NaN - emits no
-    // row, as the equality this replaces kept none. A limit caps the pairs at the prefix
-    // it can emit this step, since the rows come out in the order they are paired in.
+    const size_t chunkSize = context->getChunkSize();
     const NLLimitState* limit = probe->getLimit();
-    const size_t pairBudget = limit ? limit->getRemaining() : std::numeric_limits<size_t>::max();
+    const NLStmtContainer* loopBody = probe->getStmts();
 
-    for (size_t row = 0; row < rowCount && probeRaw.size() < pairBudget; row++) {
-        if (!keyIsMatchable(key, row)) {
-            continue;
+    // Walk the pairs a chunk at a time, holding the probe row reached and the next row of
+    // its group to pair, so a step can start and end partway through one row's matches.
+    // noRow with nothing left to pair is what advances the probe row.
+    size_t probeRow = 0;
+    size_t match = NLHashJoinIndex::noRow;
+    bool inGroup = false;
+
+    while (probeRow < rowCount) {
+        const size_t remaining = limit ? limit->getRemaining() : chunkSize;
+        if (remaining == 0) {
+            return;
         }
 
-        const size_t group = findKeyGroup(index, hashes[row], key, row, buildKey, keyEqual);
+        const size_t stepBudget = std::min(chunkSize, remaining);
 
-        // Every row of the group carries the key the probe row matched, so the group is
-        // walked without comparing again.
-        for (size_t match = group;
-             match != NLHashJoinIndex::noRow && probeRaw.size() < pairBudget;
-             match = index.getNextInGroup(match)) {
-            probeRaw.push_back(row);
-            buildRaw.push_back(match);
+        probeRaw.clear();
+        buildRaw.clear();
+
+        while (probeRow < rowCount && probeRaw.size() < stepBudget) {
+            if (!inGroup) {
+                if (!keyIsMatchable(key, probeRow)) {
+                    probeRow++;
+                    continue;
+                }
+
+                match = findKeyGroup(index, hashes[probeRow], key, probeRow, buildKey, keyEqual);
+                inGroup = true;
+            }
+
+            // Every row of the group carries the key this probe row matched, so the group
+            // is walked without comparing again.
+            while (match != NLHashJoinIndex::noRow && probeRaw.size() < stepBudget) {
+                probeRaw.push_back(probeRow);
+                buildRaw.push_back(match);
+
+                match = index.getNextInGroup(match);
+            }
+
+            if (match == NLHashJoinIndex::noRow) {
+                probeRow++;
+                inGroup = false;
+            }
         }
-    }
 
-    for (const NLCarriedColumn& column : probe->probeColumns()) {
-        const NLGatherFunction gather = column.getGatherFunc();
-        gather(column.getInput(), probeIndices, column.getOutput());
-    }
+        if (probeRaw.empty()) {
+            return;
+        }
 
-    for (const NLCarriedColumn& column : probe->buildColumns()) {
-        const NLGatherFunction gather = column.getGatherFunc();
-        gather(column.getInput(), buildIndices, column.getOutput());
+        for (const NLCarriedColumn& column : probe->probeColumns()) {
+            const NLGatherFunction gather = column.getGatherFunc();
+            gather(column.getInput(), probeIndices, column.getOutput());
+        }
+
+        for (const NLCarriedColumn& column : probe->buildColumns()) {
+            const NLGatherFunction gather = column.getGatherFunc();
+            gather(column.getInput(), buildIndices, column.getOutput());
+        }
+
+        runBody(context, loopBody);
     }
 }
 

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -492,10 +492,15 @@ public:
     static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
     static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
 
-    // The embedding key of a join, which selectOptKeyAppendFunction turns away: an
-    // embedding is no DISTINCT key, but two embedding columns do compare with `=`, so the
-    // vector serializes to the bytes a join matches on.
-    static NLKeyAppendFunction selectOptEmbeddingKeyAppendFunction();
+    // Hash and equality for a join key: an ID chunk of this kind, a nullable value chunk
+    // of this value type, a plain numeric chunk, a type-erased cell. Used by
+    // nl.hash_join_collect to chain a build row under its hash and by nl.hash_join_probe
+    // to find and confirm the build rows a probe row matches. An embedding is a key here,
+    // as `=` compares two vectors, though it is no DISTINCT key.
+    static NLJoinKeyFunctions selectJoinKeyFunctions(NLChunkKind kind);
+    static NLJoinKeyFunctions selectOptJoinKeyFunctions(ValueType valueType);
+    static NLJoinKeyFunctions selectPlainJoinKeyFunctions(ValueType valueType);
+    static NLJoinKeyFunctions selectListElementJoinKeyFunctions();
 
     // Per-row test of whether a join key can match. An ID chunk holds neither a null nor
     // a NaN, so every row of it matches; a nullable value chunk reads its present flag, a

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -491,10 +491,15 @@ public:
     static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
     static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
 
+    // The embedding key of a join, which selectOptKeyAppendFunction turns away: an
+    // embedding is no DISTINCT key, but two embedding columns do compare with `=`, so the
+    // vector serializes to the bytes a join matches on.
+    static NLKeyAppendFunction selectOptEmbeddingKeyAppendFunction();
+
     // Per-row test of whether a join key can match. An ID chunk holds neither a null nor
     // a NaN, so every row of it matches; a nullable value chunk reads its present flag, a
-    // type-erased cell its tag, and a double column of either shape also rejects a NaN,
-    // which no key equals - itself included. Used by nl.hash_join_collect to leave a key
+    // type-erased cell its tag, and a double or embedding column also rejects a NaN, which
+    // no key equals - itself included. Used by nl.hash_join_collect to leave a key
     // out of the index and by nl.hash_join_probe to leave a probe row unmatched.
     static NLKeyIsMatchableFunction everyKeyMatchable();
     static NLKeyIsMatchableFunction selectOptKeyMatchableFunction(ValueType valueType);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -83,7 +83,8 @@ public:
     static void runCheckLabelConstraint(NLExecutionContext* context, NLFunctionData* data);
     static void runCheckEdgeTypeConstraint(NLExecutionContext* context, NLFunctionData* data);
 
-    static void runCrossProduct(NLExecutionContext* context, NLFunctionData* data);
+    // Drive the pairs of a cross product, running the body once per chunk of them.
+    static void runCrossProductLoop(NLExecutionContext* context, NLFunctionData* data);
 
     // Reset a limit counter to its budget; runs each time its block runs.
     static void runLimitInit(NLExecutionContext* context, NLFunctionData* data);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -491,13 +491,15 @@ public:
     static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
     static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
 
-    // Per-row null test for a join key. A chunk that cannot hold a null answers false for
-    // every row, so the ID kinds and the plainly-held values share one handle; a nullable
-    // value chunk reads its present flag and a type-erased cell its tag. Used by
-    // nl.hash_join_collect and nl.hash_join_probe to leave a null key unmatched.
-    static NLIsNullFunction neverNull();
-    static NLIsNullFunction selectOptIsNullFunction(ValueType valueType);
-    static NLIsNullFunction selectListElementIsNullFunction();
+    // Per-row test of whether a join key can match. An ID chunk holds neither a null nor
+    // a NaN, so every row of it matches; a nullable value chunk reads its present flag, a
+    // type-erased cell its tag, and a double column of either shape also rejects a NaN,
+    // which no key equals - itself included. Used by nl.hash_join_collect to leave a key
+    // out of the index and by nl.hash_join_probe to leave a probe row unmatched.
+    static NLKeyIsMatchableFunction everyKeyMatchable();
+    static NLKeyIsMatchableFunction selectOptKeyMatchableFunction(ValueType valueType);
+    static NLKeyIsMatchableFunction selectPlainKeyMatchableFunction(ValueType valueType);
+    static NLKeyIsMatchableFunction selectListElementKeyMatchableFunction();
 
     // Non-null row count for a COUNT. An ID chunk has no null rows, so countAllRows
     // is its handle (the row count); a nullable value chunk of this value type

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -148,7 +148,7 @@ public:
     // Emit each probe row paired with the build rows its key matches: look each probe
     // row's key up in the index, then gather the probe columns and the build buffers by
     // the matched pairs into fresh output chunks. A null probe key matches nothing.
-    static void runHashJoinProbe(NLExecutionContext* context, NLFunctionData* data);
+    static void runHashJoinProbeLoop(NLExecutionContext* context, NLFunctionData* data);
 
     // Empty the seen-set of a DISTINCT; runs each time its block runs.
     static void runDistinctReset(NLExecutionContext* context, NLFunctionData* data);

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -135,6 +135,20 @@ public:
     // the pattern missed.
     static void runOptionalDrainLoop(NLExecutionContext* context, NLFunctionData* data);
 
+    // Empty the buffers and the key index of a hash join's build side; runs each time
+    // its block runs.
+    static void runHashJoinReset(NLExecutionContext* context, NLFunctionData* data);
+
+    // Append the current chunk of every build column to its buffer and index each row
+    // under its key. Runs once per build-loop step, growing the buffers row-aligned; a
+    // row whose key is null is buffered but left out of the index.
+    static void runHashJoinCollect(NLExecutionContext* context, NLFunctionData* data);
+
+    // Emit each probe row paired with the build rows its key matches: look each probe
+    // row's key up in the index, then gather the probe columns and the build buffers by
+    // the matched pairs into fresh output chunks. A null probe key matches nothing.
+    static void runHashJoinProbe(NLExecutionContext* context, NLFunctionData* data);
+
     // Empty the seen-set of a DISTINCT; runs each time its block runs.
     static void runDistinctReset(NLExecutionContext* context, NLFunctionData* data);
 
@@ -476,6 +490,14 @@ public:
     // as a key (an embedding), which cannot be a DISTINCT key.
     static NLKeyAppendFunction selectKeyAppendFunction(NLChunkKind kind);
     static NLKeyAppendFunction selectOptKeyAppendFunction(ValueType valueType);
+
+    // Per-row null test for a join key. A chunk that cannot hold a null answers false for
+    // every row, so the ID kinds and the plainly-held values share one handle; a nullable
+    // value chunk reads its present flag and a type-erased cell its tag. Used by
+    // nl.hash_join_collect and nl.hash_join_probe to leave a null key unmatched.
+    static NLIsNullFunction neverNull();
+    static NLIsNullFunction selectOptIsNullFunction(ValueType valueType);
+    static NLIsNullFunction selectListElementIsNullFunction();
 
     // Non-null row count for a COUNT. An ID chunk has no null rows, so countAllRows
     // is its handle (the row count); a nullable value chunk of this value type

--- a/query/ir/interpreter/NLHashJoinIndex.cpp
+++ b/query/ir/interpreter/NLHashJoinIndex.cpp
@@ -1,0 +1,89 @@
+#include "NLHashJoinIndex.h"
+
+#include <algorithm>
+
+using namespace db;
+
+namespace {
+
+constexpr size_t minimumBucketCount = 16;
+
+}
+
+NLHashJoinIndex::NLHashJoinIndex() {
+}
+
+NLHashJoinIndex::~NLHashJoinIndex() {
+}
+
+void NLHashJoinIndex::clear() {
+    _hashes.clear();
+    _nextGroups.clear();
+    _nextInGroup.clear();
+    _groupTails.clear();
+    _buckets.clear();
+    _groupCount = 0;
+}
+
+void NLHashJoinIndex::addRows(size_t count) {
+    const size_t rowCount = _hashes.size() + count;
+
+    _hashes.resize(rowCount, 0);
+    _nextGroups.resize(rowCount, noRow);
+    _nextInGroup.resize(rowCount, noRow);
+    _groupTails.resize(rowCount, noRow);
+}
+
+void NLHashJoinIndex::openGroup(size_t row, uint64_t hash) {
+    _hashes[row] = hash;
+    _nextInGroup[row] = noRow;
+    _groupTails[row] = row;
+    _groupCount++;
+
+    if (_groupCount > _buckets.size()) {
+        growBuckets();
+    }
+
+    chainGroup(row, hash);
+}
+
+void NLHashJoinIndex::addToGroup(size_t head, size_t row) {
+    _hashes[row] = _hashes[head];
+    _nextInGroup[row] = noRow;
+
+    _nextInGroup[_groupTails[head]] = row;
+    _groupTails[head] = row;
+}
+
+size_t NLHashJoinIndex::getFirstGroup(uint64_t hash) const {
+    if (_buckets.empty()) {
+        return noRow;
+    }
+
+    return _buckets[hash & (_buckets.size() - 1)];
+}
+
+void NLHashJoinIndex::growBuckets() {
+    std::vector<size_t> oldBuckets;
+    oldBuckets.swap(_buckets);
+
+    const size_t bucketCount = std::max(minimumBucketCount, oldBuckets.size() * 2);
+    _buckets.assign(bucketCount, noRow);
+
+    for (const size_t bucket : oldBuckets) {
+        size_t head = bucket;
+
+        while (head != noRow) {
+            const size_t next = _nextGroups[head];
+            chainGroup(head, _hashes[head]);
+            head = next;
+        }
+    }
+}
+
+void NLHashJoinIndex::chainGroup(size_t head, uint64_t hash) {
+    const size_t bucket = hash & (_buckets.size() - 1);
+
+    _nextGroups[head] = _buckets[bucket];
+    _buckets[bucket] = head;
+}

--- a/query/ir/interpreter/NLHashJoinIndex.h
+++ b/query/ir/interpreter/NLHashJoinIndex.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <limits>
+#include <vector>
+
+namespace db {
+
+// The index of a hash join's build side: the rows carrying one key form a group, and one
+// bucket chains the groups of every key falling in it. It holds hashes and row numbers
+// only - a key stays in the build buffer, where the caller compares it - so walking a
+// bucket confirms each group's key once and the rows within a group need no comparison.
+class NLHashJoinIndex {
+public:
+    static constexpr size_t noRow = std::numeric_limits<size_t>::max();
+
+    NLHashJoinIndex();
+    ~NLHashJoinIndex();
+
+    void clear();
+
+    // Extend the row set by count rows numbered from getRowCount(), none indexed yet.
+    void addRows(size_t count);
+
+    void openGroup(size_t row, uint64_t hash);
+
+    // Add a row to the group opened at head, whose key it carries. The group keeps the
+    // order its rows were added in, which is the order the probe emits its matches in.
+    void addToGroup(size_t head, size_t row);
+
+    size_t getRowCount() const { return _hashes.size(); }
+
+    size_t getFirstGroup(uint64_t hash) const;
+    size_t getNextGroup(size_t head) const { return _nextGroups[head]; }
+
+    size_t getNextInGroup(size_t row) const { return _nextInGroup[row]; }
+
+    uint64_t getHash(size_t row) const { return _hashes[row]; }
+
+private:
+    std::vector<uint64_t> _hashes;
+    std::vector<size_t> _nextGroups;
+    std::vector<size_t> _nextInGroup;
+    std::vector<size_t> _groupTails;
+    std::vector<size_t> _buckets;
+    size_t _groupCount {0};
+
+    void growBuckets();
+    void chainGroup(size_t head, uint64_t hash);
+};
+
+}

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -201,14 +201,7 @@ void NLHashJoinState::reset() {
         buffer->clear();
     }
 
-    _rowsByKey.clear();
-    _rowCount = 0;
-}
-
-const std::vector<size_t>& NLHashJoinState::rowsFor(const std::string& key) const {
-    const auto rows = _rowsByKey.find(key);
-
-    return rows == _rowsByKey.end() ? _noRows : rows->second;
+    _index.clear();
 }
 
 NLGroupTable::Assignment NLGroupTable::assign(const std::string& key) {

--- a/query/ir/interpreter/NLProgram.cpp
+++ b/query/ir/interpreter/NLProgram.cpp
@@ -196,6 +196,21 @@ void NLSortState::reset() {
     _sorted = false;
 }
 
+void NLHashJoinState::reset() {
+    for (Column* buffer : _buffers) {
+        buffer->clear();
+    }
+
+    _rowsByKey.clear();
+    _rowCount = 0;
+}
+
+const std::vector<size_t>& NLHashJoinState::rowsFor(const std::string& key) const {
+    const auto rows = _rowsByKey.find(key);
+
+    return rows == _rowsByKey.end() ? _noRows : rows->second;
+}
+
 NLGroupTable::Assignment NLGroupTable::assign(const std::string& key) {
     const size_t nextGroup = _groups.size();
     const auto [slot, inserted] = _groups.try_emplace(key, nextGroup);

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1336,6 +1336,168 @@ private:
 // collide by concatenation (e.g. "a"+"b" versus "ab"+"").
 using NLKeyAppendFunction = void (*)(const Column* column, size_t row, std::string& key);
 
+// Type of handle that answers whether one row of a column is null. One per column kind /
+// value type, selected during translation the same way the key-append family is; a column
+// that cannot hold a null answers false for every row. A null row serializes to a key like
+// any other, so this is what tells the two apart where nulls must not match - a join key,
+// where Cypher gives null rather than true for `=` against a null.
+using NLIsNullFunction = bool (*)(const Column* column, size_t row);
+
+// Runtime state of one hash join's build side: the build rows, materialized column by
+// column, and the index from a row's serialized key to the rows carrying it.
+// nl.hash_join_buffer empties it, nl.hash_join_collect grows it once per build-loop step,
+// and nl.hash_join_probe reads it once per probe-loop step. The joining sibling of
+// NLSortState: it indexes the rows it accumulates rather than ordering them, and they
+// come back out through the probe rather than through a loop of its own.
+class NLHashJoinState {
+public:
+    // Empty the buffers and the key index, so the build side starts fresh. Runs each time
+    // nl.hash_join_buffer's block runs - once at function scope for a top-level join.
+    void reset();
+
+    // Record one build column's buffer. Kept in collect order, so the key column index
+    // the nl.hash_join_buffer carries indexes this list too.
+    void addColumnBuffer(Column* buffer) { _buffers.push_back(buffer); }
+
+    const std::vector<Column*>& buffers() const { return _buffers; }
+    Column* buffer(size_t index) const { return _buffers[index]; }
+
+    // Index a build row under its serialized key. The rows of one key keep collect order,
+    // so a probe row's matches come out in the order the build side produced them.
+    void indexRow(const std::string& key, size_t row) { _rowsByKey[key].push_back(row); }
+
+    // The build rows carrying a key, empty when none does.
+    const std::vector<size_t>& rowsFor(const std::string& key) const;
+
+    // How many rows the buffers hold, which is what the next collected chunk's rows are
+    // numbered from.
+    size_t getRowCount() const { return _rowCount; }
+    void addRows(size_t rows) { _rowCount += rows; }
+
+private:
+    // One buffer per collected build column, row-aligned, grown by nl.hash_join_collect.
+    std::vector<Column*> _buffers;
+
+    // Serialized key -> the build rows holding it, in collect order.
+    std::unordered_map<std::string, std::vector<size_t>> _rowsByKey;
+
+    // Rows collected so far, so each chunk's rows are numbered from where the last ended.
+    size_t _rowCount {0};
+
+    // Answered for a key no build row carries, so the probe reads an empty range rather
+    // than testing for a miss.
+    std::vector<size_t> _noRows;
+};
+
+// nl.hash_join_buffer data: empties a build side each time the block it lives in runs -
+// once at function scope for a top-level join, once per enclosing step for a nested one.
+class NLHashJoinResetData : public NLFunctionData {
+public:
+    NLHashJoinResetData(NLHashJoinState* state)
+        : _state(state)
+    {
+    }
+
+    NLHashJoinState* getState() const { return _state; }
+
+private:
+    NLHashJoinState* _state {nullptr};
+};
+
+// nl.hash_join_collect data: appends the current chunk of every build column to its
+// buffer and indexes each row's key. The appends share NLSortCollectData::Append's shape;
+// the key is one of those columns, read again through the serializer and the null test.
+class NLHashJoinCollectData : public NLFunctionData {
+public:
+    NLHashJoinCollectData(NLHashJoinState* state)
+        : _state(state)
+    {
+    }
+
+    NLHashJoinState* getState() const { return _state; }
+
+    const std::vector<NLSortCollectData::Append>& appends() const { return _appends; }
+
+    void addAppend(const NLSortCollectData::Append& append) {
+        _appends.push_back(append);
+    }
+
+    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLIsNullFunction isNull) {
+        _key = key;
+        _keyAppend = keyAppend;
+        _keyIsNull = isNull;
+    }
+
+    const Column* getKeyColumn() const { return _key; }
+    NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
+    NLIsNullFunction getKeyIsNull() const { return _keyIsNull; }
+
+    std::string* getKeyScratch() { return &_keyScratch; }
+
+private:
+    NLHashJoinState* _state {nullptr};
+    std::vector<NLSortCollectData::Append> _appends;
+
+    const Column* _key {nullptr};
+    NLKeyAppendFunction _keyAppend {nullptr};
+    NLIsNullFunction _keyIsNull {nullptr};
+
+    // Scratch reused to build each row's key, cleared once per row
+    std::string _keyScratch;
+};
+
+// nl.hash_join_probe data: per probe column its input chunk, the fresh output chunk and
+// the gather that repeats a row once per match; per build column its buffer, the fresh
+// output chunk and the gather that reads the matched rows back - both in the
+// NLCarriedColumn (input, output, gather) shape the edge and sort loops use. The two
+// index scratches hold this step's matched pairs, one row of each side per output row.
+class NLHashJoinProbeData : public NLFunctionData {
+public:
+    NLHashJoinProbeData(NLHashJoinState* state)
+        : _state(state)
+    {
+    }
+
+    NLHashJoinState* getState() const { return _state; }
+
+    const std::vector<NLCarriedColumn>& probeColumns() const { return _probeColumns; }
+    const std::vector<NLCarriedColumn>& buildColumns() const { return _buildColumns; }
+
+    void addProbeColumn(const NLCarriedColumn& column) { _probeColumns.push_back(column); }
+    void addBuildColumn(const NLCarriedColumn& column) { _buildColumns.push_back(column); }
+
+    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLIsNullFunction isNull) {
+        _key = key;
+        _keyAppend = keyAppend;
+        _keyIsNull = isNull;
+    }
+
+    const Column* getKeyColumn() const { return _key; }
+    NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
+    NLIsNullFunction getKeyIsNull() const { return _keyIsNull; }
+
+    std::string* getKeyScratch() { return &_keyScratch; }
+
+    ColumnVector<size_t>* getProbeIndices() { return &_probeIndices; }
+    ColumnVector<size_t>* getBuildIndices() { return &_buildIndices; }
+
+private:
+    NLHashJoinState* _state {nullptr};
+    std::vector<NLCarriedColumn> _probeColumns;
+    std::vector<NLCarriedColumn> _buildColumns;
+
+    const Column* _key {nullptr};
+    NLKeyAppendFunction _keyAppend {nullptr};
+    NLIsNullFunction _keyIsNull {nullptr};
+
+    std::string _keyScratch;
+
+    // This step's matched pairs: output row i reads _probeIndices[i] of the probe chunk
+    // and _buildIndices[i] of the buffers.
+    ColumnVector<size_t> _probeIndices;
+    ColumnVector<size_t> _buildIndices;
+};
+
 // Runtime state of one DISTINCT: the set of serialized row keys already emitted.
 // nl.distinct resets it (once at function scope for a top-level or mid-query
 // DISTINCT), and nl.distinct_filter is the sole reader and mutator - it looks up
@@ -3288,6 +3450,16 @@ public:
         return statePtr;
     }
 
+    // Allocate one hash join's runtime build side, owned by the program; the reset,
+    // collect and probe statements that share it hold a borrowed pointer. The joining
+    // sibling of allocSortState.
+    NLHashJoinState* allocHashJoinState() {
+        auto state = std::make_unique<NLHashJoinState>();
+        NLHashJoinState* statePtr = state.get();
+        _hashJoinStates.push_back(std::move(state));
+        return statePtr;
+    }
+
     // Allocate one COUNT's runtime tally, owned by the program; the reset, update
     // and emit statements that share it hold a borrowed pointer. The count sibling
     // of allocSortState.
@@ -3400,6 +3572,7 @@ private:
     std::vector<std::unique_ptr<NLLimitState>> _limitStates;
     std::vector<std::unique_ptr<NLSkipState>> _skipStates;
     std::vector<std::unique_ptr<NLSortState>> _sortStates;
+    std::vector<std::unique_ptr<NLHashJoinState>> _hashJoinStates;
     std::vector<std::unique_ptr<NLDistinctState>> _distinctStates;
     std::vector<std::unique_ptr<NLCountState>> _countStates;
     std::vector<std::unique_ptr<NLAggregateState>> _aggregateStates;

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1467,6 +1467,12 @@ public:
     void addProbeColumn(const NLCarriedColumn& column) { _probeColumns.push_back(column); }
     void addBuildColumn(const NLCarriedColumn& column) { _buildColumns.push_back(column); }
 
+    // The governing limit counter, or null for an unbounded probe. When set, only
+    // getRemaining() matched pairs are laid out; it never mutates the counter (the
+    // following nl.limit_update does).
+    NLLimitState* getLimit() const { return _limit; }
+    void setLimit(NLLimitState* limit) { _limit = limit; }
+
     void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLKeyIsMatchableFunction isMatchable) {
         _key = key;
         _keyAppend = keyAppend;
@@ -1490,6 +1496,7 @@ private:
     const Column* _key {nullptr};
     NLKeyAppendFunction _keyAppend {nullptr};
     NLKeyIsMatchableFunction _keyIsMatchable {nullptr};
+    NLLimitState* _limit {nullptr};
 
     std::string _keyScratch;
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -869,21 +869,24 @@ private:
     std::unordered_set<uint64_t> _matchingIDs;
 };
 
-// A cross product emits N*M rows (every outer row paired with every inner row),
-// but an input column holds only its N or M values, so its values must be
-// repeated to fill an N*M-row output column. That repetition is the broadcast.
-// With outer [a0,a1] (N=2) and inner [b0,b1,b2] (M=3) the result is:
+// A cross product pairs every outer row with every inner row, so the pair at
+// position p is outer row p/M with inner row p%M (M being the inner row count).
+// An input column holds only its N or M values, so filling a column of pairs
+// repeats them: that repetition is the broadcast. With outer [a0,a1] (N=2) and
+// inner [b0,b1,b2] (M=3) the whole product reads:
 //   outer -> [a0,a0,a0, a1,a1,a1]   each outer row repeated M times (block-repeat)
-//   inner -> [b0,b1,b2, b0,b1,b2]   whole inner chunk repeated N times (tile)
-// so row k across all columns is one (outer, inner) pair. `factor` is M for an
-// outer column, N for an inner one; both directions share this signature.
-// `outputRowCount` caps the fill: it is min(N*M, remaining) under a limit, so the
-// broadcast lays out only the product's first outputRowCount rows (its last block
-// or tile may be partial) and skips the rest the limit could never emit. Without
-// a limit it is the full N*M.
+//   inner -> [b0,b1,b2, b0,b1,b2]   the inner chunk repeated N times (tile)
+// so row k across all columns is one pair.
+//
+// A step fills the `rowCount` pairs starting at `position`, which is how the
+// product is cut into chunks: a slice may start and end mid-block or mid-tile, and
+// every column of the step slices at the same position, so they stay row-aligned.
+// `factor` is M for both directions - block-repeat divides the position by it,
+// tile takes the position modulo it.
 using NLBroadcastFunction = void (*)(const Column* input,
                                      size_t factor,
-                                     size_t outputRowCount,
+                                     size_t position,
+                                     size_t rowCount,
                                      Column* output);
 
 // One column used as operand of nl.cross_product: its input chunk, the output
@@ -909,11 +912,12 @@ private:
     NLBroadcastFunction _broadcast {nullptr};
 };
 
-// nl.cross_product data: the outer and inner columns of a cartesian product.
-// N (outer rows) and M (inner rows) are read at run time from the first column
-// of each group. Each outer column is block-repeated x M and each inner column
-// is tiled x N, so the product has N*M rows.
-class NLCrossProductData : public NLFunctionData {
+// nl.cross_product loop data: the outer and inner columns of a cartesian product,
+// and the body run once per chunk of the pairs they make. N (outer rows) and M
+// (inner rows) are read at run time from the first column of each group, so the
+// product has N*M pairs; the loop walks them chunk by chunk rather than laying all
+// of them out at once.
+class NLCrossProductLoopData : public NLFunctionData {
 public:
     using Columns = std::vector<NLCrossColumn>;
 
@@ -928,16 +932,20 @@ public:
         _innerColumns.push_back(column);
     }
 
-    // The governing limit counter, or null for an unbounded product. When set,
-    // the product is built only up to getRemaining() rows; it never mutates the
-    // counter (the following nl.limit_update does).
+    // The governing limit counter, or null for an unbounded loop. The loop stops
+    // once it reaches zero and a step lays out at most that many pairs; it never
+    // mutates the counter (the nl.limit_update in the body does).
     NLLimitState* getLimit() const { return _limit; }
     void setLimit(NLLimitState* limit) { _limit = limit; }
+
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
 
 private:
     Columns _outerColumns;
     Columns _innerColumns;
     NLLimitState* _limit {nullptr};
+    NLStmtContainer _stmts;
 };
 
 // Lay a constant column's single value out over rowCount rows of a fresh output

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1336,12 +1336,13 @@ private:
 // collide by concatenation (e.g. "a"+"b" versus "ab"+"").
 using NLKeyAppendFunction = void (*)(const Column* column, size_t row, std::string& key);
 
-// Type of handle that answers whether one row of a column is null. One per column kind /
-// value type, selected during translation the same way the key-append family is; a column
-// that cannot hold a null answers false for every row. A null row serializes to a key like
-// any other, so this is what tells the two apart where nulls must not match - a join key,
-// where Cypher gives null rather than true for `=` against a null.
-using NLIsNullFunction = bool (*)(const Column* column, size_t row);
+// Type of handle that answers whether one row of a join key column can match at all. One
+// per column kind / value type, selected during translation the same way the key-append
+// family is. Two values the key bytes cannot tell apart from a matchable one are not: a
+// null, for which Cypher gives null rather than true for `=`, and a NaN, which is not
+// equal to itself - and the serializer maps every NaN payload to one canonical NaN, which
+// is what DISTINCT wants and the opposite of what a join does.
+using NLKeyIsMatchableFunction = bool (*)(const Column* column, size_t row);
 
 // Runtime state of one hash join's build side: the build rows, materialized column by
 // column, and the index from a row's serialized key to the rows carrying it.
@@ -1422,15 +1423,15 @@ public:
         _appends.push_back(append);
     }
 
-    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLIsNullFunction isNull) {
+    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLKeyIsMatchableFunction isMatchable) {
         _key = key;
         _keyAppend = keyAppend;
-        _keyIsNull = isNull;
+        _keyIsMatchable = isMatchable;
     }
 
     const Column* getKeyColumn() const { return _key; }
     NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
-    NLIsNullFunction getKeyIsNull() const { return _keyIsNull; }
+    NLKeyIsMatchableFunction getKeyIsMatchable() const { return _keyIsMatchable; }
 
     std::string* getKeyScratch() { return &_keyScratch; }
 
@@ -1440,7 +1441,7 @@ private:
 
     const Column* _key {nullptr};
     NLKeyAppendFunction _keyAppend {nullptr};
-    NLIsNullFunction _keyIsNull {nullptr};
+    NLKeyIsMatchableFunction _keyIsMatchable {nullptr};
 
     // Scratch reused to build each row's key, cleared once per row
     std::string _keyScratch;
@@ -1466,15 +1467,15 @@ public:
     void addProbeColumn(const NLCarriedColumn& column) { _probeColumns.push_back(column); }
     void addBuildColumn(const NLCarriedColumn& column) { _buildColumns.push_back(column); }
 
-    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLIsNullFunction isNull) {
+    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLKeyIsMatchableFunction isMatchable) {
         _key = key;
         _keyAppend = keyAppend;
-        _keyIsNull = isNull;
+        _keyIsMatchable = isMatchable;
     }
 
     const Column* getKeyColumn() const { return _key; }
     NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
-    NLIsNullFunction getKeyIsNull() const { return _keyIsNull; }
+    NLKeyIsMatchableFunction getKeyIsMatchable() const { return _keyIsMatchable; }
 
     std::string* getKeyScratch() { return &_keyScratch; }
 
@@ -1488,7 +1489,7 @@ private:
 
     const Column* _key {nullptr};
     NLKeyAppendFunction _keyAppend {nullptr};
-    NLIsNullFunction _keyIsNull {nullptr};
+    NLKeyIsMatchableFunction _keyIsMatchable {nullptr};
 
     std::string _keyScratch;
 

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1470,9 +1470,9 @@ private:
 // output chunk and the gather that reads the matched rows back - both in the
 // NLCarriedColumn (input, output, gather) shape the edge and sort loops use. The two
 // index scratches hold this step's matched pairs, one row of each side per output row.
-class NLHashJoinProbeData : public NLFunctionData {
+class NLHashJoinProbeLoopData : public NLFunctionData {
 public:
-    NLHashJoinProbeData(NLHashJoinState* state)
+    NLHashJoinProbeLoopData(NLHashJoinState* state)
         : _state(state)
     {
     }
@@ -1514,6 +1514,9 @@ public:
     ColumnVector<size_t>* getProbeIndices() { return &_probeIndices; }
     ColumnVector<size_t>* getBuildIndices() { return &_buildIndices; }
 
+    NLStmtContainer* getStmts() { return &_stmts; }
+    const NLStmtContainer* getStmts() const { return &_stmts; }
+
 private:
     NLHashJoinState* _state {nullptr};
     std::vector<NLCarriedColumn> _probeColumns;
@@ -1532,6 +1535,8 @@ private:
     // and _buildIndices[i] of the buffers.
     ColumnVector<size_t> _probeIndices;
     ColumnVector<size_t> _buildIndices;
+
+    NLStmtContainer _stmts;
 };
 
 // Runtime state of one DISTINCT: the set of serialized row keys already emitted.

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 #include <algorithm>
 #include <memory>
 #include <optional>
@@ -16,6 +17,7 @@
 #include "GraphPath.h"
 #include "ID.h"
 #include "LocalMemory.h"
+#include "NLHashJoinIndex.h"
 #include "ProcedureState.h"
 #include "columns/ColumnEdgeTypes.h"
 #include "columns/ColumnIDs.h"
@@ -1352,15 +1354,31 @@ using NLKeyAppendFunction = void (*)(const Column* column, size_t row, std::stri
 // is what DISTINCT wants and the opposite of what a join does.
 using NLKeyIsMatchableFunction = bool (*)(const Column* column, size_t row);
 
+// Type of handle that hashes every row of a join key column, one hash per row, for the
+// build index to chain rows under and the probe to look them up by. The key is read where
+// it lives and never copied; a row the matchable gate rejects hashes to anything, since
+// no lookup ever reaches it.
+using NLKeyHashFunction = void (*)(const Column* column, std::vector<uint64_t>& hashes);
+
+// Type of handle that answers whether a probe row's key equals a build row's, both read in
+// place from columns of one chunk type.
+using NLKeyEqualFunction = bool (*)(const Column* probe, size_t probeRow, const Column* build, size_t buildRow);
+
+// The two handlers a join reads a key column through, selected together from its chunk type.
+struct NLJoinKeyFunctions {
+    NLKeyHashFunction _hash {nullptr};
+    NLKeyEqualFunction _equal {nullptr};
+};
+
 // Runtime state of one hash join's build side: the build rows, materialized column by
-// column, and the index from a row's serialized key to the rows carrying it.
-// nl.hash_join_buffer empties it, nl.hash_join_collect grows it once per build-loop step,
-// and nl.hash_join_probe reads it once per probe-loop step. The joining sibling of
+// column, and the index chaining each row under its key's hash. nl.hash_join_buffer
+// empties it, nl.hash_join_collect grows it once per build-loop step, and
+// nl.hash_join_probe reads it once per probe-loop step. The joining sibling of
 // NLSortState: it indexes the rows it accumulates rather than ordering them, and they
 // come back out through the probe rather than through a loop of its own.
 class NLHashJoinState {
 public:
-    // Empty the buffers and the key index, so the build side starts fresh. Runs each time
+    // Empty the buffers and the index, so the build side starts fresh. Runs each time
     // nl.hash_join_buffer's block runs - once at function scope for a top-level join.
     void reset();
 
@@ -1371,31 +1389,14 @@ public:
     const std::vector<Column*>& buffers() const { return _buffers; }
     Column* buffer(size_t index) const { return _buffers[index]; }
 
-    // Index a build row under its serialized key. The rows of one key keep collect order,
-    // so a probe row's matches come out in the order the build side produced them.
-    void indexRow(const std::string& key, size_t row) { _rowsByKey[key].push_back(row); }
-
-    // The build rows carrying a key, empty when none does.
-    const std::vector<size_t>& rowsFor(const std::string& key) const;
-
-    // How many rows the buffers hold, which is what the next collected chunk's rows are
-    // numbered from.
-    size_t getRowCount() const { return _rowCount; }
-    void addRows(size_t rows) { _rowCount += rows; }
+    NLHashJoinIndex& getIndex() { return _index; }
+    const NLHashJoinIndex& getIndex() const { return _index; }
 
 private:
     // One buffer per collected build column, row-aligned, grown by nl.hash_join_collect.
     std::vector<Column*> _buffers;
 
-    // Serialized key -> the build rows holding it, in collect order.
-    std::unordered_map<std::string, std::vector<size_t>> _rowsByKey;
-
-    // Rows collected so far, so each chunk's rows are numbered from where the last ended.
-    size_t _rowCount {0};
-
-    // Answered for a key no build row carries, so the probe reads an empty range rather
-    // than testing for a miss.
-    std::vector<size_t> _noRows;
+    NLHashJoinIndex _index;
 };
 
 // nl.hash_join_buffer data: empties a build side each time the block it lives in runs -
@@ -1431,28 +1432,37 @@ public:
         _appends.push_back(append);
     }
 
-    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLKeyIsMatchableFunction isMatchable) {
+    // The collected key chunk and the buffer it is appended to, whose rows a new row's key
+    // is compared against to find the group already holding it.
+    void setKeyColumns(const Column* key,
+                       const Column* buildKey,
+                       const NLJoinKeyFunctions& keyFunctions,
+                       NLKeyIsMatchableFunction isMatchable) {
         _key = key;
-        _keyAppend = keyAppend;
+        _buildKey = buildKey;
+        _keyFunctions = keyFunctions;
         _keyIsMatchable = isMatchable;
     }
 
     const Column* getKeyColumn() const { return _key; }
-    NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
+    const Column* getBuildKeyColumn() const { return _buildKey; }
+    NLKeyHashFunction getKeyHash() const { return _keyFunctions._hash; }
+    NLKeyEqualFunction getKeyEqual() const { return _keyFunctions._equal; }
     NLKeyIsMatchableFunction getKeyIsMatchable() const { return _keyIsMatchable; }
 
-    std::string* getKeyScratch() { return &_keyScratch; }
+    std::vector<uint64_t>* getHashScratch() { return &_hashScratch; }
 
 private:
     NLHashJoinState* _state {nullptr};
     std::vector<NLSortCollectData::Append> _appends;
 
     const Column* _key {nullptr};
-    NLKeyAppendFunction _keyAppend {nullptr};
+    const Column* _buildKey {nullptr};
+    NLJoinKeyFunctions _keyFunctions;
     NLKeyIsMatchableFunction _keyIsMatchable {nullptr};
 
-    // Scratch reused to build each row's key, cleared once per row
-    std::string _keyScratch;
+    // This step's key hashes, one per row of the collected chunk
+    std::vector<uint64_t> _hashScratch;
 };
 
 // nl.hash_join_probe data: per probe column its input chunk, the fresh output chunk and
@@ -1481,17 +1491,25 @@ public:
     NLLimitState* getLimit() const { return _limit; }
     void setLimit(NLLimitState* limit) { _limit = limit; }
 
-    void setKeyColumn(const Column* key, NLKeyAppendFunction keyAppend, NLKeyIsMatchableFunction isMatchable) {
+    // The probe key chunk and the build key buffer it is matched against, read through
+    // the handlers of their shared chunk type.
+    void setKeyColumns(const Column* key,
+                       const Column* buildKey,
+                       const NLJoinKeyFunctions& keyFunctions,
+                       NLKeyIsMatchableFunction isMatchable) {
         _key = key;
-        _keyAppend = keyAppend;
+        _buildKey = buildKey;
+        _keyFunctions = keyFunctions;
         _keyIsMatchable = isMatchable;
     }
 
     const Column* getKeyColumn() const { return _key; }
-    NLKeyAppendFunction getKeyAppend() const { return _keyAppend; }
+    const Column* getBuildKeyColumn() const { return _buildKey; }
+    NLKeyHashFunction getKeyHash() const { return _keyFunctions._hash; }
+    NLKeyEqualFunction getKeyEqual() const { return _keyFunctions._equal; }
     NLKeyIsMatchableFunction getKeyIsMatchable() const { return _keyIsMatchable; }
 
-    std::string* getKeyScratch() { return &_keyScratch; }
+    std::vector<uint64_t>* getHashScratch() { return &_hashScratch; }
 
     ColumnVector<size_t>* getProbeIndices() { return &_probeIndices; }
     ColumnVector<size_t>* getBuildIndices() { return &_buildIndices; }
@@ -1502,11 +1520,13 @@ private:
     std::vector<NLCarriedColumn> _buildColumns;
 
     const Column* _key {nullptr};
-    NLKeyAppendFunction _keyAppend {nullptr};
+    const Column* _buildKey {nullptr};
+    NLJoinKeyFunctions _keyFunctions;
     NLKeyIsMatchableFunction _keyIsMatchable {nullptr};
     NLLimitState* _limit {nullptr};
 
-    std::string _keyScratch;
+    // This step's key hashes, one per row of the probe chunk
+    std::vector<uint64_t> _hashScratch;
 
     // This step's matched pairs: output row i reads _probeIndices[i] of the probe chunk
     // and _buildIndices[i] of the buffers.

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2779,24 +2779,30 @@ void NLTranslator::translateHashJoinCollect(nl::HashJoinCollect collect, NLStmtC
 
     // One growing buffer per build column, row-aligned. The buffer keeps the column's
     // element type; the append copies a chunk's rows onto its tail, exactly as a sort
-    // accumulates them.
+    // accumulates them. The types are recorded beside them for the probe, which declares
+    // these columns among its own results and is checked against what was allocated here.
+    llvm::SmallVector<mlir::Type, 4>& buildTypes = _hashJoinBuildTypes[collectState];
+
     for (const mlir::Value column : columns) {
-        Column* bufferColumn = allocColumnForChunkType(column.getType());
+        const mlir::Type chunkType = column.getType();
+        buildTypes.push_back(chunkType);
+
+        Column* bufferColumn = allocColumnForChunkType(chunkType);
         state->addColumnBuffer(bufferColumn);
 
         const NLSortCollectData::Append append {getColumn(column),
                                                 bufferColumn,
-                                                selectAppendForChunkType(column.getType())};
+                                                selectAppendForChunkType(chunkType)};
         data->addAppend(append);
     }
 
     // The key is one of those columns, read a second time to index each row: the
-    // serializer turns a row into the bytes the probe looks up, and the null test keeps a
-    // null row out of the index.
+    // serializer turns a row into the bytes the probe looks up, and the match gate keeps
+    // a row no probe key can match - a null, a NaN - out of the index.
     const mlir::Value keyColumn = columns[buildKey];
     data->setKeyColumn(getColumn(keyColumn),
                        selectKeyAppendForChunkType(keyColumn.getType()),
-                       selectIsNullForChunkType(keyColumn.getType()));
+                       selectKeyMatchableForChunkType(keyColumn.getType()));
 
     body->emplaceStmt(&NLExecutor::runHashJoinCollect, data);
 }
@@ -2842,21 +2848,30 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
                                              selectGatherForChunkType(column.getType())));
     }
 
+    // A build result is gathered out of the buffer the collect allocated, so the type it
+    // declares has to be the type that buffer holds: reading a column of one element type
+    // as another would take its rows apart at the wrong width.
+    const llvm::SmallVector<mlir::Type, 4>& buildTypes = _hashJoinBuildTypes[probeState];
     for (size_t columnIndex = 0; columnIndex < buildCount; columnIndex++) {
         const mlir::Value result = results[columns.size() + columnIndex];
+        const mlir::Type bufferType = buildTypes[columnIndex];
 
-        Column* output = allocColumnForChunkType(result.getType());
+        if (result.getType() != bufferType) {
+            throw IRException("nl.hash_join_probe must declare each build result as the chunk type the nl.hash_join_collect appended");
+        }
+
+        Column* output = allocColumnForChunkType(bufferType);
         _valueSlots[result] = output;
 
         data->addBuildColumn(NLCarriedColumn(state->buffer(columnIndex),
                                              output,
-                                             selectGatherForChunkType(result.getType())));
+                                             selectGatherForChunkType(bufferType)));
     }
 
     const mlir::Value keyColumn = columns[probeKey];
     data->setKeyColumn(getColumn(keyColumn),
                        selectKeyAppendForChunkType(keyColumn.getType()),
-                       selectIsNullForChunkType(keyColumn.getType()));
+                       selectKeyMatchableForChunkType(keyColumn.getType()));
 
     body->emplaceStmt(&NLExecutor::runHashJoinProbe, data);
 }
@@ -4200,20 +4215,22 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
 }
 
-// The null-testing sibling of selectKeyAppendForChunkType: a nullable value chunk reads
-// its present flag and a type-erased cell its tag; every other chunk holds no null row, so
-// one handle answers false for all of them.
-NLIsNullFunction NLTranslator::selectIsNullForChunkType(mlir::Type chunkType) {
+// The gating sibling of selectKeyAppendForChunkType: a nullable value chunk reads its
+// present flag and a type-erased cell its tag, a double chunk of either shape also
+// rejects a NaN, and every other chunk holds a matchable key in every row.
+NLKeyIsMatchableFunction NLTranslator::selectKeyMatchableForChunkType(mlir::Type chunkType) {
     const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
     const mlir::Type elementType = chunk.getElementType();
 
     if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
-        return NLExecutor::selectOptIsNullFunction(valueTypeFromElementType(nullableType.getValueType()));
+        return NLExecutor::selectOptKeyMatchableFunction(valueTypeFromElementType(nullableType.getValueType()));
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
-        return NLExecutor::selectListElementIsNullFunction();
+        return NLExecutor::selectListElementKeyMatchableFunction();
+    } else if (isPlainValueElementType(elementType)) {
+        return NLExecutor::selectPlainKeyMatchableFunction(valueTypeFromElementType(elementType));
     }
 
-    return NLExecutor::neverNull();
+    return NLExecutor::everyKeyMatchable();
 }
 
 // The value-reduction sibling of selectCountForChunkType: a type-erased column of tagged

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -742,7 +742,14 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
         } else if (nl::HashJoinCollect hashJoinCollect = mlir::dyn_cast<nl::HashJoinCollect>(operation)) {
             translateHashJoinCollect(hashJoinCollect, body);
         } else if (nl::HashJoinProbe hashJoinProbe = mlir::dyn_cast<nl::HashJoinProbe>(operation)) {
-            translateHashJoinProbe(hashJoinProbe, body);
+            IteratorConfig config;
+            config._kind = IteratorKind::HashJoinProbe;
+            config._hashJoinState = hashJoinProbe.getState();
+
+            const mlir::OperandRange probeColumns = hashJoinProbe.getColumns();
+            config._probeColumns.assign(probeColumns.begin(), probeColumns.end());
+
+            _iteratorConfigs[hashJoinProbe.getResult()] = config;
         } else if (nl::Distinct distinct = mlir::dyn_cast<nl::Distinct>(operation)) {
             translateDistinctState(distinct, body);
         } else if (nl::DistinctFilter distinctFilter = mlir::dyn_cast<nl::DistinctFilter>(operation)) {
@@ -868,6 +875,10 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         // like a hop - a downstream LIMIT can bound its loop through the ordinary
         // early-exit, and a step lays out only the prefix the budget can emit.
         translateCrossProductLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::HashJoinProbe) {
+        // A probe expands the rows it is given the way a product does, so a downstream
+        // LIMIT bounds its loop through the same early-exit.
+        translateHashJoinProbeLoop(config, loopBody, limit, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -2823,18 +2834,21 @@ void NLTranslator::translateHashJoinCollect(nl::HashJoinCollect collect, NLStmtC
     body->emplaceStmt(&NLExecutor::runHashJoinCollect, data);
 }
 
-void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContainer* body) {
-    const mlir::Value probeState = probe.getState();
+void NLTranslator::translateHashJoinProbeLoop(const IteratorConfig& config,
+                                              mlir::Block& loopBody,
+                                              NLLimitState* limit,
+                                              NLStmtContainer* body) {
+    const mlir::Value probeState = config._hashJoinState;
     NLHashJoinState* state = hashJoinStateFor(probeState);
 
-    const mlir::OperandRange columns = probe.getColumns();
-    const mlir::ResultRange results = probe.getResults();
+    const std::span<const mlir::Value> columns = config._probeColumns;
 
     // The build buffers are allocated by the collect, which the lowering places in the
     // build loop ahead of this probe, so by here they say how many columns the build side
-    // contributes - and the results are the probe columns followed by those.
+    // contributes - and the loop binds one variable per probe column, then one per build
+    // column, the order the iterator lays its chunks out in.
     const size_t buildCount = state->buffers().size();
-    if (results.size() != columns.size() + buildCount) {
+    if (loopBody.getNumArguments() != columns.size() + buildCount) {
         throw IRException("nl.hash_join_probe emits one column per probe column and per build column");
     }
 
@@ -2845,16 +2859,14 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
         throw IRException("hash join probe key column index is out of range");
     }
 
-    NLHashJoinProbeData* data = _program->allocFunctionData<NLHashJoinProbeData>(state);
+    NLHashJoinProbeLoopData* data = _program->allocFunctionData<NLHashJoinProbeLoopData>(state);
+    data->setLimit(limit);
 
-    // The optional limit handle is a separate operand group, so it never appears among
-    // the columns; null leaves the probe unbounded.
-    data->setLimit(limitStateFor(probe.getLimit()));
-
-    // Reserve the matched-pair scratches so a step that matches no more than a chunk's
-    // worth of rows stays allocation-free, the same as the edge and sort loops' indices.
+    // Reserve the matched-pair scratches so a step that pairs no more than a chunk's worth
+    // of rows stays allocation-free, the same as the edge and sort loops' indices.
     data->getProbeIndices()->reserve(_program->getChunkSize());
     data->getBuildIndices()->reserve(_program->getChunkSize());
+    data->getHashScratch()->reserve(_program->getChunkSize());
 
     // A probe column is read from this step's chunk and repeated once per match; a build
     // column is read back from its buffer at the matched row. Both are the gather the
@@ -2863,27 +2875,27 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
         const mlir::Value column = columns[columnIndex];
 
         Column* output = allocColumnForChunkType(column.getType());
-        _valueSlots[results[columnIndex]] = output;
+        _valueSlots[loopBody.getArgument(static_cast<unsigned>(columnIndex))] = output;
 
         data->addProbeColumn(NLCarriedColumn(getColumn(column),
                                              output,
                                              selectGatherForChunkType(column.getType())));
     }
 
-    // A build result is gathered out of the buffer the collect allocated, so the type it
-    // declares has to be the type that buffer holds: reading a column of one element type
-    // as another would take its rows apart at the wrong width.
+    // A build chunk is gathered out of the buffer the collect allocated, so the type the
+    // iterator declares has to be the type that buffer holds: reading a column of one
+    // element type as another would take its rows apart at the wrong width.
     const llvm::SmallVector<mlir::Type, 4>& buildTypes = _hashJoinBuildTypes[probeState];
     for (size_t columnIndex = 0; columnIndex < buildCount; columnIndex++) {
-        const mlir::Value result = results[columns.size() + columnIndex];
+        const mlir::Value bound = loopBody.getArgument(static_cast<unsigned>(columns.size() + columnIndex));
         const mlir::Type bufferType = buildTypes[columnIndex];
 
-        if (result.getType() != bufferType) {
-            throw IRException("nl.hash_join_probe must declare each build result as the chunk type the nl.hash_join_collect appended");
+        if (bound.getType() != bufferType) {
+            throw IRException("nl.hash_join_probe must declare each build chunk as the chunk type the nl.hash_join_collect appended");
         }
 
         Column* output = allocColumnForChunkType(bufferType);
-        _valueSlots[result] = output;
+        _valueSlots[bound] = output;
 
         data->addBuildColumn(NLCarriedColumn(state->buffer(columnIndex),
                                              output,
@@ -2905,9 +2917,10 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
                         state->buffer(buildKey),
                         selectJoinKeyFunctionsForChunkType(keyColumn.getType()),
                         selectKeyMatchableForChunkType(keyColumn.getType()));
-    data->getHashScratch()->reserve(_program->getChunkSize());
 
-    body->emplaceStmt(&NLExecutor::runHashJoinProbe, data);
+    body->emplaceStmt(&NLExecutor::runHashJoinProbeLoop, data);
+
+    translateBlock(loopBody, data->getStmts());
 }
 
 NLHashJoinState* NLTranslator::hashJoinStateFor(mlir::Value handle) const {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2829,6 +2829,10 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
 
     NLHashJoinProbeData* data = _program->allocFunctionData<NLHashJoinProbeData>(state);
 
+    // The optional limit handle is a separate operand group, so it never appears among
+    // the columns; null leaves the probe unbounded.
+    data->setLimit(limitStateFor(probe.getLimit()));
+
     // Reserve the matched-pair scratches so a step that matches no more than a chunk's
     // worth of rows stays allocation-free, the same as the edge and sort loops' indices.
     data->getProbeIndices()->reserve(_program->getChunkSize());

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -728,6 +728,12 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateSortBuffer(sortBuffer, body);
         } else if (nl::SortCollect sortCollect = mlir::dyn_cast<nl::SortCollect>(operation)) {
             translateSortCollect(sortCollect, body);
+        } else if (nl::HashJoinBuffer hashJoinBuffer = mlir::dyn_cast<nl::HashJoinBuffer>(operation)) {
+            translateHashJoinBuffer(hashJoinBuffer, body);
+        } else if (nl::HashJoinCollect hashJoinCollect = mlir::dyn_cast<nl::HashJoinCollect>(operation)) {
+            translateHashJoinCollect(hashJoinCollect, body);
+        } else if (nl::HashJoinProbe hashJoinProbe = mlir::dyn_cast<nl::HashJoinProbe>(operation)) {
+            translateHashJoinProbe(hashJoinProbe, body);
         } else if (nl::Distinct distinct = mlir::dyn_cast<nl::Distinct>(operation)) {
             translateDistinctState(distinct, body);
         } else if (nl::DistinctFilter distinctFilter = mlir::dyn_cast<nl::DistinctFilter>(operation)) {
@@ -2739,6 +2745,140 @@ NLSortState* NLTranslator::sortStateFor(mlir::Value handle) const {
     return stateIt->second;
 }
 
+void NLTranslator::translateHashJoinBuffer(nl::HashJoinBuffer buffer, NLStmtContainer* body) {
+    // Allocate the runtime build side and map the handle to it, so the collect and the
+    // probe that name the handle share the same buffers and index. The buffer columns
+    // themselves are allocated by the collect, which knows their types.
+    NLHashJoinState* state = _program->allocHashJoinState();
+    _hashJoinStates[buffer.getState()] = state;
+
+    // The reset empties the buffers and the index each time the block holding this
+    // nl.hash_join_buffer runs: once at function scope for a top-level join.
+    NLHashJoinResetData* resetData = _program->allocFunctionData<NLHashJoinResetData>(state);
+    body->emplaceStmt(&NLExecutor::runHashJoinReset, resetData);
+}
+
+void NLTranslator::translateHashJoinCollect(nl::HashJoinCollect collect, NLStmtContainer* body) {
+    const mlir::Value collectState = collect.getState();
+    NLHashJoinState* state = hashJoinStateFor(collectState);
+
+    // The buffers are allocated once, by the single collect feeding a build side.
+    // Generated IR has exactly one collect per build side; a second would append to the
+    // same buffers and index the same rows twice, so it is rejected here.
+    if (!state->buffers().empty()) {
+        throw IRException("an nl.hash_join_buffer must be fed by a single nl.hash_join_collect");
+    }
+
+    const mlir::OperandRange columns = collect.getColumns();
+    const uint64_t buildKey = hashJoinBufferOf(collectState).getBuildKey();
+    if (buildKey >= columns.size()) {
+        throw IRException("hash join build key column index is out of range");
+    }
+
+    NLHashJoinCollectData* data = _program->allocFunctionData<NLHashJoinCollectData>(state);
+
+    // One growing buffer per build column, row-aligned. The buffer keeps the column's
+    // element type; the append copies a chunk's rows onto its tail, exactly as a sort
+    // accumulates them.
+    for (const mlir::Value column : columns) {
+        Column* bufferColumn = allocColumnForChunkType(column.getType());
+        state->addColumnBuffer(bufferColumn);
+
+        const NLSortCollectData::Append append {getColumn(column),
+                                                bufferColumn,
+                                                selectAppendForChunkType(column.getType())};
+        data->addAppend(append);
+    }
+
+    // The key is one of those columns, read a second time to index each row: the
+    // serializer turns a row into the bytes the probe looks up, and the null test keeps a
+    // null row out of the index.
+    const mlir::Value keyColumn = columns[buildKey];
+    data->setKeyColumn(getColumn(keyColumn),
+                       selectKeyAppendForChunkType(keyColumn.getType()),
+                       selectIsNullForChunkType(keyColumn.getType()));
+
+    body->emplaceStmt(&NLExecutor::runHashJoinCollect, data);
+}
+
+void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContainer* body) {
+    const mlir::Value probeState = probe.getState();
+    NLHashJoinState* state = hashJoinStateFor(probeState);
+
+    const mlir::OperandRange columns = probe.getColumns();
+    const mlir::ResultRange results = probe.getResults();
+
+    // The build buffers are allocated by the collect, which the lowering places in the
+    // build loop ahead of this probe, so by here they say how many columns the build side
+    // contributes - and the results are the probe columns followed by those.
+    const size_t buildCount = state->buffers().size();
+    if (results.size() != columns.size() + buildCount) {
+        throw IRException("nl.hash_join_probe emits one column per probe column and per build column");
+    }
+
+    const uint64_t probeKey = hashJoinBufferOf(probeState).getProbeKey();
+    if (probeKey >= columns.size()) {
+        throw IRException("hash join probe key column index is out of range");
+    }
+
+    NLHashJoinProbeData* data = _program->allocFunctionData<NLHashJoinProbeData>(state);
+
+    // Reserve the matched-pair scratches so a step that matches no more than a chunk's
+    // worth of rows stays allocation-free, the same as the edge and sort loops' indices.
+    data->getProbeIndices()->reserve(_program->getChunkSize());
+    data->getBuildIndices()->reserve(_program->getChunkSize());
+
+    // A probe column is read from this step's chunk and repeated once per match; a build
+    // column is read back from its buffer at the matched row. Both are the gather the
+    // edge and sort loops use, over the pair of index scratches the probe fills.
+    for (size_t columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        const mlir::Value column = columns[columnIndex];
+
+        Column* output = allocColumnForChunkType(column.getType());
+        _valueSlots[results[columnIndex]] = output;
+
+        data->addProbeColumn(NLCarriedColumn(getColumn(column),
+                                             output,
+                                             selectGatherForChunkType(column.getType())));
+    }
+
+    for (size_t columnIndex = 0; columnIndex < buildCount; columnIndex++) {
+        const mlir::Value result = results[columns.size() + columnIndex];
+
+        Column* output = allocColumnForChunkType(result.getType());
+        _valueSlots[result] = output;
+
+        data->addBuildColumn(NLCarriedColumn(state->buffer(columnIndex),
+                                             output,
+                                             selectGatherForChunkType(result.getType())));
+    }
+
+    const mlir::Value keyColumn = columns[probeKey];
+    data->setKeyColumn(getColumn(keyColumn),
+                       selectKeyAppendForChunkType(keyColumn.getType()),
+                       selectIsNullForChunkType(keyColumn.getType()));
+
+    body->emplaceStmt(&NLExecutor::runHashJoinProbe, data);
+}
+
+NLHashJoinState* NLTranslator::hashJoinStateFor(mlir::Value handle) const {
+    const auto stateIt = _hashJoinStates.find(handle);
+    if (stateIt == _hashJoinStates.end()) {
+        throw IRException("hash join handle must be produced by an nl.hash_join_buffer");
+    }
+
+    return stateIt->second;
+}
+
+nl::HashJoinBuffer NLTranslator::hashJoinBufferOf(mlir::Value handle) {
+    nl::HashJoinBuffer buffer = handle.getDefiningOp<nl::HashJoinBuffer>();
+    if (!buffer) {
+        throw IRException("hash join handle must be produced by an nl.hash_join_buffer");
+    }
+
+    return buffer;
+}
+
 void NLTranslator::translateDistinctState(nl::Distinct distinct, NLStmtContainer* body) {
     // Allocate the runtime seen-set and map the handle to it, so the filter that
     // names the handle finds the same set.
@@ -4058,6 +4198,22 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     }
 
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
+}
+
+// The null-testing sibling of selectKeyAppendForChunkType: a nullable value chunk reads
+// its present flag and a type-erased cell its tag; every other chunk holds no null row, so
+// one handle answers false for all of them.
+NLIsNullFunction NLTranslator::selectIsNullForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        return NLExecutor::selectOptIsNullFunction(valueTypeFromElementType(nullableType.getValueType()));
+    } else if (mlir::isa<storage::ListElementType>(elementType)) {
+        return NLExecutor::selectListElementIsNullFunction();
+    }
+
+    return NLExecutor::neverNull();
 }
 
 // The value-reduction sibling of selectCountForChunkType: a type-erased column of tagged

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2801,7 +2801,7 @@ void NLTranslator::translateHashJoinCollect(nl::HashJoinCollect collect, NLStmtC
     // a row no probe key can match - a null, a NaN - out of the index.
     const mlir::Value keyColumn = columns[buildKey];
     data->setKeyColumn(getColumn(keyColumn),
-                       selectKeyAppendForChunkType(keyColumn.getType()),
+                       selectJoinKeyAppendForChunkType(keyColumn.getType()),
                        selectKeyMatchableForChunkType(keyColumn.getType()));
 
     body->emplaceStmt(&NLExecutor::runHashJoinCollect, data);
@@ -2874,7 +2874,7 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
 
     const mlir::Value keyColumn = columns[probeKey];
     data->setKeyColumn(getColumn(keyColumn),
-                       selectKeyAppendForChunkType(keyColumn.getType()),
+                       selectJoinKeyAppendForChunkType(keyColumn.getType()),
                        selectKeyMatchableForChunkType(keyColumn.getType()));
 
     body->emplaceStmt(&NLExecutor::runHashJoinProbe, data);
@@ -4217,6 +4217,21 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     }
 
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
+}
+
+// The join's sibling of selectKeyAppendForChunkType. An embedding has no byte identity a
+// DISTINCT can group by, which is what that one answers for, but `=` between two embedding
+// columns compares the vectors - so a join on one serializes them rather than turning the
+// query away with a diagnostic about duplicates.
+NLKeyAppendFunction NLTranslator::selectJoinKeyAppendForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const auto nullableType = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
+
+    if (nullableType && valueTypeFromElementType(nullableType.getValueType()) == ValueType::Embedding) {
+        return NLExecutor::selectOptEmbeddingKeyAppendFunction();
+    }
+
+    return selectKeyAppendForChunkType(chunkType);
 }
 
 // The gating sibling of selectKeyAppendForChunkType: a nullable value chunk reads its

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -711,7 +711,16 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
         } else if (nl::CheckEdgeTypeConstraint checkEdgeTypeConstraint = mlir::dyn_cast<nl::CheckEdgeTypeConstraint>(operation)) {
             translateCheckEdgeTypeConstraint(checkEdgeTypeConstraint, body);
         } else if (nl::CrossProduct crossProduct = mlir::dyn_cast<nl::CrossProduct>(operation)) {
-            translateCrossProduct(crossProduct, body);
+            IteratorConfig config;
+            config._kind = IteratorKind::CrossProduct;
+
+            const mlir::OperandRange outerColumns = crossProduct.getOuterColumns();
+            config._crossOuterColumns.assign(outerColumns.begin(), outerColumns.end());
+
+            const mlir::OperandRange innerColumns = crossProduct.getInnerColumns();
+            config._crossInnerColumns.assign(innerColumns.begin(), innerColumns.end());
+
+            _iteratorConfigs[crossProduct.getResult()] = config;
         } else if (nl::Limit limit = mlir::dyn_cast<nl::Limit>(operation)) {
             translateLimit(limit, body);
         } else if (nl::LimitUpdate update = mlir::dyn_cast<nl::LimitUpdate>(operation)) {
@@ -854,6 +863,11 @@ void NLTranslator::translateFor(nl::For forLoop, NLStmtContainer* body) {
         translateOptionalDrainLoop(config, loopBody, limit, body);
     } else if (config._kind == IteratorKind::ProcedureInit) {
         translateProcedureInitLoop(config, loopBody, limit, body);
+    } else if (config._kind == IteratorKind::CrossProduct) {
+        // A product expands the rows it is given rather than accumulating them, so -
+        // like a hop - a downstream LIMIT can bound its loop through the ordinary
+        // early-exit, and a step lays out only the prefix the budget can emit.
+        translateCrossProductLoop(config, loopBody, limit, body);
     } else {
         translateEdgeLoop(config, loopBody, limit, body);
     }
@@ -4389,45 +4403,47 @@ Column* NLTranslator::allocColumnForResultChunkType(mlir::Type chunkType) {
     return allocColumnForKind(chunkKindFromElementType(elementType));
 }
 
-void NLTranslator::translateCrossProduct(nl::CrossProduct cross, NLStmtContainer* body) {
-    const mlir::OperandRange outerColumns = cross.getOuterColumns();
-    const mlir::OperandRange innerColumns = cross.getInnerColumns();
+void NLTranslator::translateCrossProductLoop(const IteratorConfig& config,
+                                             mlir::Block& loopBody,
+                                             NLLimitState* limit,
+                                             NLStmtContainer* body) {
+    const std::span<const mlir::Value> outerColumns = config._crossOuterColumns;
+    const std::span<const mlir::Value> innerColumns = config._crossInnerColumns;
 
-    // At run time runCrossProduct takes N from the first outer column and M from
-    // the first inner column, so a side with no column cannot be sized. Reject
-    // that here: DBLowering never emits it, but the nl IR may come from elsewhere.
+    // At run time the loop takes N from the first outer column and M from the first
+    // inner column, so a side with no column cannot be sized. Reject that here:
+    // DBLowering never emits it, but the nl IR may come from elsewhere.
     if (outerColumns.empty() || innerColumns.empty()) {
         throw IRException("nl.cross_product needs at least one column on each side");
     }
 
-    NLCrossProductData* data = _program->allocFunctionData<NLCrossProductData>();
+    NLCrossProductLoopData* loopData = _program->allocFunctionData<NLCrossProductLoopData>();
+    loopData->setLimit(limit);
 
-    // The optional limit handle is a separate operand group, so it never appears
-    // among the columns; null leaves the product unbounded.
-    data->setLimit(limitStateFor(cross.getLimit()));
-
-    // The results are the outer columns followed by the inner, the order
-    // inferReturnTypes lays them out, so walk the result list in step.
-    const mlir::ResultRange results = cross.getResults();
-    size_t resultIndex = 0;
+    // The loop binds one variable per crossed column - the outer columns followed by
+    // the inner, the order inferReturnTypes lays the iterator's chunks out - so walk
+    // the block arguments in step.
+    unsigned argumentIndex = 0;
 
     for (const mlir::Value column : outerColumns) {
-        addCrossColumn(column, results[resultIndex], /*isOuter=*/true, data);
-        resultIndex++;
+        addCrossColumn(column, loopBody.getArgument(argumentIndex), /*isOuter=*/true, loopData);
+        argumentIndex++;
     }
 
     for (const mlir::Value column : innerColumns) {
-        addCrossColumn(column, results[resultIndex], /*isOuter=*/false, data);
-        resultIndex++;
+        addCrossColumn(column, loopBody.getArgument(argumentIndex), /*isOuter=*/false, loopData);
+        argumentIndex++;
     }
 
-    body->emplaceStmt(&NLExecutor::runCrossProduct, data);
+    body->emplaceStmt(&NLExecutor::runCrossProductLoop, loopData);
+
+    translateBlock(loopBody, loopData->getStmts());
 }
 
 void NLTranslator::addCrossColumn(mlir::Value inputValue,
                                   mlir::Value resultValue,
                                   bool isOuter,
-                                  NLCrossProductData* data) {
+                                  NLCrossProductLoopData* data) {
     const Column* input = getColumn(inputValue);
 
     const auto chunkType = mlir::cast<nl::ChunkType>(inputValue.getType());

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2810,13 +2810,15 @@ void NLTranslator::translateHashJoinCollect(nl::HashJoinCollect collect, NLStmtC
         data->addAppend(append);
     }
 
-    // The key is one of those columns, read a second time to index each row: the
-    // serializer turns a row into the bytes the probe looks up, and the match gate keeps
-    // a row no probe key can match - a null, a NaN - out of the index.
+    // The key is one of those columns, read a second time to chain each row under its
+    // hash; the match gate keeps a row no probe key can match - a null, a NaN - out of
+    // the index.
     const mlir::Value keyColumn = columns[buildKey];
-    data->setKeyColumn(getColumn(keyColumn),
-                       selectJoinKeyAppendForChunkType(keyColumn.getType()),
-                       selectKeyMatchableForChunkType(keyColumn.getType()));
+    data->setKeyColumns(getColumn(keyColumn),
+                        state->buffer(buildKey),
+                        selectJoinKeyFunctionsForChunkType(keyColumn.getType()),
+                        selectKeyMatchableForChunkType(keyColumn.getType()));
+    data->getHashScratch()->reserve(_program->getChunkSize());
 
     body->emplaceStmt(&NLExecutor::runHashJoinCollect, data);
 }
@@ -2836,7 +2838,9 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
         throw IRException("nl.hash_join_probe emits one column per probe column and per build column");
     }
 
-    const uint64_t probeKey = hashJoinBufferOf(probeState).getProbeKey();
+    nl::HashJoinBuffer buffer = hashJoinBufferOf(probeState);
+    const uint64_t probeKey = buffer.getProbeKey();
+    const uint64_t buildKey = buffer.getBuildKey();
     if (probeKey >= columns.size()) {
         throw IRException("hash join probe key column index is out of range");
     }
@@ -2886,10 +2890,22 @@ void NLTranslator::translateHashJoinProbe(nl::HashJoinProbe probe, NLStmtContain
                                              selectGatherForChunkType(bufferType)));
     }
 
+    // The probe key is read against the build key buffer through the handlers of one
+    // chunk type, so the two sides must have collected and probed chunks of that type.
+    if (buildKey >= buildTypes.size()) {
+        throw IRException("hash join build key column index is out of range");
+    }
+
     const mlir::Value keyColumn = columns[probeKey];
-    data->setKeyColumn(getColumn(keyColumn),
-                       selectJoinKeyAppendForChunkType(keyColumn.getType()),
-                       selectKeyMatchableForChunkType(keyColumn.getType()));
+    if (keyColumn.getType() != buildTypes[buildKey]) {
+        throw IRException("nl.hash_join_probe must read its key from a chunk of the type the build key was collected as");
+    }
+
+    data->setKeyColumns(getColumn(keyColumn),
+                        state->buffer(buildKey),
+                        selectJoinKeyFunctionsForChunkType(keyColumn.getType()),
+                        selectKeyMatchableForChunkType(keyColumn.getType()));
+    data->getHashScratch()->reserve(_program->getChunkSize());
 
     body->emplaceStmt(&NLExecutor::runHashJoinProbe, data);
 }
@@ -4233,19 +4249,22 @@ NLKeyAppendFunction NLTranslator::selectKeyAppendForChunkType(mlir::Type chunkTy
     return NLExecutor::selectKeyAppendFunction(chunkKindFromElementType(elementType));
 }
 
-// The join's sibling of selectKeyAppendForChunkType. An embedding has no byte identity a
-// DISTINCT can group by, which is what that one answers for, but `=` between two embedding
-// columns compares the vectors - so a join on one serializes them rather than turning the
-// query away with a diagnostic about duplicates.
-NLKeyAppendFunction NLTranslator::selectJoinKeyAppendForChunkType(mlir::Type chunkType) {
+// The join's sibling of selectKeyAppendForChunkType: a key is hashed and compared where it
+// lives rather than serialized. An embedding is a key here, since `=` between two embedding
+// columns compares the vectors, though it has no byte identity a DISTINCT can group by.
+NLJoinKeyFunctions NLTranslator::selectJoinKeyFunctionsForChunkType(mlir::Type chunkType) {
     const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
-    const auto nullableType = mlir::dyn_cast<storage::NullableType>(chunk.getElementType());
+    const mlir::Type elementType = chunk.getElementType();
 
-    if (nullableType && valueTypeFromElementType(nullableType.getValueType()) == ValueType::Embedding) {
-        return NLExecutor::selectOptEmbeddingKeyAppendFunction();
+    if (const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType)) {
+        return NLExecutor::selectOptJoinKeyFunctions(valueTypeFromElementType(nullableType.getValueType()));
+    } else if (mlir::isa<storage::ListElementType>(elementType)) {
+        return NLExecutor::selectListElementJoinKeyFunctions();
+    } else if (isPlainValueElementType(elementType)) {
+        return NLExecutor::selectPlainJoinKeyFunctions(valueTypeFromElementType(elementType));
     }
 
-    return selectKeyAppendForChunkType(chunkType);
+    return NLExecutor::selectJoinKeyFunctions(chunkKindFromElementType(elementType));
 }
 
 // The gating sibling of selectKeyAppendForChunkType: a nullable value chunk reads its

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -63,6 +63,7 @@ private:
         ProcedureInit,
         OptionalDrain,
         CrossProduct,
+        HashJoinProbe,
     };
 
     // Settings of the iterators passed to each for loop
@@ -96,6 +97,11 @@ private:
         // empty for the other kinds.
         llvm::SmallVector<mlir::Value, 4> _crossOuterColumns;
         llvm::SmallVector<mlir::Value, 4> _crossInnerColumns;
+
+        // The build side a HashJoinProbe iterator matches against and the probe columns it
+        // walks, in db.yield order; null and empty for the other kinds.
+        mlir::Value _hashJoinState;
+        llvm::SmallVector<mlir::Value, 4> _probeColumns;
 
         // The label names a ScanNodesByLabel or ScanNodesByPropertyValue iterator filters
         // by; empty for the other kinds. These are views into the op's interned StringAttr
@@ -397,7 +403,10 @@ private:
     // Translate an nl.hash_join_probe: allocate one fresh output column per probe
     // and per build column, map each result to its output, bake the probe key's
     // serializer and match gate, and record the per-step probe statement
-    void translateHashJoinProbe(mlir::nl::HashJoinProbe probe, NLStmtContainer* body);
+    void translateHashJoinProbeLoop(const IteratorConfig& config,
+                                    mlir::Block& loopBody,
+                                    NLLimitState* limit,
+                                    NLStmtContainer* body);
 
     // The runtime build side a hash join handle names. The handle is a required
     // operand of nl.hash_join_collect and nl.hash_join_probe, so this throws if it

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -638,6 +638,7 @@ private:
                                                     ValueType keyType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
+    static NLKeyAppendFunction selectJoinKeyAppendForChunkType(mlir::Type chunkType);
     static NLKeyIsMatchableFunction selectKeyMatchableForChunkType(mlir::Type chunkType);
 
     // The non-null row count handler for a chunk type - the all-rows count for an

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -179,6 +179,13 @@ private:
     // nl.hash_join_collect and nl.hash_join_probe find the same buffers and index
     llvm::DenseMap<mlir::Value, NLHashJoinState*> _hashJoinStates;
 
+    // nl.hash_join_buffer handle SSA value -> the chunk types the collect appended, which
+    // are what its buffers were allocated as. The probe declares the build columns among
+    // its own results, so this is what those are checked against: the buffers are read
+    // back through a gather chosen for their element type, and a result declaring another
+    // would read one column's rows as another's.
+    llvm::DenseMap<mlir::Value, llvm::SmallVector<mlir::Type, 4>> _hashJoinBuildTypes;
+
     // nl.distinct handle SSA value -> the runtime seen-set it produces, so the
     // nl.distinct_filter that names the handle finds the same set
     llvm::DenseMap<mlir::Value, NLDistinctState*> _distinctStates;
@@ -376,14 +383,14 @@ private:
     void translateHashJoinBuffer(mlir::nl::HashJoinBuffer buffer, NLStmtContainer* body);
 
     // Translate an nl.hash_join_collect: allocate one growing buffer per build
-    // column (mapped into the build side), bake the key serializer and null test
-    // from the key column the nl.hash_join_buffer names, and record the per-step
-    // append-and-index statement
+    // column (mapped into the build side), bake the key serializer and the match
+    // gate from the key column the nl.hash_join_buffer names, and record the
+    // per-step append-and-index statement
     void translateHashJoinCollect(mlir::nl::HashJoinCollect collect, NLStmtContainer* body);
 
     // Translate an nl.hash_join_probe: allocate one fresh output column per probe
     // and per build column, map each result to its output, bake the probe key's
-    // serializer and null test, and record the per-step probe statement
+    // serializer and match gate, and record the per-step probe statement
     void translateHashJoinProbe(mlir::nl::HashJoinProbe probe, NLStmtContainer* body);
 
     // The runtime build side a hash join handle names. The handle is a required
@@ -631,7 +638,7 @@ private:
                                                     ValueType keyType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
-    static NLIsNullFunction selectIsNullForChunkType(mlir::Type chunkType);
+    static NLKeyIsMatchableFunction selectKeyMatchableForChunkType(mlir::Type chunkType);
 
     // The non-null row count handler for a chunk type - the all-rows count for an
     // ID chunk, the present-value count for a !storage.nullable<...> chunk. Used by

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -175,6 +175,10 @@ private:
     // nl.sort_collect and the nl.for over nl.sort find the same buffers
     llvm::DenseMap<mlir::Value, NLSortState*> _sortStates;
 
+    // nl.hash_join_buffer handle SSA value -> the runtime build side it produces, so
+    // nl.hash_join_collect and nl.hash_join_probe find the same buffers and index
+    llvm::DenseMap<mlir::Value, NLHashJoinState*> _hashJoinStates;
+
     // nl.distinct handle SSA value -> the runtime seen-set it produces, so the
     // nl.distinct_filter that names the handle finds the same set
     llvm::DenseMap<mlir::Value, NLDistinctState*> _distinctStates;
@@ -366,6 +370,30 @@ private:
     // The runtime accumulator a sort handle names. Throws if the handle was not
     // produced by an nl.sort_buffer translated earlier.
     NLSortState* sortStateFor(mlir::Value handle) const;
+
+    // Translate an nl.hash_join_buffer: allocate its runtime build side, map the
+    // handle to it, and record the reset statement (run each time the block runs)
+    void translateHashJoinBuffer(mlir::nl::HashJoinBuffer buffer, NLStmtContainer* body);
+
+    // Translate an nl.hash_join_collect: allocate one growing buffer per build
+    // column (mapped into the build side), bake the key serializer and null test
+    // from the key column the nl.hash_join_buffer names, and record the per-step
+    // append-and-index statement
+    void translateHashJoinCollect(mlir::nl::HashJoinCollect collect, NLStmtContainer* body);
+
+    // Translate an nl.hash_join_probe: allocate one fresh output column per probe
+    // and per build column, map each result to its output, bake the probe key's
+    // serializer and null test, and record the per-step probe statement
+    void translateHashJoinProbe(mlir::nl::HashJoinProbe probe, NLStmtContainer* body);
+
+    // The runtime build side a hash join handle names. The handle is a required
+    // operand of nl.hash_join_collect and nl.hash_join_probe, so this throws if it
+    // was not produced by an nl.hash_join_buffer.
+    NLHashJoinState* hashJoinStateFor(mlir::Value handle) const;
+
+    // The nl.hash_join_buffer that produced a handle, which carries the two key
+    // column indices; throws when the handle came from anything else.
+    static mlir::nl::HashJoinBuffer hashJoinBufferOf(mlir::Value handle);
 
     // Translate an nl.distinct: allocate its runtime seen-set, map the handle to
     // it, and record the reset statement (run each time the block runs)
@@ -603,6 +631,7 @@ private:
                                                     ValueType keyType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
+    static NLIsNullFunction selectIsNullForChunkType(mlir::Type chunkType);
 
     // The non-null row count handler for a chunk type - the all-rows count for an
     // ID chunk, the present-value count for a !storage.nullable<...> chunk. Used by

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -644,7 +644,7 @@ private:
                                                     ValueType keyType);
     static NLCompareFunction selectCompareForChunkType(mlir::Type chunkType);
     static NLKeyAppendFunction selectKeyAppendForChunkType(mlir::Type chunkType);
-    static NLKeyAppendFunction selectJoinKeyAppendForChunkType(mlir::Type chunkType);
+    static NLJoinKeyFunctions selectJoinKeyFunctionsForChunkType(mlir::Type chunkType);
     static NLKeyIsMatchableFunction selectKeyMatchableForChunkType(mlir::Type chunkType);
 
     // The non-null row count handler for a chunk type - the all-rows count for an

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -62,6 +62,7 @@ private:
         Unwind,
         ProcedureInit,
         OptionalDrain,
+        CrossProduct,
     };
 
     // Settings of the iterators passed to each for loop
@@ -90,6 +91,11 @@ private:
         // The argument chunks a ProcedureInit iterator hands the procedure, in its
         // declaration order; empty for the other kinds (and for a source call).
         llvm::SmallVector<mlir::Value, 4> _procedureInputs;
+
+        // The two sides a CrossProduct iterator crosses, each in db.yield order;
+        // empty for the other kinds.
+        llvm::SmallVector<mlir::Value, 4> _crossOuterColumns;
+        llvm::SmallVector<mlir::Value, 4> _crossInnerColumns;
 
         // The label names a ScanNodesByLabel or ScanNodesByPropertyValue iterator filters
         // by; empty for the other kinds. These are views into the op's interned StringAttr
@@ -746,18 +752,22 @@ private:
     // accumulator, which carries the single group its reset created.
     bool stepKeepsASingleRow(mlir::Block* block) const;
 
-    // Translate an nl.cross_product: allocate an output column per crossed
-    // column, map each to the matching op result, and record the broadcast
-    // statement (outer columns block-repeated, inner columns tiled)
-    void translateCrossProduct(mlir::nl::CrossProduct cross, NLStmtContainer* body);
+    // Translate the loop over an nl.cross_product: allocate an output column per
+    // crossed column, map each to the matching loop variable, and record the loop
+    // that walks the pairs a chunk at a time (outer columns block-repeated, inner
+    // columns tiled)
+    void translateCrossProductLoop(const IteratorConfig& config,
+                                   mlir::Block& loopBody,
+                                   NLLimitState* limit,
+                                   NLStmtContainer* body);
 
-    // Allocate the output column for one crossed column, map the op result to
+    // Allocate the output column for one crossed column, map the loop variable to
     // it, and append it (with its block-repeat/tile broadcast) to the outer or
     // inner list of data
     void addCrossColumn(mlir::Value inputValue,
                         mlir::Value resultValue,
                         bool isOuter,
-                        NLCrossProductData* data);
+                        NLCrossProductLoopData* data);
 
     // Allocate the fresh output column for one truncated column, map the op
     // result to it, and append it (with its block-repeat prefix-copy) to data

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -615,10 +615,12 @@ bool opensSourceLoop(mlir::Operation* operation) {
 }
 
 // The db ops whose rows a projection is emitted over: a source, the nest a cross product
-// builds, and the emit loop a pipeline breaker opens over what it accumulated
+// or a hash join builds, and the emit loop a pipeline breaker opens over what it
+// accumulated
 bool opensRowLoop(mlir::Operation* operation) {
     return opensSourceLoop(operation)
         || mlir::isa<mlir::db::CrossProduct,
+                     mlir::db::HashJoin,
                      mlir::db::Sort,
                      mlir::db::GroupAggregate,
                      mlir::db::OptionalMatch>(operation);
@@ -638,6 +640,7 @@ bool reducesToOneRow(mlir::Operation* operation) {
 // are fewer than the rows a producer above it made
 bool dropsRows(mlir::Operation* operation) {
     return mlir::isa<mlir::db::FilterOp,
+                     mlir::db::HashJoin,
                      mlir::db::Skip,
                      mlir::db::Limit,
                      mlir::db::RemoveDuplicates>(operation);
@@ -844,6 +847,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerDeleteEdge(deleteEdge);
     } else if (mlir::db::CrossProduct crossProduct = mlir::dyn_cast<mlir::db::CrossProduct>(operation)) {
         lowerCrossProduct(crossProduct);
+    } else if (mlir::db::HashJoin hashJoin = mlir::dyn_cast<mlir::db::HashJoin>(operation)) {
+        lowerHashJoin(hashJoin);
     } else if (mlir::db::OptionalMatch optionalMatch = mlir::dyn_cast<mlir::db::OptionalMatch>(operation)) {
         lowerOptionalMatch(optionalMatch);
     } else if (mlir::db::Limit limit = mlir::dyn_cast<mlir::db::Limit>(operation)) {
@@ -1649,6 +1654,62 @@ void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
 
     // Cross prod result defines cardinality
     _innermostCardinality = crossResults.front();
+}
+
+void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
+    // Both nests root where this op stands - the entry block at top level, the enclosing
+    // factor's innermost loop body inside a product - so they are siblings rather than
+    // nested: the built side is read once, not once per chunk of the other.
+    mlir::Block* const rootBlock = _rootBlock;
+
+    llvm::SmallVector<mlir::Value, 4> buildColumns;
+    mlir::Block* const buildBody = lowerFactor(join.getRightFactor(), rootBlock, buildColumns);
+
+    const mlir::Location loc = _builder.getUnknownLoc();
+
+    // The build side is emptied at the top of the block the two nests are rooted in, which
+    // is also where it dominates them both: a join nested in a factor therefore starts
+    // fresh on each enclosing step rather than carrying the previous one's rows.
+    _builder.setInsertionPointToStart(rootBlock);
+    nl::HashJoinBuffer buffer = _builder.create<nl::HashJoinBuffer>(loc,
+                                                                    join.getRightKey(),
+                                                                    join.getLeftKey());
+    const mlir::Value state = buffer.getState();
+
+    // The collect sits in the built factor's innermost loop body, where all of its
+    // columns are bound together, so the buffers stay row-aligned with the key index.
+    setInsertionInto(buildBody);
+    _builder.create<nl::HashJoinCollect>(loc, state, buildColumns);
+
+    llvm::SmallVector<mlir::Value, 4> probeColumns;
+    mlir::Block* const probeBody = lowerFactor(join.getLeftFactor(), rootBlock, probeColumns);
+
+    // The probe stands where an nl.cross_product stands in a nested loop: at the deepest
+    // point of the side that walks, just before whatever consumes the joined rows.
+    setInsertionInto(probeBody);
+
+    llvm::SmallVector<mlir::Type, 8> resultTypes;
+    for (const mlir::Value column : probeColumns) {
+        resultTypes.push_back(column.getType());
+    }
+    for (const mlir::Value column : buildColumns) {
+        resultTypes.push_back(column.getType());
+    }
+
+    nl::HashJoinProbe probe = _builder.create<nl::HashJoinProbe>(loc, resultTypes, state, probeColumns);
+
+    // The join's results are the left factor's yielded columns followed by the right
+    // factor's, which is how the probe lays its own out: probed side then built side.
+    const mlir::ResultRange dbResults = join.getResults();
+    const mlir::ResultRange probeResults = probe.getResults();
+    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
+        _valueMap[dbResults[resultIndex]] = probeResults[resultIndex];
+    }
+
+    // The joined columns live in probeBody, so a join nested in a factor stands in for
+    // that factor's innermost loop the way a cross product does.
+    _innermostLoopBody = probeBody;
+    _innermostCardinality = probeResults.front();
 }
 
 mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,
@@ -2615,6 +2676,7 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
 
     const bool opensLoop = opensSourceLoop(definingOp);
     const bool isCrossProduct = mlir::isa<mlir::db::CrossProduct>(definingOp);
+    const bool isHashJoin = mlir::isa<mlir::db::HashJoin>(definingOp);
 
     const bool emitsThroughLoop = mlir::isa<mlir::db::Sort,
                                             mlir::db::GroupAggregate,
@@ -2629,7 +2691,7 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
     const bool accumulatesTheRelation = mlir::isa<mlir::db::Sort, mlir::db::GroupAggregate>(definingOp);
     const bool breaksPipeline = accumulatesTheRelation || reducesToOneRow(definingOp);
 
-    bool reachedALoop = opensLoop || isCrossProduct || emitsThroughLoop;
+    bool reachedALoop = opensLoop || isCrossProduct || isHashJoin || emitsThroughLoop;
 
     // A loop's budget only stops it from taking another step, so bounding one never trims
     // the step it is in. A cross product's budget cuts the product itself, which stands
@@ -2654,7 +2716,16 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
 
     const bool rowsDropped = rowsDroppedBeforeTheCut || dropsRows(definingOp);
 
-    if (isCrossProduct) {
+    if (isHashJoin) {
+        // A hash join's built side has to be read whole - a build loop stopped short of
+        // its rows would leave the probe unable to match them - so the budget reaches only
+        // the probed factor's loops. That is the left factor, the one the probe walks.
+        mlir::db::HashJoin join = mlir::cast<mlir::db::HashJoin>(definingOp);
+        mlir::Operation* const probeYield = join.getLeftFactor().front().getTerminator();
+        for (const mlir::Value yielded : probeYield->getOperands()) {
+            reachedALoop |= assignProducerLoops(yielded, handle, rowsDropped);
+        }
+    } else if (isCrossProduct) {
         // A cross product takes no column operands - its factors are regions - so
         // recurse through each factor's db.yield operands to reach the factor
         // scans/edge loops that produce the crossed columns.

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1674,27 +1674,21 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
         resultTypes.push_back(column.getType());
     }
 
-    // Null when no limit governs this join; otherwise the handle whose budget caps the
-    // probe, so it pairs only the prefix the limit can emit this step.
-    const mlir::Value limitHandle = _loopLimitHandle.lookup(join.getOperation());
-    nl::HashJoinProbe probe = _builder.create<nl::HashJoinProbe>(loc,
-                                                                 resultTypes,
-                                                                 state,
-                                                                 probeColumns,
-                                                                 limitHandle);
-
-    // The join's results are the left factor's yielded columns followed by the right
+    // The join's chunks are the left factor's yielded columns followed by the right
     // factor's, which is how the probe lays its own out: probed side then built side.
-    const mlir::ResultRange dbResults = join.getResults();
-    const mlir::ResultRange probeResults = probe.getResults();
-    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
-        _valueMap[dbResults[resultIndex]] = probeResults[resultIndex];
-    }
+    const nl::IteratorType iteratorType = nl::IteratorType::get(_builder.getContext(), resultTypes);
+    nl::HashJoinProbe probe = _builder.create<nl::HashJoinProbe>(loc,
+                                                                 iteratorType,
+                                                                 state,
+                                                                 probeColumns);
 
-    // The joined columns live in probeBody, so a join nested in a factor stands in for
-    // that factor's innermost loop the way a cross product does.
-    _innermostLoopBody = probeBody;
-    _innermostCardinality = probeResults.front();
+    // A key many build rows carry makes more pairs than the probe chunk holds, so the
+    // pairs come out chunk by chunk and the probe drives a loop of its own nested in the
+    // probe factor's - as a cross product's pairs do. That binds the db results to the
+    // loop variables, carries the limit handle when one governs the join, and leaves the
+    // loop body as the innermost one, where the consumer goes and where an enclosing
+    // factor roots when this join is itself a factor.
+    buildLoopForSource(probe.getResult(), join.getOperation());
 }
 
 mlir::Block* DBLowering::lowerFactor(mlir::Region& factor,

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1664,6 +1664,7 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
 
     llvm::SmallVector<mlir::Value, 4> buildColumns;
     mlir::Block* const buildBody = lowerFactor(join.getRightFactor(), rootBlock, buildColumns);
+    rowAlignFactorChunks(buildColumns);
 
     const mlir::Location loc = _builder.getUnknownLoc();
 
@@ -1683,6 +1684,7 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
 
     llvm::SmallVector<mlir::Value, 4> probeColumns;
     mlir::Block* const probeBody = lowerFactor(join.getLeftFactor(), rootBlock, probeColumns);
+    rowAlignFactorChunks(probeColumns);
 
     // The probe stands where an nl.cross_product stands in a nested loop: at the deepest
     // point of the side that walks, just before whatever consumes the joined rows.
@@ -3781,6 +3783,20 @@ void DBLowering::followCardinalityThrough(mlir::ValueRange inputChunks, mlir::Va
 
         _innermostCardinality = resultChunks[chunkIndex];
         return;
+    }
+}
+
+void DBLowering::rowAlignFactorChunks(llvm::SmallVectorImpl<mlir::Value>& chunks) {
+    mlir::Value cardinality;
+    for (const mlir::Value chunk : chunks) {
+        if (!yieldsConstantColumn(chunk)) {
+            cardinality = chunk;
+            break;
+        }
+    }
+
+    for (mlir::Value& chunk : chunks) {
+        chunk = rowAlignedChunk(chunk, cardinality);
     }
 }
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1622,38 +1622,21 @@ void DBLowering::lowerCrossProduct(mlir::db::CrossProduct product) {
     mlir::Block* const innerBody = lowerFactor(product.getRightFactor(), outerBody, innerColumns);
 
     // The cross sits at the deepest point - the inner factor's innermost loop
-    // body, where both factors have a chunk bound - just before whatever
-    // consumes the product (the lowered db.output).
+    // body, where both factors have a chunk bound.
     setInsertionInto(innerBody);
 
-    // Null when no limit governs this product (built in full); otherwise the
-    // handle whose budget caps the build, so the cross lays out only the prefix
-    // the limit can emit this step.
-    const mlir::Value limitHandle = _loopLimitHandle.lookup(product.getOperation());
     nl::CrossProduct cross = _builder.create<nl::CrossProduct>(_builder.getUnknownLoc(),
                                                                outerColumns,
-                                                               innerColumns,
-                                                               limitHandle);
+                                                               innerColumns);
 
-    // The product's results are the outer factor's yielded columns followed by
-    // the inner's, the same order nl.cross_product lays out its results.
-    const mlir::ResultRange dbResults = product.getResults();
-    const mlir::ResultRange crossResults = cross.getResults();
-    for (size_t resultIndex = 0; resultIndex < dbResults.size(); resultIndex++) {
-        _valueMap[dbResults[resultIndex]] = crossResults[resultIndex];
-    }
-
-    // The crossed columns live in innerBody, so when this product is itself
-    // nested in a factor - e.g. the three-way MATCH (a), (b), (c), where a
-    // cross_product's factor is another cross_product - it stands in for that
-    // factor's innermost loop: the enclosing factor roots its next op (or a
-    // deeper product) there. Record it the way buildLoopForSource records a real
-    // loop, so lowerFactor sees a factor whose innermost "loop" is this product.
-    // At top level nothing reads _innermostLoopBody, so this is a no-op there.
-    _innermostLoopBody = innerBody;
-
-    // Cross prod result defines cardinality
-    _innermostCardinality = crossResults.front();
+    // The pairs come out chunk by chunk, so the product drives a loop of its own
+    // nested in the inner factor's - the third level of the nest, below the two the
+    // factors opened. That binds the db results to the loop variables, carries the
+    // limit handle when one governs the product, and leaves the loop body as the
+    // innermost one, which is where the consumer (the lowered db.output) goes and
+    // where an enclosing factor roots when this product is itself a factor - the
+    // three-way MATCH (a), (b), (c).
+    buildLoopForSource(cross.getResult(), product.getOperation());
 }
 
 void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1668,17 +1668,12 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
 
     const mlir::Location loc = _builder.getUnknownLoc();
 
-    // The build side is emptied at the top of the block the two nests are rooted in, which
-    // is also where it dominates them both: a join nested in a factor therefore starts
-    // fresh on each enclosing step rather than carrying the previous one's rows.
     _builder.setInsertionPointToStart(rootBlock);
     nl::HashJoinBuffer buffer = _builder.create<nl::HashJoinBuffer>(loc,
                                                                     join.getRightKey(),
                                                                     join.getLeftKey());
     const mlir::Value state = buffer.getState();
 
-    // The collect sits in the built factor's innermost loop body, where all of its
-    // columns are bound together, so the buffers stay row-aligned with the key index.
     setInsertionInto(buildBody);
     _builder.create<nl::HashJoinCollect>(loc, state, buildColumns);
 
@@ -1686,8 +1681,6 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
     mlir::Block* const probeBody = lowerFactor(join.getLeftFactor(), rootBlock, probeColumns);
     rowAlignFactorChunks(probeColumns);
 
-    // The probe stands where an nl.cross_product stands in a nested loop: at the deepest
-    // point of the side that walks, just before whatever consumes the joined rows.
     setInsertionInto(probeBody);
 
     llvm::SmallVector<mlir::Type, 8> resultTypes;

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -1698,7 +1698,14 @@ void DBLowering::lowerHashJoin(mlir::db::HashJoin join) {
         resultTypes.push_back(column.getType());
     }
 
-    nl::HashJoinProbe probe = _builder.create<nl::HashJoinProbe>(loc, resultTypes, state, probeColumns);
+    // Null when no limit governs this join; otherwise the handle whose budget caps the
+    // probe, so it pairs only the prefix the limit can emit this step.
+    const mlir::Value limitHandle = _loopLimitHandle.lookup(join.getOperation());
+    nl::HashJoinProbe probe = _builder.create<nl::HashJoinProbe>(loc,
+                                                                 resultTypes,
+                                                                 state,
+                                                                 probeColumns,
+                                                                 limitHandle);
 
     // The join's results are the left factor's yielded columns followed by the right
     // factor's, which is how the probe lays its own out: probed side then built side.
@@ -2696,15 +2703,16 @@ bool DBLowering::assignProducerLoops(mlir::Value column,
     bool reachedALoop = opensLoop || isCrossProduct || isHashJoin || emitsThroughLoop;
 
     // A loop's budget only stops it from taking another step, so bounding one never trims
-    // the step it is in. A cross product's budget cuts the product itself, which stands
-    // only while every row it makes reaches the output: an op below the cut that drops rows
-    // - a filter, a skip, a dedup - would leave it discarding rows that would have
-    // survived, and the cut short of its count. So the product keeps the handle only on a
-    // path that drops nothing; its factor loops take it either way.
+    // the step it is in. A cross product's or a hash join's budget cuts the rows it pairs,
+    // which stands only while every row it makes reaches the output: an op below the cut
+    // that drops rows - a filter, a skip, a dedup - would leave it discarding rows that
+    // would have survived, and the cut short of its count. So either keeps the handle only
+    // on a path that drops nothing; its factor loops take it either way.
     // Declining the handle is not the same as reaching no loop: a cross product is still a
     // producer the walk found, so reachedALoop stands and the cut keeps its nest.
     const bool boundsCrossProduct = isCrossProduct && !rowsDroppedBeforeTheCut;
-    const bool takesTheHandle = opensLoop || boundsCrossProduct || emitsThroughLoop;
+    const bool boundsHashJoin = isHashJoin && !rowsDroppedBeforeTheCut;
+    const bool takesTheHandle = opensLoop || boundsCrossProduct || boundsHashJoin || emitsThroughLoop;
 
     // The first limit, in program order, to claim a producer wins, so a loop
     // shared by two limits' nests carries the outer one and never two handles.

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -85,6 +85,13 @@ class ProcedureManager;
 // one nl.get_property_type above the loops, and the concrete value type is baked
 // into the nullable value chunk the fetch produces inside the binding loop.
 //
+// db.hash_join lowers to two sibling loop nests instead: an nl.hash_join_buffer
+// hoisted to the top of the block they are rooted in, the right (built) factor's
+// nest filling it through an nl.hash_join_collect, and the left (probed) factor's
+// nest behind it, bridged by an nl.hash_join_probe that answers each probe row
+// with the build rows its key matches. The memory is O(build side) rather than
+// bounded, and the build side is read once rather than once per outer chunk.
+//
 // db.cross_product lowers to two nested factor loop nests - the inner factor's
 // loops nested inside the outer factor's innermost loop body, so the inner
 // factor re-runs once per outer chunk (a nested-loop join, bounded memory) -
@@ -207,6 +214,7 @@ private:
     void lowerDeleteNode(mlir::db::DeleteNode deleteNode);
     void lowerDeleteEdge(mlir::db::DeleteEdge deleteEdge);
     void lowerCrossProduct(mlir::db::CrossProduct product);
+    void lowerHashJoin(mlir::db::HashJoin join);
 
     // Lower a db.optional_match into an nl.optional_buffer, the pattern's own loop nest,
     // an nl.optional_collect at its deepest point and an nl.optional_drain loop yielding
@@ -361,10 +369,10 @@ private:
 
     void lowerOutput(mlir::db::Output output);
 
-    // Lower one factor region of a db.cross_product into a loop nest rooted at
-    // rootBlock, collecting its db.yield columns (mapped to their nl chunks) in
-    // yieldedChunks and returning the factor's innermost loop body - where the
-    // cross product, or a deeper factor, nests.
+    // Lower one factor region of a db.cross_product or a db.hash_join into a loop
+    // nest rooted at rootBlock, collecting its db.yield columns (mapped to their nl
+    // chunks) in yieldedChunks and returning the factor's innermost loop body -
+    // where the cross product, the probe, or a deeper factor nests.
     mlir::Block* lowerFactor(mlir::Region& factor,
                              mlir::Block* rootBlock,
                              llvm::SmallVectorImpl<mlir::Value>& yieldedChunks);

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -454,6 +454,12 @@ private:
     // reads in turn.
     void rowAlignCutChunks(llvm::SmallVectorImpl<mlir::Value>& chunks);
 
+    // Lays the constants among a hash join factor's yielded chunks over the rows that
+    // factor walks. The build side appends its chunks to growing buffers and the probe
+    // gathers both sides by matched row, so neither can read a chunk holding one value
+    // for every row rather than a row of its own.
+    void rowAlignFactorChunks(llvm::SmallVectorImpl<mlir::Value>& chunks);
+
     // The chunk whose rows the constants of a step are laid out over: the first of
     // @param chunks carrying rows of its own, and the innermost loop's cardinality when
     // every one of them is a constant, or there are none.

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(query_bench)
 add_subdirectory(scan_bench)
 add_subdirectory(vardeps)
 add_subdirectory(match-brute-force)
+add_subdirectory(cartesian_bench)
 
 set (SCRIPT_LIST_CONTENT "")
 list (LENGTH SAMPLE_LIST SAMPLE_COUNT)

--- a/samples/cartesian_bench/CMakeLists.txt
+++ b/samples/cartesian_bench/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(SAMPLE_NAME cartesian_bench)
+set(SOURCES main.cpp)
+
+turing_sample(${SAMPLE_NAME} ${SOURCES})
+
+target_link_libraries(${SAMPLE_NAME} PRIVATE
+    turing_db_s
+    turing_db_interpreter_v3_s
+    turing_db_memory_s
+    turing_db_ir_interpreter_s
+    turing_db_system_s
+    turing_db_storage_s
+    turing_db_io_fs_s
+    turing_common_s
+    argparse
+    spdlog
+)

--- a/samples/cartesian_bench/main.cpp
+++ b/samples/cartesian_bench/main.cpp
@@ -1,0 +1,697 @@
+#include <stdlib.h>
+#include <sys/resource.h>
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <argparse.hpp>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+
+#include "QueryCallbacks.h"
+#include "QueryConfig.h"
+#include "QueryState.h"
+#include "QueryStatus.h"
+#include "SystemManager.h"
+#include "TuringConfig.h"
+#include "TuringDB.h"
+#include "ID.h"
+#include "dataframe/Dataframe.h"
+#include "iterators/ChunkConfig.h"
+
+#include "LocalMemory.h"
+#include "Path.h"
+#include "TuringTime.h"
+
+using namespace db;
+
+namespace {
+
+// What the RETURN projects over the product, which sets how wide one product row is.
+enum class Projection {
+    Ids,
+    Properties,
+};
+
+// Which engine runs a product.
+enum class Engine {
+    V2,
+    V3,
+};
+
+// One product to benchmark: the labels whose nodes are crossed and what the RETURN
+// projects. Sizing goes through the two label counts, so how many rows the product
+// makes - and how many of them an engine has to hold at once - is known before it runs.
+struct ProductCase {
+    std::string_view _name;
+    std::string_view _leftLabel;
+    std::string_view _rightLabel;
+    Projection _projection {Projection::Ids};
+    size_t _limit {0};
+};
+
+// The products, ordered by the rows they make on reactome. Each crosses two label
+// scans with no predicate relating them, so neither engine can turn one into a join:
+// v2 runs CartesianProductProcessor and v3 runs nl.cross_product.
+constexpr ProductCase productCases[] = {
+    {"species_x_species", "Species", "Species", Projection::Ids},
+    {"compartment_x_compartment", "Compartment", "Compartment", Projection::Ids},
+    {"toplevel_x_toplevel", "TopLevelPathway", "TopLevelPathway", Projection::Ids},
+    {"pathway_x_species", "Pathway", "Species", Projection::Ids},
+    {"pathway_x_compartment", "Pathway", "Compartment", Projection::Ids},
+    {"pathway_x_toplevel", "Pathway", "TopLevelPathway", Projection::Ids},
+    {"reaction_x_compartment", "Reaction", "Compartment", Projection::Ids},
+    {"physical_entity_x_compartment", "PhysicalEntity", "Compartment", Projection::Ids},
+    {"pathway_x_pathway", "Pathway", "Pathway", Projection::Ids},
+    {"pathway_x_species_props", "Pathway", "Species", Projection::Properties},
+    {"pathway_x_toplevel_props", "Pathway", "TopLevelPathway", Projection::Properties},
+    {"reaction_x_reaction", "Reaction", "Reaction", Projection::Ids},
+    {"pathway_x_pathway_limited", "Pathway", "Pathway", Projection::Ids, 1000000},
+    {"reaction_x_reaction_limited", "Reaction", "Reaction", Projection::Ids, 1000},
+};
+
+// How big a case's product is, and how much of it an engine must hold at once. The
+// runner reads this before letting the case run.
+struct ProductSize {
+    size_t _leftRowCount {0};
+    size_t _rightRowCount {0};
+    size_t _productRowCount {0};
+    size_t _peakRowCount {0};
+    size_t _peakBytes {0};
+};
+
+// What one engine produced for one case over every timed round.
+struct BenchResult {
+    std::vector<double> _milliseconds;
+    size_t _rowCount {0};
+    size_t _baseResidentBytes {0};
+    size_t _peakResidentBytes {0};
+    bool _ok {false};
+    bool _skipped {false};
+    std::string _error;
+
+    // How far the run pushed the resident size past where it started. The graph itself
+    // stays resident throughout and dwarfs every product, so the growth is the only
+    // part of the peak that the product accounts for.
+    size_t getResidentGrowthBytes() const {
+        return _peakResidentBytes > _baseResidentBytes ? _peakResidentBytes - _baseResidentBytes : 0;
+    }
+};
+
+// Counts result rows without materializing them, so the v3 path pays no output cost
+// the v2 path does not.
+class CountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+// The bytes one product row costs once materialized: the two crossed node ids, plus -
+// when the projection reads a property off each side - the nullable string columns
+// the projection lays out over the very same rows.
+size_t productRowBytes(Projection projection) {
+    const size_t idBytes = 2 * sizeof(NodeID);
+
+    if (projection == Projection::Properties) {
+        return idBytes + 2 * sizeof(std::optional<std::string_view>);
+    }
+
+    return idBytes;
+}
+
+// Fills how big a case's product is from the two label counts.
+//
+// Both engines stream the product a chunk of output at a time - v2 through
+// CartesianProductProcessor's cursor, v3 through the loop nl.cross_product drives -
+// so whatever the two sides measure, a step holds one chunk.
+void computeProductSize(const ProductCase& productCase,
+                        size_t leftRowCount,
+                        size_t rightRowCount,
+                        ProductSize& size) {
+    const size_t chunkSize = ChunkConfig::CHUNK_SIZE;
+    const size_t rowBytes = productRowBytes(productCase._projection);
+
+    // A LIMIT caps both the rows the query emits and the rows either engine lays out
+    // for it: each stops once the budget is spent, and a step lays out only the prefix
+    // the budget can still take.
+    const size_t limit = productCase._limit > 0 ? productCase._limit : std::numeric_limits<size_t>::max();
+
+    size._leftRowCount = leftRowCount;
+    size._rightRowCount = rightRowCount;
+    size._productRowCount = std::min(leftRowCount * rightRowCount, limit);
+
+    size._peakRowCount = std::min(size._productRowCount, chunkSize);
+    size._peakBytes = size._peakRowCount * rowBytes;
+}
+
+// The Cypher for one case: two label scans with nothing relating them, so the whole
+// product reaches the projection.
+void buildProductQuery(const ProductCase& productCase, std::string& query) {
+    query = "MATCH (a:";
+    query += productCase._leftLabel;
+    query += "), (b:";
+    query += productCase._rightLabel;
+    query += ") RETURN ";
+
+    if (productCase._projection == Projection::Properties) {
+        query += "a.displayName, b.displayName";
+    } else {
+        query += "a, b";
+    }
+
+    if (productCase._limit > 0) {
+        query += " LIMIT ";
+        query += std::to_string(productCase._limit);
+    }
+}
+
+// The Cypher that streams one label's nodes; its row count is how many nodes carry it.
+void buildCountQuery(std::string_view label, std::string& query) {
+    query = "MATCH (n:";
+    query += label;
+    query += ") RETURN n";
+}
+
+// Resets this process's peak-resident-size watermark, so the next reading measures
+// what the run following it touched rather than the whole session.
+void resetPeakResidentBytes() {
+    std::ofstream clearRefs("/proc/self/clear_refs");
+
+    if (clearRefs) {
+        clearRefs << "5\n";
+    }
+}
+
+// The bytes a /proc/self/status field reports, or zero when the kernel does not
+// report the field.
+size_t statusFieldBytes(std::string_view field) {
+    std::ifstream status("/proc/self/status");
+    std::string line;
+
+    while (std::getline(status, line)) {
+        if (line.rfind(field.data(), 0, field.size()) != 0) {
+            continue;
+        }
+
+        std::istringstream fields(line);
+        std::string name;
+        size_t kilobytes = 0;
+        fields >> name >> kilobytes;
+
+        return kilobytes * 1024;
+    }
+
+    return 0;
+}
+
+// This process's peak resident size in bytes since the last reset.
+size_t peakResidentBytes() {
+    return statusFieldBytes("VmHWM:");
+}
+
+// This process's resident size in bytes right now.
+size_t residentBytes() {
+    return statusFieldBytes("VmRSS:");
+}
+
+// Caps this process's address space, so a product bigger than the machine can hold
+// fails with std::bad_alloc - which the runner catches and reports - instead of the
+// kernel's OOM killer taking the whole benchmark down with it.
+void capAddressSpace(size_t bytes) {
+    const rlimit limit {bytes, bytes};
+
+    if (setrlimit(RLIMIT_AS, &limit) != 0) {
+        throw std::runtime_error("could not cap the address space");
+    }
+}
+
+// median of a copy-sorted vector of millisecond samples
+double median(std::vector<double> samples) {
+    std::sort(samples.begin(), samples.end());
+    const size_t count = samples.size();
+
+    if (count == 0) {
+        return 0.0;
+    } else if (count % 2 == 1) {
+        return samples[count / 2];
+    } else {
+        return 0.5 * (samples[count / 2 - 1] + samples[count / 2]);
+    }
+}
+
+// A double formatted to a fixed number of decimals, as a string.
+std::string formatFixed(double value, int decimals) {
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(decimals) << value;
+    return stream.str();
+}
+
+// A byte count as mebibytes, to one decimal.
+std::string formatMebibytes(size_t bytes) {
+    return formatFixed(static_cast<double>(bytes) / (1024.0 * 1024.0), 1);
+}
+
+// The status name and message of a failed query, as one line.
+std::string statusText(const QueryStatus& status) {
+    std::string text {QueryStatusDescription::value(status.getStatus())};
+    if (status.hasErrorMessage()) {
+        text += ": ";
+        text += status.getError();
+    }
+
+    return text;
+}
+
+// Prints a bordered ASCII table with auto-sized, left-aligned columns.
+void printAsciiTable(const std::vector<std::string>& headers,
+                     const std::vector<std::vector<std::string>>& rows) {
+    const size_t columnCount = headers.size();
+
+    std::vector<size_t> widths(columnCount, 0);
+    for (size_t column = 0; column < columnCount; column++) {
+        widths[column] = headers[column].size();
+    }
+    for (const std::vector<std::string>& row : rows) {
+        for (size_t column = 0; column < columnCount; column++) {
+            widths[column] = std::max(widths[column], row[column].size());
+        }
+    }
+
+    const auto printSeparator = [&]() {
+        std::cout << "+";
+        for (size_t column = 0; column < columnCount; column++) {
+            std::cout << std::string(widths[column] + 2, '-') << "+";
+        }
+        std::cout << "\n";
+    };
+
+    const auto printRow = [&](const std::vector<std::string>& cells) {
+        std::cout << "|";
+        for (size_t column = 0; column < columnCount; column++) {
+            const size_t padding = widths[column] - cells[column].size();
+            std::cout << " " << cells[column] << std::string(padding + 1, ' ') << "|";
+        }
+        std::cout << "\n";
+    };
+
+    printSeparator();
+    printRow(headers);
+    printSeparator();
+    for (const std::vector<std::string>& row : rows) {
+        printRow(row);
+    }
+    printSeparator();
+}
+
+// Runs one query through the v2 pipeline once, on a memory of its own so the peak the
+// run reaches is its own. Returns its wall time in ms and fills the number of rows
+// the callbacks received.
+double runV2Once(TuringDB& database,
+                 const std::string& graphName,
+                 const QueryConfig& queryConfig,
+                 const std::string& query,
+                 size_t& rowCountOut) {
+    LocalMemory memory;
+
+    size_t rowCount = 0;
+    QueryCallbacks callbacks;
+    callbacks.setOnOutputData([&](const Dataframe* dataframe) {
+        rowCount += dataframe->getLogicalRowCount();
+    });
+
+    const QueryState state(graphName, &memory, &queryConfig, &callbacks, CommitHash::head(), ChangeID::head());
+
+    const TimePoint start = Clock::now();
+    const QueryStatus status = database.query(query, state);
+    const TimePoint end = Clock::now();
+
+    if (!status.isOk()) {
+        throw std::runtime_error(statusText(status));
+    }
+
+    rowCountOut = rowCount;
+    return duration<Milliseconds>(start, end);
+}
+
+// Runs one query through the v3 MLIR engine once, on a memory of its own. Returns its
+// wall time in ms and fills the number of rows the sink received.
+double runV3Once(QueryInterpreterV3& interpreter,
+                 const std::string& graphName,
+                 const std::string& query,
+                 size_t& rowCountOut) {
+    LocalMemory memory;
+    CountingSink sink;
+
+    QueryStatus status;
+    const TimePoint start = Clock::now();
+    interpreter.execute(status, query, graphName, CommitHash::head(), ChangeID::head(), &memory, &sink);
+    const TimePoint end = Clock::now();
+
+    if (!status.isOk()) {
+        throw std::runtime_error(statusText(status));
+    }
+
+    rowCountOut = sink.getRowCount();
+    return duration<Milliseconds>(start, end);
+}
+
+// The whole set of runs one engine makes for one case: the warmup rounds thrown away,
+// then every timed round, with the peak resident size reached across all of them.
+class BenchRunner {
+public:
+    BenchRunner(TuringDB& database, const std::string& graphName)
+        : _database(database),
+        _graphName(graphName),
+        _v2Config(),
+        _v3Interpreter(&database.getSystemManager())
+    {
+        _v2Config.getPlanGenConfig().setUseValueHashJoin(false);
+        _v3Interpreter.setUseValueHashJoin(false);
+    }
+
+    const QueryConfig& getV2Config() const { return _v2Config; }
+
+    void run(Engine engine, const std::string& query, size_t warmupRounds, size_t rounds, BenchResult& result) {
+        resetPeakResidentBytes();
+        result._baseResidentBytes = residentBytes();
+
+        try {
+            size_t rowCount = 0;
+
+            for (size_t round = 0; round < warmupRounds; round++) {
+                runOnce(engine, query, rowCount);
+            }
+
+            for (size_t round = 0; round < rounds; round++) {
+                result._milliseconds.push_back(runOnce(engine, query, rowCount));
+            }
+
+            result._rowCount = rowCount;
+            result._ok = true;
+        } catch (const std::exception& e) {
+            result._ok = false;
+            result._error = e.what();
+        }
+
+        result._peakResidentBytes = peakResidentBytes();
+    }
+
+private:
+    TuringDB& _database;
+    const std::string& _graphName;
+
+    QueryConfig _v2Config;
+    QueryInterpreterV3 _v3Interpreter;
+
+    double runOnce(Engine engine, const std::string& query, size_t& rowCountOut) {
+        if (engine == Engine::V2) {
+            return runV2Once(_database, _graphName, _v2Config, query, rowCountOut);
+        }
+
+        return runV3Once(_v3Interpreter, _graphName, query, rowCountOut);
+    }
+};
+
+// The number of nodes carrying a label, read by streaming them and counting the rows.
+size_t countLabel(TuringDB& database,
+                  const std::string& graphName,
+                  const QueryConfig& queryConfig,
+                  std::string_view label) {
+    std::string query;
+    buildCountQuery(label, query);
+
+    size_t rowCount = 0;
+    runV2Once(database, graphName, queryConfig, query, rowCount);
+
+    return rowCount;
+}
+
+}
+
+int main(int argc, char** argv) {
+    argparse::ArgumentParser parser("cartesian_bench");
+    parser.add_description("Benchmark the v3 nl.cross_product against the v2 CartesianProductProcessor on the same products");
+
+    std::string turingDirectory;
+    std::string graphName;
+    std::string caseFilter;
+    int iterations = 0;
+    int warmupRounds = 0;
+    double budgetGigabytes = 0.0;
+    double addressSpaceGigabytes = 0.0;
+    double maxProductGigarows = 0.0;
+
+    parser.add_argument("-turing-dir")
+        .default_value(std::string(""))
+        .store_into(turingDirectory);
+    parser.add_argument("-graph")
+        .default_value(std::string("reactome"))
+        .store_into(graphName);
+    parser.add_argument("-case")
+        .default_value(std::string(""))
+        .store_into(caseFilter)
+        .help("Benchmark only the cases whose name contains this text");
+    parser.add_argument("-iters")
+        .default_value(5)
+        .scan<'i', int>()
+        .store_into(iterations);
+    parser.add_argument("-warmup")
+        .default_value(1)
+        .scan<'i', int>()
+        .store_into(warmupRounds);
+    parser.add_argument("-budget-gb")
+        .default_value(4.0)
+        .scan<'g', double>()
+        .store_into(budgetGigabytes)
+        .help("Skip an engine on a case whose product would make it hold more than this at once");
+    parser.add_argument("-address-space-gb")
+        .default_value(24.0)
+        .scan<'g', double>()
+        .store_into(addressSpaceGigabytes)
+        .help("Hard address-space cap, so an over-budget product throws instead of being OOM killed");
+    parser.add_argument("-max-rows-g")
+        .default_value(1.0)
+        .scan<'g', double>()
+        .store_into(maxProductGigarows)
+        .help("Skip a case whose product exceeds this many billion rows, however it is streamed");
+
+    try {
+        parser.parse_args(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n" << parser;
+        return EXIT_FAILURE;
+    }
+
+    const double bytesPerGigabyte = 1024.0 * 1024.0 * 1024.0;
+    const size_t budgetBytes = static_cast<size_t>(budgetGigabytes * bytesPerGigabyte);
+    const size_t maxProductRows = static_cast<size_t>(maxProductGigarows * 1000000000.0);
+
+    try {
+        capAddressSpace(static_cast<size_t>(addressSpaceGigabytes * bytesPerGigabyte));
+
+        TuringConfig config;
+        if (!turingDirectory.empty()) {
+            config.setTuringDirectory(fs::Path(turingDirectory));
+        }
+        config.setSyncedOnDisk(false);
+
+        TuringDB database(&config);
+        database.init();
+
+        {
+            LocalMemory memory;
+            const QueryConfig& queryConfig = database.getDefaultQueryConfig();
+            const QueryCallbacks callbacks;
+            const QueryState state("", &memory, &queryConfig, &callbacks);
+            const QueryStatus status = database.query("load graph " + graphName, state);
+            if (!status.isOk()) {
+                throw std::runtime_error("failed to load graph '" + graphName + "': " + statusText(status));
+            }
+        }
+
+        BenchRunner runner(database, graphName);
+
+        std::vector<ProductCase> cases;
+        for (const ProductCase& productCase : productCases) {
+            if (caseFilter.empty() || productCase._name.find(caseFilter) != std::string_view::npos) {
+                cases.push_back(productCase);
+            }
+        }
+
+        if (cases.empty()) {
+            throw std::runtime_error("no case matches '" + caseFilter + "'");
+        }
+
+        std::vector<ProductSize> sizes(cases.size());
+        for (size_t caseIndex = 0; caseIndex < cases.size(); caseIndex++) {
+            const ProductCase& productCase = cases[caseIndex];
+
+            const size_t leftRowCount = countLabel(database, graphName, runner.getV2Config(), productCase._leftLabel);
+            const size_t rightRowCount = productCase._rightLabel == productCase._leftLabel
+                ? leftRowCount
+                : countLabel(database, graphName, runner.getV2Config(), productCase._rightLabel);
+
+            computeProductSize(productCase, leftRowCount, rightRowCount, sizes[caseIndex]);
+        }
+
+        std::cout << "Graph:         " << graphName << "\n";
+        std::cout << "Chunk size:    " << ChunkConfig::CHUNK_SIZE << " rows\n";
+        std::cout << "Rounds:        " << iterations << " timed, after " << warmupRounds << " warmup\n";
+        std::cout << "Budget:        " << formatFixed(budgetGigabytes, 1) << " GiB held at once\n";
+        std::cout << "Address space: " << formatFixed(addressSpaceGigabytes, 1) << " GiB capped\n";
+        std::cout << "Row cap:       " << maxProductRows << " product rows\n\n";
+
+        std::vector<std::string> sizeHeaders = {"case",
+                                                "left rows",
+                                                "right rows",
+                                                "product rows",
+                                                "row bytes",
+                                                "holds (MiB)",
+                                                "verdict"};
+        std::vector<std::vector<std::string>> sizeRows;
+
+        std::vector<bool> runsV2(cases.size(), false);
+        std::vector<bool> runsV3(cases.size(), false);
+
+        for (size_t caseIndex = 0; caseIndex < cases.size(); caseIndex++) {
+            const ProductCase& productCase = cases[caseIndex];
+            const ProductSize& size = sizes[caseIndex];
+
+            const bool overRowCap = size._productRowCount > maxProductRows;
+            const bool overBudget = size._peakBytes > budgetBytes;
+
+            runsV2[caseIndex] = !overRowCap && !overBudget;
+            runsV3[caseIndex] = !overRowCap && !overBudget;
+
+            std::string verdict = "both run";
+            if (overRowCap) {
+                verdict = "skipped: over the row cap";
+            } else if (overBudget) {
+                verdict = "skipped: over budget";
+            }
+
+            sizeRows.push_back({std::string(productCase._name),
+                                std::to_string(size._leftRowCount),
+                                std::to_string(size._rightRowCount),
+                                std::to_string(size._productRowCount),
+                                std::to_string(productRowBytes(productCase._projection)),
+                                formatMebibytes(size._peakBytes),
+                                verdict});
+        }
+
+        std::cout << "==== What each engine has to hold at once ====\n";
+        printAsciiTable(sizeHeaders, sizeRows);
+        std::cout << "\n";
+
+        std::vector<BenchResult> v2Results(cases.size());
+        std::vector<BenchResult> v3Results(cases.size());
+
+        for (size_t caseIndex = 0; caseIndex < cases.size(); caseIndex++) {
+            const ProductCase& productCase = cases[caseIndex];
+
+            std::string query;
+            buildProductQuery(productCase, query);
+
+            std::cout << "-- " << productCase._name << "\n";
+            std::cout << "   " << query << "\n";
+
+            if (runsV2[caseIndex]) {
+                runner.run(Engine::V2,
+                           query,
+                           static_cast<size_t>(warmupRounds),
+                           static_cast<size_t>(iterations),
+                           v2Results[caseIndex]);
+            } else {
+                v2Results[caseIndex]._skipped = true;
+            }
+
+            if (runsV3[caseIndex]) {
+                runner.run(Engine::V3,
+                           query,
+                           static_cast<size_t>(warmupRounds),
+                           static_cast<size_t>(iterations),
+                           v3Results[caseIndex]);
+            } else {
+                v3Results[caseIndex]._skipped = true;
+            }
+
+            const auto report = [](std::string_view label, const BenchResult& result) {
+                if (result._skipped) {
+                    std::cout << "   " << label << ": skipped\n";
+                } else if (result._ok) {
+                    std::cout << "   " << label << ": median " << formatFixed(median(result._milliseconds), 2)
+                              << " ms, " << result._rowCount << " rows, held "
+                              << formatMebibytes(result.getResidentGrowthBytes()) << " MiB\n";
+                } else {
+                    std::cout << "   " << label << ": FAILED " << result._error << "\n";
+                }
+            };
+
+            report("v2 product", v2Results[caseIndex]);
+            report("v3 product", v3Results[caseIndex]);
+
+            std::cout << "\n";
+        }
+
+        std::vector<std::string> timeHeaders = {"case",
+                                                "product rows",
+                                                "v2 (ms)",
+                                                "v3 (ms)",
+                                                "v3 speedup",
+                                                "v2 rows/ms",
+                                                "v3 rows/ms",
+                                                "v2 held (MiB)",
+                                                "v3 held (MiB)"};
+        std::vector<std::vector<std::string>> timeRows;
+
+        for (size_t caseIndex = 0; caseIndex < cases.size(); caseIndex++) {
+            const BenchResult& v2Result = v2Results[caseIndex];
+            const BenchResult& v3Result = v3Results[caseIndex];
+
+            const double v2Median = v2Result._ok ? median(v2Result._milliseconds) : 0.0;
+            const double v3Median = v3Result._ok ? median(v3Result._milliseconds) : 0.0;
+
+            const std::string speedup = v2Result._ok && v3Result._ok && v3Median > 0.0
+                ? formatFixed(v2Median / v3Median, 2) + "x"
+                : "-";
+
+            const double productRows = static_cast<double>(sizes[caseIndex]._productRowCount);
+
+            timeRows.push_back({std::string(cases[caseIndex]._name),
+                                std::to_string(sizes[caseIndex]._productRowCount),
+                                v2Result._ok ? formatFixed(v2Median, 2) : "-",
+                                v3Result._ok ? formatFixed(v3Median, 2) : "-",
+                                speedup,
+                                v2Result._ok ? formatFixed(productRows / v2Median, 0) : "-",
+                                v3Result._ok ? formatFixed(productRows / v3Median, 0) : "-",
+                                v2Result._ok ? formatMebibytes(v2Result.getResidentGrowthBytes()) : "-",
+                                v3Result._ok ? formatMebibytes(v3Result.getResidentGrowthBytes()) : "-"});
+        }
+
+        std::cout << "==== Median product time, v2 pipeline vs v3 MLIR ====\n";
+        printAsciiTable(timeHeaders, timeRows);
+
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/samples/mlir/call_crossed.nl.mlir
+++ b/samples/mlir/call_crossed.nl.mlir
@@ -7,9 +7,11 @@ func.func @main() {
   nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
     %3 = nl.procedure_init(%1, (), {}) : (!nl.procedure_state) -> !nl.iter<!nl.chunk<!storage.string>>
     nl.for %arg1 in %3 : !nl.iter<!nl.chunk<!storage.string>> {
-      %4:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.string>}
-      %5 = nl.get_node_properties(%4#0, %0) : !nl.chunk<!storage.nullable<!storage.string>>
-      nl.output(%5, %4#1) names ["n.name", "label"] : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>
+      %4 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.string>}
+      nl.for %arg2, %arg3 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.string>> {
+        %5 = nl.get_node_properties(%arg2, %0) : !nl.chunk<!storage.nullable<!storage.string>>
+        nl.output(%5, %arg3) names ["n.name", "label"] : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>
+      }
     }
   }
   return

--- a/samples/mlir/call_yield_into_match.nl.mlir
+++ b/samples/mlir/call_yield_into_match.nl.mlir
@@ -11,12 +11,14 @@ func.func @main() {
       nl.for %arg2, %arg3, %arg4, %arg5 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.edge_type_id>, !nl.chunk<!storage.node_id>> {
         %5 = nl.check_edge_type_constraint(%arg4, [1]) : !nl.chunk<!storage.bool>
         %6:4 = nl.filter %5, (%arg3, %arg5, %arg2, %arg4) : (!nl.chunk<!storage.bool>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>) -> (!nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_type_id>)
-        %7:4 = nl.cross_product{%arg0} {%6#2, %6#0, %6#1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>}
-        %8 = nl.procedure_init(%0, (%7#0, %1), {%7#2, %7#3, %7#1, %7#0}) : (!nl.procedure_state, !nl.chunk<!storage.node_id>, !nl.chunk<i64>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>>
-        nl.for %arg6, %arg7, %arg8, %arg9, %arg10 in %8 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
-          %9 = nl.eq %arg9, %arg6 : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.chunk<i1>
-          %10:5 = nl.filter %9, (%arg7, %arg8, %arg9, %arg10, %arg6) : (!nl.chunk<i1>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
-          nl.output(%10#3, %10#1) names ["n", "t"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        %7 = nl.cross_product{%arg0} {%6#2, %6#0, %6#1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>}
+        nl.for %arg6, %arg7, %arg8, %arg9 in %7 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>> {
+          %8 = nl.procedure_init(%0, (%arg6, %1), {%arg8, %arg9, %arg7, %arg6}) : (!nl.procedure_state, !nl.chunk<!storage.node_id>, !nl.chunk<i64>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>>
+          nl.for %arg10, %arg11, %arg12, %arg13, %arg14 in %8 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+            %9 = nl.eq %arg13, %arg10 : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> !nl.chunk<i1>
+            %10:5 = nl.filter %9, (%arg11, %arg12, %arg13, %arg14, %arg10) : (!nl.chunk<i1>, !nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.edge_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+            nl.output(%10#3, %10#1) names ["n", "t"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+          }
         }
       }
     }

--- a/samples/mlir/complex_predicates.nl.mlir
+++ b/samples/mlir/complex_predicates.nl.mlir
@@ -8,22 +8,24 @@ func.func @main() {
   nl.for %arg0 in %5 : !nl.iter<!nl.chunk<!storage.node_id>> {
     %6 = nl.scan_nodes()
     nl.for %arg1 in %6 : !nl.iter<!nl.chunk<!storage.node_id>> {
-      %7:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-      %8 = nl.get_node_properties(%7#0, %4) : !nl.chunk<!storage.nullable<!storage.string>>
-      %9 = nl.eq %8, %3 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
-      %10 = nl.get_node_properties(%7#1, %4) : !nl.chunk<!storage.nullable<!storage.string>>
-      %11 = nl.get_node_properties(%7#0, %4) : !nl.chunk<!storage.nullable<!storage.string>>
-      %12 = nl.eq %10, %11 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.chunk<!storage.nullable<i1>>
-      %13 = nl.and %9, %12 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
-      %14 = nl.get_node_properties(%7#1, %2) : !nl.chunk<!storage.nullable<i64>>
-      %15 = nl.eq %14, %1 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
-      %16 = nl.and %13, %15 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
-      %17:2 = nl.filter %16, (%7#1, %7#0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
-      %18 = nl.get_node_properties(%17#1, %0) : !nl.chunk<!storage.nullable<i1>>
-      %19 = nl.get_node_properties(%17#0, %0) : !nl.chunk<!storage.nullable<i1>>
-      %20 = nl.eq %18, %19 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
-      %21:2 = nl.filter %20, (%17#0, %17#1) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
-      nl.output(%21#1) : !nl.chunk<!storage.node_id>
+      %7 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.for %arg2, %arg3 in %7 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        %8 = nl.get_node_properties(%arg2, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+        %9 = nl.eq %8, %3 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.string>) -> !nl.chunk<!storage.nullable<i1>>
+        %10 = nl.get_node_properties(%arg3, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+        %11 = nl.get_node_properties(%arg2, %4) : !nl.chunk<!storage.nullable<!storage.string>>
+        %12 = nl.eq %10, %11 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.chunk<!storage.nullable<i1>>
+        %13 = nl.and %9, %12 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+        %14 = nl.get_node_properties(%arg3, %2) : !nl.chunk<!storage.nullable<i64>>
+        %15 = nl.eq %14, %1 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<i64>) -> !nl.chunk<!storage.nullable<i1>>
+        %16 = nl.and %13, %15 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+        %17:2 = nl.filter %16, (%arg3, %arg2) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+        %18 = nl.get_node_properties(%17#1, %0) : !nl.chunk<!storage.nullable<i1>>
+        %19 = nl.get_node_properties(%17#0, %0) : !nl.chunk<!storage.nullable<i1>>
+        %20 = nl.eq %18, %19 : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.nullable<i1>>) -> !nl.chunk<!storage.nullable<i1>>
+        %21:2 = nl.filter %20, (%17#0, %17#1) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+        nl.output(%21#1) : !nl.chunk<!storage.node_id>
+      }
     }
   }
   return

--- a/samples/mlir/hash_join.mlir
+++ b/samples/mlir/hash_join.mlir
@@ -1,0 +1,15 @@
+// MATCH (n), (m) WHERE n.name = m.name RETURN n, m
+
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}

--- a/samples/mlir/hash_join.nl.mlir
+++ b/samples/mlir/hash_join.nl.mlir
@@ -11,8 +11,10 @@ func.func @main() {
   %3 = nl.scan_nodes()
   nl.for %arg1 in %3 : !nl.iter<!nl.chunk<!storage.node_id>> {
     %4 = nl.get_node_properties(%arg1, %1) : !nl.chunk<!storage.nullable<!storage.string>>
-    %5:4 = nl.hash_join_probe %0, (%arg1, %4) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
-    nl.output(%5#0, %5#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    %5 = nl.hash_join_probe %0, (%arg1, %4) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>>
+    nl.for %arg2, %arg3, %arg4, %arg5 in %5 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>> {
+      nl.output(%arg2, %arg4) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    }
   }
   return
 }

--- a/samples/mlir/hash_join.nl.mlir
+++ b/samples/mlir/hash_join.nl.mlir
@@ -1,0 +1,18 @@
+// MATCH (n), (m) WHERE n.name = m.name RETURN n, m
+
+func.func @main() {
+  %0 = nl.hash_join_buffer build_key 1 probe_key 1
+  %1 = nl.get_property_type("name")
+  %2 = nl.scan_nodes()
+  nl.for %arg0 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %4 = nl.get_node_properties(%arg0, %1) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.hash_join_collect %0, (%arg0, %4) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %3 = nl.scan_nodes()
+  nl.for %arg1 in %3 : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %4 = nl.get_node_properties(%arg1, %1) : !nl.chunk<!storage.nullable<!storage.string>>
+    %5:4 = nl.hash_join_probe %0, (%arg1, %4) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
+    nl.output(%5#0, %5#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+  }
+  return
+}

--- a/samples/mlir/limit_cross_product.nl.mlir
+++ b/samples/mlir/limit_cross_product.nl.mlir
@@ -8,9 +8,11 @@ module {
     nl.for %arg0 in %1 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %2 = nl.scan_nodes()
       nl.for %arg1 in %2 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
-        %3:2 = nl.cross_product{%arg0} {%arg1} limit %0 : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-        nl.limit_update %0, %3#0 : !nl.chunk<!storage.node_id>
-        nl.output(%3#0, %3#1) limit %0 : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        %3 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+        nl.for %arg2, %arg3 in %3 limit %0 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+          nl.limit_update %0, %arg2 : !nl.chunk<!storage.node_id>
+          nl.output(%arg2, %arg3) limit %0 : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        }
       }
     }
     return

--- a/samples/mlir/load_csv_match.nl.mlir
+++ b/samples/mlir/load_csv_match.nl.mlir
@@ -18,12 +18,14 @@ module {
     nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %2 = nl.load_csv("people.csv", [0 : ui64, 2 : ui64]) : !nl.iter<!nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>>
       nl.for %arg1, %arg2 in %2 : !nl.iter<!nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>> {
-        %3:3 = nl.cross_product{%arg0} {%arg1, %arg2} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>}
-        %4 = nl.get_node_properties(%3#0, %0) : !nl.chunk<!storage.nullable<!storage.string>>
-        %5 = nl.eq %4, %3#1 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.owned_string>) -> !nl.chunk<!storage.nullable<i1>>
-        %6:3 = nl.filter %5, (%3#0, %3#1, %3#2) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>)
-        %7 = nl.get_node_properties(%6#0, %0) : !nl.chunk<!storage.nullable<!storage.string>>
-        nl.output(%7, %6#2) names ["n.name", "row[2]"] : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.owned_string>
+        %3 = nl.cross_product{%arg0} {%arg1, %arg2} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>}
+        nl.for %arg3, %arg4, %arg5 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>> {
+          %4 = nl.get_node_properties(%arg3, %0) : !nl.chunk<!storage.nullable<!storage.string>>
+          %5 = nl.eq %4, %arg4 : (!nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.owned_string>) -> !nl.chunk<!storage.nullable<i1>>
+          %6:3 = nl.filter %5, (%arg3, %arg4, %arg5) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.owned_string>, !nl.chunk<!storage.owned_string>)
+          %7 = nl.get_node_properties(%6#0, %0) : !nl.chunk<!storage.nullable<!storage.string>>
+          nl.output(%7, %6#2) names ["n.name", "row[2]"] : !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.owned_string>
+        }
       }
     }
     return

--- a/samples/mlir/nested_cross_product.nl.mlir
+++ b/samples/mlir/nested_cross_product.nl.mlir
@@ -3,20 +3,26 @@
 // This is the DBLowering output; edit nested_cross_product.mlir, not this file.
 //
 // The three-way MATCH (a), (b), (c) becomes one loop nest: the inner
-// nl.cross_product crosses each `a` chunk with each `b` chunk into the (a, b)
-// pairs, the `c` scan then re-runs inside that, and the outer nl.cross_product
-// crosses the (a, b) pairs with each `c` chunk before nl.output.
+// nl.cross_product crosses each `a` chunk with each `b` chunk, and drives a loop
+// over the (a, b) pairs it makes; the `c` scan re-runs inside that, and the outer
+// nl.cross_product crosses the pairs with each `c` chunk, driving a loop of its
+// own over the triples before nl.output. Each product emits a chunk of its result
+// per step rather than all of it at once.
 module {
   func.func @main() {
     %0 = nl.scan_nodes()
     nl.for %arg0 in %0 : !nl.iter<!nl.chunk<!storage.node_id>> {
       %1 = nl.scan_nodes()
       nl.for %arg1 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
-        %2:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-        %3 = nl.scan_nodes()
-        nl.for %arg2 in %3 : !nl.iter<!nl.chunk<!storage.node_id>> {
-          %4:3 = nl.cross_product{%2#0, %2#1} {%arg2} : {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-          nl.output(%4#0, %4#1, %4#2) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+        %2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+        nl.for %arg2, %arg3 in %2 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+          %3 = nl.scan_nodes()
+          nl.for %arg4 in %3 : !nl.iter<!nl.chunk<!storage.node_id>> {
+            %4 = nl.cross_product{%arg2, %arg3} {%arg4} : {!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+            nl.for %arg5, %arg6, %arg7 in %4 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+              nl.output(%arg5, %arg6, %arg7) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+            }
+          }
         }
       }
     }

--- a/samples/mlir/xprod_filter_pushdown.nl.mlir
+++ b/samples/mlir/xprod_filter_pushdown.nl.mlir
@@ -10,8 +10,10 @@ func.func @main() {
     %5 = nl.filter %4, (%arg0) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
     %6 = nl.scan_nodes()
     nl.for %arg1 in %6 : !nl.iter<!nl.chunk<!storage.node_id>> {
-      %7:2 = nl.cross_product{%5} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-      nl.output(%7#0, %7#1) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      %7 = nl.cross_product{%5} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.for %arg2, %arg3 in %7 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%arg2, %arg3) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      }
     }
   }
   return

--- a/samples/mlir/xprod_multifilter_pushdown.nl.mlir
+++ b/samples/mlir/xprod_multifilter_pushdown.nl.mlir
@@ -19,8 +19,10 @@ func.func @main() {
       %13 = nl.get_node_properties(%arg1, %4) : !nl.chunk<!storage.nullable<i64>>
       %14 = nl.eq %13, %0 : (!nl.chunk<!storage.nullable<i64>>, !nl.chunk<!storage.nullable<none>>) -> !nl.chunk<!storage.nullable<i1>>
       %15 = nl.filter %14, (%arg1) : (!nl.chunk<!storage.nullable<i1>>, !nl.chunk<!storage.node_id>) -> !nl.chunk<!storage.node_id>
-      %16:2 = nl.cross_product{%11} {%15} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-      nl.output(%16#0, %16#1) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      %16 = nl.cross_product{%11} {%15} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.for %arg2, %arg3 in %16 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%arg2, %arg3) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+      }
     }
   }
   return

--- a/samples/mlir/xprod_return_constant.nl.mlir
+++ b/samples/mlir/xprod_return_constant.nl.mlir
@@ -4,8 +4,10 @@ func.func @main() {
   nl.for %arg0 in %1 : !nl.iter<!nl.chunk<!storage.node_id>> {
     %2 = nl.scan_nodes()
     nl.for %arg1 in %2 : !nl.iter<!nl.chunk<!storage.node_id>> {
-      %3:2 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
-      nl.output(%0) cardinality(%3#0 : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
+      %3 = nl.cross_product{%arg0} {%arg1} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.node_id>}
+      nl.for %arg2, %arg3 in %3 : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+        nl.output(%0) cardinality(%arg2 : !nl.chunk<!storage.node_id>) : !nl.chunk<i64>
+      }
     }
   }
   return

--- a/test/net/TuringProtoRoundTripTest.cpp
+++ b/test/net/TuringProtoRoundTripTest.cpp
@@ -753,3 +753,126 @@ TEST(TuringProtoRoundTripTest, RejectsSchemaLargerThanChunkSize) {
 
     EXPECT_THROW(encodeDataframeWithChunkSize(source, 24), TuringException);
 }
+
+// Encode a ColumnOptVector<ListElementView> — the shape an out-of-range list index reads
+// as — and decode it back. A row that holds no element and a row that holds a null taken
+// out of a list both travel as a null-tagged element, so what tells them apart on the
+// far side is the column's null mask; the two must not collapse into one.
+TEST(TuringProtoRoundTripTest, RoundTripsOptionalListElementViewColumns) {
+    using OptionalElement = std::optional<db::ListElementView>;
+
+    db::LocalMemory localMem;
+    db::DataframeManager dfMan;
+    db::Dataframe source;
+
+    const std::string text(64, 'q');
+
+    std::vector<db::ListBuffer<>::ListItemVariant> items;
+    items.emplace_back(Int64 {-3});
+    items.emplace_back(StringView {text});
+    items.emplace_back(db::PropertyNull {});
+
+    const db::ListView list = localMem.listBuffer().insert(items);
+
+    std::vector<db::ListElementView> elements;
+    for (const auto& element : list) {
+        elements.push_back(element);
+    }
+    ASSERT_EQ(elements.size(), 3u);
+
+    auto* col = localMem.alloc<db::ColumnOptVector<db::ListElementView>>();
+    col->push_back(OptionalElement {elements[0]});
+    col->push_back(std::nullopt);
+    col->push_back(OptionalElement {elements[1]});
+    col->push_back(OptionalElement {elements[2]});
+    col->push_back(std::nullopt);
+    addColumn(&dfMan, &source, "element", col);
+
+    // Small enough to split the header, the mask and the string element's payload
+    for (const size_t chunkSize : std::array<size_t, 4> {48, 64, 97, 256}) {
+        SCOPED_TRACE(::testing::Message() << "chunkSize=" << chunkSize);
+
+        const auto packets = encodeDataframeWithChunkSize(source, chunkSize);
+        expectPacketSequence(packets, true);
+
+        net::proto::ChunkedBuffer<float> embeddingBuffer;
+        net::proto::ChunkedBuffer<char> stringBuffer;
+        db::ListBuffer<> listBuffer;
+        db::Dataframe decoded;
+        std::vector<net::proto::DecodedColumnSchema> schemas;
+        decodeChunkPackets(packets, &localMem, &embeddingBuffer, &stringBuffer, &listBuffer, &dfMan, &decoded, &schemas);
+
+        ASSERT_EQ(decoded.cols().size(), 1u);
+        const auto* decodedCol = decoded.cols().at(0)->as<db::ColumnOptVector<db::ListElementView>>();
+        ASSERT_NE(decodedCol, nullptr);
+
+        const std::vector<OptionalElement>& raw = decodedCol->getRaw();
+        ASSERT_EQ(raw.size(), 5u);
+
+        ASSERT_TRUE(raw[0].has_value());
+        EXPECT_EQ(raw[0]->getTag(), db::ListBufferTypeTag::Int);
+        EXPECT_EQ(raw[0]->getAs<Int64>(), -3);
+
+        EXPECT_FALSE(raw[1].has_value());
+
+        ASSERT_TRUE(raw[2].has_value());
+        EXPECT_EQ(raw[2]->getTag(), db::ListBufferTypeTag::String);
+        EXPECT_EQ(raw[2]->getAs<StringView>(), std::string_view(text));
+
+        ASSERT_TRUE(raw[3].has_value());
+        EXPECT_EQ(raw[3]->getTag(), db::ListBufferTypeTag::Null);
+
+        EXPECT_FALSE(raw[4].has_value());
+    }
+}
+
+// Encode a ColumnConst<std::optional<ListElementView>> — the shape an index read of a
+// literal list at a literal position takes — both carrying an element and carrying none.
+TEST(TuringProtoRoundTripTest, RoundTripsOptionalConstantListElementViewColumns) {
+    using OptionalElement = std::optional<db::ListElementView>;
+
+    db::LocalMemory localMem;
+    db::DataframeManager dfMan;
+    db::Dataframe source;
+
+    const std::string text(64, 'z');
+
+    std::vector<db::ListBuffer<>::ListItemVariant> items;
+    items.emplace_back(StringView {text});
+
+    const db::ListView list = localMem.listBuffer().insert(items);
+
+    auto* element = localMem.alloc<db::ColumnConst<OptionalElement>>();
+    element->set(OptionalElement {*list.begin()});
+    addColumn(&dfMan, &source, "element", element);
+
+    auto* missing = localMem.alloc<db::ColumnConst<OptionalElement>>();
+    missing->set(std::nullopt);
+    addColumn(&dfMan, &source, "missing", missing);
+
+    // The element's payload outruns the buffer, so the decode of the constant resumes on a
+    // later packet with its header already read
+    const auto packets = encodeDataframeWithChunkSize(source, 48);
+    expectPacketSequence(packets, true);
+    EXPECT_GE(countPacketsOfType(packets, net::proto::MessageTypes::CHUNK), 2u);
+
+    net::proto::ChunkedBuffer<float> embeddingBuffer;
+    net::proto::ChunkedBuffer<char> stringBuffer;
+    db::ListBuffer<> listBuffer;
+    db::Dataframe decoded;
+    std::vector<net::proto::DecodedColumnSchema> schemas;
+    decodeChunkPackets(packets, &localMem, &embeddingBuffer, &stringBuffer, &listBuffer, &dfMan, &decoded, &schemas);
+
+    ASSERT_EQ(decoded.cols().size(), 2u);
+    const auto* decodedElement = decoded.cols().at(0)->as<db::ColumnConst<OptionalElement>>();
+    const auto* decodedMissing = decoded.cols().at(1)->as<db::ColumnConst<OptionalElement>>();
+    ASSERT_NE(decodedElement, nullptr);
+    ASSERT_NE(decodedMissing, nullptr);
+
+    const OptionalElement decodedValue = decodedElement->at(0);
+    ASSERT_TRUE(decodedValue.has_value());
+    EXPECT_EQ(decodedValue->getTag(), db::ListBufferTypeTag::String);
+    EXPECT_EQ(decodedValue->getAs<StringView>(), std::string_view(text));
+
+    EXPECT_FALSE(decodedMissing->at(0).has_value());
+}

--- a/test/query/ir/AbsentPropertyNameTest.cpp
+++ b/test/query/ir/AbsentPropertyNameTest.cpp
@@ -148,3 +148,13 @@ TEST_F(AbsentPropertyNameTest, ReadingItLeavesTheSchemaAlone) {
     expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN n.nosuchprop", {{"null"}});
     expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN n.nosuchprop", {{"null"}});
 }
+
+// An absent name reads as null, so ordering it against a value is null on every row and
+// selects none of them, whatever the type of that value
+TEST_F(AbsentPropertyNameTest, OrderingItAgainstAStringMatchesNothing) {
+    expectNoRows("MATCH (n:Person) WHERE n.nosuchprop < 'x' RETURN n.name");
+}
+
+TEST_F(AbsentPropertyNameTest, OrderingItAgainstANumberMatchesNothing) {
+    expectNoRows("MATCH (n:Person) WHERE n.nosuchprop < 1 RETURN n.name");
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1811,8 +1811,6 @@ target_link_libraries(test_query_ir_repeated_edge_variable PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_repeated_edge_variable PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-# The comma-pattern join key tests read the rows of a four-pattern MATCH as text, so they
-# need StringRowSink beside the v3 engine.
 # The chunked hash join cases run hand-written db IR through the lowering at several chunk
 # sizes against the shared SimpleGraph.
 add_ir_tests(test_query_ir_hash_join_chunked HashJoinChunkedTest.cpp)
@@ -1838,6 +1836,8 @@ target_link_libraries(test_query_ir_hash_join PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_hash_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# The comma-pattern join key tests read the rows of a four-pattern MATCH as text, so they
+# need StringRowSink beside the v3 engine.
 add_turing_test(test_query_ir_comma_pattern_join_keys CommaPatternJoinKeysTest.cpp)
 target_sources(test_query_ir_comma_pattern_join_keys PRIVATE StringRowSink.cpp)
 target_link_libraries(test_query_ir_comma_pattern_join_keys PRIVATE

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -66,6 +66,9 @@ add_ir_tests(test_query_ir_collect CollectTest.cpp)
 # The chunked collect tests force the collect fold to span chunk boundaries.
 add_ir_tests(test_query_ir_collect_chunked CollectChunkedTest.cpp)
 
+# The chunked cross product tests force the product to span chunk boundaries.
+add_ir_tests(test_query_ir_cross_product_chunked CrossProductChunkedTest.cpp)
+
 # The collect row-alignment and drain tests run against the shared SimpleGraph fixture.
 add_ir_tests(test_query_ir_collect_row_alignment CollectRowAlignmentTest.cpp)
 target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_examples_s)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1813,6 +1813,26 @@ target_include_directories(test_query_ir_repeated_edge_variable PRIVATE ${CMAKE_
 
 # The comma-pattern join key tests read the rows of a four-pattern MATCH as text, so they
 # need StringRowSink beside the v3 engine.
+# The chunked hash join cases run hand-written db IR through the lowering at several chunk
+# sizes against the shared SimpleGraph.
+add_ir_tests(test_query_ir_hash_join_chunked HashJoinChunkedTest.cpp)
+target_link_libraries(test_query_ir_hash_join_chunked PRIVATE
+        turing_db_examples_s
+        turing_ir_test_rows_s)
+
+# The hash join fusion is checked at both IR levels and run against the shared SimpleGraph,
+# so it needs the frontend engine beside the dialects.
+add_turing_test(test_query_ir_hash_join HashJoinTest.cpp)
+target_sources(test_query_ir_hash_join PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_hash_join PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_hash_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_comma_pattern_join_keys CommaPatternJoinKeysTest.cpp)
 target_sources(test_query_ir_comma_pattern_join_keys PRIVATE StringRowSink.cpp)
 target_link_libraries(test_query_ir_comma_pattern_join_keys PRIVATE

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1841,6 +1841,9 @@ target_link_libraries(test_query_ir_hash_join_cost_model PRIVATE
 add_ir_tests(test_query_ir_hash_join_embedding_key HashJoinEmbeddingKeyTest.cpp)
 target_link_libraries(test_query_ir_hash_join_embedding_key PRIVATE turing_ir_test_rows_s)
 
+# The build index cases group rows by key and walk the buckets directly, with no graph or IR.
+add_ir_tests(test_query_ir_hash_join_index NLHashJoinIndexTest.cpp)
+
 # The hash join fusion is checked at both IR levels and run against the shared SimpleGraph,
 # so it needs the frontend engine beside the dialects.
 add_turing_test(test_query_ir_hash_join HashJoinTest.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1823,6 +1823,16 @@ target_link_libraries(test_query_ir_hash_join_chunked PRIVATE
 add_ir_tests(test_query_ir_hash_join_probe_results HashJoinProbeResultsTest.cpp)
 target_link_libraries(test_query_ir_hash_join_probe_results PRIVATE turing_db_examples_s)
 
+# The cost model cases build graphs of their own size and read which form the pipeline
+# leaves the cut in, so they need the frontend and the codegen beside the dialects.
+add_ir_tests(test_query_ir_hash_join_cost_model HashJoinCostModelTest.cpp)
+target_link_libraries(test_query_ir_hash_join_cost_model PRIVATE
+        turing_db_ir_codegen_s
+        turing_db_frontend_cypher_s
+        turing_db_parser_s
+        turing_db_analyzer_s
+        turing_db_ast_s)
+
 # The embedding key cases build their own graph of vectors and hold the join's rows against
 # the cross product and filter it replaces.
 add_ir_tests(test_query_ir_hash_join_embedding_key HashJoinEmbeddingKeyTest.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1823,6 +1823,11 @@ target_link_libraries(test_query_ir_hash_join_chunked PRIVATE
 add_ir_tests(test_query_ir_hash_join_probe_results HashJoinProbeResultsTest.cpp)
 target_link_libraries(test_query_ir_hash_join_probe_results PRIVATE turing_db_examples_s)
 
+# The embedding key cases build their own graph of vectors and hold the join's rows against
+# the cross product and filter it replaces.
+add_ir_tests(test_query_ir_hash_join_embedding_key HashJoinEmbeddingKeyTest.cpp)
+target_link_libraries(test_query_ir_hash_join_embedding_key PRIVATE turing_ir_test_rows_s)
+
 # The hash join fusion is checked at both IR levels and run against the shared SimpleGraph,
 # so it needs the frontend engine beside the dialects.
 add_turing_test(test_query_ir_hash_join HashJoinTest.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -69,6 +69,10 @@ add_ir_tests(test_query_ir_collect_chunked CollectChunkedTest.cpp)
 # The chunked cross product tests force the product to span chunk boundaries.
 add_ir_tests(test_query_ir_cross_product_chunked CrossProductChunkedTest.cpp)
 
+# The chunked probe cases join a side whose rows all carry one key, so the matches of a
+# probe chunk outgrow it.
+add_ir_tests(test_query_ir_hash_join_chunked_probe HashJoinChunkedProbeTest.cpp)
+
 # The collect row-alignment and drain tests run against the shared SimpleGraph fixture.
 add_ir_tests(test_query_ir_collect_row_alignment CollectRowAlignmentTest.cpp)
 target_link_libraries(test_query_ir_collect_row_alignment PRIVATE turing_db_examples_s)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1857,6 +1857,19 @@ target_link_libraries(test_query_ir_hash_join PRIVATE
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_hash_join PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# The projected-key cases check that a cut still fuses when the query returns the property
+# it joins on, so they need the frontend engine beside the dialects.
+add_turing_test(test_query_ir_hash_join_projected_key HashJoinProjectedKeyTest.cpp)
+target_sources(test_query_ir_hash_join_projected_key PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_hash_join_projected_key PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_hash_join_projected_key PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 # The comma-pattern join key tests read the rows of a four-pattern MATCH as text, so they
 # need StringRowSink beside the v3 engine.
 add_turing_test(test_query_ir_comma_pattern_join_keys CommaPatternJoinKeysTest.cpp)

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1820,6 +1820,11 @@ target_link_libraries(test_query_ir_hash_join_chunked PRIVATE
         turing_db_examples_s
         turing_ir_test_rows_s)
 
+# The probe result cases run hand-written nl IR - one program malformed - against the
+# shared SimpleGraph.
+add_ir_tests(test_query_ir_hash_join_probe_results HashJoinProbeResultsTest.cpp)
+target_link_libraries(test_query_ir_hash_join_probe_results PRIVATE turing_db_examples_s)
+
 # The hash join fusion is checked at both IR levels and run against the shared SimpleGraph,
 # so it needs the frontend engine beside the dialects.
 add_turing_test(test_query_ir_hash_join HashJoinTest.cpp)

--- a/test/query/ir/CrossProductChunkedTest.cpp
+++ b/test/query/ir/CrossProductChunkedTest.cpp
@@ -1,0 +1,532 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "columns/ColumnIDs.h"
+#include "columns/ColumnOptVector.h"
+#include "iterators/ChunkConfig.h"
+#include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Collects the node id tuples a product emits, and the row count of every chunk they
+// arrived in. A product that laid out its whole N*M result in one step shows up as an
+// oversized chunk even when the tuples themselves are right.
+template <size_t Arity>
+class NodeTupleSink : public NLOutputSink {
+public:
+    using Tuple = std::array<uint64_t, Arity>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), Arity);
+
+        std::array<const ColumnNodeIDs*, Arity> columns {};
+        for (size_t index = 0; index < Arity; index++) {
+            columns[index] = dynamic_cast<const ColumnNodeIDs*>(chunks[index]);
+            ASSERT_NE(columns[index], nullptr);
+        }
+
+        _chunkRowCounts.push_back(rowCount);
+
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Tuple tuple {};
+            for (size_t index = 0; index < Arity; index++) {
+                tuple[index] = columns[index]->getRaw()[row].getValue();
+            }
+
+            _tuples.push_back(tuple);
+        }
+    }
+
+    void sortedTuples(std::vector<Tuple>& tuples) const {
+        tuples = _tuples;
+        std::sort(tuples.begin(), tuples.end());
+    }
+
+    size_t getRowCount() const { return _tuples.size(); }
+
+    size_t getLargestChunkRowCount() const {
+        if (_chunkRowCounts.empty()) {
+            return 0;
+        }
+
+        return *std::max_element(_chunkRowCounts.begin(), _chunkRowCounts.end());
+    }
+
+private:
+    std::vector<Tuple> _tuples;
+    std::vector<size_t> _chunkRowCounts;
+};
+
+using PairSink = NodeTupleSink<2>;
+using TripleSink = NodeTupleSink<3>;
+
+// The node-id sink's sibling for the Int64 property a projection over a product reads,
+// so a property fetch that stopped being row-aligned with the product's rows is visible.
+template <size_t Arity>
+class TagTupleSink : public NLOutputSink {
+public:
+    using Tuple = std::array<std::optional<int64_t>, Arity>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), Arity);
+
+        std::array<const ColumnOptVector<int64_t>*, Arity> columns {};
+        for (size_t index = 0; index < Arity; index++) {
+            columns[index] = dynamic_cast<const ColumnOptVector<int64_t>*>(chunks[index]);
+            ASSERT_NE(columns[index], nullptr);
+        }
+
+        _chunkRowCounts.push_back(rowCount);
+
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            Tuple tuple {};
+            for (size_t index = 0; index < Arity; index++) {
+                tuple[index] = columns[index]->getRaw()[row];
+            }
+
+            _tuples.push_back(tuple);
+        }
+    }
+
+    void sortedTuples(std::vector<Tuple>& tuples) const {
+        tuples = _tuples;
+        std::sort(tuples.begin(), tuples.end());
+    }
+
+    size_t getLargestChunkRowCount() const {
+        if (_chunkRowCounts.empty()) {
+            return 0;
+        }
+
+        return *std::max_element(_chunkRowCounts.begin(), _chunkRowCounts.end());
+    }
+
+private:
+    std::vector<Tuple> _tuples;
+    std::vector<size_t> _chunkRowCounts;
+};
+
+using TagSink = TagTupleSink<1>;
+using TagPairSink = TagTupleSink<2>;
+
+// The three sides on their own. A product of label scans crosses exactly what these
+// yield, so the expectations are built from them rather than from the order addNode was
+// called in: node ids are assigned per label set, not per insertion.
+constexpr const char* leftScanProgram = R"mlir(
+func.func @main() {
+  %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+  db.output(%l) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+constexpr const char* rightScanProgram = R"mlir(
+func.func @main() {
+  %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+  db.output(%r) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+constexpr const char* thirdScanProgram = R"mlir(
+func.func @main() {
+  %t = db.scan_nodes_by_label(["T"]) : !db.column<!storage.node_id>
+  db.output(%t) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The tags of each side on its own, the property sibling of the id scans above.
+constexpr const char* leftTagScanProgram = R"mlir(
+func.func @main() {
+  %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+  %lt = db.get_node_properties(%l, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%lt) : !db.column<none>
+  return
+}
+)mlir";
+
+constexpr const char* rightTagScanProgram = R"mlir(
+func.func @main() {
+  %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+  %rt = db.get_node_properties(%r, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%rt) : !db.column<none>
+  return
+}
+)mlir";
+
+// MATCH (l:L), (r:R) RETURN l, r - the plain two-factor product.
+constexpr const char* pairProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    db.yield %l : !db.column<!storage.node_id>
+  } factor {
+    %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+    db.yield %r : !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (l:L), (r:R), (t:T) RETURN l, r, t - the cascade codegen builds for a three-way
+// product, whose right factor is itself a product. The inner product's chunks feed the
+// outer one, so each has to be chunked for the pair to be.
+constexpr const char* tripleProgram = R"mlir(
+func.func @main() {
+  %0:3 = db.cross_product factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    db.yield %l : !db.column<!storage.node_id>
+  } factor {
+    %1:2 = db.cross_product factor {
+      %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+      db.yield %r : !db.column<!storage.node_id>
+    } factor {
+      %t = db.scan_nodes_by_label(["T"]) : !db.column<!storage.node_id>
+      db.yield %t : !db.column<!storage.node_id>
+    }
+    db.yield %1#0, %1#1 : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  }
+  db.output(%0#0, %0#1, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (l:L), (r:R) RETURN l.tag, r.tag - the projection reads a property off each
+// side of the product, so the fetch runs over the product's rows rather than the scans'.
+constexpr const char* tagPairProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    db.yield %l : !db.column<!storage.node_id>
+  } factor {
+    %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+    db.yield %r : !db.column<!storage.node_id>
+  }
+  %lt = db.get_node_properties(%0#0, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %rt = db.get_node_properties(%0#1, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+  db.output(%lt, %rt) : !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+// MATCH (l:L), (r:R) RETURN l, r LIMIT 7 - a budget that runs out partway through the
+// product, so it must stop mid-step and not build the rest.
+constexpr const char* limitedPairProgram = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    db.yield %l : !db.column<!storage.node_id>
+  } factor {
+    %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+    db.yield %r : !db.column<!storage.node_id>
+  }
+  %la, %lb = db.limit(%0#0, %0#1) count 7 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%la, %lb) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+}
+
+// A cross product emits every pair of its two sides' rows. It is the one operator whose
+// result is bigger than its inputs, so it is the one that has to cut its result into
+// chunks rather than lay the whole thing out: a 64Ki-row side crossed with another is
+// 4.29e9 rows in a single step otherwise.
+//
+// Every test here runs its program at chunk sizes that split the fixture in different
+// places and at the production one, against a single expectation, and checks no chunk
+// carried more rows than the chunk size. A product that materialized its whole result
+// fails the chunk check while still emitting the right rows.
+class CrossProductChunkedTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // Nine nodes over three labels, interleaved so no side is a contiguous id range and
+    // each "tag" says which node it is:
+    //   L: n0, n2, n4, n6, n8   (5 nodes)
+    //   R: n1, n3, n5, n7       (4 nodes)
+    //   T: n1, n5               (2 nodes, both also R, so a side can overlap another)
+    // L x R is 20 rows and L x R x T is 40, both far past the small chunk sizes below.
+    std::unique_ptr<Graph> buildLabelledGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        const LabelID leftLabel = metadata.getOrCreateLabel("L");
+        const LabelID rightLabel = metadata.getOrCreateLabel("R");
+        const LabelID thirdLabel = metadata.getOrCreateLabel("T");
+        const PropertyTypeID tagID = metadata.getOrCreatePropertyType("tag", ValueType::Int64)._id;
+
+        const LabelSet leftOnly = LabelSet::fromList({leftLabel});
+        const LabelSet rightOnly = LabelSet::fromList({rightLabel});
+        const LabelSet rightAndThird = LabelSet::fromList({rightLabel, thirdLabel});
+
+        for (size_t index = 0; index < 9; index++) {
+            const bool isLeft = index % 2 == 0;
+            const bool isThird = index == 1 || index == 5;
+
+            LabelSet labelset = leftOnly;
+            if (!isLeft) {
+                labelset = isThird ? rightAndThird : rightOnly;
+            }
+
+            const NodeID node = builder.addNode(labelset);
+            builder.addNodeProperty<types::Int64>(node, tagID, static_cast<int64_t>(index));
+        }
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
+    // Parses a db-dialect program, lowers it to nl with DBLowering, and runs the lowered
+    // function against the graph view at this chunk size.
+    void runLoweredProgram(const char* programText,
+                           const GraphView& view,
+                           NLOutputSink& sink,
+                           size_t chunkSize) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule);
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+    }
+
+    // The node ids one label scan yields, sorted.
+    void readLabelNodes(const char* programText, const GraphView& view, std::vector<uint64_t>& nodes) {
+        NodeTupleSink<1> sink;
+        runLoweredProgram(programText, view, sink, ChunkConfig::CHUNK_SIZE);
+
+        std::vector<NodeTupleSink<1>::Tuple> tuples;
+        sink.sortedTuples(tuples);
+
+        nodes.clear();
+        for (const NodeTupleSink<1>::Tuple& tuple : tuples) {
+            nodes.push_back(tuple[0]);
+        }
+    }
+
+    // The tags one label scan yields, sorted: the property sibling of readLabelNodes.
+    void readLabelTags(const char* programText, const GraphView& view, std::vector<std::optional<int64_t>>& tags) {
+        TagSink sink;
+        runLoweredProgram(programText, view, sink, ChunkConfig::CHUNK_SIZE);
+
+        std::vector<TagSink::Tuple> tuples;
+        sink.sortedTuples(tuples);
+
+        tags.clear();
+        for (const TagSink::Tuple& tuple : tuples) {
+            tags.push_back(tuple[0]);
+        }
+    }
+
+    // The three sides of the products below, each read off the graph, and the shape the
+    // fixture is meant to have: five nodes crossed with four, and two for the third side.
+    void readSides(const GraphView& view,
+                   std::vector<uint64_t>& left,
+                   std::vector<uint64_t>& right,
+                   std::vector<uint64_t>& third) {
+        readLabelNodes(leftScanProgram, view, left);
+        readLabelNodes(rightScanProgram, view, right);
+        readLabelNodes(thirdScanProgram, view, third);
+
+        ASSERT_EQ(left.size(), 5u);
+        ASSERT_EQ(right.size(), 4u);
+        ASSERT_EQ(third.size(), 2u);
+    }
+
+    // Chunk sizes that cut the product in different places. Every one from 2 up makes a
+    // step whose two sides multiply out past it - at 2 the sides are 2 and 2, so a
+    // materialized product is 4 rows in a chunk that holds 2 - and the last is the
+    // production size, which holds the whole fixture in one chunk.
+    const std::vector<size_t> _chunkSizes {1, 2, 3, 4, 7, 20, ChunkConfig::CHUNK_SIZE};
+
+    std::unique_ptr<JobSystem> _jobSystem;
+};
+
+TEST_F(CrossProductChunkedTest, emitsEveryPairInChunks) {
+    auto graph = buildLabelledGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> leftNodes;
+    std::vector<uint64_t> rightNodes;
+    std::vector<uint64_t> thirdNodes;
+    readSides(reader.getView(), leftNodes, rightNodes, thirdNodes);
+
+    std::vector<PairSink::Tuple> expected;
+    for (const uint64_t left : leftNodes) {
+        for (const uint64_t right : rightNodes) {
+            expected.push_back({left, right});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    for (const size_t chunkSize : _chunkSizes) {
+        PairSink sink;
+        runLoweredProgram(pairProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<PairSink::Tuple> tuples;
+        sink.sortedTuples(tuples);
+        EXPECT_EQ(tuples, expected) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CrossProductChunkedTest, emitsEveryTripleInChunks) {
+    auto graph = buildLabelledGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> leftNodes;
+    std::vector<uint64_t> rightNodes;
+    std::vector<uint64_t> thirdNodes;
+    readSides(reader.getView(), leftNodes, rightNodes, thirdNodes);
+
+    std::vector<TripleSink::Tuple> expected;
+    for (const uint64_t left : leftNodes) {
+        for (const uint64_t right : rightNodes) {
+            for (const uint64_t third : thirdNodes) {
+                expected.push_back({left, right, third});
+            }
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    for (const size_t chunkSize : _chunkSizes) {
+        TripleSink sink;
+        runLoweredProgram(tripleProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<TripleSink::Tuple> tuples;
+        sink.sortedTuples(tuples);
+        EXPECT_EQ(tuples, expected) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CrossProductChunkedTest, readsAPropertyOffEachSideOfEveryPair) {
+    auto graph = buildLabelledGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<std::optional<int64_t>> leftTags;
+    std::vector<std::optional<int64_t>> rightTags;
+    readLabelTags(leftTagScanProgram, reader.getView(), leftTags);
+    readLabelTags(rightTagScanProgram, reader.getView(), rightTags);
+    ASSERT_EQ(leftTags.size(), 5u);
+    ASSERT_EQ(rightTags.size(), 4u);
+
+    std::vector<TagPairSink::Tuple> expected;
+    for (const std::optional<int64_t>& left : leftTags) {
+        for (const std::optional<int64_t>& right : rightTags) {
+            expected.push_back({left, right});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    for (const size_t chunkSize : _chunkSizes) {
+        TagPairSink sink;
+        runLoweredProgram(tagPairProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<TagPairSink::Tuple> tuples;
+        sink.sortedTuples(tuples);
+        EXPECT_EQ(tuples, expected) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(CrossProductChunkedTest, stopsTheProductOnceTheLimitIsSpent) {
+    auto graph = buildLabelledGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> leftNodes;
+    std::vector<uint64_t> rightNodes;
+    std::vector<uint64_t> thirdNodes;
+    readSides(reader.getView(), leftNodes, rightNodes, thirdNodes);
+
+    for (const size_t chunkSize : _chunkSizes) {
+        PairSink sink;
+        runLoweredProgram(limitedPairProgram, reader.getView(), sink, chunkSize);
+
+        EXPECT_EQ(sink.getRowCount(), 7u) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+
+        // Which seven pairs survive is chunk-size dependent - the budget takes a prefix
+        // of the order the chunking happens to produce - so only that they are seven
+        // distinct pairs of the product is invariant.
+        std::vector<PairSink::Tuple> tuples;
+        sink.sortedTuples(tuples);
+        EXPECT_EQ(std::adjacent_find(tuples.begin(), tuples.end()), tuples.end())
+            << "at chunk size " << chunkSize;
+
+        for (const PairSink::Tuple& tuple : tuples) {
+            const bool leftIsASideRow = std::find(leftNodes.begin(), leftNodes.end(), tuple[0]) != leftNodes.end();
+            const bool rightIsASideRow = std::find(rightNodes.begin(), rightNodes.end(), tuple[1]) != rightNodes.end();
+            EXPECT_TRUE(leftIsASideRow && rightIsASideRow) << "at chunk size " << chunkSize;
+        }
+    }
+}

--- a/test/query/ir/DBLoweringTest.cpp
+++ b/test/query/ir/DBLoweringTest.cpp
@@ -3743,7 +3743,8 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
     lowering.lower(dbFunction, *nlModule);
 
     // The product becomes a loop nest, not two sibling loops: exactly one
-    // nl.cross_product and exactly two nl.for loops (one scan per factor).
+    // nl.cross_product and exactly three nl.for loops - one scan per factor, plus
+    // the product's own, which walks the pairs a chunk at a time.
     size_t crossProductCount = 0;
     size_t forCount = 0;
     mlir::nl::CrossProduct cross;
@@ -3757,13 +3758,17 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
     });
 
     EXPECT_EQ(crossProductCount, 1u);
-    EXPECT_EQ(forCount, 2u);
+    EXPECT_EQ(forCount, 3u);
     ASSERT_TRUE(cross);
 
-    // One column contributed by each factor, two results (outer ++ inner).
+    // One column contributed by each factor, so the iterator produces two chunks
+    // per step (outer ++ inner).
     EXPECT_EQ(cross.getOuterColumns().size(), 1u);
     EXPECT_EQ(cross.getInnerColumns().size(), 1u);
-    EXPECT_EQ(cross.getResults().size(), 2u);
+
+    const auto iteratorType = mlir::dyn_cast<mlir::nl::IteratorType>(cross.getResult().getType());
+    ASSERT_TRUE(iteratorType);
+    EXPECT_EQ(iteratorType.getChunkTypes().size(), 2u);
 
     // The cross sits in the inner loop body, itself nested in the outer loop
     // body - so the inner factor re-runs once per outer chunk.
@@ -3776,6 +3781,14 @@ TEST_F(DBLoweringTest, lowersCrossProductToNestedLoops) {
     // outer column is the outer loop's chunk, the inner column the inner's.
     EXPECT_EQ(cross.getOuterColumns()[0], outerFor.getBody()->getArgument(0));
     EXPECT_EQ(cross.getInnerColumns()[0], innerFor.getBody()->getArgument(0));
+
+    // The product drives a third loop, nested inside the inner factor's, which
+    // binds one variable per crossed column and holds the consumer.
+    ASSERT_TRUE(cross.getResult().hasOneUse());
+    auto productFor = mlir::dyn_cast<mlir::nl::For>(*cross.getResult().getUsers().begin());
+    ASSERT_TRUE(productFor);
+    EXPECT_EQ(productFor->getParentOp(), innerFor.getOperation());
+    EXPECT_EQ(productFor.getBody()->getNumArguments(), 2u);
 }
 
 TEST_F(DBLoweringTest, limitsScanToFewerThanNodeCount) {

--- a/test/query/ir/ExplainTest.cpp
+++ b/test/query/ir/ExplainTest.cpp
@@ -234,3 +234,25 @@ TEST_F(ExplainTest, rejectsAPassThePipelineDoesNotRun) {
     expectRejected("EXPLAIN (after bogus_pass) MATCH (n) RETURN n", "Unknown EXPLAIN pass 'bogus_pass'");
     expectRejected("EXPLAIN (after bogus_pass) MATCH (n) RETURN n", "fuse_scan_by_label");
 }
+
+TEST_F(ExplainTest, dumpsTheAstOfANullTest) {
+    StringRowSink sink;
+    explain("EXPLAIN (ast) MATCH (n:Person) WHERE n.age IS NULL RETURN n.name", sink);
+
+    std::vector<std::string> stages;
+    collectStages(sink, stages);
+    EXPECT_EQ(stages, (std::vector<std::string> {"ast"}));
+
+    EXPECT_TRUE(contains(dumpOf(sink, "ast"), "Operator IS_NULL"));
+}
+
+TEST_F(ExplainTest, dumpsTheAstOfANotNullTest) {
+    StringRowSink sink;
+    explain("EXPLAIN (ast) MATCH (n:Person) WHERE n.age IS NOT NULL RETURN n.name", sink);
+
+    std::vector<std::string> stages;
+    collectStages(sink, stages);
+    EXPECT_EQ(stages, (std::vector<std::string> {"ast"}));
+
+    EXPECT_TRUE(contains(dumpOf(sink, "ast"), "Operator IS_NOT_NULL"));
+}

--- a/test/query/ir/HashJoinChunkedProbeTest.cpp
+++ b/test/query/ir/HashJoinChunkedProbeTest.cpp
@@ -1,0 +1,324 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "columns/ColumnIDs.h"
+#include "iterators/ChunkConfig.h"
+#include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The node ids one side yields on its own, for building the expectation off the graph.
+class NodeSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 1u);
+
+        const auto* const nodes = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        ASSERT_NE(nodes, nullptr);
+
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            _nodes.push_back(nodes->getRaw()[row].getValue());
+        }
+    }
+
+    void sortedNodes(std::vector<uint64_t>& nodes) const {
+        nodes = _nodes;
+        std::sort(nodes.begin(), nodes.end());
+    }
+
+private:
+    std::vector<uint64_t> _nodes;
+};
+
+// Collects the node id pairs a join emits and the row count of every chunk they arrived
+// in. A probe that laid out every match of a whole probe chunk in one step shows up as an
+// oversized chunk even when the pairs themselves are right.
+class PairSink : public NLOutputSink {
+public:
+    using Pair = std::array<uint64_t, 2>;
+
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        ASSERT_EQ(chunks.size(), 2u);
+
+        const auto* const left = dynamic_cast<const ColumnNodeIDs*>(chunks[0]);
+        const auto* const right = dynamic_cast<const ColumnNodeIDs*>(chunks[1]);
+        ASSERT_NE(left, nullptr);
+        ASSERT_NE(right, nullptr);
+
+        _chunkRowCounts.push_back(rowCount);
+
+        for (size_t row = offset; row < offset + rowCount; row++) {
+            _pairs.push_back({left->getRaw()[row].getValue(), right->getRaw()[row].getValue()});
+        }
+    }
+
+    void sortedPairs(std::vector<Pair>& pairs) const {
+        pairs = _pairs;
+        std::sort(pairs.begin(), pairs.end());
+    }
+
+    size_t getLargestChunkRowCount() const {
+        if (_chunkRowCounts.empty()) {
+            return 0;
+        }
+
+        return *std::max_element(_chunkRowCounts.begin(), _chunkRowCounts.end());
+    }
+
+private:
+    std::vector<Pair> _pairs;
+    std::vector<size_t> _chunkRowCounts;
+};
+
+// The two sides on their own. The join pairs exactly what these yield, so the expectation
+// is built from them rather than from the order addNode was called in: node ids are
+// assigned per label set, not per insertion.
+constexpr const char* leftScanProgram = R"mlir(
+func.func @main() {
+  %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+  db.output(%l) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+constexpr const char* rightScanProgram = R"mlir(
+func.func @main() {
+  %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+  db.output(%r) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// MATCH (l:L), (r:R) WHERE l.tag = r.tag RETURN l, r, as the fusion pass leaves it. Every
+// node of both sides carries tag 0, so the join is the whole product: one key group whose
+// rows are every build row, and every probe row matching all of them.
+constexpr const char* joinProgram = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    %lt = db.get_node_properties(%l, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %l, %lt : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+    %rt = db.get_node_properties(%r, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %r, %rt : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  db.output(%0#0, %0#2) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The same join under a budget that runs out partway through one probe row's matches, so
+// it has to stop mid-group and not build the rest.
+constexpr const char* limitedJoinProgram = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %l = db.scan_nodes_by_label(["L"]) : !db.column<!storage.node_id>
+    %lt = db.get_node_properties(%l, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %l, %lt : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %r = db.scan_nodes_by_label(["R"]) : !db.column<!storage.node_id>
+    %rt = db.get_node_properties(%r, "tag") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %r, %rt : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  %la, %lb = db.limit(%0#0, %0#2) count 7 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%la, %lb) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+}
+
+// A hash join emits one row per matched pair, so a key that many build rows carry makes a
+// result bigger than either side - the cross product's problem, reached through a join.
+// The probe has to cut that result into chunks rather than lay out every match of a probe
+// chunk in one step: a side of 6345 rows sharing one key is 40e6 rows in a single step
+// otherwise, which is what a reactome species join does.
+//
+// Every case runs at chunk sizes that split the result in different places and at the
+// production one, against a single expectation, and checks no chunk carried more rows than
+// the chunk size.
+class HashJoinChunkedProbeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // Ten nodes, five under each of two labels, every one carrying tag 0. The join on the
+    // tag matches every pair, so it is 25 rows, far past the small chunk sizes below.
+    std::unique_ptr<Graph> buildSharedTagGraph() {
+        auto graph = Graph::create();
+
+        auto change = graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        const LabelID leftLabel = metadata.getOrCreateLabel("L");
+        const LabelID rightLabel = metadata.getOrCreateLabel("R");
+        const PropertyTypeID tagID = metadata.getOrCreatePropertyType("tag", ValueType::Int64)._id;
+
+        const LabelSet leftOnly = LabelSet::fromList({leftLabel});
+        const LabelSet rightOnly = LabelSet::fromList({rightLabel});
+
+        for (size_t index = 0; index < 10; index++) {
+            const bool isLeft = index % 2 == 0;
+
+            const NodeID node = builder.addNode(isLeft ? leftOnly : rightOnly);
+            builder.addNodeProperty<types::Int64>(node, tagID, 0);
+        }
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        EXPECT_TRUE(submitResult);
+
+        return graph;
+    }
+
+    void runLoweredProgram(const char* programText,
+                           const GraphView& view,
+                           NLOutputSink& sink,
+                           size_t chunkSize) {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule);
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+    }
+
+    // The node ids one label scan yields, sorted.
+    void readLabelNodes(const char* programText, const GraphView& view, std::vector<uint64_t>& nodes) {
+        NodeSink sink;
+        runLoweredProgram(programText, view, sink, ChunkConfig::CHUNK_SIZE);
+
+        sink.sortedNodes(nodes);
+    }
+
+    // The two sides of the join, each read off the graph, and the shape the fixture is
+    // meant to have: five nodes on each side, so 25 pairs.
+    void readSides(const GraphView& view, std::vector<uint64_t>& left, std::vector<uint64_t>& right) {
+        readLabelNodes(leftScanProgram, view, left);
+        readLabelNodes(rightScanProgram, view, right);
+
+        ASSERT_EQ(left.size(), 5u);
+        ASSERT_EQ(right.size(), 5u);
+    }
+
+    // Chunk sizes that cut the result in different places. Every one from 2 up makes a
+    // probe step whose matches multiply out past it, and the last is the production size,
+    // which holds the whole fixture in one chunk.
+    const std::vector<size_t> _chunkSizes {1, 2, 3, 4, 7, 25, ChunkConfig::CHUNK_SIZE};
+
+    std::unique_ptr<JobSystem> _jobSystem;
+};
+
+TEST_F(HashJoinChunkedProbeTest, emitsEveryMatchedPairInChunks) {
+    auto graph = buildSharedTagGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> leftNodes;
+    std::vector<uint64_t> rightNodes;
+    readSides(reader.getView(), leftNodes, rightNodes);
+
+    std::vector<PairSink::Pair> expected;
+    for (const uint64_t left : leftNodes) {
+        for (const uint64_t right : rightNodes) {
+            expected.push_back({left, right});
+        }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    for (const size_t chunkSize : _chunkSizes) {
+        PairSink sink;
+        runLoweredProgram(joinProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<PairSink::Pair> pairs;
+        sink.sortedPairs(pairs);
+        EXPECT_EQ(pairs, expected) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+    }
+}
+
+TEST_F(HashJoinChunkedProbeTest, stopsMidGroupOnALimit) {
+    auto graph = buildSharedTagGraph();
+    const FrozenCommitTx transaction = graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+
+    std::vector<uint64_t> leftNodes;
+    std::vector<uint64_t> rightNodes;
+    readSides(reader.getView(), leftNodes, rightNodes);
+
+    for (const size_t chunkSize : _chunkSizes) {
+        PairSink sink;
+        runLoweredProgram(limitedJoinProgram, reader.getView(), sink, chunkSize);
+
+        std::vector<PairSink::Pair> pairs;
+        sink.sortedPairs(pairs);
+
+        EXPECT_EQ(pairs.size(), 7u) << "at chunk size " << chunkSize;
+        EXPECT_LE(sink.getLargestChunkRowCount(), chunkSize) << "at chunk size " << chunkSize;
+
+        for (const PairSink::Pair& pair : pairs) {
+            const bool leftIsALeftNode = std::find(leftNodes.begin(), leftNodes.end(), pair[0]) != leftNodes.end();
+            const bool rightIsARightNode = std::find(rightNodes.begin(), rightNodes.end(), pair[1]) != rightNodes.end();
+
+            EXPECT_TRUE(leftIsALeftNode) << "at chunk size " << chunkSize;
+            EXPECT_TRUE(rightIsARightNode) << "at chunk size " << chunkSize;
+        }
+    }
+}

--- a/test/query/ir/HashJoinChunkedTest.cpp
+++ b/test/query/ir/HashJoinChunkedTest.cpp
@@ -71,6 +71,44 @@ func.func @main() {
 }
 )mlir";
 
+// A join whose key is the same constant on both sides, so every probe row matches every
+// build row. A constant holds one value standing for every row rather than a row of its
+// own, so the join has to lay it out over the rows its factor walks before buffering them.
+const char* const joinOnAConstantKey = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.constant(1 : i64)
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<i64>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.constant(1 : i64)
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<i64>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The same join keyed on a NaN, which is equal to nothing - itself included - so it must
+// match nothing. The key serializer maps every NaN payload to one canonical NaN, which is
+// what DISTINCT wants and what the join must not read as a match.
+const char* const joinOnANaNKey = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.constant(0x7FF8000000000000 : f64)
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<f64>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.constant(0x7FF8000000000000 : f64)
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<f64>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
 using Blocks = std::vector<std::vector<size_t>>;
 
 Row pair(size_t left, size_t right) {
@@ -166,6 +204,23 @@ TEST_F(HashJoinChunkedTest, joinsEveryNodeWithItselfOnAStringKey) {
     }
 
     expectRowsAtEveryChunkSize(joinOnName, expected);
+}
+
+// One key for all 18 nodes on either side, so the join is the whole cross product: each
+// probe node paired with every build node, in build order.
+TEST_F(HashJoinChunkedTest, joinsEveryPairOnAConstantKey) {
+    Rows expected;
+    for (size_t probeNode = 0; probeNode < 18; probeNode++) {
+        for (size_t buildNode = 0; buildNode < 18; buildNode++) {
+            expected.push_back(pair(probeNode, buildNode));
+        }
+    }
+
+    expectRowsAtEveryChunkSize(joinOnAConstantKey, expected);
+}
+
+TEST_F(HashJoinChunkedTest, leavesEveryRowOfANaNKeyUnmatched) {
+    expectRowsAtEveryChunkSize(joinOnANaNKey, Rows {});
 }
 
 int main(int argc, char** argv) {

--- a/test/query/ir/HashJoinChunkedTest.cpp
+++ b/test/query/ir/HashJoinChunkedTest.cpp
@@ -1,0 +1,173 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "StorageDialect.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// A join on a boolean property: the four French people of SimpleGraph key alike, the four
+// who are not key alike, and the ten nodes with no isFrench at all key null and match
+// nothing.
+const char* const joinOnIsFrench = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "isFrench") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "isFrench") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A join on a string property every node carries and no two share, so the result is the
+// diagonal: one row per node, pairing it with itself.
+const char* const joinOnName = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "name") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+using Blocks = std::vector<std::vector<size_t>>;
+
+Row pair(size_t left, size_t right) {
+    return Row {std::to_string(left), std::to_string(right)};
+}
+
+}
+
+// db.hash_join run at chunk sizes that split the build side and the probe side several
+// ways. The build rows are numbered from where the previous chunk ended and the index is
+// filled before any probing, so the rows the join emits - and the order it emits them in -
+// must not depend on how the scans were chunked. That is what these cases pin.
+class HashJoinChunkedTest : public TuringTest {
+protected:
+    void initialize() override {
+        _graph = Graph::create();
+        SimpleGraph::createSimpleGraph(_graph.get());
+    }
+
+    // Parses a db-dialect program, lowers it to nl and runs the lowered function against
+    // the graph at this chunk size.
+    void runProgram(const char* programText, size_t chunkSize, RowSink& sink) {
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView view = reader.getView();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule);
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+    }
+
+    void expectRowsAtEveryChunkSize(const char* programText, const Rows& expected) {
+        for (const size_t chunkSize : _chunkSizes) {
+            RowSink sink;
+            runProgram(programText, chunkSize, sink);
+
+            EXPECT_EQ(sink.rows(), expected) << "at chunk size " << chunkSize;
+        }
+    }
+
+    // One row per chunk, then two, three and five - each splitting the eighteen nodes
+    // differently - and last the production size, which holds them all in one chunk.
+    const std::vector<size_t> _chunkSizes {1, 2, 3, 5, ChunkConfig::CHUNK_SIZE};
+
+    std::unique_ptr<Graph> _graph;
+};
+
+// Remy (0), Adam (1), Maxime (8) and Luc (9) are French; Martina (11), Suhas (12),
+// Cyrus (15) and Doruk (17) are not. The join is the two blocks, and the interests - which
+// carry no isFrench - match nothing, not even each other.
+TEST_F(HashJoinChunkedTest, joinsTheTwoBlocksOfABooleanKey) {
+    const Blocks blocks {{0, 1, 8, 9}, {11, 12, 15, 17}};
+
+    // The probe walks its rows in scan order and each row's matches come out in build
+    // order, so the rows are the blocks read one probe node at a time.
+    Rows expected;
+    for (size_t probeNode = 0; probeNode < 18; probeNode++) {
+        for (const std::vector<size_t>& block : blocks) {
+            if (std::find(block.begin(), block.end(), probeNode) == block.end()) {
+                continue;
+            }
+
+            for (const size_t buildNode : block) {
+                expected.push_back(pair(probeNode, buildNode));
+            }
+        }
+    }
+
+    expectRowsAtEveryChunkSize(joinOnIsFrench, expected);
+}
+
+TEST_F(HashJoinChunkedTest, joinsEveryNodeWithItselfOnAStringKey) {
+    Rows expected;
+    for (size_t node = 0; node < 18; node++) {
+        expected.push_back(pair(node, node));
+    }
+
+    expectRowsAtEveryChunkSize(joinOnName, expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/HashJoinCostModelTest.cpp
+++ b/test/query/ir/HashJoinCostModelTest.cpp
@@ -245,6 +245,29 @@ TEST_F(HashJoinCostModelTest, sizesAHopByItsFanOut) {
     EXPECT_LT(program.find("db.get_out_edges"), program.find("} factor {")) << program;
 }
 
+// An unwind of a literal list makes a row per element, and the elements are in the IR, so
+// the side it seeds is sized through it: twenty of them over the ten Rare nodes they are
+// crossed with are two hundred rows, against the hundred of the plain scan beside them -
+// so the scan is what the join holds and the product what it streams.
+TEST_F(HashJoinCostModelTest, sizesAFactorThroughTheListItUnwinds) {
+    buildGraph(100, 10, 0);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    const mlir::db::DBPassContext forced {&view, true, true};
+
+    std::string program;
+    generate("MATCH (n) UNWIND [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20] AS x "
+             "MATCH (m:Rare) WHERE n.name = m.name RETURN n, m, x",
+             forced,
+             program);
+
+    // The product stands in the join's first factor, the side that streams; the scan it
+    // was crossed with would stand there instead were the list left uncounted.
+    EXPECT_LT(program.find("db.cross_product"), program.find("} factor {")) << program;
+}
+
 // The two overrides: forcing takes every cut the pass matches whatever the estimate says,
 // and clearing use takes none.
 TEST_F(HashJoinCostModelTest, forcingFusesTheSmallestProduct) {

--- a/test/query/ir/HashJoinCostModelTest.cpp
+++ b/test/query/ir/HashJoinCostModelTest.cpp
@@ -177,6 +177,26 @@ TEST_F(HashJoinCostModelTest, keepsTheProductWhenTheLabelsNarrowBothSides) {
     EXPECT_FALSE(fuses("MATCH (n:Rare), (m:Rare) WHERE n.name = m.name RETURN n, m"));
 }
 
+// Which side the join buffers, read off the db program: the built side is its right
+// factor, so a scan standing after the join's own `} factor {` is the side being built.
+TEST_F(HashJoinCostModelTest, buildsTheSideTheLabelsNarrow) {
+    buildGraph(400, 10);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    const mlir::db::DBPassContext forced {&view, true, true};
+
+    // Ten Rare nodes against four hundred: whichever side the query writes it on, the ten
+    // are what the join holds and the four hundred what it streams.
+    std::string program;
+    generate("MATCH (n:Rare), (m) WHERE n.name = m.name RETURN n, m", forced, program);
+    EXPECT_LT(program.find("} factor {"), program.find("db.scan_nodes_by_label")) << program;
+
+    generate("MATCH (n), (m:Rare) WHERE n.name = m.name RETURN n, m", forced, program);
+    EXPECT_LT(program.find("} factor {"), program.find("db.scan_nodes_by_label")) << program;
+}
+
 // The two overrides: forcing takes every cut the pass matches whatever the estimate says,
 // and clearing use takes none.
 TEST_F(HashJoinCostModelTest, forcingFusesTheSmallestProduct) {

--- a/test/query/ir/HashJoinCostModelTest.cpp
+++ b/test/query/ir/HashJoinCostModelTest.cpp
@@ -56,9 +56,10 @@ protected:
     }
 
     // @param nodeCount nodes labelled Point, the first @param rareCount of them labelled
-    // Rare as well, so a query naming Rare scans a small side of a large graph. Every node
-    // carries a name, which is what the cuts below key on.
-    void buildGraph(size_t nodeCount, size_t rareCount) {
+    // Rare as well, so a query naming Rare scans a small side of a large graph, and
+    // @param edgesPerNode LINKS edges out of each. Every node carries a name, which is
+    // what the cuts below key on.
+    void buildGraph(size_t nodeCount, size_t rareCount, size_t edgesPerNode = 0) {
         _graph = Graph::create();
 
         auto change = _graph->newChange();
@@ -68,6 +69,7 @@ protected:
 
         const LabelID pointLabel = metadata.getOrCreateLabel("Point");
         const LabelID rareLabel = metadata.getOrCreateLabel("Rare");
+        const EdgeTypeID linksType = metadata.getOrCreateEdgeType("LINKS");
         const PropertyTypeID nameID = metadata.getOrCreatePropertyType("name", ValueType::String)._id;
 
         const LabelSet pointLabelSet = LabelSet::fromList({pointLabel});
@@ -75,12 +77,21 @@ protected:
 
         _names.clear();
         _names.reserve(nodeCount);
+
+        std::vector<NodeID> nodes;
+        nodes.reserve(nodeCount);
         for (size_t node = 0; node < nodeCount; node++) {
             const bool isRare = node < rareCount;
-            const NodeID nodeID = builder.addNode(isRare ? rareLabelSet : pointLabelSet);
+            nodes.push_back(builder.addNode(isRare ? rareLabelSet : pointLabelSet));
 
             _names.push_back("point" + std::to_string(node));
-            builder.addNodeProperty<types::String>(nodeID, nameID, _names.back());
+            builder.addNodeProperty<types::String>(nodes.back(), nameID, _names.back());
+        }
+
+        for (size_t node = 0; node < nodeCount; node++) {
+            for (size_t edge = 0; edge < edgesPerNode; edge++) {
+                builder.addEdge(linksType, nodes[node], nodes[(node + edge + 1) % nodeCount]);
+            }
         }
 
         const auto submitResult = change->access().submit(*_jobSystem);
@@ -195,6 +206,25 @@ TEST_F(HashJoinCostModelTest, buildsTheSideTheLabelsNarrow) {
 
     generate("MATCH (n), (m:Rare) WHERE n.name = m.name RETURN n, m", forced, program);
     EXPECT_LT(program.find("} factor {"), program.find("db.scan_nodes_by_label")) << program;
+}
+
+// A factor a hop seeds carries a row per edge, not per node, and the graph counts those
+// too: a hundred nodes with three edges each is three hundred rows against the hundred the
+// bare scan beside it makes, so the bare scan is the side to hold.
+TEST_F(HashJoinCostModelTest, buildsTheScanRatherThanTheEdgesItIsCrossedWith) {
+    buildGraph(100, 0, 3);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    ASSERT_EQ(reader.getEdgeCount(), 300u);
+
+    const mlir::db::DBPassContext forced {&view, true, true};
+
+    std::string program;
+    generate("MATCH (a)-->(b), (m) WHERE b.name = m.name RETURN a, m", forced, program);
+
+    EXPECT_LT(program.find("db.scan_edges"), program.find("} factor {")) << program;
 }
 
 // The two overrides: forcing takes every cut the pass matches whatever the estimate says,

--- a/test/query/ir/HashJoinCostModelTest.cpp
+++ b/test/query/ir/HashJoinCostModelTest.cpp
@@ -227,6 +227,24 @@ TEST_F(HashJoinCostModelTest, buildsTheScanRatherThanTheEdgesItIsCrossedWith) {
     EXPECT_LT(program.find("db.scan_edges"), program.find("} factor {")) << program;
 }
 
+// A hop no edge scan swallowed - one out of a labelled scan - carries its fan-out: ten
+// Rare nodes of average degree three make thirty rows, so the bare scan of the same ten is
+// the smaller side and the one to hold.
+TEST_F(HashJoinCostModelTest, sizesAHopByItsFanOut) {
+    buildGraph(100, 10, 3);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    const mlir::db::DBPassContext forced {&view, true, true};
+
+    std::string program;
+    generate("MATCH (m:Rare), (n:Rare)-->(x) WHERE m.name = x.name RETURN m, x", forced, program);
+
+    // The hop is the side that streams, so it stands in the join's first factor.
+    EXPECT_LT(program.find("db.get_out_edges"), program.find("} factor {")) << program;
+}
+
 // The two overrides: forcing takes every cut the pass matches whatever the estimate says,
 // and clearing use takes none.
 TEST_F(HashJoinCostModelTest, forcingFusesTheSmallestProduct) {

--- a/test/query/ir/HashJoinCostModelTest.cpp
+++ b/test/query/ir/HashJoinCostModelTest.cpp
@@ -1,0 +1,213 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "metadata/LabelSet.h"
+#include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "CypherAnalyzer.h"
+#include "CypherAST.h"
+#include "CypherParser.h"
+
+#include "DBDialect.h"
+#include "DBPasses.h"
+#include "DBProgramGenerator.h"
+#include "NLDialect.h"
+#include "StorageDialect.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Which of the two forms a cross product cut by an equality is left in. The join reads its
+// whole build side and indexes every key before it emits a row, so it only repays itself
+// on a product large enough - and on one a limit does not cut short. This is the v2
+// planner's cost model (ReadStmtGenerator::shouldPlaceValueHashJoin over
+// CardinalityEstimation), reading the same node counts on the v3 pipeline.
+class HashJoinCostModelTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // @param nodeCount nodes labelled Point, the first @param rareCount of them labelled
+    // Rare as well, so a query naming Rare scans a small side of a large graph. Every node
+    // carries a name, which is what the cuts below key on.
+    void buildGraph(size_t nodeCount, size_t rareCount) {
+        _graph = Graph::create();
+
+        auto change = _graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        const LabelID pointLabel = metadata.getOrCreateLabel("Point");
+        const LabelID rareLabel = metadata.getOrCreateLabel("Rare");
+        const PropertyTypeID nameID = metadata.getOrCreatePropertyType("name", ValueType::String)._id;
+
+        const LabelSet pointLabelSet = LabelSet::fromList({pointLabel});
+        const LabelSet rareLabelSet = LabelSet::fromList({pointLabel, rareLabel});
+
+        _names.clear();
+        _names.reserve(nodeCount);
+        for (size_t node = 0; node < nodeCount; node++) {
+            const bool isRare = node < rareCount;
+            const NodeID nodeID = builder.addNode(isRare ? rareLabelSet : pointLabelSet);
+
+            _names.push_back("point" + std::to_string(node));
+            builder.addNodeProperty<types::String>(nodeID, nameID, _names.back());
+        }
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        ASSERT_TRUE(submitResult);
+    }
+
+    // The db program the pipeline leaves for a query on this graph, as text.
+    void generate(std::string_view query, const mlir::db::DBPassContext& context, std::string& program) {
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView view = reader.getView();
+
+        CypherAST ast(nullptr, query);
+        CypherParser parser(&ast);
+        parser.parse(query);
+
+        CypherAnalyzer analyzer(&ast, view);
+        analyzer.setV3();
+        analyzer.analyze();
+
+        mlir::MLIRContext mlirContext;
+        mlirContext.getOrLoadDialect<mlir::func::FuncDialect>();
+        mlirContext.getOrLoadDialect<mlir::storage::Storage>();
+        mlirContext.getOrLoadDialect<mlir::db::DB>();
+        mlirContext.getOrLoadDialect<mlir::nl::NL>();
+
+        mlir::OpBuilder builder(&mlirContext);
+        mlir::OwningOpRef<mlir::ModuleOp> owningModule = mlir::ModuleOp::create(builder.getUnknownLoc());
+        mlir::ModuleOp module = owningModule.get();
+
+        DBProgramGenerator generator(&module, nullptr, context);
+        generator.generate(&ast);
+
+        program.clear();
+        llvm::raw_string_ostream stream(program);
+        module.print(stream);
+    }
+
+    // Whether the cut of @param query is left fused on a graph the cost model reads.
+    bool fuses(std::string_view query) {
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView view = reader.getView();
+        const mlir::db::DBPassContext context {&view, false, true};
+
+        std::string program;
+        generate(query, context, program);
+
+        return program.find("db.hash_join") != std::string::npos;
+    }
+
+    std::unique_ptr<JobSystem> _jobSystem;
+    std::unique_ptr<Graph> _graph;
+    std::vector<std::string> _names;
+};
+
+// 18 nodes, so the product is 324 pairs: cheaper read whole than through a build side of
+// 18 indexed keys.
+TEST_F(HashJoinCostModelTest, keepsTheProductWhenItIsSmall) {
+    buildGraph(18, 0);
+
+    EXPECT_FALSE(fuses("MATCH (n), (m) WHERE n.name = m.name RETURN n, m"));
+}
+
+// 400 nodes are 160000 pairs, past the point where indexing one side pays for itself.
+TEST_F(HashJoinCostModelTest, fusesWhenTheProductIsLarge) {
+    buildGraph(400, 0);
+
+    EXPECT_TRUE(fuses("MATCH (n), (m) WHERE n.name = m.name RETURN n, m"));
+}
+
+// The same product under a limit of one row: the product stops as soon as it is met, where
+// the join would read all 400 build rows first.
+TEST_F(HashJoinCostModelTest, keepsTheProductUnderALimitTheJoinCannotRepay) {
+    buildGraph(400, 0);
+
+    EXPECT_FALSE(fuses("MATCH (n), (m) WHERE n.name = m.name RETURN n, m LIMIT 1"));
+}
+
+// A limit the product cannot meet within a chunk of the build side leaves the join in
+// place: 400 rows against a budget of 3 is not the early exit a smaller side would be.
+TEST_F(HashJoinCostModelTest, fusesUnderALimitTooLargeToCutTheProductShort) {
+    buildGraph(400, 0);
+
+    EXPECT_TRUE(fuses("MATCH (n), (m) WHERE n.name = m.name RETURN n, m LIMIT 3"));
+}
+
+// The labels name ten of the four hundred nodes, so the two sides are the ten - a hundred
+// pairs, whatever the size of the graph they sit in.
+TEST_F(HashJoinCostModelTest, keepsTheProductWhenTheLabelsNarrowBothSides) {
+    buildGraph(400, 10);
+
+    EXPECT_TRUE(fuses("MATCH (n), (m) WHERE n.name = m.name RETURN n, m"));
+    EXPECT_FALSE(fuses("MATCH (n:Rare), (m:Rare) WHERE n.name = m.name RETURN n, m"));
+}
+
+// The two overrides: forcing takes every cut the pass matches whatever the estimate says,
+// and clearing use takes none.
+TEST_F(HashJoinCostModelTest, forcingFusesTheSmallestProduct) {
+    buildGraph(18, 0);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    const mlir::db::DBPassContext forced {&view, true, true};
+
+    std::string program;
+    generate("MATCH (n), (m) WHERE n.name = m.name RETURN n, m", forced, program);
+
+    EXPECT_NE(program.find("db.hash_join"), std::string::npos) << program;
+}
+
+TEST_F(HashJoinCostModelTest, clearingUseFusesTheLargestProduct) {
+    buildGraph(400, 0);
+
+    const FrozenCommitTx transaction = _graph->openTransaction();
+    const GraphReader reader = transaction.readGraph();
+    const GraphView view = reader.getView();
+    const mlir::db::DBPassContext disabled {&view, false, false};
+
+    std::string program;
+    generate("MATCH (n), (m) WHERE n.name = m.name RETURN n, m", disabled, program);
+
+    EXPECT_EQ(program.find("db.hash_join"), std::string::npos) << program;
+    EXPECT_NE(program.find("db.cross_product"), std::string::npos) << program;
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/HashJoinEmbeddingKeyTest.cpp
+++ b/test/query/ir/HashJoinEmbeddingKeyTest.cpp
@@ -1,0 +1,193 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "iterators/ChunkConfig.h"
+#include "metadata/LabelSet.h"
+#include "metadata/PropertyType.h"
+#include "reader/GraphReader.h"
+#include "versioning/Change.h"
+#include "versioning/CommitBuilder.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+#include "writers/DataPartBuilder.h"
+#include "writers/MetadataBuilder.h"
+
+#include "DBDialect.h"
+#include "DBLowering.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "StorageDialect.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// The join, keyed on the embedding property.
+const char* const joinOnVector = R"mlir(
+func.func @main() {
+  %0:4 = db.hash_join factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "vec") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    %2 = db.get_node_properties(%1, "vec") : (!db.column<!storage.node_id>) -> !db.column<none>
+    db.yield %1, %2 : !db.column<!storage.node_id>, !db.column<none>
+  } on 1, 1
+  db.output(%0#0, %0#2) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The same equality as the nested loop the fusion replaces: the rows of the product the
+// filter kept. What the join answers is read against this rather than against a
+// hand-derived list, so the two forms are held to one another.
+const char* const crossOnVector = R"mlir(
+func.func @main() {
+  %0:2 = db.cross_product factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %1 : !db.column<!storage.node_id>
+  } factor {
+    %1 = db.scan_nodes() : !db.column<!storage.node_id>
+    db.yield %1 : !db.column<!storage.node_id>
+  }
+  %1 = db.get_node_properties(%0#0, "vec") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %2 = db.get_node_properties(%0#1, "vec") : (!db.column<!storage.node_id>) -> !db.column<none>
+  %3 = db.eq %1, %2 : (!db.column<none>, !db.column<none>) -> !db.column<!storage.bool>
+  %4:2 = db.filter(%3, {%0#0, %0#1}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%4#0, %4#1) names ["n", "m"] : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+}
+
+// A db.hash_join keyed on an embedding property. Two embeddings are equal when they carry
+// the same floats in the same order, so the join has to serialize the vector rather than
+// turn the query away: `=` between two embedding columns is a comparison the engine makes.
+class HashJoinEmbeddingKeyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _jobSystem = std::make_unique<JobSystem>();
+        _jobSystem->init();
+
+        buildVectorGraph();
+    }
+
+    void terminate() override {
+        _jobSystem->terminate();
+    }
+
+    // Six nodes: 0 and 1 carry the same vector, 2 carries the same floats with the sign of
+    // its zero flipped (-0.0 == 0.0, so it keys with them), 3 carries another vector, 4
+    // carries a NaN - equal to nothing, itself included - and 5 carries no vector at all.
+    void buildVectorGraph() {
+        _graph = Graph::create();
+
+        auto change = _graph->newChange();
+        auto* commitBuilder = change->access().getTip();
+        auto& builder = commitBuilder->newBuilder();
+        auto& metadata = builder.getMetadata();
+
+        metadata.getOrCreateLabel("Point");
+        const PropertyTypeID vectorID = metadata.getOrCreatePropertyType("vec", ValueType::Embedding)._id;
+
+        const LabelSet labelset = LabelSet::fromList({0});
+        const std::vector<NodeID> nodes {builder.addNode(labelset),
+                                         builder.addNode(labelset),
+                                         builder.addNode(labelset),
+                                         builder.addNode(labelset),
+                                         builder.addNode(labelset),
+                                         builder.addNode(labelset)};
+
+        const float notANumber = std::numeric_limits<float>::quiet_NaN();
+        const std::vector<std::vector<float>> vectors {{1.0f, 0.0f},
+                                                       {1.0f, 0.0f},
+                                                       {1.0f, -0.0f},
+                                                       {2.0f, 5.0f},
+                                                       {1.0f, notANumber}};
+
+        for (size_t node = 0; node < vectors.size(); node++) {
+            builder.addNodeProperty<types::Embedding>(nodes[node], vectorID, vectors[node]);
+        }
+
+        const auto submitResult = change->access().submit(*_jobSystem);
+        ASSERT_TRUE(submitResult);
+    }
+
+    void runProgram(const char* programText, size_t chunkSize, RowSink& sink) {
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView view = reader.getView();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::db::DB>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> dbModule = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(dbModule);
+
+        const mlir::func::FuncOp dbFunction = dbModule->lookupSymbol<mlir::func::FuncOp>("main");
+        ASSERT_TRUE(dbFunction);
+
+        mlir::OwningOpRef<mlir::ModuleOp> nlModule = mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+        DBLowering lowering(&context, &view);
+        lowering.lower(dbFunction, *nlModule);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*nlModule, &view, &sink, &memory, chunkSize);
+        interpreter.run();
+    }
+
+    void sortedRowsOf(const char* programText, size_t chunkSize, Rows& rows) {
+        RowSink sink;
+        runProgram(programText, chunkSize, sink);
+        sink.sortedRows(rows);
+    }
+
+    const std::vector<size_t> _chunkSizes {1, 2, 4, ChunkConfig::CHUNK_SIZE};
+
+    std::unique_ptr<JobSystem> _jobSystem;
+    std::unique_ptr<Graph> _graph;
+};
+
+TEST_F(HashJoinEmbeddingKeyTest, joinsTheRowsTheEqualityKeeps) {
+    Rows expected;
+    sortedRowsOf(crossOnVector, ChunkConfig::CHUNK_SIZE, expected);
+
+    // 0, 1 and 2 hold one vector between them, 3 holds its own, and neither the NaN of 4
+    // nor the absent vector of 5 matches anything.
+    ASSERT_EQ(expected.size(), 10u);
+
+    for (const size_t chunkSize : _chunkSizes) {
+        Rows joined;
+        sortedRowsOf(joinOnVector, chunkSize, joined);
+
+        EXPECT_EQ(joined, expected) << "at chunk size " << chunkSize;
+    }
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/HashJoinProbeResultsTest.cpp
+++ b/test/query/ir/HashJoinProbeResultsTest.cpp
@@ -45,8 +45,8 @@ private:
 };
 
 // The build columns are not operands of nl.hash_join_probe - they live in the handle - so
-// their chunk types are spelled among its results, and nothing in NLOps.td ties those to
-// the columns the collect appended. Here the last result claims a node ID column where the
+// their chunk types are spelled in its iterator, and nothing in NLOps.td ties those to the
+// columns the collect appended. Here the last chunk claims a node ID column where the
 // collect appended a nullable string, so the buffer holding string views would be gathered
 // as a column of IDs.
 constexpr const char* const mistypedBuildResultProgram = R"mlir(
@@ -61,8 +61,10 @@ func.func @main() {
   %probe = nl.scan_nodes()
   nl.for %p in %probe : !nl.iter<!nl.chunk<!storage.node_id>> {
     %pname = nl.get_node_properties(%p, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
-    %joined:4 = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
-    nl.output(%joined#0, %joined#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    %joined = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>>
+    nl.for %n, %name, %m, %mname in %joined : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>> {
+      nl.output(%n, %m) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    }
   }
   return
 }
@@ -82,8 +84,10 @@ func.func @main() {
   %probe = nl.scan_nodes()
   nl.for %p in %probe : !nl.iter<!nl.chunk<!storage.node_id>> {
     %pname = nl.get_node_properties(%p, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
-    %joined:4 = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
-    nl.output(%joined#0, %joined#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    %joined = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>>
+    nl.for %n, %name, %m, %mname in %joined : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>> {
+      nl.output(%n, %m) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+    }
   }
   return
 }
@@ -91,7 +95,7 @@ func.func @main() {
 
 }
 
-// What an nl.hash_join_probe declares its build results as, which is what the buffers the
+// What an nl.hash_join_probe declares its build chunks as, which is what the buffers the
 // collect allocated are read back through.
 class HashJoinProbeResultsTest : public TuringTest {
 protected:

--- a/test/query/ir/HashJoinProbeResultsTest.cpp
+++ b/test/query/ir/HashJoinProbeResultsTest.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <memory>
+#include <span>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "columns/Column.h"
+#include "iterators/ChunkConfig.h"
+#include "reader/GraphReader.h"
+#include "versioning/Transaction.h"
+#include "views/GraphView.h"
+
+#include "IRException.h"
+#include "LocalMemory.h"
+#include "NLDialect.h"
+#include "NLInterpreter.h"
+#include "NLOutputSink.h"
+#include "StorageDialect.h"
+
+#include "TuringTest.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+class RowCountingSink : public NLOutputSink {
+public:
+    void appendChunks(std::span<const Column* const> chunks, size_t offset, size_t rowCount) override {
+        _rowCount += rowCount;
+    }
+
+    size_t getRowCount() const { return _rowCount; }
+
+private:
+    size_t _rowCount {0};
+};
+
+// The build columns are not operands of nl.hash_join_probe - they live in the handle - so
+// their chunk types are spelled among its results, and nothing in NLOps.td ties those to
+// the columns the collect appended. Here the last result claims a node ID column where the
+// collect appended a nullable string, so the buffer holding string views would be gathered
+// as a column of IDs.
+constexpr const char* const mistypedBuildResultProgram = R"mlir(
+func.func @main() {
+  %state = nl.hash_join_buffer build_key 1 probe_key 1
+  %nameType = nl.get_property_type("name")
+  %build = nl.scan_nodes()
+  nl.for %b in %build : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %bname = nl.get_node_properties(%b, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.hash_join_collect %state, (%b, %bname) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %probe = nl.scan_nodes()
+  nl.for %p in %probe : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %pname = nl.get_node_properties(%p, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %joined:4 = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+    nl.output(%joined#0, %joined#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+  }
+  return
+}
+)mlir";
+
+// The same program with the build results spelled as the collect appended them, which is
+// what the lowering emits and what the translator has to accept.
+constexpr const char* const buildResultProgram = R"mlir(
+func.func @main() {
+  %state = nl.hash_join_buffer build_key 1 probe_key 1
+  %nameType = nl.get_property_type("name")
+  %build = nl.scan_nodes()
+  nl.for %b in %build : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %bname = nl.get_node_properties(%b, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    nl.hash_join_collect %state, (%b, %bname) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>
+  }
+  %probe = nl.scan_nodes()
+  nl.for %p in %probe : !nl.iter<!nl.chunk<!storage.node_id>> {
+    %pname = nl.get_node_properties(%p, %nameType) : !nl.chunk<!storage.nullable<!storage.string>>
+    %joined:4 = nl.hash_join_probe %state, (%p, %pname) : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>) -> (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>, !nl.chunk<!storage.node_id>, !nl.chunk<!storage.nullable<!storage.string>>)
+    nl.output(%joined#0, %joined#2) names ["n", "m"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>
+  }
+  return
+}
+)mlir";
+
+}
+
+// What an nl.hash_join_probe declares its build results as, which is what the buffers the
+// collect allocated are read back through.
+class HashJoinProbeResultsTest : public TuringTest {
+protected:
+    void initialize() override {
+        _graph = Graph::create();
+        SimpleGraph::createSimpleGraph(_graph.get());
+    }
+
+    void runProgram(const char* programText, NLOutputSink& sink) {
+        const FrozenCommitTx transaction = _graph->openTransaction();
+        const GraphReader reader = transaction.readGraph();
+        const GraphView view = reader.getView();
+
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::func::FuncDialect>();
+        context.getOrLoadDialect<mlir::storage::Storage>();
+        context.getOrLoadDialect<mlir::nl::NL>();
+
+        const mlir::ParserConfig parserConfig(&context);
+        mlir::OwningOpRef<mlir::ModuleOp> module = mlir::parseSourceString<mlir::ModuleOp>(programText, parserConfig);
+        ASSERT_TRUE(module);
+
+        LocalMemory memory;
+        NLInterpreter interpreter(*module, &view, &sink, &memory, ChunkConfig::CHUNK_SIZE);
+        interpreter.run();
+    }
+
+    std::unique_ptr<Graph> _graph;
+};
+
+TEST_F(HashJoinProbeResultsTest, rejectsABuildResultTypedOtherThanItsBuffer) {
+    RowCountingSink sink;
+
+    EXPECT_THROW(runProgram(mistypedBuildResultProgram, sink), IRException);
+}
+
+// Every node carries its own name, so the join is the diagonal.
+TEST_F(HashJoinProbeResultsTest, joinsOnABuildResultTypedAsItsBuffer) {
+    RowCountingSink sink;
+    runProgram(buildResultProgram, sink);
+
+    EXPECT_EQ(sink.getRowCount(), 18u);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/HashJoinProjectedKeyTest.cpp
+++ b/test/query/ir/HashJoinProjectedKeyTest.cpp
@@ -1,0 +1,175 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+
+}
+
+// A join whose key property the query also returns. The projection and the key read one
+// property of one variable, so the reuse pass hands both the same column - and the cut
+// still has to fuse, since the join yields that column among its results.
+class HashJoinProjectedKeyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+        _interpreter->setForceValueHashJoin(true);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void explainStage(std::string_view query, std::string_view stage, std::string& program) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        program.clear();
+        for (const StringRowSink::Row& row : sink.getRows()) {
+            if (row.front() == stage) {
+                program = row.back();
+            }
+        }
+
+        EXPECT_FALSE(program.empty()) << "query: " << query << "\nno " << stage << " stage reported";
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    // The rows the join produces against the rows the cross product and its filter
+    // produce, which is what the cut stands as when the join is not forced. Neither form
+    // is ordered, so the two are held against each other sorted.
+    void expectJoinMatchesTheProduct(std::string_view query) {
+        StringRowSink joined;
+        _interpreter->setForceValueHashJoin(true);
+        runQuery(query, joined);
+
+        StringRowSink product;
+        _interpreter->setForceValueHashJoin(false);
+        runQuery(query, product);
+        _interpreter->setForceValueHashJoin(true);
+
+        Rows joinedRows = joined.getRows();
+        Rows productRows = product.getRows();
+        std::sort(joinedRows.begin(), joinedRows.end());
+        std::sort(productRows.begin(), productRows.end());
+
+        EXPECT_FALSE(joinedRows.empty()) << "query: " << query;
+        EXPECT_EQ(joinedRows, productRows) << "query: " << query;
+    }
+
+    static bool contains(std::string_view text, std::string_view part) {
+        return text.find(part) != std::string_view::npos;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(HashJoinProjectedKeyTest, fusesWhenTheReturnProjectsTheKeyProperty) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = m.name RETURN n.name", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+    EXPECT_FALSE(contains(program, "db.cross_product")) << program;
+}
+
+TEST_F(HashJoinProjectedKeyTest, fusesWhenTheReturnProjectsTheKeyOfBothSides) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = m.name RETURN n.name, m.name", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+    EXPECT_FALSE(contains(program, "db.cross_product")) << program;
+}
+
+// Every node carries its own name, so the join is the diagonal: one row per node, whose
+// projected key is that node's name.
+TEST_F(HashJoinProjectedKeyTest, projectsTheKeyOfEveryJoinedRow) {
+    StringRowSink sink;
+    runQuery("MATCH (n), (m) WHERE n.name = m.name RETURN n.name", sink);
+
+    const Rows& rows = sink.getRows();
+    EXPECT_EQ(rows.size(), 18u);
+
+    for (const StringRowSink::Row& row : rows) {
+        ASSERT_EQ(row.size(), 1u);
+        EXPECT_FALSE(row.front().empty());
+    }
+}
+
+TEST_F(HashJoinProjectedKeyTest, projectsTheKeyOfBothSidesOfEveryJoinedRow) {
+    StringRowSink sink;
+    runQuery("MATCH (n), (m) WHERE n.name = m.name RETURN n.name, m.name", sink);
+
+    const Rows& rows = sink.getRows();
+    EXPECT_EQ(rows.size(), 18u);
+
+    for (const StringRowSink::Row& row : rows) {
+        ASSERT_EQ(row.size(), 2u);
+        EXPECT_EQ(row.front(), row.back());
+    }
+}
+
+// Only Remy and Adam carry an age, and both carry 32, so the join on the age is the four
+// pairs of those two - and a null key matches nothing, so no other node reaches a row.
+TEST_F(HashJoinProjectedKeyTest, projectsANullableKeyOffTheJoinedRows) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.age = m.age RETURN n.name, n.age", "db", program);
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+
+    expectRows("MATCH (n), (m) WHERE n.age = m.age RETURN n.name, n.age",
+               {{"Remy", "32"}, {"Remy", "32"}, {"Adam", "32"}, {"Adam", "32"}});
+}
+
+TEST_F(HashJoinProjectedKeyTest, joinsTheRowsTheProductAndItsFilterProduce) {
+    expectJoinMatchesTheProduct("MATCH (n), (m) WHERE n.name = m.name RETURN n.name");
+    expectJoinMatchesTheProduct("MATCH (n), (m) WHERE n.name = m.name RETURN n.name, m.name");
+    expectJoinMatchesTheProduct("MATCH (n), (m) WHERE n.age = m.age RETURN n.name, n.age");
+    expectJoinMatchesTheProduct("MATCH (n), (m) WHERE n.name = m.name RETURN n, n.name, m");
+}

--- a/test/query/ir/HashJoinTest.cpp
+++ b/test/query/ir/HashJoinTest.cpp
@@ -273,6 +273,20 @@ TEST_F(HashJoinTest, keepsTheProductWhenTheEqualityReadsOneFactor) {
     EXPECT_FALSE(contains(program, "db.hash_join")) << program;
 }
 
+// A column a procedure yielded carries no type until lowering resolves it, so two of them
+// could hold two kinds of value: nothing here proves the join would answer the equality
+// the way the filter does, and the product stays.
+TEST_F(HashJoinTest, keepsTheProductWhenNeitherKeyHasAResolvedType) {
+    std::string program;
+    explainStage("EXPLAIN (db) CALL db.labels() YIELD label CALL db.edgeTypes() YIELD edgeType "
+                 "WHERE label = edgeType RETURN label, edgeType",
+                 "db",
+                 program);
+
+    EXPECT_TRUE(contains(program, "db.cross_product")) << program;
+    EXPECT_FALSE(contains(program, "db.hash_join")) << program;
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/HashJoinTest.cpp
+++ b/test/query/ir/HashJoinTest.cpp
@@ -47,6 +47,11 @@ protected:
         SimpleGraph::createSimpleGraph(graph);
 
         _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        // SimpleGraph is 18 nodes, so the cost model would leave every one of these cuts
+        // as the product it stands as - what the join does with a cut it takes is what
+        // these cases are about, so they force it, as the v2 join tests force theirs.
+        _interpreter->setForceValueHashJoin(true);
     }
 
     void runQuery(std::string_view query, StringRowSink& sink) {

--- a/test/query/ir/HashJoinTest.cpp
+++ b/test/query/ir/HashJoinTest.cpp
@@ -1,0 +1,278 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+
+}
+
+// The fuse_hash_join pass and the db.hash_join it emits, end to end on the shared
+// SimpleGraph: which shapes fuse, what the fused program looks like at both levels, and
+// that the rows it produces are the rows the cross product and its filter produced.
+//
+// SimpleGraph's 18 nodes carry a distinct name each, so a join on the name is the
+// diagonal; only Remy (0) and Adam (1) carry an age, so a join on the age is where the
+// null keys have to stay unmatched.
+class HashJoinTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectCount(std::string_view query, size_t expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        const Rows expectedRows {{std::to_string(expected)}};
+        EXPECT_EQ(sink.getRows(), expectedRows) << "query: " << query;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    // The db or nl program the pipeline produced for a query, as EXPLAIN reports it.
+    void explainStage(std::string_view query, std::string_view stage, std::string& program) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        program.clear();
+        for (const StringRowSink::Row& row : sink.getRows()) {
+            if (row.front() == stage) {
+                program = row.back();
+            }
+        }
+
+        EXPECT_FALSE(program.empty()) << "query: " << query << "\nno " << stage << " stage reported";
+    }
+
+    static bool contains(std::string_view text, std::string_view part) {
+        return text.find(part) != std::string_view::npos;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(HashJoinTest, fusesAProductAndItsPropertyEqualityIntoAHashJoin) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = m.name RETURN n, m", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+    EXPECT_TRUE(contains(program, "on 1, 1")) << program;
+    EXPECT_FALSE(contains(program, "db.cross_product")) << program;
+    EXPECT_FALSE(contains(program, "db.filter")) << program;
+    EXPECT_FALSE(contains(program, "db.eq")) << program;
+}
+
+// The key is read inside each factor, not over the product's rows: the join has to index
+// the build side as it walks it, so the property fetch moves in beside the scan.
+TEST_F(HashJoinTest, sinksTheKeyIntoBothFactors) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = m.name RETURN n, m", "db", program);
+
+    const size_t firstFetch = program.find("db.get_node_properties");
+    const size_t secondFetch = program.find("db.get_node_properties", firstFetch + 1);
+
+    ASSERT_NE(secondFetch, std::string::npos) << program;
+    EXPECT_EQ(program.find("db.get_node_properties", secondFetch + 1), std::string::npos) << program;
+    EXPECT_LT(firstFetch, program.find("} factor {")) << program;
+}
+
+// A key that is the column itself needs no sinking, so the join names the column already
+// yielded rather than adding one.
+TEST_F(HashJoinTest, joinsOnTheColumnItselfWhenTheKeyIsTheVariable) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n = m RETURN n", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+    EXPECT_TRUE(contains(program, "on 0, 0")) << program;
+}
+
+TEST_F(HashJoinTest, lowersTheJoinToASiblingBuildLoopAndProbeLoop) {
+    std::string program;
+    explainStage("EXPLAIN (nl) MATCH (n), (m) WHERE n.name = m.name RETURN n, m", "nl", program);
+
+    EXPECT_TRUE(contains(program, "nl.hash_join_buffer build_key 1 probe_key 1")) << program;
+    EXPECT_TRUE(contains(program, "nl.hash_join_collect")) << program;
+    EXPECT_TRUE(contains(program, "nl.hash_join_probe")) << program;
+    EXPECT_FALSE(contains(program, "nl.cross_product")) << program;
+
+    // Two loops one after the other rather than one inside the other: the build side is
+    // read once, not once per chunk of the probe side.
+    const size_t buildLoop = program.find("nl.for");
+    const size_t probeLoop = program.find("nl.for", buildLoop + 1);
+    ASSERT_NE(probeLoop, std::string::npos) << program;
+    EXPECT_LT(program.find("nl.hash_join_collect"), probeLoop) << program;
+    EXPECT_LT(probeLoop, program.find("nl.hash_join_probe")) << program;
+}
+
+// Every node carries its own name, so the join is the diagonal: one row per node, each
+// pairing a node with itself.
+TEST_F(HashJoinTest, joinsEveryNodeWithItselfOnItsName) {
+    expectCount("MATCH (n), (m) WHERE n.name = m.name RETURN count(*)", 18);
+
+    StringRowSink sink;
+    runQuery("MATCH (n), (m) WHERE n.name = m.name RETURN n, m", sink);
+
+    Rows expected;
+    for (size_t node = 0; node < 18; node++) {
+        expected.push_back({std::to_string(node), std::to_string(node)});
+    }
+
+    EXPECT_EQ(sink.getRows(), expected);
+}
+
+// `=` against a null gives null and the filter kept only the true rows, so a node with no
+// age joins with nothing - not even with another node that has no age either. Remy (0) and
+// Adam (1) are the only two aged nodes, and they share 32.
+TEST_F(HashJoinTest, leavesARowWithANullKeyUnmatched) {
+    const Rows expected {{"0", "0"}, {"0", "1"}, {"1", "0"}, {"1", "1"}};
+    expectRows("MATCH (n), (m) WHERE n.age = m.age RETURN n, m", expected);
+}
+
+// Four French people and four who are not, so the join is the two blocks: 4x4 twice. The
+// interests carry no isFrench at all and drop out.
+TEST_F(HashJoinTest, joinsEveryPairSharingABooleanProperty) {
+    expectCount("MATCH (n), (m) WHERE n.isFrench = m.isFrench RETURN count(*)", 32);
+}
+
+// The join key of each side is bound by a traversal rather than by a scan, so the factors
+// are loop nests and not single scans.
+TEST_F(HashJoinTest, joinsTwoTraversalsOnAPropertyOfTheirEnds) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (a)-->(b), (c)-->(d) WHERE b.name = c.name RETURN a, d",
+                 "db",
+                 program);
+    EXPECT_TRUE(contains(program, "db.hash_join")) << program;
+
+    // Each node's name is its own, so the join holds exactly where b and c are one node:
+    // the pairs of edges meeting head to tail, which is what the two-hop pattern walks -
+    // the same count, read off a plan with no join in it.
+    expectCount("MATCH (a)-->(b), (c)-->(d) WHERE b.name = c.name RETURN count(*)", 12);
+    expectCount("MATCH (a)-->(b)-->(d) RETURN count(*)", 12);
+}
+
+// Once the key is a column of its own, the column it was read from is dead unless the
+// query reads it too: trim_unread_columns drops it from the yield and renumbers the key
+// behind it, so neither b nor c is buffered on the build side or gathered on the probe.
+TEST_F(HashJoinTest, dropsTheColumnAKeyWasReadFromWhenNothingElseReadsIt) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (a)-->(b), (c)-->(d) WHERE b.name = c.name RETURN a, d",
+                 "db",
+                 program);
+
+    // Two columns per factor - the one the projection reads and the key it matches on -
+    // where the fusion left three, b and c among them.
+    EXPECT_TRUE(contains(program, "%0:4 = db.hash_join")) << program;
+    EXPECT_TRUE(contains(program, "on 1, 1")) << program;
+    EXPECT_TRUE(contains(program, "db.output(%0#0, %0#2)")) << program;
+}
+
+// An edge property keys a join the same way a node property does.
+TEST_F(HashJoinTest, joinsTwoEdgesOnASharedEdgeProperty) {
+    expectCount("MATCH (a)-[e]->(b), (c)-[f]->(d) WHERE e.duration = f.duration RETURN count(*)", 28);
+}
+
+// A predicate the join does not absorb still applies over its rows.
+TEST_F(HashJoinTest, appliesAFurtherPredicateOverTheJoinedRows) {
+    const Rows expected {{"0", "0"}};
+    expectRows("MATCH (n), (m) WHERE n.age = m.age AND n.name = 'Remy' AND m.name = 'Remy' RETURN n, m",
+               expected);
+}
+
+TEST_F(HashJoinTest, cutsTheJoinedRowsWithALimit) {
+    const Rows expected {{"0", "0"}, {"1", "1"}, {"2", "2"}};
+    expectRows("MATCH (n), (m) WHERE n.name = m.name RETURN n, m LIMIT 3", expected);
+}
+
+// Two columns whose types the db level cannot tell apart are left to the cross product:
+// the join matches keys by the bytes they serialize to, and a node ID beside a number
+// would answer a comparison the equality did not.
+TEST_F(HashJoinTest, keepsTheProductWhenTheKeysNeedNotShareAType) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n = m.age RETURN n, m", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.cross_product")) << program;
+    EXPECT_FALSE(contains(program, "db.hash_join")) << program;
+}
+
+// Two different property names could resolve to two different value types, so only a
+// shared name fuses.
+TEST_F(HashJoinTest, keepsTheProductWhenTheSidesReadDifferentProperties) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = m.dob RETURN n, m", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.cross_product")) << program;
+    EXPECT_FALSE(contains(program, "db.hash_join")) << program;
+}
+
+// A hash join answers equality alone; an ordering predicate stays a filter over the
+// product.
+TEST_F(HashJoinTest, keepsTheProductWhenThePredicateIsNotAnEquality) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.age > m.age RETURN n, m", "db", program);
+
+    EXPECT_TRUE(contains(program, "db.cross_product")) << program;
+    EXPECT_FALSE(contains(program, "db.hash_join")) << program;
+}
+
+// Both sides of the equality read one factor, so it is a single-variable predicate and
+// there is no join to make of it.
+TEST_F(HashJoinTest, keepsTheProductWhenTheEqualityReadsOneFactor) {
+    std::string program;
+    explainStage("EXPLAIN (db) MATCH (n), (m) WHERE n.name = n.dob RETURN n, m", "db", program);
+
+    EXPECT_FALSE(contains(program, "db.hash_join")) << program;
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/HashJoinTest.cpp
+++ b/test/query/ir/HashJoinTest.cpp
@@ -313,8 +313,8 @@ TEST_F(HashJoinTest, joinsThreePatternsOnAPropertyOfTwoOfThem) {
     expectCount("MATCH (a), (b), (c) WHERE a.name = c.name RETURN count(*)", 324);
 }
 
-// A LIMIT over a join bounds the probe, so a step pairs only the rows the cut can emit
-// rather than every match of its chunk.
+// A LIMIT over a join bounds the loop the probe drives, so a step pairs only the rows the
+// cut can emit and the loop stops once the budget is spent.
 TEST_F(HashJoinTest, boundsTheProbeWithALimit) {
     std::string program;
     explainStage("EXPLAIN (nl) MATCH (n), (m) WHERE n.name = m.name RETURN n, m LIMIT 3", "nl", program);
@@ -322,8 +322,11 @@ TEST_F(HashJoinTest, boundsTheProbeWithALimit) {
     const size_t probe = program.find("nl.hash_join_probe");
     ASSERT_NE(probe, std::string::npos) << program;
 
-    const std::string_view probeLine(program.data() + probe, program.find('\n', probe) - probe);
-    EXPECT_TRUE(contains(probeLine, "limit")) << program;
+    const size_t probeLoop = program.find("nl.for", probe);
+    ASSERT_NE(probeLoop, std::string::npos) << program;
+
+    const std::string_view loopLine(program.data() + probeLoop, program.find('\n', probeLoop) - probeLoop);
+    EXPECT_TRUE(contains(loopLine, "limit")) << program;
 }
 
 // The budget runs out inside a probe row's matches, not on a row boundary: the four French

--- a/test/query/ir/HashJoinTest.cpp
+++ b/test/query/ir/HashJoinTest.cpp
@@ -287,6 +287,47 @@ TEST_F(HashJoinTest, keepsTheProductWhenNeitherKeyHasAResolvedType) {
     EXPECT_FALSE(contains(program, "db.hash_join")) << program;
 }
 
+// The built side is buffered whole while the probed side streams, so the join builds the
+// plain scan and probes the factor holding the cascade's product: buffering that one would
+// hold every pair of b and c where the scan holds one row per node.
+TEST_F(HashJoinTest, buildsTheFactorWithNoProductAndProbesTheOther) {
+    std::string program;
+    explainStage("EXPLAIN (nl) MATCH (a), (b), (c) WHERE a.name = c.name RETURN a, b, c", "nl", program);
+
+    // The collect fills the build side, so what stands after it is on the probed side.
+    const size_t collect = program.find("nl.hash_join_collect");
+    const size_t product = program.find("nl.cross_product");
+    ASSERT_NE(collect, std::string::npos) << program;
+    ASSERT_NE(product, std::string::npos) << program;
+    EXPECT_LT(collect, product) << program;
+}
+
+// Every node's name is its own, so the equality is the diagonal and b is crossed with it:
+// 18 pairs of a and c, each against all 18 nodes.
+TEST_F(HashJoinTest, joinsThreePatternsOnAPropertyOfTwoOfThem) {
+    expectCount("MATCH (a), (b), (c) WHERE a.name = c.name RETURN count(*)", 324);
+}
+
+// A LIMIT over a join bounds the probe, so a step pairs only the rows the cut can emit
+// rather than every match of its chunk.
+TEST_F(HashJoinTest, boundsTheProbeWithALimit) {
+    std::string program;
+    explainStage("EXPLAIN (nl) MATCH (n), (m) WHERE n.name = m.name RETURN n, m LIMIT 3", "nl", program);
+
+    const size_t probe = program.find("nl.hash_join_probe");
+    ASSERT_NE(probe, std::string::npos) << program;
+
+    const std::string_view probeLine(program.data() + probe, program.find('\n', probe) - probe);
+    EXPECT_TRUE(contains(probeLine, "limit")) << program;
+}
+
+// The budget runs out inside a probe row's matches, not on a row boundary: the four French
+// people all match Remy (0), so the fifth row is the first match of Adam (1).
+TEST_F(HashJoinTest, cutsTheMatchesOfOneProbeRowWithALimit) {
+    const Rows expected {{"0", "0"}, {"0", "1"}, {"0", "8"}, {"0", "9"}, {"1", "0"}};
+    expectRows("MATCH (n), (m) WHERE n.isFrench = m.isFrench RETURN n, m LIMIT 5", expected);
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/NLExecutorTest.cpp
+++ b/test/query/ir/NLExecutorTest.cpp
@@ -925,8 +925,10 @@ constexpr const char* crossListChunkProgram = R"mlir(
 func.func @main() {
   %xs = nl.constant([1, 2])
   %ys = nl.constant([3, 4])
-  %p:2 = nl.cross_product{%xs} {%ys} : {!nl.chunk<!storage.list<i64>>} {!nl.chunk<!storage.list<i64>>}
-  nl.output(%p#0, %p#1) : !nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.list<i64>>
+  %pairs = nl.cross_product{%xs} {%ys} : {!nl.chunk<!storage.list<i64>>} {!nl.chunk<!storage.list<i64>>}
+  nl.for %px, %py in %pairs : !nl.iter<!nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.list<i64>>> {
+    nl.output(%px, %py) : !nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.list<i64>>
+  }
   func.return
 }
 )mlir";
@@ -948,8 +950,10 @@ func.func @main() {
   nl.for %scores in %groups : !nl.iter<!nl.chunk<!storage.list<i64>>> {
     %others = nl.scan_nodes()
     nl.for %b in %others : !nl.iter<!nl.chunk<!storage.node_id>> {
-      %p:2 = nl.cross_product{%scores} {%b} : {!nl.chunk<!storage.list<i64>>} {!nl.chunk<!storage.node_id>}
-      nl.output(%p#0, %p#1) : !nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.node_id>
+      %pairs = nl.cross_product{%scores} {%b} : {!nl.chunk<!storage.list<i64>>} {!nl.chunk<!storage.node_id>}
+      nl.for %pscores, %pb in %pairs : !nl.iter<!nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.node_id>> {
+        nl.output(%pscores, %pb) : !nl.chunk<!storage.list<i64>>, !nl.chunk<!storage.node_id>
+      }
     }
   }
   func.return
@@ -971,8 +975,10 @@ func.func @main() {
   nl.for %scores in %groups : !nl.iter<!nl.chunk<!storage.list<i64>>> {
     %others = nl.scan_nodes()
     nl.for %b in %others : !nl.iter<!nl.chunk<!storage.node_id>> {
-      %p:2 = nl.cross_product{%b} {%scores} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.list<i64>>}
-      nl.output(%p#0, %p#1) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<i64>>
+      %pairs = nl.cross_product{%b} {%scores} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.list<i64>>}
+      nl.for %pb, %pscores in %pairs : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<i64>>> {
+        nl.output(%pb, %pscores) : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<i64>>
+      }
     }
   }
   func.return

--- a/test/query/ir/NLHashJoinIndexTest.cpp
+++ b/test/query/ir/NLHashJoinIndexTest.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "NLHashJoinIndex.h"
+
+using namespace db;
+
+namespace {
+
+// The keys of the indexed rows, standing in for the build buffer the executor compares
+// against. Every hash collides in a bucket of four, so a bucket chains several keys.
+class KeyTable {
+public:
+    void add(int key) { _keys.push_back(key); }
+
+    int getKey(size_t row) const { return _keys[row]; }
+    size_t size() const { return _keys.size(); }
+
+    static uint64_t hashOf(int key) { return static_cast<uint64_t>(key) % 4; }
+
+private:
+    std::vector<int> _keys;
+};
+
+// What NLExecutor::runHashJoinCollect and runHashJoinProbe both do: walk the bucket's
+// groups and confirm each one's key.
+size_t findKeyGroup(const NLHashJoinIndex& index, const KeyTable& keys, int key) {
+    const uint64_t hash = KeyTable::hashOf(key);
+
+    for (size_t group = index.getFirstGroup(hash); group != NLHashJoinIndex::noRow; group = index.getNextGroup(group)) {
+        const bool sameHash = index.getHash(group) == hash;
+
+        if (sameHash && keys.getKey(group) == key) {
+            return group;
+        }
+    }
+
+    return NLHashJoinIndex::noRow;
+}
+
+void indexRow(NLHashJoinIndex& index, const KeyTable& keys, size_t row) {
+    const int key = keys.getKey(row);
+    const size_t group = findKeyGroup(index, keys, key);
+
+    if (group == NLHashJoinIndex::noRow) {
+        index.openGroup(row, KeyTable::hashOf(key));
+    } else {
+        index.addToGroup(group, row);
+    }
+}
+
+void collectMatches(const NLHashJoinIndex& index, const KeyTable& keys, int key, std::vector<size_t>& rows) {
+    rows.clear();
+
+    const size_t group = findKeyGroup(index, keys, key);
+    for (size_t row = group; row != NLHashJoinIndex::noRow; row = index.getNextInGroup(row)) {
+        rows.push_back(row);
+    }
+}
+
+}
+
+TEST(NLHashJoinIndexTest, answersNoGroupWhileEmpty) {
+    const NLHashJoinIndex index;
+
+    EXPECT_EQ(index.getRowCount(), 0u);
+    EXPECT_EQ(index.getFirstGroup(42), NLHashJoinIndex::noRow);
+}
+
+TEST(NLHashJoinIndexTest, groupsTheRowsOfOneKeyInIndexOrder) {
+    KeyTable keys;
+    for (const int key : {7, 9, 7, 9, 7}) {
+        keys.add(key);
+    }
+
+    NLHashJoinIndex index;
+    index.addRows(keys.size());
+    for (size_t row = 0; row < keys.size(); row++) {
+        indexRow(index, keys, row);
+    }
+
+    std::vector<size_t> rows;
+    collectMatches(index, keys, 7, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {0, 2, 4}));
+
+    collectMatches(index, keys, 9, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {1, 3}));
+
+    collectMatches(index, keys, 8, rows);
+    EXPECT_TRUE(rows.empty());
+}
+
+TEST(NLHashJoinIndexTest, tellsTwoKeysOfOneBucketApart) {
+    KeyTable keys;
+    for (const int key : {1, 5, 9, 5, 1}) {
+        keys.add(key);
+    }
+
+    NLHashJoinIndex index;
+    index.addRows(keys.size());
+    for (size_t row = 0; row < keys.size(); row++) {
+        indexRow(index, keys, row);
+    }
+
+    ASSERT_EQ(KeyTable::hashOf(1), KeyTable::hashOf(5));
+    ASSERT_EQ(KeyTable::hashOf(1), KeyTable::hashOf(9));
+
+    std::vector<size_t> rows;
+    collectMatches(index, keys, 1, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {0, 4}));
+
+    collectMatches(index, keys, 5, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {1, 3}));
+
+    collectMatches(index, keys, 9, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {2}));
+}
+
+TEST(NLHashJoinIndexTest, leavesAnUnindexedRowOutOfEveryGroup) {
+    KeyTable keys;
+    for (const int key : {3, 3, 3, 3}) {
+        keys.add(key);
+    }
+
+    NLHashJoinIndex index;
+    index.addRows(keys.size());
+    indexRow(index, keys, 1);
+    indexRow(index, keys, 3);
+
+    std::vector<size_t> rows;
+    collectMatches(index, keys, 3, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {1, 3}));
+
+    EXPECT_EQ(index.getRowCount(), 4u);
+}
+
+TEST(NLHashJoinIndexTest, keepsEveryGroupInIndexOrderAcrossGrowth) {
+    constexpr size_t rowCount = 5000;
+    constexpr int keyCount = 37;
+
+    KeyTable keys;
+    for (size_t row = 0; row < rowCount; row++) {
+        keys.add(static_cast<int>(row) % keyCount);
+    }
+
+    NLHashJoinIndex index;
+    index.addRows(rowCount);
+    for (size_t row = 0; row < rowCount; row++) {
+        indexRow(index, keys, row);
+    }
+
+    std::vector<size_t> rows;
+    for (int key = 0; key < keyCount; key++) {
+        collectMatches(index, keys, key, rows);
+
+        const size_t expectedCount = (rowCount + keyCount - 1 - static_cast<size_t>(key)) / keyCount;
+        ASSERT_EQ(rows.size(), expectedCount) << "at key " << key;
+
+        for (size_t position = 0; position < rows.size(); position++) {
+            EXPECT_EQ(rows[position], static_cast<size_t>(key) + position * keyCount);
+        }
+    }
+}
+
+TEST(NLHashJoinIndexTest, forgetsEveryRowOnClear) {
+    KeyTable keys;
+    for (const int key : {1, 1, 1}) {
+        keys.add(key);
+    }
+
+    NLHashJoinIndex index;
+    index.addRows(keys.size());
+    indexRow(index, keys, 0);
+    indexRow(index, keys, 2);
+
+    index.clear();
+
+    EXPECT_EQ(index.getRowCount(), 0u);
+    EXPECT_EQ(index.getFirstGroup(KeyTable::hashOf(1)), NLHashJoinIndex::noRow);
+
+    index.addRows(keys.size());
+    indexRow(index, keys, 1);
+
+    std::vector<size_t> rows;
+    collectMatches(index, keys, 1, rows);
+    EXPECT_EQ(rows, (std::vector<size_t> {1}));
+}

--- a/test/query/ir/NullComparisonTest.cpp
+++ b/test/query/ir/NullComparisonTest.cpp
@@ -108,6 +108,24 @@ TEST_F(NullComparisonTest, rejectsAnIsTestAgainstAValue) {
     runQueryExpectingError("MATCH (n:Person) RETURN n.age IS 5", "must be NULL");
 }
 
+// Ordering a value against null is null, the same as testing it for equality. The type of
+// the other operand does not change that
+TEST_F(NullComparisonTest, orderingAStringAgainstNullIsNull) {
+    expectRows("MATCH (n:Person) RETURN n.name, n.name < null", allNull);
+}
+
+TEST_F(NullComparisonTest, orderingANumberAgainstNullIsNull) {
+    expectRows("MATCH (n:Person) RETURN n.name, n.age >= null", allNull);
+}
+
+TEST_F(NullComparisonTest, orderingAgainstNullReadsTheSameOnEitherSide) {
+    expectRows("MATCH (n:Person) RETURN n.name, null > n.name", allNull);
+}
+
+TEST_F(NullComparisonTest, orderingAgainstNullMatchesNoRow) {
+    expectRows("MATCH (n:Person) WHERE n.name < null RETURN n.name", {});
+}
+
 int main(int argc, char** argv) {
     return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/ReducedRowOutputTest.cpp
+++ b/test/query/ir/ReducedRowOutputTest.cpp
@@ -133,8 +133,10 @@ func.func @main() {
   nl.for %interest in %interests : !nl.iter<!nl.chunk<!storage.node_id>> {
     %groups = nl.collect(%buffer) : !nl.iter<!nl.chunk<!storage.list<!storage.node_id>>>
     nl.for %list in %groups : !nl.iter<!nl.chunk<!storage.list<!storage.node_id>>> {
-      %crossedInterest, %crossedList = nl.cross_product {%interest} {%list} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.list<!storage.node_id>>}
-      nl.output(%crossedInterest, %crossedList, %count) names ["interest", "people", "total"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<!storage.node_id>>, !nl.chunk<ui64>
+      %pairs = nl.cross_product {%interest} {%list} : {!nl.chunk<!storage.node_id>} {!nl.chunk<!storage.list<!storage.node_id>>}
+      nl.for %crossedInterest, %crossedList in %pairs : !nl.iter<!nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<!storage.node_id>>> {
+        nl.output(%crossedInterest, %crossedList, %count) names ["interest", "people", "total"] : !nl.chunk<!storage.node_id>, !nl.chunk<!storage.list<!storage.node_id>>, !nl.chunk<ui64>
+      }
     }
   }
   func.return


### PR DESCRIPTION
Implement the hash join.

```
v3 on reactome, single node, median of 3 runs after one warmup, 40 GB address-space cap,
against main at d2da6f43f

MATCH (p1:Pathway)-[:species]->(s1:Species), (p2:TopLevelPathway)-[:species]->(s2:Species)
WHERE s1.dbId = s2.dbId RETURN count(*)
651,943 rows           353 ms -> 3 ms

MATCH (p1:Pathway)-[:species]->(s1:Species), (p2:Pathway)-[:species]->(s2:Species)
WHERE s1.dbId = s2.dbId RETURN count(*)
40,244,478 rows        std::bad_alloc -> 130 ms

MATCH (p1:Pathway)-[:species]->(s1:Species), (p2:Pathway)-[:species]->(s2:Species)
WHERE s1.dbId = s2.dbId RETURN p1.displayName, p2.displayName, s1.displayName
40,244,478 rows        std::bad_alloc -> 1138 ms

MATCH (a:Pathway), (b:Pathway) RETURN a, b
542,424,100 rows       3776 ms -> 136 ms

MATCH (a:Reaction), (b:Reaction) RETURN count(*)
6,965,404,681 rows     std::bad_alloc -> 1722 ms
```
