### PR TITLE
Return nothing for absent labels, edge types and properties, and null predicates, instead of rejecting them

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -306,6 +306,18 @@ void ExprAnalyzer::analyzeBinaryExpr(BinaryExpr* expr) {
                 break;
             }
 
+            // Ordering a value against a null is null, the same as comparing it against
+            // one. Only the MLIR engine answers such a comparison: the legacy planner
+            // hands the operator a null column no ordering kernel reads
+            const bool ordersAgainstNull =
+                pair == TypePairBitset(EvaluatedType::Null, EvaluatedType::Null)
+                || pair == TypePairBitset(EvaluatedType::Integer, EvaluatedType::Null)
+                || pair == TypePairBitset(EvaluatedType::Double, EvaluatedType::Null);
+
+            if (_isV3 && ordersAgainstNull) {
+                break;
+            }
+
             const std::string error = fmt::format(
                 "Operands are not valid or compatible numeric types: '{}' and '{}'",
                 EvaluatedTypeName::value(a),
@@ -613,6 +625,10 @@ ValueType ExprAnalyzer::analyzePropertyExpr(PropertyExpr* expr, bool allowCreate
 
     ValueType vt = ValueType::Invalid;
 
+    // A name no property in the graph carries has no value on any row and no type: the
+    // read is null. v2 cannot plan a null property read, so it still rejects the name.
+    bool readsAsNull = false;
+
     if (!propTypeFound) {
         // Property does not exist yet
 
@@ -620,19 +636,24 @@ ValueType ExprAnalyzer::analyzePropertyExpr(PropertyExpr* expr, bool allowCreate
         auto it = _toBeCreatedTypes.find(name);
 
         if (it == _toBeCreatedTypes.end()) {
-            if (!allowCreate) {
-                // Property does not exist and is not meant to be created in this query
-                const std::string error = fmt::format("Property type '{}' not found", propName->getName());
-                throwError(error, expr);
-            } else {
+            if (allowCreate) {
                 // Property does not exist but is created
                 addToBeCreatedType(propName->getName(), defaultType, expr);
                 it = _toBeCreatedTypes.find(name);
+            } else if (_isV3) {
+                readsAsNull = true;
+            } else {
+                // Property does not exist and is not meant to be created in this query
+                const std::string error = fmt::format("Property type '{}' not found", propName->getName());
+                throwError(error, expr);
             }
         }
 
-        // Property is meant to be created in this query
-        vt = it->second;
+        if (!readsAsNull) {
+            // Property is meant to be created in this query
+            vt = it->second;
+        }
+
         expr->setPropertyName(name);
     } else {
         // Property already exists
@@ -640,14 +661,18 @@ ValueType ExprAnalyzer::analyzePropertyExpr(PropertyExpr* expr, bool allowCreate
         expr->setPropertyName(propName->getName());
     }
 
-    const auto maybeEvalType = toEvaluatedType(vt);
-    if (!maybeEvalType.has_value()) {
-        const std::string_view name = propName->getName();
-        const std::string error = fmt::format("Property type '{}' is invalid", name);
-        throwError(error, expr);
-    }
+    EvaluatedType type = EvaluatedType::Null;
 
-    EvaluatedType type = *maybeEvalType;
+    if (!readsAsNull) {
+        const auto maybeEvalType = toEvaluatedType(vt);
+        if (!maybeEvalType.has_value()) {
+            const std::string_view name = propName->getName();
+            const std::string error = fmt::format("Property type '{}' is invalid", name);
+            throwError(error, expr);
+        }
+
+        type = *maybeEvalType;
+    }
 
     expr->setEntityVarDecl(varDecl);
     expr->setType(type);

--- a/query/analyzer/ReadStmtAnalyzer.cpp
+++ b/query/analyzer/ReadStmtAnalyzer.cpp
@@ -380,12 +380,14 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
         const LabelMap& labelMap = _graphMetadata.labels();
 
         for (const Symbol* label : *labels) {
-            const std::optional<LabelID> labelID = labelMap.get(label->getName());
-            if (!labelID) {
-                throwError(fmt::format("Unknown label: {}", label->getName()), nodePattern);
+            const std::string_view labelName = label->getName();
+            const bool graphHasLabel = labelMap.get(labelName).has_value();
+
+            if (!graphHasLabel && !_isV3) { // v3 matches no node instead of failing
+                throwError(fmt::format("Unknown label: {}", labelName), nodePattern);
             }
 
-            data->addLabelConstraint(label->getName());
+            data->addLabelConstraint(labelName);
         }
     }
 
@@ -401,11 +403,14 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
             }
 
             const std::optional<PropertyType> propType = propTypeMap.get(propName->getName());
-            if (!propType) {
+
+            if (!propType && !_isV3) { // v3 reads it as null, so the constraint matches nothing
                 throwError(fmt::format("Unknown property: {}", propName->getName()), nodePattern);
             }
 
-            if (!constraintTypeCompatible(propType->_valueType, expr->getType())) {
+            const bool incompatibleValue = propType
+                                           && !constraintTypeCompatible(propType->_valueType, expr->getType());
+            if (incompatibleValue) {
                 throwError(fmt::format("Cannot evaluate node property: types '{}' and '{}' are incompatible",
                                        ValueTypeName::value(propType->_valueType),
                                        EvaluatedTypeName::value(expr->getType())),
@@ -424,7 +429,9 @@ void ReadStmtAnalyzer::analyze(NodePattern* nodePattern) {
             BinaryExpr* predExpr = BinaryExpr::create(_ast, BinaryOperator::Equal, propExpr, expr);
             _exprAnalyzer->analyzeRootExpr(predExpr);
 
-            data->addExprConstraint(propName->getName(), propType->_valueType, predExpr);
+            const ValueType constraintType = propType ? propType->_valueType : ValueType::Invalid;
+
+            data->addExprConstraint(propName->getName(), constraintType, predExpr);
         }
     }
 }
@@ -450,14 +457,14 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
         const EdgeTypeMap& edgeTypeMap = _graphMetadata.edgeTypes();
 
         for (const Symbol* edgeTypeSymbol : *types) {
-            const std::optional<EdgeTypeID> etID = edgeTypeMap.get(edgeTypeSymbol->getName());
-            if (!etID) {
-                throwError(fmt::format("Unknown edge type: {}",
-                                       edgeTypeSymbol->getName()),
-                           edgePattern);
+            const std::string_view edgeTypeName = edgeTypeSymbol->getName();
+            const bool graphHasEdgeType = edgeTypeMap.get(edgeTypeName).has_value();
+
+            if (!graphHasEdgeType && !_isV3) { // v3 matches no edge instead of failing
+                throwError(fmt::format("Unknown edge type: {}", edgeTypeName), edgePattern);
             }
 
-            data->addEdgeTypeConstraint(edgeTypeSymbol->getName());
+            data->addEdgeTypeConstraint(edgeTypeName);
         }
     }
 
@@ -473,11 +480,14 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
             }
 
             const std::optional<PropertyType> propType = propTypeMap.get(propName->getName());
-            if (!propType) {
+
+            if (!propType && !_isV3) { // v3 reads it as null, so the constraint matches nothing
                 throwError(fmt::format("Unknown property: {}", propName->getName()), edgePattern);
             }
 
-            if (!constraintTypeCompatible(propType->_valueType, expr->getType())) {
+            const bool incompatibleValue = propType
+                                           && !constraintTypeCompatible(propType->_valueType, expr->getType());
+            if (incompatibleValue) {
                 throwError(fmt::format("Cannot evaluate edge property: types '{}' and '{}' are incompatible",
                                        ValueTypeName::value(propType->_valueType),
                                        EvaluatedTypeName::value(expr->getType())),
@@ -496,7 +506,9 @@ void ReadStmtAnalyzer::analyze(EdgePattern* edgePattern) {
             BinaryExpr* predExpr = BinaryExpr::create(_ast, BinaryOperator::Equal, propExpr, expr);
             _exprAnalyzer->analyzeRootExpr(predExpr);
 
-            data->addExprConstraint(propName->getName(), propType->_valueType, predExpr);
+            const ValueType constraintType = propType ? propType->_valueType : ValueType::Invalid;
+
+            data->addExprConstraint(propName->getName(), constraintType, predExpr);
         }
     }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -124,6 +124,18 @@ std::string_view toStringView(llvm::StringRef text) {
     return std::string_view(text.data(), text.size());
 }
 
+// The untyped null column the null literal compiles to: nullable with no value type of
+// its own, so nothing about it says which column would carry a value
+bool isUntypedNullColumn(mlir::Value column) {
+    const auto columnType = mlir::dyn_cast<mlir::db::ColumnType>(column.getType());
+    if (!columnType) {
+        return false;
+    }
+
+    const auto nullableType = mlir::dyn_cast<mlir::storage::NullableType>(columnType.getType());
+    return nullableType && mlir::isa<mlir::NoneType>(nullableType.getValueType());
+}
+
 mlir::ArrayAttr strArrayAttr(mlir::OpBuilder& builder, std::span<const std::string_view> names) {
     llvm::SmallVector<llvm::StringRef> refs;
     for (const std::string_view name : names) {
@@ -4665,6 +4677,17 @@ void DBProgramGenerator::translateBinaryExpr(const Expr* expr, const BinaryExpr*
     const bool comparesAgainstNull = lhsExpr->getType() == EvaluatedType::Null
                                      || rhsExpr->getType() == EvaluatedType::Null;
 
+    // AND, OR and XOR read a null side as an unknown boolean, which the runtime truth
+    // tables answer against the other side's value per row. With both sides null there is
+    // no value to answer against and the result is null, whichever of the three it is
+    const bool isThreeValuedLogic = op == BinaryOperator::And
+                                    || op == BinaryOperator::Or
+                                    || op == BinaryOperator::Xor;
+    if (isThreeValuedLogic && isUntypedNullColumn(lhs) && isUntypedNullColumn(rhs)) {
+        _part._exprMap[expr] = nullConstantColumn();
+        return;
+    }
+
     switch (op) {
         case BinaryOperator::Equal:
             if (comparesAgainstNull) {
@@ -4714,16 +4737,32 @@ void DBProgramGenerator::translateBinaryExpr(const Expr* expr, const BinaryExpr*
             _part._exprMap[expr] = _opBuilder.create<mlir::db::DivOp>(loc, noneType, lhs, rhs).getResult();
         break;
         case BinaryOperator::GreaterThan:
-            _part._exprMap[expr] = _opBuilder.create<mlir::db::GtOp>(loc, boolType, lhs, rhs).getResult();
+            if (comparesAgainstNull) {
+                _part._exprMap[expr] = nullConstantColumn();
+            } else {
+                _part._exprMap[expr] = _opBuilder.create<mlir::db::GtOp>(loc, boolType, lhs, rhs).getResult();
+            }
         break;
         case BinaryOperator::LessThan:
-            _part._exprMap[expr] = _opBuilder.create<mlir::db::LtOp>(loc, boolType, lhs, rhs).getResult();
+            if (comparesAgainstNull) {
+                _part._exprMap[expr] = nullConstantColumn();
+            } else {
+                _part._exprMap[expr] = _opBuilder.create<mlir::db::LtOp>(loc, boolType, lhs, rhs).getResult();
+            }
         break;
         case BinaryOperator::GreaterThanOrEqual:
-            _part._exprMap[expr] = _opBuilder.create<mlir::db::GteOp>(loc, boolType, lhs, rhs).getResult();
+            if (comparesAgainstNull) {
+                _part._exprMap[expr] = nullConstantColumn();
+            } else {
+                _part._exprMap[expr] = _opBuilder.create<mlir::db::GteOp>(loc, boolType, lhs, rhs).getResult();
+            }
         break;
         case BinaryOperator::LessThanOrEqual:
-            _part._exprMap[expr] = _opBuilder.create<mlir::db::LteOp>(loc, boolType, lhs, rhs).getResult();
+            if (comparesAgainstNull) {
+                _part._exprMap[expr] = nullConstantColumn();
+            } else {
+                _part._exprMap[expr] = _opBuilder.create<mlir::db::LteOp>(loc, boolType, lhs, rhs).getResult();
+            }
         break;
         case BinaryOperator::NotEqual:
             if (comparesAgainstNull) {
@@ -4918,6 +4957,12 @@ mlir::Value DBProgramGenerator::translatePropertyExpr(const PropertyExpr* propEx
         bioassert(fieldColumn, "CSV header access on a row no load published: {}.{}", varName, propName);
 
         return fieldColumn;
+    }
+
+    // No property in the graph carries the name - the analyzer typed the read null for
+    // it - so there is nothing to fetch and every row reads null
+    if (propExpr->getType() == EvaluatedType::Null) {
+        return nullConstantColumn();
     }
 
     // Every row a CREATE wrote holds a provisional ID, which the graph a fetch reads knows

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -777,6 +777,11 @@ void applyNotOnConst(Column* result, const Column* operand) {
     UnaryPredicateExecutor<Not, CustomBool>::apply(typedResult, typedOperand);
 }
 
+// NOT of an unknown truth value is unknown; the ColumnConst<PropertyNull> result already
+// reads as null, so nothing is computed.
+void applyNotOnNullConst(Column*, const Column*) {
+}
+
 // Block-repeat: each input row is emitted `factor` times in a row, so input row
 // i lands at output indices [i*factor, (i+1)*factor). This lays out an outer
 // column of a cross product, where each outer row pairs with the whole inner
@@ -4259,6 +4264,13 @@ NLCaseWriteFn NLExecutor::selectCaseWrite(ValueType valueType,
 
 NLUnaryFn NLExecutor::selectNot(const Column* operand, LocalMemory* memory, Column*& result) {
     const ContainerKind::Code kind = operand->getContainerKind();
+
+    // The untyped null constant negates to a null rather than to the boolean the constant
+    // branch below would read out of it
+    if (dynamic_cast<const ColumnConst<PropertyNull>*>(operand)) {
+        result = memory->alloc<ColumnConst<PropertyNull>>();
+        return &applyNotOnNullConst;
+    }
 
     if (kind == ContainerKind::code<ColumnConst<CustomBool>>()) {
         result = memory->alloc<ColumnConst<CustomBool>>();

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -3233,6 +3233,12 @@ void DBLowering::lowerNot(mlir::db::NotOp notOp) {
         resultElement = storage::NullableType::get(bldCtxt, boolElement);
     }
 
+    // NOT of an unknown truth value is unknown, and an untyped null names no boolean
+    // column to carry it: the negation is the same untyped null its operand is
+    if (isUntypedNullChunk(operandType)) {
+        resultElement = mlir::cast<nl::ChunkType>(operandType).getElementType();
+    }
+
     const nl::ChunkType resultType = nl::ChunkType::get(bldCtxt, resultElement);
 
     mlir::Block* const insertBlock = ownerBlock(operandChunk);

--- a/storage/columns/AllowedKinds.h
+++ b/storage/columns/AllowedKinds.h
@@ -268,7 +268,13 @@ template <ColumnOperator Op>
 struct PairRestrictions<Op> {
     using Allowed = GenerateKindPairList<
         // Boolean properties; optional (3-valued logic) and non-optional
-        OptionalKindPairs<types::Bool::Primitive, types::Bool::Primitive>::Pairs
+        OptionalKindPairs<types::Bool::Primitive, types::Bool::Primitive>::Pairs,
+
+        std::tuple<
+            // A null of unknown type, which the truth tables read as an unknown truth
+            // value: the lowering reads the other side as nullable to meet it
+            KindPair<std::optional<types::Bool::Primitive>, PropertyNull>
+        >
     >;
 
     using AllowedMixed = AllowedMixedList<

--- a/storage/columns/BinaryPredicates.h
+++ b/storage/columns/BinaryPredicates.h
@@ -27,9 +27,15 @@ struct TuringNotEqual;
 static constexpr CustomBool sentinelFalse(false);
 static constexpr CustomBool sentinelTrue(true);
 
+// A null of unknown type is an unknown truth value in a Boolean operation, so the
+// three-valued operators take it as an operand beside the booleans
 template <typename T>
 concept BooleanOpt = std::same_as<TypeUtils::unwrap_optional_t<T>, types::Bool::Primitive>
-                  || std::same_as<ColumnMask::Bool_t, T>;
+                  || std::same_as<ColumnMask::Bool_t, T>
+                  || std::same_as<std::decay_t<T>, PropertyNull>;
+
+template <typename... Ts>
+concept HoldsPropertyNull = (std::same_as<std::decay_t<Ts>, PropertyNull> || ...);
 
 template <typename F>
 concept TestsEquality =
@@ -394,6 +400,9 @@ struct BinaryPredicate {
             return optionalOr(std::forward<T>(a), std::forward<U>(b));
         } else if constexpr (std::is_same_v<F, std::logical_and<>>) {
             return optionalAnd(std::forward<T>(a), std::forward<U>(b));
+        } else if constexpr (HoldsPropertyNull<T, U>) {
+            // An operand of unknown value leaves the predicate's answer unknown
+            return std::nullopt;
         } else { // General implementation for >, <, <=, etc
             return optionalPredicate<F>(std::forward<T>(a), std::forward<U>(b));
         }

--- a/test/query/ir/AbsentPropertyNameTest.cpp
+++ b/test/query/ir/AbsentPropertyNameTest.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A property name no node or edge in the graph carries reads as null on every row, the
+// same as the null literal: nothing in the graph holds a value for it.
+class AbsentPropertyNameTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    void expectNoRows(std::string_view query) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_TRUE(sink.rows().empty()) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    std::string _graphName {"simpledb"};
+};
+
+TEST_F(AbsentPropertyNameTest, ReadsAsNullOnEveryRow) {
+    expectRows("MATCH (n:Person) RETURN n.name, n.nosuchprop",
+               {{"Remy", "null"},
+                {"Adam", "null"},
+                {"Maxime", "null"},
+                {"Luc", "null"},
+                {"Martina", "null"},
+                {"Suhas", "null"},
+                {"Cyrus", "null"},
+                {"Doruk", "null"}});
+}
+
+TEST_F(AbsentPropertyNameTest, EqualityAgainstItMatchesNothing) {
+    expectNoRows("MATCH (n:Person) WHERE n.nosuchprop = 1 RETURN n.name");
+}
+
+TEST_F(AbsentPropertyNameTest, InlineConstraintMatchesNothing) {
+    expectNoRows("MATCH (n:Person {nosuchprop: 1}) RETURN n.name");
+}
+
+TEST_F(AbsentPropertyNameTest, IsNullHoldsOnEveryRow) {
+    expectCounts("MATCH (n:Person) WHERE n.nosuchprop IS NULL RETURN count(n)", {8});
+}
+
+TEST_F(AbsentPropertyNameTest, IsNotNullHoldsOnNoRow) {
+    expectCounts("MATCH (n:Person) WHERE n.nosuchprop IS NOT NULL RETURN count(n)", {0});
+}
+
+// count skips nulls, so it counts none of the 8 rows it reads
+TEST_F(AbsentPropertyNameTest, CountOfItIsZero) {
+    expectCounts("MATCH (n:Person) RETURN count(n.nosuchprop)", {0});
+}
+
+TEST_F(AbsentPropertyNameTest, EdgePropertyReadsAsNull) {
+    expectRows("MATCH (n:Person)-[e:KNOWS_WELL]->(m) RETURN e.nosuchprop",
+               {{"null"}, {"null"}});
+}
+
+TEST_F(AbsentPropertyNameTest, EdgeInlineConstraintMatchesNothing) {
+    expectNoRows("MATCH (n:Person)-[e:KNOWS_WELL {nosuchprop: 1}]->(m) RETURN m.name");
+}
+
+// A read creates nothing: the name is still absent for the statement that follows
+TEST_F(AbsentPropertyNameTest, ReadingItLeavesTheSchemaAlone) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN n.nosuchprop", {{"null"}});
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN n.nosuchprop", {{"null"}});
+}

--- a/test/query/ir/AbsentPropertyNameTest.cpp
+++ b/test/query/ir/AbsentPropertyNameTest.cpp
@@ -119,6 +119,12 @@ TEST_F(AbsentPropertyNameTest, IsNullHoldsOnEveryRow) {
     expectCounts("MATCH (n:Person) WHERE n.nosuchprop IS NULL RETURN count(n)", {8});
 }
 
+// Unlabelled, over every node of the graph: no node carries the name, so every one of
+// them answers the test
+TEST_F(AbsentPropertyNameTest, IsNullHoldsOnEveryNodeOfTheGraph) {
+    expectCounts("MATCH (n) WHERE n.no_such_prop IS NULL RETURN count(n)", {18});
+}
+
 TEST_F(AbsentPropertyNameTest, IsNotNullHoldsOnNoRow) {
     expectCounts("MATCH (n:Person) WHERE n.nosuchprop IS NOT NULL RETURN count(n)", {0});
 }

--- a/test/query/ir/AbsentSchemaNameTest.cpp
+++ b/test/query/ir/AbsentSchemaNameTest.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// A label or an edge type the graph never assigned matches nothing: the pattern it
+// constrains is empty, and the query around it runs to completion.
+class AbsentSchemaNameTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectNoRows(std::string_view query) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_TRUE(sink.rows().empty()) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    std::string _graphName {"simpledb"};
+};
+
+TEST_F(AbsentSchemaNameTest, AbsentLabelScanMatchesNothing) {
+    expectNoRows("MATCH (n:NoSuchLabel) RETURN n.name");
+}
+
+// The labels of a node pattern are a conjunction, so one absent name empties the whole
+// pattern instead of weakening it to the names the graph does know
+TEST_F(AbsentSchemaNameTest, AbsentLabelBesideAKnownOneMatchesNothing) {
+    expectNoRows("MATCH (n:Person:NoSuchLabel) RETURN n.name");
+}
+
+TEST_F(AbsentSchemaNameTest, AbsentLabelOnTheTargetOfAHopMatchesNothing) {
+    expectNoRows("MATCH (n:Person)-[:KNOWS_WELL]->(m:NoSuchLabel) RETURN m.name");
+}
+
+TEST_F(AbsentSchemaNameTest, AHopOutOfAnAbsentLabelMatchesNothing) {
+    expectNoRows("MATCH (n:NoSuchLabel)-[:KNOWS_WELL]->(m) RETURN m.name");
+}
+
+TEST_F(AbsentSchemaNameTest, AbsentEdgeTypeMatchesNothing) {
+    expectNoRows("MATCH (n:Person)-[:NOSUCHTYPE]->(m) RETURN m.name");
+}
+
+TEST_F(AbsentSchemaNameTest, AbsentEdgeTypeOnAnIncomingHopMatchesNothing) {
+    expectNoRows("MATCH (n:Person)<-[:NOSUCHTYPE]-(m) RETURN m.name");
+}
+
+// The keyless count still emits its one group over the empty scan
+TEST_F(AbsentSchemaNameTest, CountOverAnAbsentLabelIsZero) {
+    expectCounts("MATCH (n:NoSuchLabel) RETURN count(n)", {0});
+}
+
+// The same test written as a predicate, which already answered false per row
+TEST_F(AbsentSchemaNameTest, CountOverAnAbsentLabelPredicateIsZero) {
+    expectCounts("MATCH (n) WHERE n:NoSuchLabel RETURN count(n)", {0});
+}
+
+// An OPTIONAL MATCH of an absent edge type misses every row it joins onto, so all 8
+// people come back null-padded
+TEST_F(AbsentSchemaNameTest, OptionalMatchOfAnAbsentEdgeTypePadsEveryRow) {
+    expectCounts("MATCH (n:Person) OPTIONAL MATCH (n)-[:NOSUCHTYPE]->(m) RETURN count(*)", {8});
+}

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1351,6 +1351,39 @@ target_link_libraries(test_query_ir_optional_match PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_optional_match PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_null_predicate NullPredicateTest.cpp)
+target_link_libraries(test_query_ir_null_predicate PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_null_predicate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_absent_property_name AbsentPropertyNameTest.cpp)
+target_link_libraries(test_query_ir_absent_property_name PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_absent_property_name PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_turing_test(test_query_ir_absent_schema_name AbsentSchemaNameTest.cpp)
+target_link_libraries(test_query_ir_absent_schema_name PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_absent_schema_name PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_optional_match_write OptionalMatchWriteTest.cpp)
 target_link_libraries(test_query_ir_optional_match_write PRIVATE
         turing_db_s

--- a/test/query/ir/NullPredicateTest.cpp
+++ b/test/query/ir/NullPredicateTest.cpp
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Three-valued logic over a predicate whose value is null, written both as the null
+// literal and as a property name the graph does not carry. A WHERE keeps the rows its
+// predicate answers true on, so a null answer drops the row without failing the query.
+class NullPredicateTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    void expectNoRows(std::string_view query) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_TRUE(sink.rows().empty()) << "query: " << query << "\nactual:\n" << actualText;
+    }
+
+    void expectCounts(std::string_view query, const Counts& expected) {
+        CountSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Counts actual;
+        sink.sortedCounts(actual);
+
+        EXPECT_EQ(actual, expected) << "query: " << query;
+    }
+
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+    std::string _graphName {"simpledb"};
+};
+
+// An ordering comparison against a null is null, so it keeps no row - where it used to be
+// rejected as a comparison of incompatible types
+TEST_F(NullPredicateTest, OrderingAgainstTheNullLiteralKeepsNoRow) {
+    expectNoRows("MATCH (n:Person) WHERE n.age > null RETURN n.name");
+}
+
+TEST_F(NullPredicateTest, OrderingAgainstAnAbsentPropertyKeepsNoRow) {
+    expectNoRows("MATCH (n:Person) WHERE n.nosuchprop > 5 RETURN n.name");
+}
+
+// The null can sit on either side, under any of the four ordering operators
+TEST_F(NullPredicateTest, OrderingKeepsNoRowWhicheverSideTheNullIsOn) {
+    expectNoRows("MATCH (n:Person) WHERE null <= n.age RETURN n.name");
+    expectNoRows("MATCH (n:Person) WHERE null < null RETURN n.name");
+    expectNoRows("MATCH (n:Person) WHERE n.age >= null RETURN n.name");
+}
+
+// Projected rather than filtered on, the comparison reads as the null it is
+TEST_F(NullPredicateTest, OrderingAgainstANullProjectsNull) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN n.age > null", {{"null"}});
+}
+
+// null OR true is true, and null OR false is null: only Remy answers the other side true
+TEST_F(NullPredicateTest, OrTakesTheRowItsOtherSideAnswersTrue) {
+    expectRows("MATCH (n:Person) WHERE n.age = null OR n.name = 'Remy' RETURN n.name", {{"Remy"}});
+}
+
+TEST_F(NullPredicateTest, OrOverAnAbsentPropertyTakesTheRowItsOtherSideAnswersTrue) {
+    expectRows("MATCH (n:Person) WHERE n.nosuchprop = 1 OR n.name = 'Remy' RETURN n.name", {{"Remy"}});
+}
+
+// null AND true is null and null AND false is false, so no row survives either way
+TEST_F(NullPredicateTest, AndKeepsNoRowWhenOneSideIsNull) {
+    expectCounts("MATCH (n:Person) WHERE n.age = null AND n.name = 'Remy' RETURN count(n)", {0});
+}
+
+// Two null sides answer null, whichever operator joins them
+TEST_F(NullPredicateTest, TwoNullSidesKeepNoRow) {
+    expectCounts("MATCH (n:Person) WHERE n.age = null OR n.name = null RETURN count(n)", {0});
+    expectCounts("MATCH (n:Person) WHERE n.age = null AND n.name = null RETURN count(n)", {0});
+}
+
+// null XOR anything is null
+TEST_F(NullPredicateTest, XorKeepsNoRowWhenOneSideIsNull) {
+    expectCounts("MATCH (n:Person) WHERE n.age = null XOR n.name = 'Remy' RETURN count(n)", {0});
+}
+
+// NOT of a null is null, not true: negating an unknown answer keeps no row
+TEST_F(NullPredicateTest, NotOfANullKeepsNoRow) {
+    expectCounts("MATCH (n:Person) WHERE NOT n.age = null RETURN count(n)", {0});
+}
+
+TEST_F(NullPredicateTest, NotOfAnAbsentPropertyComparisonKeepsNoRow) {
+    expectCounts("MATCH (n:Person) WHERE NOT n.nosuchprop = 1 RETURN count(n)", {0});
+}
+
+// The rows an ordinary predicate answers are unaffected: IS NULL answers a real boolean
+// on every row, so its negation keeps the 2 people who carry an age
+TEST_F(NullPredicateTest, NotOfARealBooleanStillNegatesIt) {
+    expectCounts("MATCH (n:Person) WHERE NOT n.age IS NULL RETURN count(n)", {2});
+    expectCounts("MATCH (n:Person) WHERE NOT n.name = 'Remy' RETURN count(n)", {7});
+}
+
+// A null answer composes through the operators around it: the OR answers true on Remy and
+// null elsewhere, and the AND and the NOT read that answer per row
+TEST_F(NullPredicateTest, ANullAnswerComposesThroughTheOperatorsAroundIt) {
+    expectRows("MATCH (n:Person) WHERE (n.age = null OR n.name = 'Remy') AND n.name = 'Remy' RETURN n.name",
+               {{"Remy"}});
+    expectCounts("MATCH (n:Person) WHERE NOT (n.age = null OR n.name = 'Remy') RETURN count(n)", {0});
+}
+
+// An ordering comparison beside a null one: the absent property answers null, the ordering
+// answers true on the 2 people who carry an age
+TEST_F(NullPredicateTest, OrJoinsANullSideToAnOrderingComparison) {
+    expectRows("MATCH (n:Person) WHERE n.nosuchprop = 1 OR n.age > 30 RETURN n.name",
+               {{"Remy"}, {"Adam"}});
+}
+
+// The three-valued operators still answer per row when the null is one row's value rather
+// than the whole column's: Remy and Adam carry an age, the other 6 read null
+TEST_F(NullPredicateTest, OrOverAPerRowNullAnswersPerRow) {
+    expectRows("MATCH (n:Person) WHERE n.age = 32 OR n.name = 'Luc' RETURN n.name",
+               {{"Remy"}, {"Adam"}, {"Luc"}});
+}

--- a/test/query/ir/ScanByPropertyValueV3Test.cpp
+++ b/test/query/ir/ScanByPropertyValueV3Test.cpp
@@ -105,8 +105,8 @@ TEST_F(ScanByPropertyValueV3Test, labelConjunctionNarrowsTheScan) {
     expectSortedRows("MATCH (n:Person:Bioinformatics) WHERE n.isFrench = false RETURN n.name", {{"Martina"}});
 }
 
-TEST_F(ScanByPropertyValueV3Test, labelAbsentFromTheSchemaIsRejectedBeforeTheScan) {
-    runQueryExpectingError("MATCH (n:Nobody) WHERE n.age = 32 RETURN n.name", "Unknown label: Nobody");
+TEST_F(ScanByPropertyValueV3Test, labelAbsentFromTheSchemaMatchesNothing) {
+    expectSortedRows("MATCH (n:Nobody) WHERE n.age = 32 RETURN n.name", {});
 }
 
 TEST_F(ScanByPropertyValueV3Test, labelledScanYieldsInScanOrder) {


### PR DESCRIPTION
Return nothing instead of ANALYZE_ERROR for missing label or property name.
```
MATCH (n:NoSuchLabel) RETURN n.name                                      0 rows, was ANALYZE_ERROR: Unknown label
MATCH (n:Person)-[:NOSUCHTYPE]->(m) RETURN m.name                        0 rows, was ANALYZE_ERROR: Unknown edge type

MATCH (n:Person) RETURN n.nosuchprop                                     8 rows of null, was ANALYZE_ERROR: Property type not found
MATCH (n:Person {nosuchprop: 1}) RETURN n.name                           0 rows, was ANALYZE_ERROR: Unknown property

MATCH (n:Person) WHERE n.age > null RETURN n.name                        0 rows, was ANALYZE_ERROR: Operands are not valid or compatible numeric types
MATCH (n:Person) WHERE n.age = null OR n.name = 'Remy' RETURN n.name     Remy, was EXEC_ERROR: Unsupported binary operation
MATCH (n:Person) WHERE NOT n.age = null RETURN count(n)                  0, was 8
```
