### PR TITLE
QA: 3 failing Cypher tests on v3

### DIFF
--- a/test/query/ir/AbsentLabelAndTypeTest.cpp
+++ b/test/query/ir/AbsentLabelAndTypeTest.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A label or an edge type the graph does not carry is a pattern that matches nothing, not
+// an ill-formed query. The predicate form already answers false rather than failing, and
+// the scans are built to emit no rows for a name they cannot resolve.
+class AbsentLabelAndTypeTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink, QueryStatus& status) {
+        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+    }
+
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+        runQuery(query, sink, status);
+        ASSERT_TRUE(status.isOk()) << query << ": " << status.getError();
+
+        std::vector<StringRowSink::Row> actual;
+        sink.sortedRows(actual);
+
+        std::vector<StringRowSink::Row> sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(AbsentLabelAndTypeTest, matchesNoNodeOfAnAbsentLabel) {
+    expectRows("MATCH (n:NoSuchLabel) RETURN n.name", {});
+}
+
+TEST_F(AbsentLabelAndTypeTest, countsNoNodeOfAnAbsentLabel) {
+    expectRows("MATCH (n:NoSuchLabel) RETURN count(n)", {{"0"}});
+}
+
+TEST_F(AbsentLabelAndTypeTest, matchesNoNodeCarryingAnAbsentLabelBesideAKnownOne) {
+    expectRows("MATCH (n:Person:NoSuchLabel) RETURN n.name", {});
+}
+
+TEST_F(AbsentLabelAndTypeTest, matchesNoEdgeOfAnAbsentType) {
+    expectRows("MATCH (n:Person)-[:NOSUCHTYPE]->(m) RETURN m.name", {});
+}
+
+TEST_F(AbsentLabelAndTypeTest, matchesNoEdgeOfAnAbsentTypeOverTheWholeGraph) {
+    expectRows("MATCH ()-[e:NOSUCHTYPE]->() RETURN count(e)", {{"0"}});
+}
+
+// The whole point of the clause: a pattern that matches nothing leaves every input row in
+// place with the pattern's variables null.
+TEST_F(AbsentLabelAndTypeTest, padsEveryRowOfAnOptionalMatchOnAnAbsentType) {
+    expectRows("MATCH (n:Person) OPTIONAL MATCH (n)-[:NOSUCHTYPE]->(m) RETURN count(*)", {{"8"}});
+}
+
+TEST_F(AbsentLabelAndTypeTest, bindsNoVariableOfAnOptionalMatchOnAnAbsentType) {
+    expectRows("MATCH (n:Person) OPTIONAL MATCH (n)-[:NOSUCHTYPE]->(m) RETURN count(m)", {{"0"}});
+}
+
+TEST_F(AbsentLabelAndTypeTest, testsAnAbsentLabelAsAPredicate) {
+    expectRows("MATCH (n) WHERE n:NoSuchLabel RETURN count(n)", {{"0"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2108,3 +2108,14 @@ target_link_libraries(test_query_ir_create_then_delete PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_create_then_delete PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_absent_label_and_type AbsentLabelAndTypeTest.cpp)
+target_sources(test_query_ir_absent_label_and_type PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_absent_label_and_type PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_absent_label_and_type PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2130,3 +2130,14 @@ target_link_libraries(test_query_ir_labels_list PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_labels_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_edge_type_function EdgeTypeFunctionTest.cpp)
+target_sources(test_query_ir_edge_type_function PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_edge_type_function PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_edge_type_function PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2119,3 +2119,14 @@ target_link_libraries(test_query_ir_absent_label_and_type PRIVATE
         turing_db_storage_s
         turing_db_interpreter_v3_s)
 target_include_directories(test_query_ir_absent_label_and_type PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_labels_list LabelsListTest.cpp)
+target_sources(test_query_ir_labels_list PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_labels_list PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_labels_list PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/EdgeTypeFunctionTest.cpp
+++ b/test/query/ir/EdgeTypeFunctionTest.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Remy's four outgoing edges, each beside its type
+const std::vector<StringRowSink::Row> remyEdgeTypes = {
+    {"Adam", "KNOWS_WELL"},
+    {"Ghosts", "INTERESTED_IN"},
+    {"Computers", "INTERESTED_IN"},
+    {"Eighties", "INTERESTED_IN"},
+};
+
+}
+
+// type(relationship) reads the type of an edge the pattern bound. The engine answers it
+// under the name edgeType, so what is missing is the name openCypher gives it.
+class EdgeTypeFunctionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink, QueryStatus& status) {
+        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+    }
+
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+        runQuery(query, sink, status);
+        ASSERT_TRUE(status.isOk()) << query << ": " << status.getError();
+
+        std::vector<StringRowSink::Row> actual;
+        sink.sortedRows(actual);
+
+        std::vector<StringRowSink::Row> sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(EdgeTypeFunctionTest, readsTheTypeOfAMatchedEdge) {
+    expectRows("MATCH (n)-[e]->(m) WHERE n.name = 'Remy' RETURN m.name, type(e)", remyEdgeTypes);
+}
+
+TEST_F(EdgeTypeFunctionTest, readsTheTypeUnderAnAlias) {
+    expectRows("MATCH (n)-[e]->(m) WHERE n.name = 'Remy' RETURN m.name, type(e) AS edge",
+               remyEdgeTypes);
+}
+
+TEST_F(EdgeTypeFunctionTest, groupsOnTheTypeOfAnEdge) {
+    expectRows("MATCH ()-[e]->() RETURN type(e), count(e)",
+               {{"KNOWS_WELL", "3"}, {"INTERESTED_IN", "15"}});
+}
+
+TEST_F(EdgeTypeFunctionTest, filtersOnTheTypeOfAnEdge) {
+    expectRows("MATCH (n)-[e]->(m) WHERE type(e) = 'KNOWS_WELL' RETURN n.name, m.name",
+               {{"Remy", "Adam"}, {"Adam", "Remy"}, {"Ghosts", "Remy"}});
+}
+
+TEST_F(EdgeTypeFunctionTest, readsTheTypeUnderItsTuringName) {
+    expectRows("MATCH (n)-[e]->(m) WHERE n.name = 'Remy' RETURN m.name, edgeType(e)",
+               remyEdgeTypes);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/LabelsListTest.cpp
+++ b/test/query/ir/LabelsListTest.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// labels() answers a list of strings, so it composes with the operations a list column
+// takes. Bio is the simpledb node carrying Interest and nothing else, which keeps the
+// expected list one element long whatever order a label set reports its labels in.
+class LabelsListTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink, QueryStatus& status) {
+        _interpreter->execute(status, query, _graphName, CommitHash::head(), ChangeID::head(), &_env->getMem(), &sink);
+    }
+
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        QueryStatus status;
+        runQuery(query, sink, status);
+        ASSERT_TRUE(status.isOk()) << query << ": " << status.getError();
+
+        std::vector<StringRowSink::Row> actual;
+        sink.sortedRows(actual);
+
+        std::vector<StringRowSink::Row> sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(LabelsListTest, readsTheLabelsOfANodeAsAList) {
+    expectRows("MATCH (n {name: 'Bio'}) RETURN labels(n) AS ls", {{"Interest"}});
+}
+
+TEST_F(LabelsListTest, appendsToTheLabelsOfANode) {
+    expectRows("MATCH (n {name: 'Bio'}) RETURN labels(n) + ['x'] AS ls", {{"Interest, x"}});
+}
+
+TEST_F(LabelsListTest, prependsToTheLabelsOfANode) {
+    expectRows("MATCH (n {name: 'Bio'}) RETURN ['x'] + labels(n) AS ls", {{"x, Interest"}});
+}
+
+TEST_F(LabelsListTest, concatenatesTheLabelsOfANodeWithTheEmptyList) {
+    expectRows("MATCH (n {name: 'Bio'}) RETURN labels(n) + [] AS ls", {{"Interest"}});
+}
+
+TEST_F(LabelsListTest, concatenatesTheLabelsOfTwoNodes) {
+    expectRows("MATCH (a {name: 'Bio'}), (b {name: 'Cooking'}) RETURN labels(a) + labels(b) AS ls",
+               {{"Interest, Interest"}});
+}
+
+TEST_F(LabelsListTest, unwindsTheLabelsOfANodeAppendedTo) {
+    expectRows("MATCH (n {name: 'Bio'}) UNWIND labels(n) + ['x'] AS label RETURN label",
+               {{"Interest"}, {"x"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Pin three Cypher queries v3 answers wrong.

Triage: Analyzer does hard type checking on labels and edge types and just errors if label or edge type do not exist:
FIXED in #892 
```
an absent label or edge type is an error instead of an empty match:
MATCH (n:NoSuchLabel) RETURN n.name
expected: no rows
v3:       ANALYZE_ERROR: Unknown label: NoSuchLabel

MATCH (n:Person)-[:NOSUCHTYPE]->(m) RETURN m.name
expected: no rows
v3:       ANALYZE_ERROR: Unknown edge type: NOSUCHTYPE

MATCH (n:Person) OPTIONAL MATCH (n)-[:NOSUCHTYPE]->(m) RETURN count(*)
expected: 8
v3:       ANALYZE_ERROR: Unknown edge type: NOSUCHTYPE

MATCH (n) WHERE n:NoSuchLabel RETURN count(n)
expected: 0            <- already correct, the same test written as a predicate
v3:       0
```

Triage: labels() function returns a string not a list
Fixed in #910 
```
labels() is typed String, so its list does not concatenate:
MATCH (n {name: 'Bio'}) RETURN labels(n) + ['x'] AS ls
expected: Interest, x
v3:       ANALYZE_ERROR: Operands are not valid and compatible types for '+': 'String' and 'List'

MATCH (n {name: 'Bio'}) RETURN labels(n) + [] AS ls
expected: Interest
v3:       ANALYZE_ERROR: Operands are not valid and compatible types for '+': 'String' and 'List'

MATCH (a {name: 'Bio'}), (b {name: 'Cooking'}) RETURN labels(a) + labels(b) AS ls
expected: Interest, Interest
v3:       Unsupported binary operation of columns of kinds
          db::ColumnVector<std::optional<std::string>> and db::ColumnVector<std::optional<std::string>>

MATCH (n) RETURN labels(n) AS ls, count(n)
expected: 10 groups    <- already correct, the runtime groups on it as a list
v3:       10 groups
```

Triage: type(e) does not parse because type is a reserved keyword in the grammar
FIXED #887 
```
TYPE is a reserved token, so openCypher's spelling does not parse:
MATCH (n)-[e]->(m) WHERE n.name = 'Remy' RETURN m.name, type(e)
expected: (Adam, KNOWS_WELL) (Ghosts, INTERESTED_IN) (Computers, INTERESTED_IN) (Eighties, INTERESTED_IN)
v3:       PARSE_ERROR: syntax error, unexpected TYPE

MATCH ()-[e]->() RETURN type(e), count(e)
expected: (KNOWS_WELL, 3) (INTERESTED_IN, 15)
v3:       PARSE_ERROR: syntax error, unexpected TYPE

MATCH (n)-[e]->(m) WHERE n.name = 'Remy' RETURN m.name, edgeType(e)
expected: the four rows above    <- already correct, the engine answers it under this name
v3:       the four rows
```

Triage: db::ColumnMask can not be outputted to TuringShell.
FIXED #888 
```
not pinned, the shell cannot print the result:
MATCH (n) RETURN n:Person
expected: 18 rows, true on the 8 Person nodes
shell:    EXEC_ERROR: Unsupported unary operation on column of type db::ColumnMask, no rows
```

Triage: output issue?
FIXED in #891 
```
MATCH (n) RETURN n:Person ORDER BY n.name
expected: the same 18 rows
shell:    the 18 rows, the sort materialises the mask first
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
