### PR TITLE
MLIR: skip the pass verifier and trim call carry sets before the unwind fusion

### DIFF
--- a/docs/gnn_sample_v3_query.md
+++ b/docs/gnn_sample_v3_query.md
@@ -1,0 +1,349 @@
+# 3-hop GNN neighbourhood sampling — `gnn.neighbourhoodSample`, v3 syntax
+
+The `#v3 ` prefix routes the statement to `QueryInterpreterV3`. The same text
+without the prefix runs on v2, so both engines can be compared on one server
+process.
+
+Three chained calls, one per hop. Each call yields into the next hop's
+variable, so the result is the same four columns the pattern-match form
+produced (`n, m, k, l`) and nothing downstream of the query has to change.
+The three forms below differ only in how the seed nodes are supplied.
+
+## The procedure follows out-edges only
+
+`gnn.neighbourhoodSample` samples a node's **outgoing** edges. On the graph
+`0->1, 0->4, 1->2, 2->3, 4->5`:
+
+| seed | 0 | 1 | 2 | 3 | 4 | 5 |
+| --- | --- | --- | --- | --- | --- | --- |
+| sampled `tgt` | 1, 4 | 2 | 3 | none | 5 | none |
+
+Nodes 3 and 5 have only in-edges and sample nothing. This is not what the
+pattern-match form it replaces did: `(n)-[]-(m)-[]-(k)-[]-(l)` is
+**undirected**, and the sampler then added both directions client-side. So the
+procedure under-samples the neighbourhood on a graph read as undirected, which
+is how the DGL backend reads it — `_undirected_dedupe` there builds "the
+canonical directed edge list of an undirected graph".
+
+The signature has no reverse-direction option, so an undirected sample is not
+expressible in one call. It needs either that option on the procedure or the
+reverse edges materialised in the graph.
+
+## Form 1 — `OR` chain
+
+```cypher
+#v3 MATCH (n) WHERE n = <id1> OR n = <id2> OR ... OR n = <idN>
+CALL gnn.neighbourhoodSample(n, <fanout1>, <seed1>) YIELD tgt AS m
+CALL gnn.neighbourhoodSample(m, <fanout2>, <seed2>) YIELD tgt AS k
+CALL gnn.neighbourhoodSample(k, <fanout3>, <seed3>) YIELD tgt AS l
+RETURN n, m, k, l
+```
+
+The DGL sampler sends it on one line. At the benchmark's parameters that is
+2048 seeds and fanout 15 per hop, giving a 30 KB statement:
+
+```cypher
+#v3 MATCH (n) WHERE n = 2751903 OR n = 1103886 OR ... (2048 terms) CALL gnn.neighbourhoodSample(n, 15, 11) YIELD tgt AS m CALL gnn.neighbourhoodSample(m, 15, 22) YIELD tgt AS k CALL gnn.neighbourhoodSample(k, 15, 33) YIELD tgt AS l RETURN n, m, k, l
+```
+
+## Form 2 — `UNWIND` over the id list
+
+```cypher
+#v3 UNWIND [<id1>, <id2>, ..., <idN>] AS id MATCH (n) WHERE n = id
+CALL gnn.neighbourhoodSample(n, <fanout1>, <seed1>) YIELD tgt AS m
+CALL gnn.neighbourhoodSample(m, <fanout2>, <seed2>) YIELD tgt AS k
+CALL gnn.neighbourhoodSample(k, <fanout3>, <seed3>) YIELD tgt AS l
+RETURN n, m, k, l
+```
+
+At the benchmark's parameters, on one line:
+
+```cypher
+#v3 UNWIND [2751903, 1103886, ... (2048 ids)] AS id MATCH (n) WHERE n = id CALL gnn.neighbourhoodSample(n, 15, 11) YIELD tgt AS m CALL gnn.neighbourhoodSample(m, 15, 22) YIELD tgt AS k CALL gnn.neighbourhoodSample(k, 15, 33) YIELD tgt AS l RETURN n, m, k, l
+```
+
+On v3 with the trim fix on `mlir-skip-pass-verifier` this compiles to the
+same program as form 1: `fuse_unwind_equality` folds the unwind and the equality
+into a node-ID disjunction, `fuse_scan_by_node_ids` folds that into
+`db.const_scan_nodes([...])`, and the three calls follow. Same seek, same rows,
+and 2048 ids parse and compile as one list literal instead of 2048 `OR` terms.
+
+Before the fix it did not fold, and at 2048 seeds it ran 8.8 s on v2 and 18.1 s
+on v3, against 4-14 ms for the other two forms. What ran was the unfused shape:
+
+```
+%0:2 = db.cross_product factor { db.unwind_const([...]) } factor { db.scan_nodes() }
+%1   = db.eq %0#1, %0#0
+%2:2 = db.filter(%1, {%0#1, %0#0})
+%5:3 = db.call_procedure("gnn.neighbourhoodSample", {%2#0, %3, %4}, {%2#0, %2#1}) yields ["tgt"]
+```
+
+Every unwound id crossed with all 2.98 M nodes. The cause was not a second
+reader of the unwound column: its only users are the `eq` and the `filter`, and
+the fusion allows both. The call carries every column in flight, `id` among
+them, so the filter's `id` result has a reader and the fused rows would have to
+keep an `id` column. The only column that could stand in for it is `n`, a node
+ID column, and the fusion refuses an entity column there: `RETURN id` would
+print a node. `UNWIND [0, 1, 7] AS id MATCH (n) WHERE n = id RETURN n, id`
+stays unfused for the same reason, with no `CALL` at all.
+
+Nothing reads `id` past the call, so the carried column is dead, and dropping
+dead carried columns is what `trim_unread_columns` does. It did not here for two
+reasons: it had no carry-set layout for `db.call_procedure`, so a call's carry
+set was never trimmed, and it ran last, after the fusions. The fix gives the pass
+the call layout and runs it a second time before `fuse_unwind_equality`.
+`EXPLAIN` reports the two runs as `trim_unread_columns 1` and
+`trim_unread_columns 2`.
+
+v2 has no such fusion and form 2 is still 8.8 s there. Use form 1 on v2.
+
+## Form 3 — `db.getNodes` over the id list
+
+```cypher
+#v3 CALL db.getNodes([<id1>, <id2>, ..., <idN>]) YIELD id AS n
+CALL gnn.neighbourhoodSample(n, <fanout1>, <seed1>) YIELD tgt AS m
+CALL gnn.neighbourhoodSample(m, <fanout2>, <seed2>) YIELD tgt AS k
+CALL gnn.neighbourhoodSample(k, <fanout3>, <seed3>) YIELD tgt AS l
+RETURN n, m, k, l
+```
+
+`db.getNodes` takes node ids, so it substitutes for the `OR` chain in native id
+mode only. In `dbId` mode the seeds are property values and form 1 is still
+needed.
+
+It is not the fastest form on either engine at 2048 seeds: 13.1 ms on v2 and
+13.2 ms on v3, against 3.9 and 7.8 for form 1. It trades form 1's compile cost
+for a slower execution, and on this graph that is a bad trade.
+
+## The three forms are equivalent samplers, not identical ones
+
+A fixed `seed` makes the sample deterministic for a given input order and
+chunking. Order and chunking differ between the three forms and between the two
+engines, so the rows differ when a node's out-degree exceeds the fanout and a
+choice actually gets made. 128 seeds on reactome, `RETURN n, m, k, l` row
+counts:
+
+| fanout | v2 OR | v2 UNWIND | v2 getNodes | v3 OR | v3 UNWIND | v3 getNodes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 15 | 3421 | 3440 | 3354 | 3421 | 3405 | 3354 |
+| 200 | 4756 | 4756 | 4756 | 4756 | 4756 | 4756 |
+| 2000 | 4756 | 4756 | 4756 | 4756 | 4756 | 4756 |
+
+The v3 UNWIND column is the unfused build. With the trim fix form 2 compiles to
+form 1's program on v3, and the two return the identical row set, not merely
+the same count: 42329 rows each at 2048 seeds and fanout 15, equal once sorted.
+
+At fanout 200 no node in the sampled neighbourhood has a higher out-degree, so
+no sampling happens and all six results are the identical row set, not merely
+the same count. That is the way to check v2 against v3 for equality: raise the
+fanout until it saturates. At fanout 15 the two engines are not bit-comparable
+on this query, and a difference in rows is the RNG draw order, not a bug.
+
+## Runnable example
+
+Three seeds, fanout 3, against reactome (2.98 M nodes, 11.6 M edges):
+
+```cypher
+#v3 MATCH (n) WHERE n = 0 OR n = 1 OR n = 7 CALL gnn.neighbourhoodSample(n, 3, 11) YIELD tgt AS m CALL gnn.neighbourhoodSample(m, 3, 22) YIELD tgt AS k CALL gnn.neighbourhoodSample(k, 3, 33) YIELD tgt AS l RETURN n, m, k, l
+```
+
+45 rows: 7 for node 0, 15 for node 1, 23 for node 7. Columns come back as
+`["n","m","k","l"]`, all `UInt64`.
+
+Read that split off the batched query, by swapping the projection for
+`RETURN n, count(l)`. Running the three seeds as three separate queries gives 7,
+15 and 8 rows, which is 30, because the sample depends on input order and
+chunking and one seed per query is a different input.
+
+## Signature
+
+`gnn.neighbourhoodSample(node, sampleSize [, seed])` yields `src`, `edge`,
+`edgeType`, `tgt`. `sampleSize` and `seed` must be constants; `sampleSize` is
+capped at `ChunkConfig::CHUNK_SIZE`. A node's sample is emitted whole, so a
+sample wider than the caller's chunk budget takes the step over budget rather
+than being split.
+
+Chaining the calls applies a real per-node fanout. The pattern-match form it
+replaces has none, and approximates one with a global `LIMIT`, which is why it
+returned roughly 3x more input nodes per batch than the configured
+`fanouts = [15, 15, 15]` asks for.
+
+## Cost
+
+Server-reported median at 2048 seeds on reactome, 5 runs after a warm-up, same
+server process:
+
+| form | v2 | v3 |
+| --- | --- | --- |
+| pattern match + global `LIMIT 512000` (what DGL did before) | 100 ms | 82 ms |
+| form 1, `OR` chain | 17 ms | 30 ms |
+| form 2, `UNWIND` | 19,752 ms | 25,898 ms |
+| form 3, `db.getNodes` | 23 ms | **17 ms** |
+
+Re-measured 2026-09-10 through the shell's `#v3`, which reports the same
+`QueryStatus` total the server does. Same seeds and fanout, one process per
+build, the two builds alternated over three rounds with the first discarded as
+warm-up. `v3 branch` is `origin/main` plus the two commits of
+`mlir-skip-pass-verifier`:
+
+| form | v2 | v3 main | v3 branch |
+| --- | --- | --- | --- |
+| pattern match + global `LIMIT 512000` | 12.7 ms | 11.4 ms | **8.9 ms** |
+| form 1, `OR` chain | **3.9 ms** | 7.8 ms | 6.1 ms |
+| form 2, `UNWIND` | 8,839 ms | 18,131 ms | 18,083 ms |
+| form 3, `db.getNodes` | 13.1 ms | 13.2 ms | 14.3 ms |
+
+Three of the four orderings differ from the table above it. Form 1 is the
+fastest form here on both engines, not form 3. v3 beats v2 on the pattern
+match, not on form 3. And the absolutes are 1.3x to 9x lower across the four
+forms, so whatever separates the two measurements is not one constant factor
+and I could not pin it down; the seed set, the graph state and the server's
+output layer all differ. Trust the shape, not the milliseconds.
+
+v3 loses on form 1 because its compile cost scales with the number of `OR`
+terms — against v2: +0.7 ms at 1 term, +2.0 ms at 256, +6.3 ms at 1024,
++11.3 ms at 2048, +25.2 ms at 4096. The cost is compile-time, not execution:
+it is already there for `MATCH (n) WHERE <2048 OR terms> RETURN n` with no
+`CALL` at all, and it does not grow as calls are chained.
+
+The two commits on the branch take 22% off both `OR`-chain forms by removing
+compile work only: the MLIR verifier no longer runs after each db pass, and the
+mask cone is walked without recursion or a hash set. Nothing changes for form 2
+or form 3, which barely compile anything. Form 3 replaces the 2048 predicate
+terms with one list literal, so the compile cost goes away, but it pays that
+back in execution.
+
+The trim fix on the same branch changes form 2 alone. Driver phase timers on the
+fixed build, same 2048 seeds and fanout 15, medians of 5 runs with the load
+under 1, in milliseconds:
+
+```
+         parse  analyze  codegen   lower  translate  execute   compile   total    rows
+form 1   1.467    0.568    2.595   0.134      0.060    4.088     4.824   8.912   42329
+form 2   0.426    0.133    1.393   0.130      0.062    4.128     2.143   6.271   42329
+form 3   0.432    0.134    0.393   0.140      0.079   15.019     1.178  16.198   42337
+```
+
+Form 2 is now the cheapest form on v3. It executes like form 1 and compiles in
+less than half the time, because the 2048 ids are one list literal. Form 1 and
+form 3 measure as they did before the fix, within run-to-run spread - form 1 at
+HEAD compiles in 4.746 and executes in 3.937 - so the second trim run costs
+nothing visible.
+Form 2 before the fix, same driver, same seeds: 17,841 ms of execution, median
+of 3, for 42551 rows. That is a different sample, not a wrong one: the unfused
+shape feeds the calls in list order and the fused one in id order.
+
+## Where form 1's compile time goes
+
+Measured on an Intel Core Ultra 7 265, Release build, at 088b0533b. The
+machine is shared with sibling worktrees running their own suites, and a
+contended run reads 30-40% slow across the board, so every number below comes
+from a window with the load under 3 and was checked for a tight per-run spread.
+
+Profiled with `build/samples/mlir/mlir`, which prints v3's six phase timers, so
+the shell's single total is not the only number available:
+
+```
+build/samples/mlir/mlir -q "<form 1 at N seeds>" -g ~/.turing/graphs/reactome -e -quiet
+```
+
+Random seed ids on reactome, 5 runs per point, medians in milliseconds:
+
+```
+     N   parse  analyze  codegen   lower  translate  execute   compile   total    rows
+     1   0.043    0.018    0.193   0.072      0.047    0.024     0.374   0.398       0
+    16   0.056    0.020    0.224   0.076      0.047    0.131     0.424   0.555     935
+    64   0.090    0.029    0.306   0.074      0.048    0.317     0.547   0.864    2445
+   256   0.234    0.067    0.639   0.085      0.053    0.789     1.079   1.868    5728
+   512   0.392    0.119    1.104   0.078      0.049    1.565     1.742   3.307   12455
+  1024   0.757    0.221    2.156   0.124      0.074    3.057     3.334   6.390   26414
+  2048   1.499    0.586    4.458   0.073      0.049    3.900     6.665  10.565   46075
+  4096   3.277    1.169    8.743   0.081      0.054    6.434    13.324  19.758   96368
+  8192   6.807    2.362   18.101   0.083      0.060   11.118    27.413  38.530  194392
+```
+
+Compile is linear in the seed count at 3.3 us per `OR` term, flat from 512 up.
+Codegen is two thirds of it, parse a quarter, analyze the rest. Execution is
+also linear but at 1.35 us per seed, so compile passes execution at 16 seeds
+and is 2.5x it at 8192. Lowering and translation do not move: 0.08 ms and
+0.05 ms at every N.
+
+Lowering and translation stay flat because the `OR` chain is gone before they
+run. `EXPLAIN (codegen)` shows what emission builds - `db.constant`, `db.eq`,
+`db.or` per term, so 3N-1 ops - and the fourth pass, `fuse_scan_by_node_ids`,
+collapses all of it to one `db.const_scan_nodes([...])`. At 8192 seeds that is
+a 24575-op module built and thrown away.
+
+`perf record --call-graph lbr`, 40 runs at 1 seed and 40 at 8192, samples
+classified by stack and differenced:
+
+```
+codegen: emit                8.52 ms   1.04 us/term
+parse                        8.27 ms   1.01 us/term
+codegen: MLIR verifier       7.38 ms   0.90 us/term
+codegen: db pass bodies      3.46 ms   0.42 us/term
+analyze                      2.51 ms   0.31 us/term
+free / madvise / teardown    3.5  ms   0.43 us/term   (outside the timed regions)
+```
+
+Emission is `DBProgramGenerator::translateBinaryExpr`, 8.0 of the 8.5 ms: one
+microsecond to create three MLIR ops, walking down the 8192-deep `OR` tree.
+
+The verifier is second and it is not our code. MLIR verifies the whole module
+after every pass, and the module is still 24575 ops for the first three passes.
+7.38 ms over four full verifications is 1.8 ms each, 75 ns/op.
+
+Among the pass bodies `fuse_scan_by_node_ids` is the expensive one, about
+3.1 ms. Two thirds of that is not the match but the cleanup:
+`replaceFilterWithSource` needs the mask cone, and `collectMaskCone` walks the
+24575-op chain into a `SmallPtrSet`, recursing ~6300 frames deep and rehashing
+as the set grows. `push_down_filters` walks the same module but its own cost is
+only 0.14 ms.
+
+Attributing that cone walk is a trap worth writing down. Its recursion is deeper
+than the 32-entry LBR window, so the pass frame above it is truncated away and a
+call-graph profile leaves the samples unparented. `collectMaskCone`,
+`collectConePostOrder` and `replaceFilterWithSource` are shared by
+`push_down_filters` and `fuse_scan_by_node_ids`, so classifying by helper name
+bills them to whichever pass the regex names first - which put 2.49 ms on
+`push_down_filters` here on the first pass over the data. Of the 940 cone-walk
+samples only 174 keep a pass frame, and all 174 say `fuse_scan_by_node_ids`.
+
+Parse splits into bison stack push/pop 0.34 us/term,
+`SourceManager::setLocation` 0.19 (a hash-map insert per node), AST
+construction 0.11, lexing 0.07. Analyze is all
+`ExprAnalyzer::analyzeBinaryExpr`.
+
+Two controls. The three `CALL`s are not part of the cost:
+`MATCH (n) WHERE <N OR terms> RETURN n` compiles in 7.95 ms at 2048 against
+form 1's 10.05 ms, and 35.6 ms at 8192 against 33.8 ms, equal within run-to-run
+spread. And form 3 pays 6x less to compile and more to run: at 2048 seeds
+compile 1.08 ms against form 1's 6.67 ms, execution 15.4 ms against 3.90 ms.
+
+The two commits on `mlir-skip-pass-verifier` cut the compile side. Codegen no
+longer runs the MLIR verifier after each db pass, and the mask cone is walked
+iteratively with the membership set consulted only for a multiply-used result:
+
+```
+                       HEAD   verifier off   + cone walk
+codegen @ 2048        4.458          2.881         2.546 ms
+codegen @ 8192       18.101         11.323        10.254 ms
+codegen slope          2.20           1.37          1.25  us/term
+compile slope          3.32           2.48          2.37  us/term
+```
+
+At 8192 seeds the cone walk itself goes from 1.92 ms to 0.80, and what is left
+of it is 0.38 ms in the walk loop, 0.29 in `isMaskComputeOp` and 0.10 in
+`getDefiningOp`. That is a pointer chase per op and it is the floor for this
+emission shape: `isMaskComputeOp` was rewritten three ways - a tablegen
+`MaskCompute` trait, one hoisted `TypeID` compared against an array, and the
+same as a fold - and all three land within 0.03 us/term of the original
+`isa<>`, which is the run-to-run spread. The comparison scheme is not what
+costs; reaching the op's name impl is.
+
+`db.getNodes` also rejects an out-of-range id where `n = <id>` matches nothing:
+
+```
+CALL db.getNodes([2979330]) YIELD id AS n RETURN n
+Invalid node ID: 2979330
+```

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -1123,6 +1123,7 @@ void DBProgramGenerator::runPasses() {
     }
 
     mlir::PassManager passManager(_mlirCtxt);
+    passManager.enableVerifier(false);
     for (const DBPassFactory factory : dbPassPipeline) {
         passManager.addPass(factory());
     }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -137,9 +137,10 @@ using DBPassFactory = std::unique_ptr<mlir::Pass> (*)();
 // The optimisation pipeline every query runs through, in order. An EXPLAIN prefix
 // reporting on a pass walks the same table one pass at a time, which is what keeps the
 // pipeline it reports on and the pipeline that runs the same one.
-const std::array<DBPassFactory, 10> dbPassPipeline = {
+const std::array<DBPassFactory, 11> dbPassPipeline = {
     &mlir::db::createFuseScanByLabel,
     &mlir::db::createPushDownFilters,
+    &mlir::db::createTrimUnreadColumns,
     &mlir::db::createFuseUnwindEquality,
     &mlir::db::createFuseScanByNodeIDs,
     &mlir::db::createFuseScanByPropertyValue,
@@ -150,10 +151,16 @@ const std::array<DBPassFactory, 10> dbPassPipeline = {
     &mlir::db::createTrimUnreadColumns,
 };
 
-// The stage a dump of one pass is reported under: "after fuse_scan_edges"
-void makePassLabel(std::string_view selector, std::string_view passName, std::string& label) {
+// The stage a dump of one pass is reported under: "after fuse_scan_edges", or "after
+// trim_unread_columns 2" for a run of a pass the pipeline runs more than once
+void makePassLabel(std::string_view selector, std::string_view passName, size_t run, std::string& label) {
     label = selector;
     label += passName;
+
+    if (run > 0) {
+        label += ' ';
+        label += std::to_string(run);
+    }
 }
 
 void fillPipelinePassNames(std::vector<std::string_view>& passNames) {
@@ -161,6 +168,17 @@ void fillPipelinePassNames(std::vector<std::string_view>& passNames) {
         const std::unique_ptr<mlir::Pass> pass = factory();
         passNames.push_back(toStringView(pass->getArgument()));
     }
+}
+
+// Which run of its pass the pipeline position is, counted from 1, or 0 for a pass the
+// pipeline runs once
+size_t passRunNumber(std::span<const std::string_view> pipelinePasses, size_t passIndex) {
+    const std::string_view passName = pipelinePasses[passIndex];
+    if (std::ranges::count(pipelinePasses, passName) == 1) {
+        return 0;
+    }
+
+    return static_cast<size_t>(std::ranges::count(pipelinePasses.first(passIndex + 1), passName));
 }
 
 // The row tag an OPTIONAL MATCH carries beside the columns its pattern walks. A backtick
@@ -1146,16 +1164,20 @@ void DBProgramGenerator::runExplainedPasses() {
 
     const bool printsEveryPass = _explain->isRequested(ExplainStage::PASSES);
 
+    std::vector<std::string_view> pipelinePasses;
+    fillPipelinePassNames(pipelinePasses);
+
     std::string module;
     ExplainReport::renderModule(*_module, module);
 
-    for (const DBPassFactory factory : dbPassPipeline) {
-        std::unique_ptr<mlir::Pass> pass = factory();
-        const std::string_view passName = toStringView(pass->getArgument());
+    for (size_t passIndex = 0; passIndex < dbPassPipeline.size(); passIndex++) {
+        std::unique_ptr<mlir::Pass> pass = dbPassPipeline[passIndex]();
+        const std::string_view passName = pipelinePasses[passIndex];
+        const size_t run = passRunNumber(pipelinePasses, passIndex);
 
         if (_explain->isPassPrintedBefore(passName)) {
             std::string label;
-            makePassLabel("before ", passName, label);
+            makePassLabel("before ", passName, run, label);
 
             _explain->addText(label, module);
         }
@@ -1173,7 +1195,7 @@ void DBProgramGenerator::runExplainedPasses() {
         const bool changedTheModule = rewritten != module;
         if (_explain->isPassPrintedAfter(passName) || (printsEveryPass && changedTheModule)) {
             std::string label;
-            makePassLabel("after ", passName, label);
+            makePassLabel("after ", passName, run, label);
 
             _explain->addText(label, rewritten);
         }

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -230,25 +230,56 @@ struct MaskCone {
     llvm::SmallSetVector<Value, 4> _inputs;
 };
 
+// One suspended operand loop of the cone walk: the op whose operands are being
+// visited, and how many of them are done.
+struct ConeFrame {
+    Operation* _op {nullptr};
+    unsigned _nextOperand {0};
+};
+
 // Gathers the mask's compute cone and the external columns feeding it. Valid
 // even when the cone spans blocks.
-void collectConePostOrder(Value value, llvm::SmallPtrSet<Operation*, 8>& visited, MaskCone& cone) {
-    Operation* const def = value.getDefiningOp();
+void collectConePostOrder(Value mask, llvm::SmallPtrSet<Operation*, 8>& visited, MaskCone& cone) {
+    Operation* const maskDef = mask.getDefiningOp();
 
-    if (!def || !isMaskComputeOp(def)) {
-        cone._inputs.insert(value);
+    if (!maskDef || !isMaskComputeOp(maskDef)) {
+        cone._inputs.insert(mask);
         return;
     }
 
-    if (!visited.insert(def).second) {
+    // A caller walking several conjuncts into one cone shares the set across the
+    // calls, so a root already collected by an earlier conjunct is dropped here.
+    if (!visited.insert(maskDef).second) {
         return;
     }
 
-    for (const Value operand : def->getOperands()) {
-        collectConePostOrder(operand, visited, cone);
-    }
+    llvm::SmallVector<ConeFrame> stack {ConeFrame {maskDef, 0}};
+    while (!stack.empty()) {
+        ConeFrame& frame = stack.back();
 
-    cone._ops.push_back(def);
+        if (frame._nextOperand == frame._op->getNumOperands()) {
+            cone._ops.push_back(frame._op);
+            stack.pop_back();
+            continue;
+        }
+
+        const Value operand = frame._op->getOperand(frame._nextOperand);
+        frame._nextOperand++;
+
+        Operation* const operandDef = operand.getDefiningOp();
+        if (!operandDef || !isMaskComputeOp(operandDef)) {
+            cone._inputs.insert(operand);
+            continue;
+        }
+
+        // A second path can only reach an op through a value that something else
+        // also reads, so a singly-used result needs no membership check. An OR
+        // chain is singly-used throughout and never touches the set at all.
+        const bool reachableOnce = operandDef->getNumResults() == 1 && operand.hasOneUse();
+        if (reachableOnce || visited.insert(operandDef).second) {
+            stack.push_back(ConeFrame {operandDef, 0});
+        }
+    }
 }
 
 MaskCone collectMaskCone(Value mask) {

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -1149,6 +1149,11 @@ bool matchCarrySetLayout(Operation* op, CarrySetLayout& layout) {
     } else if (isa<Limit, Skip, Sort, GroupAggregate, Collect>(op)) {
         layout = CarrySetLayout {._operandOffset = 0, ._resultOffset = 0};
         return true;
+    } else if (CallProcedure call = dyn_cast<CallProcedure>(op)) {
+        const size_t inputCount = call.getInputs().size();
+        const size_t yieldCount = call.getYields().size();
+        layout = CarrySetLayout {._operandOffset = inputCount, ._resultOffset = yieldCount};
+        return true;
     }
 
     return false;
@@ -1319,6 +1324,10 @@ void trimAttributes(Operation* op, llvm::ArrayRef<size_t> kept, OperationState& 
         trimGroupAggregateKinds(groupAggregate, kept, state, builder);
     } else if (Collect collect = dyn_cast<Collect>(op)) {
         trimCollectAttributes(collect, kept, state, builder);
+    } else if (CallProcedure call = dyn_cast<CallProcedure>(op)) {
+        const int32_t inputCount = static_cast<int32_t>(call.getInputs().size());
+        const int32_t keptCount = static_cast<int32_t>(kept.size());
+        state.attributes.set(call.getOperandSegmentSizesAttrName(), builder.getDenseI32ArrayAttr({inputCount, keptCount}));
     }
 }
 

--- a/query/ir/dialect/db/DBPasses.td
+++ b/query/ir/dialect/db/DBPasses.td
@@ -49,7 +49,7 @@ def ReusePropertyReads : Pass<"reuse_property_reads"> {
 }
 
 def TrimUnreadColumns : Pass<"trim_unread_columns"> {
-    let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products and grouping ops";
+    let summary = "Drop the columns no later op reads from hops, filters, cuts, sorts, products, grouping ops and calls";
     let dependentDialects = ["mlir::db::DB"];
 }
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -195,6 +195,7 @@ add_call_v3_test(test_query_ir_standalone_call StandaloneCallTest.cpp)
 add_call_v3_test(test_query_ir_empty_result_column_names EmptyResultColumnNamesTest.cpp)
 add_call_v3_test(test_query_ir_scan_by_node_ids_v3 ScanByNodeIDsV3Test.cpp)
 add_call_v3_test(test_query_ir_unwind_node_seed_v3 UnwindNodeSeedV3Test.cpp)
+add_call_v3_test(test_query_ir_unwind_node_seed_call_v3 UnwindNodeSeedCallV3Test.cpp)
 add_call_v3_test(test_query_ir_scan_by_property_value_v3 ScanByPropertyValueV3Test.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,
@@ -264,6 +265,7 @@ add_ir_tests(test_query_ir_push_down_filter PushDownFilterTest.cpp)
 add_ir_tests(test_query_ir_fuse_scan_by_node_ids FuseScanByNodeIDsTest.cpp)
 add_ir_tests(test_query_ir_fuse_scan_by_property_value FuseScanByPropertyValueTest.cpp)
 add_ir_tests(test_query_ir_trim_unread_columns TrimUnreadColumnsTest.cpp)
+add_ir_tests(test_query_ir_trim_call_carry_set TrimCallCarrySetTest.cpp)
 add_ir_tests(test_query_ir_reuse_property_reads ReusePropertyReadsTest.cpp)
 
 # The edge-scan fusion tests check the rewritten db program, then lower and run it

--- a/test/query/ir/ExplainTest.cpp
+++ b/test/query/ir/ExplainTest.cpp
@@ -130,7 +130,22 @@ TEST_F(ExplainTest, reportsEveryPassOfABracketedList) {
 
     std::vector<std::string> stages;
     collectStages(sink, stages);
-    EXPECT_EQ(stages, (std::vector<std::string> {"after fuse_scan_by_label", "after trim_unread_columns"}));
+    EXPECT_EQ(stages, (std::vector<std::string> {"after fuse_scan_by_label",
+                                                 "after trim_unread_columns 1",
+                                                 "after trim_unread_columns 2"}));
+}
+
+// The pipeline trims twice, so each run of the pass reports under its own number.
+TEST_F(ExplainTest, numbersTheRunsOfAPassThePipelineRepeats) {
+    StringRowSink sink;
+    explain("EXPLAIN (around trim_unread_columns) MATCH (n:Person) RETURN n.name", sink);
+
+    std::vector<std::string> stages;
+    collectStages(sink, stages);
+    EXPECT_EQ(stages, (std::vector<std::string> {"before trim_unread_columns 1",
+                                                 "after trim_unread_columns 1",
+                                                 "before trim_unread_columns 2",
+                                                 "after trim_unread_columns 2"}));
 }
 
 TEST_F(ExplainTest, reportsTheModuleEnteringAndLeavingThePipeline) {

--- a/test/query/ir/TrimCallCarrySetTest.cpp
+++ b/test/query/ir/TrimCallCarrySetTest.cpp
@@ -1,0 +1,195 @@
+#include <gtest/gtest.h>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "DBDialect.h"
+#include "DBOps.h"
+#include "DBPasses.h"
+#include "StorageDialect.h"
+
+namespace {
+
+template <typename OpType>
+llvm::SmallVector<OpType> collect(mlir::ModuleOp module) {
+    llvm::SmallVector<OpType> ops;
+    module.walk([&](OpType op) {
+        ops.push_back(op);
+    });
+
+    return ops;
+}
+
+}
+
+// A call replicates each carried column once per row the procedure emits for it, so a
+// column nothing reads past the call is copied for no reader. The trim cuts it from the
+// carry set and leaves the arguments as they were.
+class TrimCallCarrySetTest : public ::testing::Test {
+protected:
+    TrimCallCarrySetTest() {
+        _context.getOrLoadDialect<mlir::func::FuncDialect>();
+        _context.getOrLoadDialect<mlir::storage::Storage>();
+        _context.getOrLoadDialect<mlir::db::DB>();
+    }
+
+    mlir::OwningOpRef<mlir::ModuleOp> parse(const char* programText) {
+        return mlir::parseSourceString<mlir::ModuleOp>(programText, mlir::ParserConfig(&_context));
+    }
+
+    bool runTrim(mlir::ModuleOp module) {
+        mlir::PassManager passManager(&_context);
+        passManager.addPass(mlir::db::createTrimUnreadColumns());
+
+        return mlir::succeeded(passManager.run(module));
+    }
+
+    mlir::MLIRContext _context;
+};
+
+// MATCH (n) WITH n, n.age AS age CALL gnn.neighbourhoodSample(n, 3) YIELD tgt RETURN n, tgt
+const char* const callCarryingAnUnreadAge = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %size = db.constant(3 : i64)
+  %tgt, %nc, %agec = db.call_procedure("gnn.neighbourhoodSample", {%n, %size}, {%n, %age}) yields ["tgt"] : (!db.column<!storage.node_id>, !db.column<i64>, !db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<none>, !db.column<!storage.node_id>, !db.column<i64>)
+  db.output(%nc, %tgt) : !db.column<!storage.node_id>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(TrimCallCarrySetTest, dropsTheCarriedColumnNothingReadsPastTheCall) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(callCarryingAnUnreadAge);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::CallProcedure> calls = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(calls.size(), 1u);
+    mlir::db::CallProcedure call = calls.front();
+
+    // The arguments stay: the node and the sample size still drive the procedure.
+    const mlir::OperandRange inputs = call.getInputs();
+    ASSERT_EQ(inputs.size(), 2u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(inputs[0].getDefiningOp()));
+    EXPECT_TRUE(mlir::isa<mlir::db::ConstantOp>(inputs[1].getDefiningOp()));
+
+    // Only the node rides past the call, coming out as the result after the yield.
+    const mlir::OperandRange carried = call.getCarriedColumns();
+    ASSERT_EQ(carried.size(), 1u);
+    EXPECT_EQ(carried.front(), inputs[0]);
+    EXPECT_EQ(call->getNumResults(), 2u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    const mlir::OperandRange columns = outputs.front().getColumns();
+    ASSERT_EQ(columns.size(), 2u);
+    EXPECT_EQ(columns[0], call->getResult(1));
+    EXPECT_EQ(columns[1], call->getResult(0));
+}
+
+// MATCH (n) CALL gnn.neighbourhoodSample(n, 3) YIELD tgt RETURN tgt
+const char* const callWhoseCarrySetIsUnread = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %size = db.constant(3 : i64)
+  %tgt, %nc = db.call_procedure("gnn.neighbourhoodSample", {%n, %size}, {%n}) yields ["tgt"] : (!db.column<!storage.node_id>, !db.column<i64>, !db.column<!storage.node_id>) -> (!db.column<none>, !db.column<!storage.node_id>)
+  db.output(%tgt) : !db.column<none>
+  return
+}
+)mlir";
+
+// The yield is the call's own row set, so unlike a filter or a cut it needs no carried
+// column left to be sized by.
+TEST_F(TrimCallCarrySetTest, dropsTheWholeCarrySetOfACallNothingReadsPast) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(callWhoseCarrySetIsUnread);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::CallProcedure> calls = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(calls.size(), 1u);
+    mlir::db::CallProcedure call = calls.front();
+
+    EXPECT_EQ(call.getInputs().size(), 2u);
+    EXPECT_EQ(call.getCarriedColumns().size(), 0u);
+    EXPECT_EQ(call->getNumResults(), 1u);
+
+    llvm::SmallVector<mlir::db::Output> outputs = collect<mlir::db::Output>(*module);
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_EQ(outputs.front().getColumns().size(), 1u);
+    EXPECT_EQ(outputs.front().getColumns().front(), call->getResult(0));
+}
+
+// MATCH (n) WITH n, n.age AS age CALL gnn.neighbourhoodSample(n, 3) YIELD tgt RETURN n, age, tgt
+const char* const callWhoseCarrySetIsRead = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %size = db.constant(3 : i64)
+  %tgt, %nc, %agec = db.call_procedure("gnn.neighbourhoodSample", {%n, %size}, {%n, %age}) yields ["tgt"] : (!db.column<!storage.node_id>, !db.column<i64>, !db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<none>, !db.column<!storage.node_id>, !db.column<i64>)
+  db.output(%nc, %agec, %tgt) : !db.column<!storage.node_id>, !db.column<i64>, !db.column<none>
+  return
+}
+)mlir";
+
+TEST_F(TrimCallCarrySetTest, leavesACallWhoseCarrySetIsReadAlone) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(callWhoseCarrySetIsRead);
+    ASSERT_TRUE(module);
+
+    llvm::SmallVector<mlir::db::CallProcedure> before = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(before.size(), 1u);
+
+    ASSERT_TRUE(runTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::CallProcedure> after = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(after.size(), 1u);
+    EXPECT_EQ(after.front(), before.front());
+    EXPECT_EQ(after.front().getCarriedColumns().size(), 2u);
+    EXPECT_EQ(after.front()->getNumResults(), 3u);
+}
+
+// MATCH (n) WITH n, n.age AS age CALL gnn.neighbourhoodSample(n, 3) YIELD tgt AS m
+// CALL gnn.neighbourhoodSample(m, 3) YIELD tgt AS k RETURN n, m, k
+const char* const chainedCallsCarryingAnUnreadAge = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %age = db.get_node_properties(%n, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %size = db.constant(3 : i64)
+  %m, %nc, %agec = db.call_procedure("gnn.neighbourhoodSample", {%n, %size}, {%n, %age}) yields ["tgt"] : (!db.column<!storage.node_id>, !db.column<i64>, !db.column<!storage.node_id>, !db.column<i64>) -> (!db.column<none>, !db.column<!storage.node_id>, !db.column<i64>)
+  %k, %ncc, %mc, %agecc = db.call_procedure("gnn.neighbourhoodSample", {%m, %size}, {%nc, %m, %agec}) yields ["tgt"] : (!db.column<none>, !db.column<i64>, !db.column<!storage.node_id>, !db.column<none>, !db.column<i64>) -> (!db.column<none>, !db.column<!storage.node_id>, !db.column<none>, !db.column<i64>)
+  db.output(%ncc, %mc, %k) : !db.column<!storage.node_id>, !db.column<none>, !db.column<none>
+  return
+}
+)mlir";
+
+// The age rides through both calls and is read after neither: trimming the second call
+// leaves the first's copy unread, and the same run trims that too.
+TEST_F(TrimCallCarrySetTest, trimsAChainOfCallsInOneRun) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(chainedCallsCarryingAnUnreadAge);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runTrim(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::CallProcedure> calls = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(calls.size(), 2u);
+    mlir::db::CallProcedure firstCall = calls[0];
+    mlir::db::CallProcedure secondCall = calls[1];
+
+    ASSERT_EQ(firstCall.getCarriedColumns().size(), 1u);
+    EXPECT_EQ(firstCall.getCarriedColumns().front(), firstCall.getInputs().front());
+    EXPECT_EQ(firstCall->getNumResults(), 2u);
+
+    const mlir::OperandRange secondCarried = secondCall.getCarriedColumns();
+    ASSERT_EQ(secondCarried.size(), 2u);
+    EXPECT_EQ(secondCarried[0], firstCall->getResult(1));
+    EXPECT_EQ(secondCarried[1], firstCall->getResult(0));
+    EXPECT_EQ(secondCall->getNumResults(), 3u);
+}

--- a/test/query/ir/UnwindNodeSeedCallV3Test.cpp
+++ b/test/query/ir/UnwindNodeSeedCallV3Test.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+namespace {
+
+// Remy (0) has edges out to Adam (1), Computers (2), Eighties (3) and Ghosts (6); Adam to
+// Remy, Bio (4) and Cooking (5); Ghosts to Remy. A sample size above every out-degree takes
+// them all.
+const std::vector<StringRowSink::Row> seededNeighbours {
+    {"0", "1"}, {"0", "2"}, {"0", "3"}, {"0", "6"},
+    {"1", "0"}, {"1", "4"}, {"1", "5"},
+    {"6", "0"}};
+
+}
+
+// An UNWIND of node IDs compared to a pattern node seeds the calls chained behind it from
+// exactly those nodes, whether the query still reads the unwound values or not.
+class UnwindNodeSeedCallV3Test : public CallV3Test {
+};
+
+TEST_F(UnwindNodeSeedCallV3Test, seedsACallFromTheListedNodes) {
+    StringRowSink sink;
+    runQuery("UNWIND [0, 1, 6] AS id MATCH (n) WHERE n = id "
+             "CALL gnn.neighbourhoodSample(n, 10, 11) YIELD tgt RETURN n, tgt",
+             sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, seededNeighbours);
+}
+
+TEST_F(UnwindNodeSeedCallV3Test, readsTheUnwoundValuePastTheCall) {
+    StringRowSink sink;
+    runQuery("UNWIND [0, 1, 6] AS id MATCH (n) WHERE n = id "
+             "CALL gnn.neighbourhoodSample(n, 10, 11) YIELD tgt RETURN id, tgt",
+             sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, seededNeighbours);
+}
+
+// Every path of three out-edges from the seeds: 8 leave Remy, 4 leave Adam and 4 leave
+// Ghosts, all of them through Remy.
+TEST_F(UnwindNodeSeedCallV3Test, matchesTheDisjunctionFormThroughChainedCalls) {
+    const std::string calls = " CALL gnn.neighbourhoodSample(n, 10, 11) YIELD tgt AS m"
+                              " CALL gnn.neighbourhoodSample(m, 10, 22) YIELD tgt AS k"
+                              " CALL gnn.neighbourhoodSample(k, 10, 33) YIELD tgt AS l"
+                              " RETURN n, m, k, l";
+
+    StringRowSink bySeed;
+    runQuery("UNWIND [0, 1, 6] AS id MATCH (n) WHERE n = id" + calls, bySeed);
+
+    StringRowSink byDisjunction;
+    runQuery("MATCH (n) WHERE n = 0 OR n = 1 OR n = 6" + calls, byDisjunction);
+
+    std::vector<StringRowSink::Row> bySeedRows;
+    bySeed.sortedRows(bySeedRows);
+    std::vector<StringRowSink::Row> byDisjunctionRows;
+    byDisjunction.sortedRows(byDisjunctionRows);
+
+    EXPECT_EQ(bySeedRows.size(), 16u);
+    EXPECT_EQ(bySeedRows, byDisjunctionRows);
+}

--- a/test/query/ir/UnwindNodeSeedCodegenTest.cpp
+++ b/test/query/ir/UnwindNodeSeedCodegenTest.cpp
@@ -216,6 +216,31 @@ TEST_F(UnwindNodeSeedCodegenTest, aProjectedValueUnwindStaysAnUnwindConst) {
     EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
 }
 
+// The call carries every column in flight, the unwound values among them, and nothing
+// reads them past it: trimmed away before the fusion looks, they fold as with no call.
+TEST_F(UnwindNodeSeedCodegenTest, aValueUnwindComparedToTheNodeFusesPastACall) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (n) WHERE n = x "
+                                                              "CALL gnn.neighbourhoodSample(n, 3, 11) YIELD tgt RETURN n, tgt");
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::CrossProduct>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 1u);
+
+    llvm::SmallVector<mlir::db::CallProcedure> calls = collect<mlir::db::CallProcedure>(*module);
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls.front().getCarriedColumns().size(), 1u);
+}
+
+TEST_F(UnwindNodeSeedCodegenTest, aValueUnwindReadPastACallStaysAnUnwindConst) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x MATCH (n) WHERE n = x "
+                                                              "CALL gnn.neighbourhoodSample(n, 3, 11) YIELD tgt RETURN x, tgt");
+
+    EXPECT_EQ(countOps<mlir::db::UnwindConst>(*module), 1u);
+    EXPECT_EQ(countOps<mlir::db::ConstScanNodes>(*module), 0u);
+    EXPECT_EQ(countOps<mlir::db::ScanNodes>(*module), 1u);
+}
+
 TEST_F(UnwindNodeSeedCodegenTest, unwindWithoutAMatchStaysAnUnwindConst) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = generate("UNWIND [5, 2] AS x RETURN x");
 


### PR DESCRIPTION
Take the compile-time work out of the db pass pipeline and fold an UNWIND seed past a CALL.

- The MLIR verifier no longer runs after each db pass. At 8192 `OR` terms it ran four times over a 24575-op module, 7.4 ms of an 18.1 ms codegen.
- Fix `collectMaskCone`
- `trim_unread_columns` trims a call procedure

3-hop `gnn.neighbourhoodSample` on reactome, 2048 seeds, fanout 15, through the shell, medians of 5 runs after a warm-up in one process:

| form | v2 | v3 |
| --- | --- | --- |
| form 1, `OR` chain | 5.5 ms | 7.9 ms |
| form 2, `UNWIND` | 8,798 ms | 5.4 ms |
| form 3, `db.getNodes` | 16.0 ms | 16.6 ms |

Form 2 on v3 main, same method: 18,131 ms.
