### PR TITLE
LDBC Fix two analyzer rejections of valid projections

### DIFF
--- a/query/AST/decl/DeclContext.cpp
+++ b/query/AST/decl/DeclContext.cpp
@@ -72,12 +72,9 @@ VarDecl* DeclContext::getOrCreateNodePatternVariable(CypherAST* ast, std::string
     return getOrCreateNamedVariable(ast, EvaluatedType::NodePattern, name);
 }
 
+// The item computes a column of its own, so an alias spelling a name already in scope
+// declares a second variable that shadows the first rather than naming it again
 VarDecl* DeclContext::declareProjectedVariable(CypherAST* ast, EvaluatedType type, std::string_view name) {
-    VarDecl* declared = getDecl(name);
-    if (declared && declared->getType() == type) {
-        return declared;
-    }
-
     VarDecl* decl = VarDecl::create(ast, this, name, type);
     decl->setIsUnnamed(false);
     _declMap[decl->getName()] = decl;

--- a/query/analyzer/CypherAnalyzer.cpp
+++ b/query/analyzer/CypherAnalyzer.cpp
@@ -490,7 +490,7 @@ void CypherAnalyzer::analyzeProjection(Projection* projection, const Stmt* claus
     }
 
     if (projection->isDistinct()) {
-        analyzeDistinct(projection, clause);
+        analyzeDistinct(projection, clause, isAggregate);
     }
 
     if (isAggregate) {
@@ -536,12 +536,16 @@ void CypherAnalyzer::setV3() {
     _writeAnalyzer->setV3();
 }
 
-void CypherAnalyzer::analyzeDistinct(const Projection* projection, const Stmt* clause) const {
+void CypherAnalyzer::analyzeDistinct(const Projection* projection,
+                                     const Stmt* clause,
+                                     bool isAggregate) const {
     if (!_isV3) { // only supported by MLIR v3
         throwError("DISTINCT not yet supported.", clause);
     }
 
-    if (!projection->hasOrderBy()) {
+    // An aggregating projection emits one row per group, so no two of its rows are equal
+    // and the dedup drops nothing: its keys answer to analyzeAggregateOrderBy instead
+    if (isAggregate || !projection->hasOrderBy()) {
         return;
     }
 
@@ -550,14 +554,12 @@ void CypherAnalyzer::analyzeDistinct(const Projection* projection, const Stmt* c
     for (const OrderByItem* item : orderBy->getItems()) {
         const Expr* keyExpr = item->getExpr();
 
-        // A constant key holds the same value in every row, so it orders nothing and
-        // names no column the dedup could have dropped
-        if (!keyExpr->isDynamic()) {
-            continue;
-        }
-
-        if (!projection->hasItem(keyExpr)) {
-            throwError("ORDER BY with DISTINCT may only order by returned columns.", keyExpr);
+        // The dedup keys its rows on the columns the projection carries, so a key over
+        // those holds one value per row it kept - the test a grouping key answers too
+        if (!isGroupWise(keyExpr, projection)) {
+            throwError("ORDER BY with DISTINCT may only order by expressions over the "
+                       "returned columns.",
+                       keyExpr);
         }
     }
 }

--- a/query/analyzer/CypherAnalyzer.h
+++ b/query/analyzer/CypherAnalyzer.h
@@ -98,7 +98,7 @@ private:
     void analyzeWithOrderBy(const Projection* projection) const;
     void throwOnUnpublishedKeyVariable(const Expr* keyExpr, const Projection* projection) const;
     void declareItemAlias(Expr* item, std::string_view alias);
-    void analyzeDistinct(const Projection* projection, const Stmt* clause) const;
+    void analyzeDistinct(const Projection* projection, const Stmt* clause, bool isAggregate) const;
     void analyzeNestedAggregates(const Projection* projection) const;
     void analyzeAggregateArguments(const Expr* expr, const Projection* projection) const;
     bool readsAnAggregateItem(const Expr* expr, const Projection* projection) const;

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -4129,23 +4129,100 @@ void DBProgramGenerator::translateDistinct(const Projection* projection,
     // keeps is the first of them - the projection capped at a single row
     if (dedupedColumns.empty()) {
         translateDistinctOverConstants(projection, projected);
+    } else {
+        llvm::SmallVector<mlir::Type> dedupedTypes;
+        for (const mlir::Value column : dedupedColumns) {
+            dedupedTypes.push_back(column.getType());
+        }
+
+        const mlir::Location loc = _opBuilder.getUnknownLoc();
+        auto distinctOp = _opBuilder.create<mlir::db::RemoveDuplicates>(loc, dedupedTypes, mlir::ValueRange{dedupedColumns});
+
+        // The dedup hands back one column per column it read, so its results take the place
+        // of the ones it was given and the constant columns stay as they were
+        const mlir::ResultRange results = distinctOp.getResults();
+        for (size_t resultIndex = 0; resultIndex < dedupedItems.size(); resultIndex++) {
+            projected[dedupedItems[resultIndex]] = results[resultIndex];
+        }
+    }
+
+    rebindDistinctColumns(projection, projected);
+}
+
+void DBProgramGenerator::rebindDistinctColumns(const Projection* projection,
+                                               llvm::ArrayRef<mlir::Value> projected) {
+    bioassert(projected.size() == projection->items().size(),
+              "One projected column per return item expected");
+
+    GroupedColumns itemColumns;
+
+    size_t itemIndex = 0;
+    for (const Projection::ReturnItem& item : projection->items()) {
+        const mlir::Value column = projected[itemIndex];
+        itemIndex++;
+
+        if (const VarDecl* const* itemDecl = std::get_if<VarDecl*>(&item)) {
+            rebindVariableColumn(*itemDecl, column);
+            continue;
+        }
+
+        const Expr* itemExpr = *std::get_if<Expr*>(&item);
+        itemColumns.emplace_back(itemExpr, column);
+
+        const VarDecl* exprDecl = itemExpr->getExprVarDecl();
+        if (!exprDecl) {
+            continue;
+        }
+
+        _part._projectedColumns[exprDecl] = column;
+
+        // Only a bare variable is still that variable once the projection has run; every
+        // other item is a value computed from one, and reading the variable is no read of
+        // the column the item produced
+        if (itemExpr->getKind() == Expr::Kind::SYMBOL) {
+            rebindVariableColumn(exprDecl, column);
+        }
+    }
+
+    // A key spelling an item out again - the e.duration of
+    // RETURN DISTINCT e.duration ORDER BY e.duration + 1 - is a tree of its own, so
+    // binding it to the item's column is what stops it being computed a second time over
+    // the rows the dedup dropped
+    bindOrderByKeyColumns(projection, itemColumns);
+}
+
+void DBProgramGenerator::rebindVariableColumn(const VarDecl* decl, mlir::Value column) {
+    rebindYieldedColumn(decl, column);
+
+    // An edge identity has no variable of its own: its column is published under the
+    // traversal variable that produced it, which is where the replacement has to land
+    const VariableDependencyGraph::EdgeIdentityMap& edgeIdentities = _vdg.edgeIdentities();
+    const auto identityIt = edgeIdentities.find(decl);
+    const bool hasIdentity = identityIt != edgeIdentities.end() && !identityIt->second.empty();
+
+    const VariableDependency* boundVar = nullptr;
+
+    if (hasIdentity) {
+        boundVar = identityIt->second.front();
+    } else {
+        for (const auto& [var, values] : _part._varMap) {
+            if (var->getDecl() == decl) {
+                boundVar = var;
+                break;
+            }
+        }
+    }
+
+    if (!boundVar) {
         return;
     }
 
-    llvm::SmallVector<mlir::Type> dedupedTypes;
-    for (const mlir::Value column : dedupedColumns) {
-        dedupedTypes.push_back(column.getType());
-    }
+    registerValue(boundVar, column);
 
-    const mlir::Location loc = _opBuilder.getUnknownLoc();
-    auto distinctOp = _opBuilder.create<mlir::db::RemoveDuplicates>(loc, dedupedTypes, mlir::ValueRange{dedupedColumns});
-
-    // The dedup hands back one column per column it read, so its results take the place
-    // of the ones it was given and the constant columns stay as they were
-    const mlir::ResultRange results = distinctOp.getResults();
-    for (size_t resultIndex = 0; resultIndex < dedupedItems.size(); resultIndex++) {
-        projected[dedupedItems[resultIndex]] = results[resultIndex];
-    }
+    // The edge types published for the variable were read over the rows this column
+    // replaces, so they no longer line up with it: dropping them has the next read fetch
+    // them over this column instead
+    _part._edgeTypeMap.erase(boundVar);
 }
 
 void DBProgramGenerator::translateDistinctOverConstants(const Projection* projection,

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -572,6 +572,14 @@ private:
     void translateDistinctOverConstants(const Projection* projection,
                                         llvm::SmallVectorImpl<mlir::Value>& projected);
 
+    // Binds every variable a dedup projected to the column the dedup handed back, so that
+    // a key read off one - the c.name of WITH DISTINCT c, p ORDER BY c.name - is computed
+    // over the rows that survived rather than over the ones the match produced
+    void rebindDistinctColumns(const Projection* projection, llvm::ArrayRef<mlir::Value> projected);
+
+    // Replaces the column @param decl is read through, wherever the part publishes it
+    void rebindVariableColumn(const VarDecl* decl, mlir::Value column);
+
     void runPasses();
 
     // Whether the EXPLAIN prefix asked about a pass at all, which is what decides

--- a/test/query/analyzer/DistinctOrderByTest.cpp
+++ b/test/query/analyzer/DistinctOrderByTest.cpp
@@ -14,13 +14,15 @@ using namespace db;
 namespace {
 
 const std::string_view unprojectedKeyReason =
-    "ORDER BY with DISTINCT may only order by returned columns";
+    "ORDER BY with DISTINCT may only order by expressions over the returned columns";
 
 }
 
-// After a DISTINCT only the returned columns are left, so an ORDER BY key the projection
-// does not carry names a column the dedup dropped. The rule is a property of the query
-// alone, so the analyzer is what turns those queries away, before any plan is generated.
+// After a DISTINCT only the returned columns are left, so an ORDER BY key has to be
+// computable from them: a key over a variable the projection carries holds one value per
+// row the dedup kept, and one over a variable it dropped holds none. The rule is a
+// property of the query alone, so the analyzer is what turns those queries away, before
+// any plan is generated.
 class DistinctOrderByTest : public turing::test::TuringTest {
 public:
     void initialize() override {
@@ -63,16 +65,32 @@ protected:
     std::unique_ptr<ProcedureManager> _procedures;
 };
 
-// The key is a property of a returned node, which the projection does not carry: it was
-// read once per pre-dedup row, so it no longer lines up with the rows that survived
-TEST_F(DistinctOrderByTest, rejectsUnprojectedKey) {
-    expectRejected("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b.name", unprojectedKeyReason);
+// The key reads a property of a node the projection returns. b survives the dedup, so
+// b.name holds one value per row it kept and the key is read off the deduped column
+TEST_F(DistinctOrderByTest, acceptsAPropertyOfAProjectedVariable) {
+    EXPECT_NO_THROW(analyzeQuery("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b.name"));
+}
+
+TEST_F(DistinctOrderByTest, acceptsAPropertyKeyBesideAProjectedOne) {
+    EXPECT_NO_THROW(analyzeQuery("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b, b.name"));
+}
+
+// a is in no column the projection carries, so the dedup drops it whole: a.name was read
+// once per pre-dedup row and no longer lines up with the rows that survived
+TEST_F(DistinctOrderByTest, rejectsAKeyOverAnUnprojectedVariable) {
+    expectRejected("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY a.name", unprojectedKeyReason);
 }
 
 // One projected key does not excuse the other: the query is rejected on the key the
 // dedup dropped, wherever it sits among the keys
-TEST_F(DistinctOrderByTest, rejectsUnprojectedKeyAmongProjectedOnes) {
-    expectRejected("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b, b.name", unprojectedKeyReason);
+TEST_F(DistinctOrderByTest, rejectsAnUnprojectedKeyAmongProjectedOnes) {
+    expectRejected("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b, a.name", unprojectedKeyReason);
+}
+
+// The projection returns a value computed from b rather than b, so b itself does not
+// survive it and b.age has no value per deduped row to order on
+TEST_F(DistinctOrderByTest, rejectsAKeyOverAVariableTheProjectionDropped) {
+    expectRejected("MATCH (a)-->(b) RETURN DISTINCT b.name ORDER BY b.age", unprojectedKeyReason);
 }
 
 TEST_F(DistinctOrderByTest, acceptsDistinctWithoutOrderBy) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2257,3 +2257,15 @@ add_call_v3_test(test_query_ir_neo4j_case_example Neo4jCaseExampleTest.cpp)
 
 # type() over an edge, run end to end against simpledb.
 add_call_v3_test(test_query_ir_edge_type_function EdgeTypeFunctionTest.cpp)
+
+# An aggregate aliased to the name it reads, run end to end against simpledb.
+add_turing_test(test_query_ir_shadowed_alias ShadowedAliasTest.cpp)
+target_link_libraries(test_query_ir_shadowed_alias PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_shadowed_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -1075,6 +1075,16 @@ target_link_libraries(test_query_ir_distinct PRIVATE
         MLIRParser)
 target_include_directories(test_query_ir_distinct PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_turing_test(test_query_ir_distinct_order_by_property DistinctOrderByPropertyTest.cpp)
+target_link_libraries(test_query_ir_distinct_order_by_property PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_distinct_order_by_property PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_turing_test(test_query_ir_count_distinct CountDistinctTest.cpp)
 target_link_libraries(test_query_ir_count_distinct PRIVATE
         turing_db_s

--- a/test/query/ir/DistinctOrderByPropertyTest.cpp
+++ b/test/query/ir/DistinctOrderByPropertyTest.cpp
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "JobSystem.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+#include "writers/GraphWriter.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// ORDER BY over a property of a variable a DISTINCT projects. The dedup keeps one row per
+// distinct (c, p) pair, and c.name is one value per pair, so the key is read off the
+// deduped column rather than the rows the match produced.
+class DistinctOrderByPropertyTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        buildGraph(system.createGraph(_graphName));
+    }
+
+    // Five Persons over three Cities. Person 2 is located in Antwerp over two edges, so the
+    // match produces its pair twice and the answer depends on the dedup. Person 7 also
+    // works in Ghent, which is the one edge of a second type.
+    void buildGraph(Graph* graph) {
+        JobSystem jobSystem;
+        jobSystem.init();
+
+        GraphWriter writer(graph, &jobSystem);
+
+        const auto addCity = [&](std::string_view name) {
+            const NodeID city = writer.addNode({"City"});
+            writer.addNodeProperty<types::String>(city, "name", std::string_view(name));
+            return city;
+        };
+
+        const NodeID antwerp = addCity("Antwerp");
+        const NodeID brussels = addCity("Brussels");
+        const NodeID ghent = addCity("Ghent");
+
+        const auto addEdge = [&](std::string_view type, NodeID person, NodeID city, std::string_view name) {
+            const EdgeRecord edge = writer.addEdge(std::string(type), person, city);
+            writer.addEdgeProperty<types::String>(edge, "name", std::string_view(name));
+        };
+
+        const auto addPerson = [&](int64_t id, NodeID city, std::string_view edgeName) {
+            const NodeID person = writer.addNode({"Person"});
+            writer.addNodeProperty<types::Int64>(person, "id", std::move(id));
+            addEdge("IS_LOCATED_IN", person, city, edgeName);
+            return person;
+        };
+
+        addPerson(10, antwerp, "a-ten-antwerp");
+        const NodeID second = addPerson(2, antwerp, "b-two-antwerp");
+        const NodeID seventh = addPerson(7, brussels, "c-seven-brussels");
+        addPerson(3, antwerp, "d-three-antwerp");
+        addPerson(5, ghent, "e-five-ghent");
+
+        addEdge("IS_LOCATED_IN", second, antwerp, "f-two-antwerp-again");
+        addEdge("WORKS_IN", seventh, ghent, "g-seven-ghent");
+
+        writer.submit();
+        jobSystem.terminate();
+    }
+
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << status.getError();
+
+        std::string description;
+        describeRows(sink.rows(), description);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\nactual rows:\n" << description;
+    }
+
+    const std::string _graphName = "cities";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The three lowest Person ids of the first City by name. Charged to the six rows the match
+// produced instead of the five the dedup left, the answer would repeat Antwerp 2.
+TEST_F(DistinctOrderByPropertyTest, ordersDistinctPairsByTheirProperties) {
+    expectRowsInOrder("MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person) "
+                      "WITH DISTINCT c, p ORDER BY c.name ASC, p.id ASC "
+                      "RETURN c.name, p.id LIMIT 3",
+                      {{"Antwerp", "2"}, {"Antwerp", "3"}, {"Antwerp", "10"}});
+}
+
+// The same query without the cut: five pairs, not the six the match produced. The id order
+// is the integer one, so 10 comes after 3.
+TEST_F(DistinctOrderByPropertyTest, dedupsThePairsTheMatchRepeats) {
+    expectRowsInOrder("MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person) "
+                      "WITH DISTINCT c, p ORDER BY c.name ASC, p.id ASC "
+                      "RETURN c.name, p.id",
+                      {{"Antwerp", "2"},
+                       {"Antwerp", "3"},
+                       {"Antwerp", "10"},
+                       {"Brussels", "7"},
+                       {"Ghent", "5"}});
+}
+
+// The key read over the deduped column descending, which is the same five pairs reversed
+TEST_F(DistinctOrderByPropertyTest, ordersDistinctPairsDescending) {
+    expectRowsInOrder("MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person) "
+                      "WITH DISTINCT c, p ORDER BY c.name DESC, p.id DESC "
+                      "RETURN c.name, p.id",
+                      {{"Ghent", "5"},
+                       {"Brussels", "7"},
+                       {"Antwerp", "10"},
+                       {"Antwerp", "3"},
+                       {"Antwerp", "2"}});
+}
+
+// A key computing over a property of a projected variable, not the property alone: p.id + 1
+// is determined by p exactly as p.id is, and is read off the deduped column too.
+TEST_F(DistinctOrderByPropertyTest, ordersDistinctPairsByAnExpressionOverAProperty) {
+    expectRowsInOrder("MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person) "
+                      "WITH DISTINCT c, p ORDER BY c.name ASC, p.id + 1 DESC "
+                      "RETURN c.name, p.id",
+                      {{"Antwerp", "10"},
+                       {"Antwerp", "3"},
+                       {"Antwerp", "2"},
+                       {"Brussels", "7"},
+                       {"Ghent", "5"}});
+}
+
+// One variable rather than a pair, and the cut charged to the sorted distinct rows: the
+// three lowest Person ids of the graph.
+TEST_F(DistinctOrderByPropertyTest, ordersASingleDistinctVariableByItsProperty) {
+    expectRowsInOrder("MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person) "
+                      "WITH DISTINCT p ORDER BY p.id ASC LIMIT 3 "
+                      "RETURN p.id",
+                      {{"2"}, {"3"}, {"5"}});
+}
+
+// The key tests the type of an edge the dedup kept. The self-join repeats every edge of a
+// Person who has two, so the seven distinct edges come from eleven matched rows: read over
+// those instead, the type would not line up with the edge it belongs to.
+TEST_F(DistinctOrderByPropertyTest, ordersDistinctEdgesByTheirType) {
+    expectRowsInOrder("MATCH (p:Person)-[e]->(c:City), (p)-->(c2:City) "
+                      "WITH DISTINCT e ORDER BY e:WORKS_IN DESC, e.name ASC "
+                      "RETURN e.name",
+                      {{"g-seven-ghent"},
+                       {"a-ten-antwerp"},
+                       {"b-two-antwerp"},
+                       {"c-seven-brussels"},
+                       {"d-three-antwerp"},
+                       {"e-five-ghent"},
+                       {"f-two-antwerp-again"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/DistinctTest.cpp
+++ b/test/query/ir/DistinctTest.cpp
@@ -857,13 +857,35 @@ TEST_F(DistinctTest, limitsDistinctRows) {
     EXPECT_EQ(std::unique(rows.begin(), rows.end()), rows.end());
 }
 
-// A key the projection does not carry cannot be honoured after the dedup: it was read
-// once per pre-dedup row, so it no longer lines up with the rows that survived. Cypher
-// rejects the query for the same reason, and so does the analyzer.
-TEST_F(DistinctTest, rejectsOrderByOnUnreturnedKey) {
-    DistinctNodeSink sink;
-    EXPECT_THROW(runQuery("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY b.name", &sink),
+// A property of a variable the dedup kept holds one value per row it kept, so the key is
+// read off the deduped column: the twelve distinct targets in name order.
+TEST_F(DistinctTest, ordersDistinctTargetsByAnUnreturnedProperty) {
+    expectNames("MATCH (a)-->(b) WITH DISTINCT b ORDER BY b.name RETURN b.name",
+                distinctTargetNames);
+}
+
+// The projection returns a value computed from b rather than b, so b itself is gone after
+// the dedup and b.age has no value per surviving row to order on.
+TEST_F(DistinctTest, rejectsOrderByOnAVariableTheProjectionDropped) {
+    DistinctNameSink sink;
+    EXPECT_THROW(runQuery("MATCH (a)-->(b) RETURN DISTINCT b.name ORDER BY b.age", &sink),
                  TuringException);
+}
+
+// a is in no column the projection carries, so the dedup drops it whole: it was read once
+// per pre-dedup row and no longer lines up with the rows that survived.
+TEST_F(DistinctTest, rejectsOrderByOnAnUnprojectedVariable) {
+    DistinctNodeSink sink;
+    EXPECT_THROW(runQuery("MATCH (a)-->(b) RETURN DISTINCT b ORDER BY a.name", &sink),
+                 TuringException);
+}
+
+// An aggregate key groups the projection as an aggregate item would, so the rows are one
+// per name before the dedup ever sees them and DISTINCT drops nothing. Gym is pointed at
+// three times and no other node more than twice, so it is the group the order opens on.
+TEST_F(DistinctTest, ordersDistinctGroupsByAnAggregateKey) {
+    const Names expected = {"Gym"};
+    expectNames("MATCH (a)-->(b) RETURN DISTINCT b.name ORDER BY count(b) DESC LIMIT 1", expected);
 }
 
 // A DISTINCT projection ordered by the very expression it returns. The key and the
@@ -877,6 +899,18 @@ TEST_F(DistinctTest, dedupsAndOrdersAnExpression) {
              &sink);
 
     const OptInt64Values expected = {0, std::nullopt};
+    EXPECT_EQ(sink.values(), expected);
+}
+
+// The key spells the returned item out again and computes over it. The two are separate
+// trees, so the key is only read off the deduped column once it is matched to the item:
+// computed afresh it would read the eighteen edges the dedup was given. A null sorts
+// after every value, so descending it comes first.
+TEST_F(DistinctTest, dedupsAndOrdersByAnExpressionOverAProjectedItem) {
+    DistinctOptInt64Sink sink;
+    runQuery("MATCH (a)-[e]->(b) RETURN DISTINCT e.duration ORDER BY e.duration + 1 DESC", &sink);
+
+    const OptInt64Values expected = {std::nullopt, 200, 20, 15, 10};
     EXPECT_EQ(sink.values(), expected);
 }
 

--- a/test/query/ir/OrderByAliasKeyTest.cpp
+++ b/test/query/ir/OrderByAliasKeyTest.cpp
@@ -23,7 +23,6 @@
 #include "NLOutputSink.h"
 #include "StorageDialect.h"
 
-#include "AnalyzeException.h"
 #include "CypherAST.h"
 #include "CypherAnalyzer.h"
 #include "CypherParser.h"
@@ -183,13 +182,13 @@ TEST_F(OrderByAliasKeyTest, aliasInsideACompoundKeyOrdersDescending) {
                     edgeDurationsDescending);
 }
 
-// A DISTINCT drops rows before the sort sees them, so a key computed from an item would
-// be one value per row the dedup was given rather than per row it kept. The analyzer
-// turns those keys away, which is what leaves the column of an item safe to key on.
-TEST_F(OrderByAliasKeyTest, aliasInsideACompoundKeyIsRejectedUnderDistinct) {
-    const std::string_view query =
-        "MATCH (a)-[e]->(b) RETURN DISTINCT e.duration AS edgeDuration ORDER BY edgeDuration + 1";
+// A DISTINCT drops rows before the sort sees them, so the key is computed over the
+// deduped column: one value per row the dedup kept. The eighteen edges carry five
+// distinct durations, and the null closes the order.
+TEST_F(OrderByAliasKeyTest, aliasInsideACompoundKeyOrdersUnderDistinct) {
+    const OptInt64Values expected = {10, 15, 20, 200, std::nullopt};
 
-    OrderedOptInt64Sink sink;
-    EXPECT_THROW(runQuery(query, &sink), AnalyzeException);
+    expectDurations("MATCH (a)-[e]->(b) RETURN DISTINCT e.duration AS edgeDuration "
+                    "ORDER BY edgeDuration + 1",
+                    expected);
 }

--- a/test/query/ir/ShadowedAliasTest.cpp
+++ b/test/query/ir/ShadowedAliasTest.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// An item may be aliased to a name its own expression reads: WITH sum(fans) AS fans folds
+// the fans column the barrier before it published and publishes the total under that name
+// again. The alias names a column of its own, so the aggregate reads the one it was given
+// and reduces nothing that is already reduced.
+class ShadowedAliasTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRowsInOrder(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectRejected(std::string_view query, std::string_view reason) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_FALSE(status.isOk()) << "query accepted: " << query;
+
+        const std::string& error = status.getError();
+
+        EXPECT_NE(error.find(reason), std::string::npos)
+            << "query: " << query << "\nerror: " << error;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// Fifteen INTERESTED_IN edges reach ten interests. count(p) behind the (i, p) key is 1 on
+// every row, so the sum behind i alone is how many people reach that interest, and Gym is
+// reached by three, more than any other
+TEST_F(ShadowedAliasTest, sumsAGroupedCountUnderTheNameItReads) {
+    expectRowsInOrder("MATCH (i:Interest)<-[:INTERESTED_IN]-(p:Person) "
+                      "WITH i, p, count(p) AS fans "
+                      "WITH i, sum(fans) AS fans "
+                      "RETURN i.name, fans ORDER BY fans DESC LIMIT 1",
+                      {{"Gym", "3"}});
+}
+
+// The WHERE reads the name the aggregate took over, so it reads the sum: Bio, Computers
+// and Cooking are reached by two people each, Gym by three
+TEST_F(ShadowedAliasTest, filtersOnTheNameTheAggregateTookOver) {
+    expectRows("MATCH (i:Interest)<-[:INTERESTED_IN]-(p:Person) "
+               "WITH i, p, count(p) AS fans "
+               "WITH i, sum(fans) AS fans WHERE fans > 1 "
+               "RETURN i.name, fans",
+               {{"Bio", "2"}, {"Computers", "2"}, {"Cooking", "2"}, {"Gym", "3"}});
+}
+
+// The same shadowing on a RETURN: the ten published counts sum back to the fifteen edges
+// they were counted from
+TEST_F(ShadowedAliasTest, sumsAPublishedCountUnderItsOwnNameOnReturn) {
+    expectRows("MATCH (i:Interest)<-[:INTERESTED_IN]-(p:Person) "
+               "WITH i.name AS interest, count(p) AS fans "
+               "RETURN sum(fans) AS fans",
+               {{"15"}});
+}
+
+// The shadowing alias behind a grouping key, which is the shape the two barriers above
+// reduce to: each person's reach is summed back under the name it was published with
+TEST_F(ShadowedAliasTest, groupsASumUnderTheNameItReads) {
+    expectRows("MATCH (i:Interest)<-[:INTERESTED_IN]-(p:Person) "
+               "WITH p.name AS person, i.name AS interest, count(i) AS reach "
+               "RETURN person, sum(reach) AS reach",
+               {{"Adam", "2"},
+                {"Cyrus", "2"},
+                {"Doruk", "1"},
+                {"Luc", "2"},
+                {"Martina", "1"},
+                {"Maxime", "2"},
+                {"Remy", "3"},
+                {"Suhas", "2"}});
+}
+
+// A second item reading the alias of an aggregate is still an aggregate over an aggregate,
+// whether or not that alias shadows a name the barrier published
+TEST_F(ShadowedAliasTest, rejectsAnAggregateOverAnAliasOfTheSameProjection) {
+    expectRejected("MATCH (i:Interest)<-[:INTERESTED_IN]-(p:Person) "
+                   "WITH i.name AS interest, count(p) AS fans "
+                   "RETURN sum(fans) AS fans, count(fans)",
+                   "Aggregate functions may not be nested");
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Order a DISTINCT projection by any expression over the columns it returns, and alias an aggregate to the name it reads.

The analyzer required the key to be a returned column and rejected everything else and notably order by a property not returned.

```
MATCH (c:City)<-[:IS_LOCATED_IN]-(p:Person)
WITH DISTINCT c, p ORDER BY c.name ASC, p.id ASC
RETURN c.name, p.id LIMIT 3

RETURN DISTINCT b ORDER BY b.name
RETURN DISTINCT b ORDER BY b:Person
RETURN DISTINCT e ORDER BY e:KNOWS_WELL
RETURN DISTINCT e.duration ORDER BY e.duration + 1
RETURN DISTINCT b.name AS n ORDER BY n + 1
RETURN DISTINCT b ORDER BY count(b)

RETURN DISTINCT b ORDER BY a.name
RETURN DISTINCT b.name ORDER BY b.age
ORDER BY with DISTINCT may only order by expressions over the returned columns.
```

An alias spelling a name already in scope reused its declaration, so `sum(x) AS x` read its own alias and the analyzer called it an aggregate over an aggregate.

```
MATCH (p:Person)<-[:HAS_CREATOR]-(m:Message)
WITH p, m, count(m) AS perMessage
WITH p, sum(perMessage) AS perMessage
RETURN p.id, perMessage ORDER BY perMessage DESC LIMIT 2

150  227
6    150

Aggregate functions may not be nested: the argument of 'sum' names an aggregate of the same projection
```
