### PR TITLE
Storage: output a mask like any other boolean column

### DIFF
--- a/net/encoders/JsonEncoder.h
+++ b/net/encoders/JsonEncoder.h
@@ -10,6 +10,7 @@
 #include "list/ListUtils.h"
 
 #include "columns/AllowedKinds.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOperatorDispatcher.h"
 #include "dataframe/Dataframe.h"
 
@@ -67,6 +68,20 @@ public:
             const T& value = col->operator[](row);
 
             encodeValue(value);
+        }
+    }
+
+    void operator()(const ColumnMask* col) {
+        if (_logicalRowCount == 0) {
+            return;
+        }
+
+        encodeValue(col->operator[](0));
+
+        for (size_t row = 1; row < _logicalRowCount; row++) {
+            _writer.write(",");
+
+            encodeValue(col->operator[](row));
         }
     }
 

--- a/net/encoders/OutputValues.h
+++ b/net/encoders/OutputValues.h
@@ -16,6 +16,7 @@
 
 namespace db {
 
+class ColumnMask;
 class EntityList;
 
 template <typename T>
@@ -106,6 +107,10 @@ struct ColumnTypeGenerator {
         } else {
             COMPILE_ERROR("Unknown column type");
         }
+    }
+
+    void operator()(const ColumnMask*) {
+        _name = "Bool";
     }
 };
 

--- a/net/encoders/TuringProtoEncoder.h
+++ b/net/encoders/TuringProtoEncoder.h
@@ -8,6 +8,7 @@
 #include "OutputValues.h"
 #include "TuringProtoOutBuf.h"
 #include "TuringProtoHeaders.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
 #include "metadata/PropertyType.h"
@@ -141,6 +142,10 @@ struct ColumnHeaderWriter {
     void operator()(const db::ColumnConst<std::optional<T>>* col) {
         const auto typeCode = ColInternalKindToProtoEnum::map<T>();
         writeColumnSchema(typeCode, net::proto::ColumnKind::OPTIONAL_CONSTANT);
+    }
+
+    void operator()(const db::ColumnMask* col) {
+        writeColumnSchema(net::proto::ColumnInternalKind::BOOL, net::proto::ColumnKind::VECTOR);
     }
 };
 
@@ -422,6 +427,16 @@ public:
                           "TuringProtoEncoder only supports trivially copyable types and string");
             _outBuf->copyFixedLenData(&*opt, sizeof(T));
         }
+    }
+
+    void operator()(const db::ColumnMask* col) {
+        static_assert(sizeof(db::ColumnMask::ValueType) == sizeof(db::types::Bool::Primitive),
+                      "A mask is decoded as a BOOL vector, so its values must be bool-sized");
+
+        writeRowCount(col->size());
+
+        const size_t columnByteSize = sizeof(db::ColumnMask::ValueType) * col->size();
+        _outBuf->copyVector<db::ColumnMask::ValueType>(col->data(), columnByteSize);
     }
 
 private:

--- a/query/pipeline/processors/CountProcessor.cpp
+++ b/query/pipeline/processors/CountProcessor.cpp
@@ -111,6 +111,11 @@ public:
         _count = typed->size();
     }
 
+    // A mask carries no null, so every one of its rows counts
+    void operator()(const ColumnMask* typed) {
+        _count = typed->size();
+    }
+
     // e.g. COUNT(l) over an unwound heterogeneous list: a cell tagged null holds a null
     // value, so it counts like the empty cell of a nullable column - not at all
     void operator()(const ColumnVector<ListElementView>* typed) {

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -489,8 +489,7 @@ struct OutputtedTypes {
         ListElementView
     >>;
 
-  using Excluded = ExcludedContainers<ContainerKind::code<ColumnSet>(),
-                                      ContainerKind::code<ColumnMask>()>;
+    using Excluded = ExcludedContainers<ContainerKind::code<ColumnSet>()>;
 };
 
 /// Totally ordered types, e.g. sorted in ORDER BY

--- a/test/net/TuringProtoRoundTripTest.cpp
+++ b/test/net/TuringProtoRoundTripTest.cpp
@@ -22,6 +22,7 @@
 #include "TuringProtoOutBuf.h"
 #include "LocalMemory.h"
 #include "columns/ColumnConst.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOptVector.h"
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
@@ -34,6 +35,7 @@ namespace {
 using UInt64 = db::types::UInt64::Primitive;
 using Int64 = db::types::Int64::Primitive;
 using StringView = db::types::String::Primitive;
+using Bool = db::types::Bool::Primitive;
 using Embedding = db::types::Embedding::Primitive;
 
 struct FramedPacket {
@@ -234,6 +236,40 @@ TEST(TuringProtoRoundTripTest, RoundTripsNumericColumnsAcrossChunkSizes) {
         EXPECT_EQ(decodedScores->getRaw(),
                   (std::vector<Int64> {-10, 25, 99, -42, 0, 7}));
     }
+}
+
+// A label predicate answers with a mask, a boolean column that carries no nulls of its
+// own, so it goes on the wire as a plain BOOL vector.
+TEST(TuringProtoRoundTripTest, RoundTripsMaskColumns) {
+    db::LocalMemory localMem;
+    db::DataframeManager dfMan;
+    db::Dataframe source;
+
+    auto* isPerson = localMem.alloc<db::ColumnMask>();
+    isPerson->push_back(true);
+    isPerson->push_back(false);
+    isPerson->push_back(false);
+    isPerson->push_back(true);
+    addColumn(&dfMan, &source, "n:Person", isPerson);
+
+    const auto packets = encodeDataframeWithChunkSize(source, 64);
+    expectPacketSequence(packets, true);
+
+    net::proto::ChunkedBuffer<float> embeddingBuffer;
+    net::proto::ChunkedBuffer<char> stringBuffer;
+    db::ListBuffer<> listBuffer;
+    db::Dataframe decoded;
+    std::vector<net::proto::DecodedColumnSchema> schemas;
+    decodeChunkPackets(packets, &localMem, &embeddingBuffer, &stringBuffer, &listBuffer, &dfMan, &decoded, &schemas);
+
+    ASSERT_EQ(decoded.cols().size(), 1u);
+    EXPECT_EQ(decoded.getLogicalRowCount(), 4u);
+    EXPECT_EQ(decoded.cols().at(0)->getName(), "n:Person");
+
+    const auto* decodedFlags = decoded.cols().at(0)->as<db::ColumnVector<Bool>>();
+    ASSERT_NE(decodedFlags, nullptr);
+
+    EXPECT_EQ(decodedFlags->getRaw(), (std::vector<Bool> {true, false, false, true}));
 }
 
 // Optional string columns combine two harder cases: variable-length data

--- a/test/query-test-suite/QueryResultFormatter.cpp
+++ b/test/query-test-suite/QueryResultFormatter.cpp
@@ -17,6 +17,7 @@
 #include "QueryStatus.h"
 #include "columns/AllowedKinds.h"
 #include "columns/ColumnConst.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOperatorDispatcher.h"
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
@@ -184,6 +185,10 @@ struct Stringify {
 
     template <typename T>
     void operator()(const db::ColumnConst<T>* typed) {
+        _string = valueToString(typed->at(_row));
+    }
+
+    void operator()(const db::ColumnMask* typed) {
         _string = valueToString(typed->at(_row));
     }
 };

--- a/test/query/ir/EquivalenceTest.cpp
+++ b/test/query/ir/EquivalenceTest.cpp
@@ -41,6 +41,7 @@
 #include "TuringDB.h"
 #include "columns/AllowedKinds.h"
 #include "columns/ColumnConst.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOperatorDispatcher.h"
 #include "columns/ColumnVector.h"
 #include "dataframe/Dataframe.h"
@@ -213,6 +214,10 @@ struct Stringify {
 
     template <typename T>
     void operator()(const ColumnConst<T>* typed) {
+        _string = valueToString(typed->at(_row));
+    }
+
+    void operator()(const ColumnMask* typed) {
         _string = valueToString(typed->at(_row));
     }
 };

--- a/tools/turingdb/TuringShell.cpp
+++ b/tools/turingdb/TuringShell.cpp
@@ -31,6 +31,7 @@
 #include "columns/Column.h"
 #include "columns/ColumnVector.h"
 #include "columns/ColumnConst.h"
+#include "columns/ColumnMask.h"
 #include "columns/ColumnOptVector.h"
 #include "columns/AllowedKinds.h"
 #include "columns/ColumnOperatorDispatcher.h"
@@ -627,6 +628,10 @@ struct CellWriter {
 
     template <typename T>
     void operator()(const ColumnConst<T>* column) {
+        writeValue(_table, column->at(_row));
+    }
+
+    void operator()(const ColumnMask* column) {
         writeValue(_table, column->at(_row));
     }
 };


### PR DESCRIPTION
Print the result of a label predicate.

```
#v3 MATCH (n) RETURN n:Person

before: EXEC_ERROR: Unsupported unary operation on column of type db::ColumnMask
after:  18 rows, true on Remy, Adam, Maxime, Luc, Martina, Suhas, Cyrus, Doruk
```