### PR TITLE
Implement UNWIND of variables

### DIFF
--- a/query/AST/Literal.cpp
+++ b/query/AST/Literal.cpp
@@ -1,6 +1,9 @@
 #include "Literal.h"
 
+#include <algorithm>
+
 #include "CypherAST.h"
+#include "expr/LiteralExpr.h"
 
 using namespace db;
 
@@ -173,6 +176,23 @@ ListLiteral* ListLiteral::create(CypherAST* ast) {
 
 void ListLiteral::addItem(Expr* item) {
     _items.push_back(item);
+}
+
+bool ListLiteral::isLiteralTree() const {
+    const auto isLiteralItem = [](const Expr* item) {
+        if (item->getKind() != Expr::Kind::LITERAL) {
+            return false;
+        }
+
+        const Literal* literal = static_cast<const LiteralExpr*>(item)->getLiteral();
+        if (literal->getKind() != Kind::LIST) {
+            return true;
+        }
+
+        return static_cast<const ListLiteral*>(literal)->isLiteralTree();
+    };
+
+    return std::ranges::all_of(_items, isLiteralItem);
 }
 
 MapLiteral::MapLiteral()

--- a/query/AST/Literal.h
+++ b/query/AST/Literal.h
@@ -171,6 +171,11 @@ public:
 
     void addItem(Expr* item);
 
+    /// Whether every item is a literal, at any depth - what makes the whole list a value
+    /// known without reading a row, rather than one built per row out of what its items
+    /// read.
+    bool isLiteralTree() const;
+
     bool empty() const { return _items.empty(); }
     size_t size() const { return _items.size(); }
 

--- a/query/AST/expr/ExprChildren.cpp
+++ b/query/AST/expr/ExprChildren.cpp
@@ -1,6 +1,7 @@
 #include "ExprChildren.h"
 
 #include "FunctionInvocation.h"
+#include "Literal.h"
 
 #include "BinaryExpr.h"
 #include "CaseExpr.h"
@@ -9,6 +10,7 @@
 #include "FunctionInvocationExpr.h"
 #include "IndexExpr.h"
 #include "ListExpr.h"
+#include "LiteralExpr.h"
 #include "StringExpr.h"
 #include "UnaryExpr.h"
 
@@ -112,6 +114,22 @@ bool ExprChildren::collect(const Expr* expr, std::vector<const Expr*>& children)
         }
         break;
 
+        case Expr::Kind::LITERAL: {
+            const Literal* literal = static_cast<const LiteralExpr*>(expr)->getLiteral();
+
+            // A map holds its values under keys rather than in a list this can hand back
+            if (literal->getKind() != Literal::Kind::LIST) {
+                return false;
+            }
+
+            for (const Expr* item : static_cast<const ListLiteral*>(literal)->items()) {
+                children.push_back(item);
+            }
+
+            return true;
+        }
+        break;
+
         case Expr::Kind::SYMBOL:
         case Expr::Kind::PROPERTY:
         case Expr::Kind::ENTITY_TYPES:
@@ -121,8 +139,8 @@ bool ExprChildren::collect(const Expr* expr, std::vector<const Expr*>& children)
         break;
 
         default:
-            // A path holds a pattern and a literal may hold a map, neither of which is a
-            // list of sub-expressions this can hand back
+            // A path holds a pattern, which is not a list of sub-expressions this can
+            // hand back
             return false;
         break;
     }

--- a/query/AST/stmt/UnwindStmt.cpp
+++ b/query/AST/stmt/UnwindStmt.cpp
@@ -1,36 +1,25 @@
 #include "UnwindStmt.h"
 
-#include <algorithm>
-
 #include "CypherAST.h"
 #include "Literal.h"
 #include "expr/LiteralExpr.h"
 
 using namespace db;
 
-namespace {
-
-bool isLiteralExpr(const Expr* expr) {
-    if (expr->getKind() != Expr::Kind::LITERAL) {
-        return false;
-    }
-
-    const Literal* literal = static_cast<const LiteralExpr*>(expr)->getLiteral();
-    if (literal->getKind() != Literal::Kind::LIST) {
-        return true;
-    }
-
-    const ListLiteral::Items& items = static_cast<const ListLiteral*>(literal)->items();
-    return std::ranges::all_of(items, isLiteralExpr);
-}
-
-}
-
 UnwindStmt::~UnwindStmt() {
 }
 
 bool UnwindStmt::unwindsLiteral() const {
-    return isLiteralExpr(_arg);
+    if (_arg->getKind() != Expr::Kind::LITERAL) {
+        return false;
+    }
+
+    const Literal* literal = static_cast<const LiteralExpr*>(_arg)->getLiteral();
+    if (literal->getKind() != Literal::Kind::LIST) {
+        return true;
+    }
+
+    return static_cast<const ListLiteral*>(literal)->isLiteralTree();
 }
 
 UnwindStmt* UnwindStmt::create(CypherAST* ast, Expr* expr, Symbol* sym) {

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -54,6 +54,16 @@ EvaluatedType unifiedBranchType(EvaluatedType carried, EvaluatedType branch) {
     return EvaluatedType::Invalid;
 }
 
+// The types a list is homogeneous in: the scalars a value column holds, the entities a
+// pattern binds - [n, m] is a list of nodes, as collect(n) gathers one - and the lists a
+// nesting is made of.
+bool namesAListElementType(EvaluatedType type) {
+    return convertibleToValueType(type)
+        || type == EvaluatedType::NodePattern
+        || type == EvaluatedType::EdgePattern
+        || type == EvaluatedType::List;
+}
+
 // The shape of the list these elements make: depth 1 over the one type they share, or
 // one level deeper than the lists they are. Elements that share no type - an empty list,
 // a mix of types, lists of differing shape - leave the leaf Invalid, which is what makes
@@ -87,7 +97,7 @@ ListShape sharedListShape(std::span<Expr* const> elements) {
         }
     }
 
-    if (!convertibleToValueType(shared) && shared != EvaluatedType::List) {
+    if (!namesAListElementType(shared)) {
         return ListShape(EvaluatedType::Invalid, 1);
     }
 
@@ -1245,17 +1255,10 @@ void ExprAnalyzer::analyzeListExpr(ListExpr* expr) {
 
 void ExprAnalyzer::analyzeListElements(Expr* expr, std::span<Expr* const> elements) {
     for (Expr* element : elements) {
-        // Analyzed before the literal check, so an element that is ill-formed - a name no
-        // pattern declares - is reported as that rather than as the gap it also falls in
         analyzeExpr(element);
 
-        if (element->getKind() != Expr::Kind::LITERAL) {
-            throwError("Non-literal list elements are not yet supported", element);
-        }
-
-        // An element is an expression of its own, so its flags are the list's. Elements
-        // are literals today, and a map literal is one: the {age: n.age} of
-        // ORDER BY [{age: n.age}] reads a row through its value
+        // An element is an expression of its own, so its flags are the list's: the n of
+        // [n, m] reads a row, and so does the {age: n.age} of ORDER BY [{age: n.age}]
         if (element->isDynamic()) {
             expr->setDynamic();
         }

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -446,13 +446,18 @@ mlir::Type sharedAttrType(llvm::ArrayRef<mlir::Attribute> elements) {
 
 // The element type of the lists a db.make_list builds: the one type its element columns
 // name, or the type-erased tagged scalar where they name no single one. A column whose own
-// type is resolved during lowering names `none`, which is the type such columns share - so
-// the verdict is taken again over the resolved chunks when the op is lowered.
+// type is resolved during lowering names `none`, and no verdict can be taken against a
+// type that is not known yet: the whole list stays `none` and lowering takes the verdict
+// over the resolved chunks.
 mlir::Type sharedColumnElement(mlir::MLIRContext* context, llvm::ArrayRef<mlir::Value> columns) {
     mlir::Type shared;
 
     for (const mlir::Value column : columns) {
         const mlir::Type element = mlir::cast<mlir::db::ColumnType>(column.getType()).getType();
+
+        if (mlir::isa<mlir::NoneType>(element)) {
+            return element;
+        }
 
         if (!shared) {
             shared = element;

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -444,6 +444,26 @@ mlir::Type sharedAttrType(llvm::ArrayRef<mlir::Attribute> elements) {
     return std::ranges::all_of(elements, hasFirstType) ? firstType : nullptr;
 }
 
+// The element type of the lists a db.make_list builds: the one type its element columns
+// name, or the type-erased tagged scalar where they name no single one. A column whose own
+// type is resolved during lowering names `none`, which is the type such columns share - so
+// the verdict is taken again over the resolved chunks when the op is lowered.
+mlir::Type sharedColumnElement(mlir::MLIRContext* context, llvm::ArrayRef<mlir::Value> columns) {
+    mlir::Type shared;
+
+    for (const mlir::Value column : columns) {
+        const mlir::Type element = mlir::cast<mlir::db::ColumnType>(column.getType()).getType();
+
+        if (!shared) {
+            shared = element;
+        } else if (shared != element) {
+            return mlir::storage::ListElementType::get(context);
+        }
+    }
+
+    return shared;
+}
+
 mlir::Value findVarOrThrow(const DBProgramGenerator::VariableIdentityMap& map,
                         const VariableDependency* var) {
     const auto findIt = map.find(var);
@@ -754,6 +774,10 @@ mlir::Attribute DBProgramGenerator::listElementAttr(const Literal* literal) {
 }
 
 mlir::Value DBProgramGenerator::translateListLiteral(const ListLiteral* list) {
+    if (!list->isLiteralTree()) {
+        return translateListOfColumns(list);
+    }
+
     llvm::SmallVector<mlir::Attribute> elements;
     translateListElements(list, elements);
 
@@ -764,6 +788,22 @@ mlir::Value DBProgramGenerator::translateListLiteral(const ListLiteral* list) {
                                                                            _opBuilder.getArrayAttr(elements));
 
     return constant.getResult();
+}
+
+mlir::Value DBProgramGenerator::translateListOfColumns(const ListLiteral* list) {
+    llvm::SmallVector<mlir::Value> elementColumns;
+    for (const Expr* item : list->items()) {
+        elementColumns.push_back(getOrTranslateExprColumn(item));
+    }
+
+    const mlir::Type elementType = sharedColumnElement(_mlirCtxt, elementColumns);
+    const mlir::Type listType = mlir::storage::ListType::get(_mlirCtxt, elementType);
+
+    mlir::db::MakeList makeList = _opBuilder.create<mlir::db::MakeList>(_opBuilder.getUnknownLoc(),
+                                                                        allocColumnType(listType),
+                                                                        mlir::ValueRange {elementColumns});
+
+    return makeList.getResult();
 }
 
 template<typename EdgeOp>

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -721,8 +721,13 @@ private:
     // element has to have
     mlir::Attribute listElementAttr(const Literal* literal);
 
-    // The column holding a list literal's value: the one list, standing for every row
+    // The column holding a list literal's value: the one list, standing for every row -
+    // or, where an item is read per row, one list per row
     mlir::Value translateListLiteral(const ListLiteral* list);
+
+    // The column of the lists a db.make_list builds out of the column each item rides:
+    // what a list whose items are not all literals evaluates to
+    mlir::Value translateListOfColumns(const ListLiteral* list);
 
     void addScanNodes(const VariableDependency* var);
 

--- a/query/ir/dialect/db/DBOps.cpp
+++ b/query/ir/dialect/db/DBOps.cpp
@@ -782,6 +782,24 @@ LogicalResult Unwind::verify() {
     return success();
 }
 
+// There is a column for the list to be built out of, and what the op produces is a list.
+LogicalResult MakeList::verify() {
+    if (getElements().empty()) {
+        return emitOpError("requires at least one element column");
+    }
+
+    const ColumnType resultColumn = llvm::dyn_cast<ColumnType>(getResult().getType());
+    if (!resultColumn) {
+        return emitOpError("result must be a column");
+    }
+
+    if (!llvm::isa<storage::ListType>(resultColumn.getType())) {
+        return emitOpError("result must be a column of lists");
+    }
+
+    return success();
+}
+
 // The unwound column's element type is the homogeneity verdict: a type-erased
 // list_element column accepts any elements, a typed one requires them to share that one
 // type - the shared check the const_list verifier runs too.

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -354,6 +354,51 @@ def Unwind : TuringOp<"unwind", [Pure]> {
 }
 
 /**
+* MakeList
+*/
+def MakeList : TuringOp<"make_list", [Pure]> {
+  let summary = "Build one list per row out of the row's cell in each element column";
+
+  let description = [{
+    The list `[n, m]` whose elements are read per row rather than known at plan time -
+    the row-varying form db.constant's array of literals is the constant case of. It
+    reads one column per element and produces one list cell per row:
+
+      %xs = db.make_list(%n, %m) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+                                -> !db.column<!storage.list<!storage.node_id>>
+
+    Row r of the result is the list of row r of each operand, in operand order. A cell
+    is a view over the query's list buffer, as an nl.collect drain's is, so a row copies
+    in O(1) however long the list. An operand holding one value for every row rather
+    than one per row is laid out over the rows during lowering, so `[n, 1]` gives every
+    row a two-element list.
+
+    The result element type is the homogeneity verdict, as db.unwind_const's is: columns
+    that agree give a list of that type, columns that disagree a list of type-erased
+    tagged scalars, matching Cypher's LIST OF ANY. A column whose own type is resolved
+    during lowering - a property fetch's - names none here, so the verdict is taken
+    again over the resolved chunks when the op is lowered:
+
+      %xs = db.make_list(%age, %name) : (!db.column<none>, !db.column<none>)
+                                     -> !db.column<!storage.list<none>>
+
+    `UNWIND [n, m] AS x` is this op feeding db.unwind, which spreads each cell back into
+    one row per element.
+  }];
+
+  let arguments = (ins Variadic<Column>:$elements);
+  let results   = (outs Column:$result);
+  let hasVerifier = 1;
+
+  // The element columns print inside the parens, as db.collect's columns do; the operand
+  // and result types follow as a function type, so the list is spelled beside the columns
+  // it was built from.
+  let assemblyFormat = [{
+    `(` $elements `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : TuringOp<"scan_edges", [Pure, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -376,8 +376,9 @@ def MakeList : TuringOp<"make_list", [Pure]> {
     The result element type is the homogeneity verdict, as db.unwind_const's is: columns
     that agree give a list of that type, columns that disagree a list of type-erased
     tagged scalars, matching Cypher's LIST OF ANY. A column whose own type is resolved
-    during lowering - a property fetch's - names none here, so the verdict is taken
-    again over the resolved chunks when the op is lowered:
+    during lowering - a property fetch's - names none here, and no verdict is taken
+    against a type that is not known yet: one such column makes the whole list none, and
+    lowering takes the verdict over the resolved chunks:
 
       %xs = db.make_list(%age, %name) : (!db.column<none>, !db.column<none>)
                                      -> !db.column<!storage.list<none>>

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -378,6 +378,22 @@ LogicalResult DistinctFilter::verify() {
     return success();
 }
 
+// An nl.make_list must read at least one element chunk: there would be no cell to build a
+// list out of, and nothing to size the step from. A list known without reading a row is an
+// nl.constant instead.
+LogicalResult MakeList::verify() {
+    if (getElements().empty()) {
+        return emitOpError("requires at least one element chunk");
+    }
+
+    const Type elementType = llvm::cast<ChunkType>(getResult().getType()).getElementType();
+    if (!llvm::isa<storage::ListType>(elementType)) {
+        return emitOpError("result must be a chunk of lists");
+    }
+
+    return success();
+}
+
 void For::build(OpBuilder& builder, OperationState& state, Value iterator) {
     For::build(builder, state, iterator, Value());
 }

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -237,6 +237,33 @@ def Unwind : NLOp<"unwind", [Pure]> {
 }
 
 /**
+* MakeList
+*/
+def MakeList : NLOp<"make_list", [Pure, RowAlignedThroughOperands]> {
+  let summary = "Row-wise build of one list per row out of every element chunk";
+  let description = [{
+    Imperative counterpart of db.make_list. Row r of the result is the list of row r of
+    each operand, in operand order, written into the query's list buffer as one
+    contiguous run:
+
+      %xs = nl.make_list(%n, %m)
+              : (!nl.chunk<!storage.node_id>, !nl.chunk<!storage.node_id>)
+              -> !nl.chunk<!storage.list<!storage.node_id>>
+
+    Every operand carries rows - lowering lays a constant one out over them first - so
+    the cells are read at the same row index and the chunk is as long as they are. The
+    element type is the list of the type the operands share, or of type-erased tagged
+    scalars where they disagree, and is spelled out rather than inferred, as nl.unwind's
+    is.
+  }];
+
+  let arguments = (ins Variadic<NLChunk>:$elements);
+  let results   = (outs NLChunk:$result);
+
+  let assemblyFormat = "`(` $elements `)` attr-dict `:` functional-type(operands, results)";
+}
+
+/**
 * ScanEdges
 */
 def ScanEdges : NLOp<"scan_edges", [Pure, InferTypeOpAdaptor]> {

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -259,6 +259,7 @@ def MakeList : NLOp<"make_list", [Pure, RowAlignedThroughOperands]> {
 
   let arguments = (ins Variadic<NLChunk>:$elements);
   let results   = (outs NLChunk:$result);
+  let hasVerifier = 1;
 
   let assemblyFormat = "`(` $elements `)` attr-dict `:` functional-type(operands, results)";
 }

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -193,8 +193,8 @@ void unwindListValueEmit(const Column* source,
     }
 }
 
-// The present-in-every-row sibling of unwindListValueEmit: an entity ID and a nested list
-// are always there, so the elements drain into a plain column rather than a nullable one.
+// The present-in-every-row sibling of unwindListValueEmit: a nested list is always there,
+// so the elements drain into a plain column rather than a nullable one.
 template <typename Element>
 void unwindListPlainEmit(const Column* source,
                          const ColumnVector<size_t>* rows,
@@ -214,6 +214,38 @@ void unwindListPlainEmit(const Column* source,
         bioassert(element.getTag() == expectedTag, "Unwound element does not have the unwound list's element type.");
 
         outputRaw[index] = element.getAs<Element>();
+    }
+}
+
+// The entity sibling of unwindListPlainEmit: an ID column spells a null entity as an
+// invalid ID, so the tagged null a list holds drains back into one rather than tripping
+// the tag check.
+template <typename IDType>
+void unwindListValidIDEmit(const Column* source,
+                           const ColumnVector<size_t>* rows,
+                           const ColumnVector<size_t>* positions,
+                           Column* output) {
+    const std::vector<ListView>& lists = static_cast<const ColumnVector<ListView>*>(source)->getRaw();
+    const std::vector<size_t>& rowsRaw = rows->getRaw();
+    const std::vector<size_t>& positionsRaw = positions->getRaw();
+
+    std::vector<IDType>& outputRaw = static_cast<ColumnVector<IDType>*>(output)->getRaw();
+    outputRaw.resize(rowsRaw.size());
+
+    constexpr ListBufferTypeTag expectedTag = TypeToListBufferTag<IDType>::Tag;
+
+    for (size_t index = 0; index < rowsRaw.size(); index++) {
+        const ListElementView element = lists[rowsRaw[index]].elements()[positionsRaw[index]];
+        const ListBufferTypeTag tag = element.getTag();
+
+        if (tag == ListBufferTypeTag::Null) {
+            outputRaw[index] = IDType {};
+            continue;
+        }
+
+        bioassert(tag == expectedTag, "Unwound element does not have the unwound list's entity type.");
+
+        outputRaw[index] = element.getAs<IDType>();
     }
 }
 
@@ -2520,17 +2552,42 @@ ListBuffer<>::ListItemVariant valueListItem(const Column* input, size_t row, Loc
     return ListBuffer<>::ListItemVariant {*cell};
 }
 
-// The sibling of valueListItem for a column whose cells are present in every row: an
-// entity ID, and a nested list held as the one element it is.
+// The sibling of valueListItem for a column whose cells are present in every row: a
+// nested list, held as the one element it is.
 template <typename Element>
 ListBuffer<>::ListItemVariant plainListItem(const Column* input, size_t row, LocalMemory*) {
     return ListBuffer<>::ListItemVariant {(*static_cast<const ColumnVector<Element>*>(input))[row]};
+}
+
+// The entity sibling of valueListItem: an entity an OPTIONAL MATCH did not match is an
+// invalid ID, which is how a null entity is spelled, so it joins the list as the tagged
+// null rather than as the value 2^64-1 - the null collectValidIDFold drops instead.
+template <typename IDType>
+ListBuffer<>::ListItemVariant validIDListItem(const Column* input, size_t row, LocalMemory*) {
+    const IDType id = (*static_cast<const ColumnVector<IDType>*>(input))[row];
+    if (!id.isValid()) {
+        return ListBuffer<>::ListItemVariant {PropertyNull {}};
+    }
+
+    return ListBuffer<>::ListItemVariant {id};
 }
 
 // The sibling of valueListItem for a type-erased column: the cell already carries the tag
 // its value is stored under, so it goes into the list as the type that tag names.
 ListBuffer<>::ListItemVariant taggedColumnListItem(const Column* input, size_t row, LocalMemory*) {
     return taggedListItem((*static_cast<const ColumnVector<ListElementView>*>(input))[row]);
+}
+
+// The nullable sibling of taggedColumnListItem: a column an OPTIONAL MATCH padded, or one
+// an index read off a list, has no cell in every row.
+ListBuffer<>::ListItemVariant optTaggedColumnListItem(const Column* input, size_t row, LocalMemory*) {
+    const std::optional<ListElementView>& element =
+        (*static_cast<const ColumnOptVector<ListElementView>*>(input))[row];
+    if (!element.has_value()) {
+        return ListBuffer<>::ListItemVariant {PropertyNull {}};
+    }
+
+    return taggedListItem(*element);
 }
 
 // The sibling of valueListItem for a column that owns its characters - a CSV field's. The
@@ -4428,6 +4485,12 @@ void NLExecutor::runMakeList(NLExecutionContext*, NLFunctionData* data) {
     // Every element column is row-aligned with the others, so the first gives the rows
     const size_t rowCount = elements.front()._column->size();
 
+    const auto isRowAligned = [rowCount](const NLMakeListData::Element& element) {
+        return element._column->size() == rowCount;
+    };
+    bioassert(std::ranges::all_of(elements, isRowAligned),
+              "Element columns of a list build are not row-aligned.");
+
     std::vector<ListView>& outputRaw = static_cast<ColumnVector<ListView>*>(makeList->getResult())->getRaw();
     outputRaw.resize(rowCount);
 
@@ -4456,19 +4519,19 @@ NLListItemReadFunction NLExecutor::selectValueListItemRead(ValueType valueType) 
 }
 
 NLListItemReadFunction NLExecutor::selectNodeListItemRead() {
-    return &plainListItem<NodeID>;
+    return &validIDListItem<NodeID>;
 }
 
 NLListItemReadFunction NLExecutor::selectEdgeListItemRead() {
-    return &plainListItem<EdgeID>;
+    return &validIDListItem<EdgeID>;
 }
 
 NLListItemReadFunction NLExecutor::selectNestedListItemRead() {
     return &plainListItem<ListView>;
 }
 
-NLListItemReadFunction NLExecutor::selectTaggedListItemRead() {
-    return &taggedColumnListItem;
+NLListItemReadFunction NLExecutor::selectTaggedListItemRead(bool nullable) {
+    return nullable ? &optTaggedColumnListItem : &taggedColumnListItem;
 }
 
 NLListItemReadFunction NLExecutor::selectOwnedStringListItemRead(bool nullable) {
@@ -5274,11 +5337,11 @@ NLUnwindElementEmitFunction NLExecutor::selectListUnwindValueEmit(ValueType valu
 }
 
 NLUnwindElementEmitFunction NLExecutor::selectListUnwindNodeEmit() {
-    return &unwindListPlainEmit<NodeID>;
+    return &unwindListValidIDEmit<NodeID>;
 }
 
 NLUnwindElementEmitFunction NLExecutor::selectListUnwindEdgeEmit() {
-    return &unwindListPlainEmit<EdgeID>;
+    return &unwindListValidIDEmit<EdgeID>;
 }
 
 NLUnwindElementEmitFunction NLExecutor::selectListUnwindListEmit() {

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -161,8 +161,9 @@ void unwindListElementEmit(const Column* source,
 
 // Copy the elements one step covers out of a list column into a typed value column: each
 // output row is the element at its position in the list its source row holds. The list's
-// element type is the column's, so every element is present and shares that type - the
-// tag check is what holds a list whose elements disagree with it to that promise.
+// element type is the column's, so every element either carries that type or is the null
+// a list built out of a column with an absent cell holds - the tag check is what holds a
+// list whose elements disagree with both to that promise.
 template <typename Primitive>
 void unwindListValueEmit(const Column* source,
                          const ColumnVector<size_t>* rows,
@@ -179,7 +180,14 @@ void unwindListValueEmit(const Column* source,
 
     for (size_t index = 0; index < rowsRaw.size(); index++) {
         const ListElementView element = lists[rowsRaw[index]].elements()[positionsRaw[index]];
-        bioassert(element.getTag() == expectedTag, "Unwound element does not have the unwound list's value type.");
+        const ListBufferTypeTag tag = element.getTag();
+
+        if (tag == ListBufferTypeTag::Null) {
+            outputRaw[index] = std::nullopt;
+            continue;
+        }
+
+        bioassert(tag == expectedTag, "Unwound element does not have the unwound list's value type.");
 
         outputRaw[index] = element.getAs<Primitive>();
     }
@@ -2500,6 +2508,54 @@ void collectListEmit(const Column* values,
     }
 }
 
+// Read one cell of a nullable value column as the element it contributes to a list: the
+// value it holds, or the tagged null Cypher leaves in the list where the row has none.
+template <typename Primitive>
+ListBuffer<>::ListItemVariant valueListItem(const Column* input, size_t row, LocalMemory*) {
+    const std::optional<Primitive>& cell = (*static_cast<const ColumnOptVector<Primitive>*>(input))[row];
+    if (!cell.has_value()) {
+        return ListBuffer<>::ListItemVariant {PropertyNull {}};
+    }
+
+    return ListBuffer<>::ListItemVariant {*cell};
+}
+
+// The sibling of valueListItem for a column whose cells are present in every row: an
+// entity ID, and a nested list held as the one element it is.
+template <typename Element>
+ListBuffer<>::ListItemVariant plainListItem(const Column* input, size_t row, LocalMemory*) {
+    return ListBuffer<>::ListItemVariant {(*static_cast<const ColumnVector<Element>*>(input))[row]};
+}
+
+// The sibling of valueListItem for a type-erased column: the cell already carries the tag
+// its value is stored under, so it goes into the list as the type that tag names.
+ListBuffer<>::ListItemVariant taggedColumnListItem(const Column* input, size_t row, LocalMemory*) {
+    return taggedListItem((*static_cast<const ColumnVector<ListElementView>*>(input))[row]);
+}
+
+// The sibling of valueListItem for a column that owns its characters - a CSV field's. The
+// list stores a view rather than the characters, and the column refills on the next step,
+// so they are copied into the query's string buffer for the view to span.
+ListBuffer<>::ListItemVariant ownedStringListItem(const Column* input, size_t row, LocalMemory* memory) {
+    const std::string& owned = (*static_cast<const ColumnVector<std::string>*>(input))[row];
+    const std::span<const char> characters {owned.data(), owned.size()};
+
+    return ListBuffer<>::ListItemVariant {memory->stringBuffer().insert(characters)};
+}
+
+// The nullable sibling of ownedStringListItem: the label set labels(n) joins is owned and
+// absent on a node carrying none.
+ListBuffer<>::ListItemVariant optOwnedStringListItem(const Column* input, size_t row, LocalMemory* memory) {
+    const std::optional<std::string>& owned = (*static_cast<const ColumnOptVector<std::string>*>(input))[row];
+    if (!owned.has_value()) {
+        return ListBuffer<>::ListItemVariant {PropertyNull {}};
+    }
+
+    const std::span<const char> characters {owned->data(), owned->size()};
+
+    return ListBuffer<>::ListItemVariant {memory->stringBuffer().insert(characters)};
+}
+
 // The fold and the list emit an entity collect of this ID reads. The list emits through
 // the value path's template - its elements are the IDs the fold appended - so there is
 // no entity emit of its own.
@@ -4361,6 +4417,62 @@ void NLExecutor::runCase(NLExecutionContext*, NLFunctionData* data) {
             writeDefault(result, defaultValue, row);
         }
     }
+}
+
+void NLExecutor::runMakeList(NLExecutionContext*, NLFunctionData* data) {
+    const NLMakeListData* makeList = static_cast<NLMakeListData*>(data);
+
+    const std::vector<NLMakeListData::Element>& elements = makeList->elements();
+    ListBuffer<>& listBuffer = makeList->getMemory()->listBuffer();
+
+    // Every element column is row-aligned with the others, so the first gives the rows
+    const size_t rowCount = elements.front()._column->size();
+
+    std::vector<ListView>& outputRaw = static_cast<ColumnVector<ListView>*>(makeList->getResult())->getRaw();
+    outputRaw.resize(rowCount);
+
+    std::vector<ListBuffer<>::ListItemVariant> row;
+    row.reserve(elements.size());
+
+    for (size_t rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        row.clear();
+        for (const NLMakeListData::Element& element : elements) {
+            row.push_back(element._read(element._column, rowIndex, makeList->getMemory()));
+        }
+
+        outputRaw[rowIndex] = listBuffer.insert(row);
+    }
+}
+
+NLListItemReadFunction NLExecutor::selectValueListItemRead(ValueType valueType) {
+    NLListItemReadFunction selected = nullptr;
+
+    const auto select = [&]<SupportedType T>() {
+        selected = &valueListItem<typename T::Primitive>;
+    };
+    ValueTypeDispatcher(valueType).execute(select);
+
+    return selected;
+}
+
+NLListItemReadFunction NLExecutor::selectNodeListItemRead() {
+    return &plainListItem<NodeID>;
+}
+
+NLListItemReadFunction NLExecutor::selectEdgeListItemRead() {
+    return &plainListItem<EdgeID>;
+}
+
+NLListItemReadFunction NLExecutor::selectNestedListItemRead() {
+    return &plainListItem<ListView>;
+}
+
+NLListItemReadFunction NLExecutor::selectTaggedListItemRead() {
+    return &taggedColumnListItem;
+}
+
+NLListItemReadFunction NLExecutor::selectOwnedStringListItemRead(bool nullable) {
+    return nullable ? &optOwnedStringListItem : &ownedStringListItem;
 }
 
 NLCaseResetFn NLExecutor::selectCaseReset(ValueType valueType) {

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -258,6 +258,10 @@ public:
     // holds, the default when none does, and an absent value when there is no default.
     static void runCase(NLExecutionContext* context, NLFunctionData* data);
 
+    // Build one list per row (nl.make_list): row r takes the cell each element column
+    // holds at r, in operand order, as one contiguous run of the query's list buffer.
+    static void runMakeList(NLExecutionContext* context, NLFunctionData* data);
+
     // Size the CASE result to the step's rows, all absent
     static NLCaseResetFn selectCaseReset(ValueType valueType);
 
@@ -557,6 +561,17 @@ public:
     static NLUnwindElementEmitFunction selectListUnwindListEmit();
     static NLUnwindElementEmitFunction selectTaggedUnwindElementEmit();
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
+
+    // The reads an nl.make_list takes one element out of a column with: a nullable value
+    // column gives the value it holds or a tagged null, an entity and a nested list the
+    // cell they hold in every row, a type-erased column the cell under the tag it already
+    // carries, and a column owning its characters a copy of them.
+    static NLListItemReadFunction selectValueListItemRead(ValueType valueType);
+    static NLListItemReadFunction selectNodeListItemRead();
+    static NLListItemReadFunction selectEdgeListItemRead();
+    static NLListItemReadFunction selectNestedListItemRead();
+    static NLListItemReadFunction selectTaggedListItemRead();
+    static NLListItemReadFunction selectOwnedStringListItemRead(bool nullable);
 
     // The fold and list-emit for an entity chunk of this kind, whose elements carry a
     // node or edge ID. An edge-type ID is no entity, so the kind is rejected.

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -563,14 +563,15 @@ public:
     static NLCollectListEmitFunction selectCollectListEmit(ValueType valueType);
 
     // The reads an nl.make_list takes one element out of a column with: a nullable value
-    // column gives the value it holds or a tagged null, an entity and a nested list the
-    // cell they hold in every row, a type-erased column the cell under the tag it already
-    // carries, and a column owning its characters a copy of them.
+    // column gives the value it holds or a tagged null, an entity the ID it holds or that
+    // same null where an OPTIONAL MATCH left the ID invalid, a nested list the cell it
+    // holds in every row, a type-erased column the cell under the tag it already carries,
+    // and a column owning its characters a copy of them.
     static NLListItemReadFunction selectValueListItemRead(ValueType valueType);
     static NLListItemReadFunction selectNodeListItemRead();
     static NLListItemReadFunction selectEdgeListItemRead();
     static NLListItemReadFunction selectNestedListItemRead();
-    static NLListItemReadFunction selectTaggedListItemRead();
+    static NLListItemReadFunction selectTaggedListItemRead(bool nullable);
     static NLListItemReadFunction selectOwnedStringListItemRead(bool nullable);
 
     // The fold and list-emit for an entity chunk of this kind, whose elements carry a

--- a/query/ir/interpreter/NLProgram.h
+++ b/query/ir/interpreter/NLProgram.h
@@ -3026,6 +3026,46 @@ private:
     NLCaseWriteFn _writeDefault {nullptr};
 };
 
+// Read the cell one element column holds at @param row as the value the list buffer
+// stores for it, tagged with the type it is. One per column kind, selected during
+// translation the way the case write families are. The memory is what a column owning its
+// characters copies them into, as the concatenation kernel copies its result.
+using NLListItemReadFunction = ListBuffer<>::ListItemVariant (*)(const Column* input,
+                                                                 size_t row,
+                                                                 LocalMemory* memory);
+
+// Row-wise list build (nl.make_list): row r of the result is the list of row r of every
+// element column, written into the query's list buffer as one contiguous run. Every
+// element column carries rows and they are row-aligned, so the first of them gives the
+// rows this step writes.
+class NLMakeListData : public NLFunctionData {
+public:
+    struct Element {
+        const Column* _column {nullptr};
+        NLListItemReadFunction _read {nullptr};
+    };
+
+    NLMakeListData(Column* result, LocalMemory* memory)
+        : _result(result),
+        _memory(memory)
+    {
+    }
+
+    Column* getResult() const { return _result; }
+    LocalMemory* getMemory() const { return _memory; }
+
+    const std::vector<Element>& elements() const { return _elements; }
+
+    void addElement(const Element& element) {
+        _elements.push_back(element);
+    }
+
+private:
+    Column* _result {nullptr};
+    LocalMemory* _memory {nullptr};
+    std::vector<Element> _elements;
+};
+
 using NLUnaryFunctionKernel = void (*)(NLExecutionContext* context, Column* result, const Column* input);
 
 class NLUnaryFunctionData : public NLFunctionData {

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -2004,7 +2004,9 @@ NLListItemReadFunction NLTranslator::selectListItemRead(mlir::Type chunkType) {
     } else if (mlir::isa<storage::ListType>(elementType)) {
         return NLExecutor::selectNestedListItemRead();
     } else if (mlir::isa<storage::ListElementType>(elementType)) {
-        return NLExecutor::selectTaggedListItemRead();
+        return NLExecutor::selectTaggedListItemRead(/*nullable=*/false);
+    } else if (isNullableListElement(elementType)) {
+        return NLExecutor::selectTaggedListItemRead(/*nullable=*/true);
     } else if (isOwnedStringElement(elementType)) {
         return NLExecutor::selectOwnedStringListItemRead(/*nullable=*/false);
     }

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -680,6 +680,8 @@ void NLTranslator::translateBlock(mlir::Block& block, NLStmtContainer* body) {
             translateToNullable(toNullable, body);
         } else if (nl::Case caseOp = mlir::dyn_cast<nl::Case>(operation)) {
             translateCase(caseOp, body);
+        } else if (nl::MakeList makeList = mlir::dyn_cast<nl::MakeList>(operation)) {
+            translateMakeList(makeList, body);
         } else if (lookupUnaryFunctionSelector(operation)) {
             translateUnaryFunction(&operation, body);
         } else if (lookupBinaryFunctionSelector(operation)) {
@@ -1990,6 +1992,52 @@ void NLTranslator::translateToNullable(nl::ToNullable toNullable, NLStmtContaine
 
     NLUnaryData* data = _program->allocFunctionData<NLUnaryData>(operand, result, fn);
     body->emplaceStmt(&NLExecutor::runUnary, data);
+}
+
+NLListItemReadFunction NLTranslator::selectListItemRead(mlir::Type chunkType) {
+    const mlir::Type elementType = mlir::cast<nl::ChunkType>(chunkType).getElementType();
+
+    if (mlir::isa<storage::NodeIDType>(elementType)) {
+        return NLExecutor::selectNodeListItemRead();
+    } else if (mlir::isa<storage::EdgeIDType>(elementType)) {
+        return NLExecutor::selectEdgeListItemRead();
+    } else if (mlir::isa<storage::ListType>(elementType)) {
+        return NLExecutor::selectNestedListItemRead();
+    } else if (mlir::isa<storage::ListElementType>(elementType)) {
+        return NLExecutor::selectTaggedListItemRead();
+    } else if (isOwnedStringElement(elementType)) {
+        return NLExecutor::selectOwnedStringListItemRead(/*nullable=*/false);
+    }
+
+    const auto nullableType = mlir::dyn_cast<storage::NullableType>(elementType);
+    if (!nullableType) {
+        throw IRException("nl.make_list requires a nullable value chunk for a scalar element column");
+    }
+
+    const mlir::Type valueElement = nullableType.getValueType();
+    if (isOwnedStringElement(valueElement)) {
+        return NLExecutor::selectOwnedStringListItemRead(/*nullable=*/true);
+    }
+
+    return NLExecutor::selectValueListItemRead(valueTypeFromElementType(valueElement));
+}
+
+void NLTranslator::translateMakeList(nl::MakeList makeList, NLStmtContainer* body) {
+    const mlir::Value resultValue = makeList.getResult();
+
+    Column* const result = allocColumnForChunkType(resultValue.getType());
+    _valueSlots[resultValue] = result;
+
+    NLMakeListData* data = _program->allocFunctionData<NLMakeListData>(result, _memory);
+
+    for (const mlir::Value elementChunk : makeList.getElements()) {
+        data->addElement(NLMakeListData::Element {
+            ._column = getColumn(elementChunk),
+            ._read = selectListItemRead(elementChunk.getType()),
+        });
+    }
+
+    body->emplaceStmt(&NLExecutor::runMakeList, data);
 }
 
 void NLTranslator::translateCase(nl::Case caseOp, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -679,6 +679,15 @@ private:
     void translateToNullable(mlir::nl::ToNullable toNullable, NLStmtContainer* body);
 
     void translateCase(mlir::nl::Case caseOp, NLStmtContainer* body);
+
+    // Allocates the list column an nl.make_list writes, and binds the read each element
+    // column's cells go into the list buffer through
+    void translateMakeList(mlir::nl::MakeList makeList, NLStmtContainer* body);
+
+    // The read one element column of an nl.make_list contributes its cell through, chosen
+    // by what the chunk holds
+    static NLListItemReadFunction selectListItemRead(mlir::Type chunkType);
+
     void translateUnaryFunction(mlir::Operation* op, NLStmtContainer* body);
 
     void translateBinaryFunction(mlir::Operation* op, NLStmtContainer* body);

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -787,6 +787,8 @@ void DBLowering::lowerOperation(mlir::Operation& operation) {
         lowerVectorSearch(vectorSearch);
     } else if (mlir::db::Unwind unwind = mlir::dyn_cast<mlir::db::Unwind>(operation)) {
         lowerUnwind(unwind);
+    } else if (mlir::db::MakeList makeList = mlir::dyn_cast<mlir::db::MakeList>(operation)) {
+        lowerMakeList(makeList);
     } else if (mlir::db::ScanEdges scanEdges = mlir::dyn_cast<mlir::db::ScanEdges>(operation)) {
         lowerScanEdges(scanEdges);
     } else if (mlir::db::ScanEdgesByType scanEdgesByType = mlir::dyn_cast<mlir::db::ScanEdgesByType>(operation)) {
@@ -1135,6 +1137,78 @@ void DBLowering::lowerUnwind(mlir::db::Unwind unwind) {
                                                   sourceChunk,
                                                   carriedChunks);
     buildLoopForSource(rows.getResult(), unwind.getOperation());
+}
+
+mlir::Type DBLowering::listedElementType(mlir::MLIRContext* context, llvm::ArrayRef<mlir::Value> chunks) {
+    mlir::Type shared;
+
+    for (const mlir::Value chunk : chunks) {
+        mlir::Type element = mlir::cast<nl::ChunkType>(chunk.getType()).getElementType();
+
+        // A cell that is absent is a tagged null of the list its neighbours are in, so a
+        // nullable column names the type of the value it holds.
+        if (const auto nullable = mlir::dyn_cast<storage::NullableType>(element)) {
+            element = nullable.getValueType();
+        }
+
+        // A column owning its characters puts a view of them in the list, the same string
+        // a borrowed column puts there, so the two agree
+        if (mlir::isa<storage::OwnedStringType>(element)) {
+            element = storage::StringType::get(context);
+        }
+
+        if (!shared) {
+            shared = element;
+        } else if (shared != element) {
+            return storage::ListElementType::get(context);
+        }
+    }
+
+    return shared;
+}
+
+void DBLowering::lowerMakeList(mlir::db::MakeList makeList) {
+    llvm::SmallVector<mlir::Value, 4> chunks;
+    for (const mlir::Value elementColumn : makeList.getElements()) {
+        chunks.push_back(mapValue(elementColumn));
+    }
+
+    // MakeList::verify guarantees an element column, so an empty operand list here means
+    // unverified IR - the defensive backstop lowerCollect keeps too.
+    if (chunks.empty()) {
+        throw IRException("db.make_list requires at least one element column");
+    }
+
+    // An element holding one value for every row rather than one per row is laid out over
+    // the rows the others carry, so every cell of a list is read at the same row index.
+    const mlir::Value cardinality = cardinalityDriver(chunks);
+
+    for (mlir::Value& chunk : chunks) {
+        chunk = rowAlignedChunk(chunk, cardinality);
+
+        // An entity ID, a list, a tagged cell and a CSV field's owned characters are
+        // present in every row and go into the list as they stand; only a scalar value
+        // column is read as nullable, the way lowerCollect reads the column it gathers.
+        const mlir::Type element = mlir::cast<nl::ChunkType>(chunk.getType()).getElementType();
+        const bool holdsCellsPresentInEveryRow = mlir::isa<storage::NodeIDType,
+                                                           storage::EdgeIDType,
+                                                           storage::ListType,
+                                                           storage::ListElementType,
+                                                           storage::OwnedStringType>(element);
+
+        if (!holdsCellsPresentInEveryRow) {
+            chunk = nullableValueChunk(chunk);
+        }
+    }
+
+    mlir::MLIRContext* const context = _builder.getContext();
+    const mlir::Type listType = storage::ListType::get(context, listedElementType(context, chunks));
+    const nl::ChunkType resultType = nl::ChunkType::get(context, listType);
+
+    setInsertionForNaryOp(chunks);
+
+    nl::MakeList lists = _builder.create<nl::MakeList>(_builder.getUnknownLoc(), resultType, chunks);
+    _valueMap[makeList.getResult()] = lists.getResult();
 }
 
 void DBLowering::lowerScanEdges(mlir::db::ScanEdges scanEdges) {

--- a/query/ir/lowering/DBLowering.h
+++ b/query/ir/lowering/DBLowering.h
@@ -184,6 +184,7 @@ private:
     void lowerLoadCSV(mlir::db::LoadCSV loadCSV);
     void lowerVectorSearch(mlir::db::VectorSearch vectorSearch);
     void lowerUnwind(mlir::db::Unwind unwind);
+    void lowerMakeList(mlir::db::MakeList makeList);
     void lowerScanEdges(mlir::db::ScanEdges scanEdges);
     void lowerScanEdgesByType(mlir::db::ScanEdgesByType scanEdgesByType);
     void lowerGetOutEdges(mlir::db::GetOutEdges getOutEdges);
@@ -471,6 +472,11 @@ private:
     // list_element when they share none, and any other source keeps its own element,
     // its cells being the elements themselves
     static mlir::Type unwoundElementType(mlir::MLIRContext* context, mlir::Type sourceElement);
+
+    // The element type of the lists @param chunks build: the one type every chunk carries,
+    // falling back to the type-erased list_element when they carry no single one - the
+    // homogeneity verdict taken over the resolved chunks rather than over the db columns
+    static mlir::Type listedElementType(mlir::MLIRContext* context, llvm::ArrayRef<mlir::Value> chunks);
 
     // The nl chunk a db value lowered to, and the block that holds a chunk
     mlir::Value mapValue(mlir::Value dbValue) const;

--- a/query/plan/ExprProgramGenerator.cpp
+++ b/query/plan/ExprProgramGenerator.cpp
@@ -318,6 +318,13 @@ Column* ExprProgramGenerator::generateLiteralExpr(const LiteralExpr* literalExpr
             const Literal* lit = literalExpr->getLiteral();
             const ListLiteral* list = static_cast<const ListLiteral*>(lit);
 
+            // The list is built once, here, and held as the one value every row reads, so
+            // an element that is read per row has nothing to put in it yet. The MLIR
+            // engine builds those lists a row at a time instead (db.make_list).
+            if (!list->isLiteralTree()) {
+                throw PlannerException("Non-literal list elements are not yet supported");
+            }
+
             std::vector<ListBuffer<>::ListItemVariant> items;
             items.reserve(list->size());
 

--- a/query/plan/PipelineGenerator.cpp
+++ b/query/plan/PipelineGenerator.cpp
@@ -162,6 +162,13 @@ struct AddLiteralToList {
 void fillList(const ListLiteral* list,
               ExprProgramGenerator* exprGen,
               std::vector<ListBuffer<>::ListItemVariant>& items) {
+    // The list is built once, here, and spread over the rows it makes, so an element that
+    // is read per row has nothing to put in it yet. The MLIR engine builds those lists a
+    // row at a time instead (db.make_list).
+    if (!list->isLiteralTree()) {
+        throw PlannerException("Non-literal list elements are not yet supported");
+    }
+
     using Types = ListableTypes;
     using AddItem = ColumnSingleDispatcher<Types::Allowed,
                                            AddLiteralToList,

--- a/test/query-test-suite/tests/return-list-exprs.json
+++ b/test/query-test-suite/tests/return-list-exprs.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "return [(10 + 3), (true AND false)]",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | return [(10 + 3), (true AND false)]\n       |         ^^^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | return [(10 + 3), (true AND false)]\n       |         ^^^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | return [(10 + 3), (true AND false)]\\n       |         ^^^^^^^^\\n-------* Non-literal list elements are not yet supported\"}"
+    "plan": "flowchart TD\n    0[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v6\n__expr__ (LITERAL): v0\n__expr__ (LITERAL): v1\n__expr__ (LITERAL): v3\n__expr__ (LITERAL): v4\n    `\"]\n    1[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->1",
+    "result": "PLAN ERROR\nNon-literal list elements are not yet supported",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"Non-literal list elements are not yet supported\"}"
   },
   "tags": [],
   "write-required": false

--- a/test/query-test-suite/tests/return-list-of-properties.json
+++ b/test/query-test-suite/tests/return-list-of-properties.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "MATCH (n) RETURN [n.name]",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) RETURN [n.name]\n       |                   ^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | MATCH (n) RETURN [n.name]\n       |                   ^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | MATCH (n) RETURN [n.name]\\n       |                   ^^^^^^\\n-------* Non-literal list elements are not yet supported\"}"
+    "plan": "flowchart TD\n    0[\"`\n        __SCAN_NODES__\n    `\"]\n    1[\"`\n        __VAR__\n        __name__: n\n    `\"]\n    2[\"`\n        __FILTER_NODE__\n    `\"]\n    3[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): v1\n    `\"]\n    4[\"`\n        __GET_PROPERTY_WITH_NULL__\n        __var__ n\n        __prop__ name\n    `\"]\n    5[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->2\n    1-->4\n    2-->1\n    3-->5\n    4-->3",
+    "result": "PLAN ERROR\nNon-literal list elements are not yet supported",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"Non-literal list elements are not yet supported\"}"
   },
   "tags": [
     "lists",

--- a/test/query-test-suite/tests/return-symbol-non-node-edge.json
+++ b/test/query-test-suite/tests/return-symbol-non-node-edge.json
@@ -3,9 +3,9 @@
   "graph": "simpledb",
   "query": "return [1,2,3,4] as embedding, [true, \"i love turingdb\", 20.3, embedding]",
   "expect": {
-    "plan": "ANALYZE ERROR\n-------* Query error\n     1 | return [1,2,3,4] as embedding, [true, \"i love turingdb\", 20.3, embedding]\n       |                                                                ^^^^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "result": "ANALYZE ERROR\n-------* Query error\n     1 | return [1,2,3,4] as embedding, [true, \"i love turingdb\", 20.3, embedding]\n       |                                                                ^^^^^^^^^\n-------* Non-literal list elements are not yet supported",
-    "resultJson": "{\"error\":\"ANALYZE_ERROR\",\"error_details\":\"-------* Query error\\n     1 | return [1,2,3,4] as embedding, [true, \\\"i love turingdb\\\", 20.3, embedding]\\n       |                                                                ^^^^^^^^^\\n-------* Non-literal list elements are not yet supported\"}"
+    "plan": "flowchart TD\n    0[\"`\n        __EXPR_EVAL__\n        __exprs__\n__expr__ (LITERAL): embedding\n__expr__ (LITERAL): v8\n    `\"]\n    1[\"`\n        __PRODUCE_RESULTS__\n    `\"]\n    0-->1",
+    "result": "PLAN ERROR\nNon-literal list elements are not yet supported",
+    "resultJson": "{\"error\":\"PLAN_ERROR\",\"error_details\":\"Non-literal list elements are not yet supported\"}"
   },
   "tags": [],
   "write-required": false

--- a/test/query/analyzer/NestedAggregateTest.cpp
+++ b/test/query/analyzer/NestedAggregateTest.cpp
@@ -81,6 +81,13 @@ TEST_F(NestedAggregateTest, rejectsCountOverAnAggregateAlias) {
                    nestedAggregateReason);
 }
 
+// A list around the alias is no screen: the argument still names an aggregate of the same
+// projection, so what collect would fold is one value per group rather than the rows of it
+TEST_F(NestedAggregateTest, rejectsAnAggregateAliasInsideAListArgument) {
+    expectRejected("MATCH (a)-[e]->(b) RETURN a, sum(e.duration) AS s, collect([s])",
+                   nestedAggregateReason);
+}
+
 // The nesting spelled out in the call rather than reached through an alias
 TEST_F(NestedAggregateTest, rejectsAnAggregateSpelledInsideAnAggregate) {
     expectRejected("MATCH (a)-[e]->(b) RETURN a, count(DISTINCT sum(e.duration))",

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2270,3 +2270,15 @@ target_link_libraries(test_query_ir_shadowed_alias PRIVATE
         turing_db_interpreter_v3_s
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_shadowed_alias PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# UNWIND of a list whose elements are read per row, run end to end against simpledb.
+add_turing_test(test_query_ir_unwind_variables UnwindVariablesTest.cpp)
+target_sources(test_query_ir_unwind_variables PRIVATE StringRowSink.cpp)
+target_link_libraries(test_query_ir_unwind_variables PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s)
+target_include_directories(test_query_ir_unwind_variables PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/query/ir/CypherListLiteralTest.cpp
+++ b/test/query/ir/CypherListLiteralTest.cpp
@@ -838,6 +838,22 @@ TEST_F(CypherListLiteralTest, buildsAListOfAnUnwoundVariablePerRow) {
     expectRows("UNWIND [1, 2] AS x RETURN [x]", expected);
 }
 
+// An element read off a list by index carries the tag its value was stored under, and the
+// column holding it is nullable: the list takes the value under that tag.
+TEST_F(CypherListLiteralTest, buildsAListOfAnIndexedElementPerRow) {
+    const Rows expected = {{"[1]"}};
+
+    expectRows("UNWIND [[1, 'a']] AS xs WITH xs[0] AS first RETURN [first]", expected);
+}
+
+// The same read past the end of the list, which has no element: the row has no cell, and
+// the list holds the null that is.
+TEST_F(CypherListLiteralTest, buildsAListOfAnAbsentIndexedElement) {
+    const Rows expected = {{"[null]"}};
+
+    expectRows("UNWIND [[1, 'a']] AS xs WITH xs[7] AS missing RETURN [missing]", expected);
+}
+
 TEST_F(CypherListLiteralTest, rejectsAnArithmeticListElement) {
     // The grammar admits no expression inside a list, so an arithmetic element is turned
     // away by the parser rather than built per row. Pinned so that teaching the grammar

--- a/test/query/ir/CypherListLiteralTest.cpp
+++ b/test/query/ir/CypherListLiteralTest.cpp
@@ -54,8 +54,6 @@ namespace {
 using Row = std::vector<std::string>;
 using Rows = std::vector<Row>;
 
-const std::string_view nonLiteralListElementReason = "Non-literal list elements are not yet supported";
-
 std::string renderList(ListView list);
 
 // Render one element of a list as its value, recursing into a nested list.
@@ -826,19 +824,23 @@ TEST_F(CypherListLiteralTest, rejectsMapListElements) {
     expectRejected("RETURN [{age: 32}]", "Only booleans, integers, floats, strings, nulls");
 }
 
-TEST_F(CypherListLiteralTest, rejectsAPropertyListElement) {
-    // Elements are literals today: a property reads a row, which the list cannot carry.
-    expectRejected("MATCH (n) WHERE n.name = 'Remy' RETURN [n.age]", nonLiteralListElementReason);
+TEST_F(CypherListLiteralTest, buildsAListOfAPropertyPerRow) {
+    // A property reads a row, so the list is one cell per row rather than the one value
+    // every row shares - the db.make_list form of a list literal.
+    const Rows expected = {{"[32]"}};
+
+    expectRows("MATCH (n) WHERE n.name = 'Remy' RETURN [n.age]", expected);
 }
 
-TEST_F(CypherListLiteralTest, rejectsAnUnwoundVariableListElement) {
-    expectRejected("UNWIND [1, 2] AS x RETURN [x]", nonLiteralListElementReason);
+TEST_F(CypherListLiteralTest, buildsAListOfAnUnwoundVariablePerRow) {
+    const Rows expected = {{"[1]"}, {"[2]"}};
+
+    expectRows("UNWIND [1, 2] AS x RETURN [x]", expected);
 }
 
 TEST_F(CypherListLiteralTest, rejectsAnArithmeticListElement) {
-    // The grammar admits no expression inside a list, so an arithmetic element never
-    // reaches the analyzer's message above - the same limitation surfaces as a parse
-    // failure. Pinned so that teaching the grammar the expression moves the rejection to
-    // the analyzer visibly, rather than silently.
+    // The grammar admits no expression inside a list, so an arithmetic element is turned
+    // away by the parser rather than built per row. Pinned so that teaching the grammar
+    // the expression shows up as the element becoming supported, rather than silently.
     expectRejected("RETURN [1 + 1]", "syntax error");
 }

--- a/test/query/ir/DBDialectTest.cpp
+++ b/test/query/ir/DBDialectTest.cpp
@@ -1276,6 +1276,38 @@ func.func @main() {
 }
 )mlir";
 
+// MATCH (n)-->(m) RETURN [n, m]: a list built out of the column each element rides, one
+// cell per row. The two columns share a type, so the cells are lists of node IDs.
+const char* const makeListProgram = R"mlir(
+func.func @main() {
+  %srcs, %eids, %etypes, %tgts = db.scan_edges() : !db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>
+  %xs = db.make_list(%srcs, %tgts) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.list<!storage.node_id>>
+  db.output(%xs) : !db.column<!storage.list<!storage.node_id>>
+  return
+}
+)mlir";
+
+// A make_list producing something other than a column of lists: the op builds lists, so
+// the verifier rejects it.
+const char* const scalarMakeListProgram = R"mlir(
+func.func @main() {
+  %n = db.scan_nodes() : !db.column<!storage.node_id>
+  %xs = db.make_list(%n) : (!db.column<!storage.node_id>) -> !db.column<!storage.node_id>
+  db.output(%xs) : !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// A make_list reading no column: there is no cell to build a list out of, so the verifier
+// rejects it. A list known without reading a row is a db.constant instead.
+const char* const emptyMakeListProgram = R"mlir(
+func.func @main() {
+  %xs = db.make_list() : () -> !db.column<!storage.list<i64>>
+  db.output(%xs) : !db.column<!storage.list<i64>>
+  return
+}
+)mlir";
+
 // RETURN [1, 2, 3]: the same literals as a value rather than a source, so the whole list
 // is one cell. A list literal is a db.constant value like any other, carried as the array
 // of its elements; the column type is inferred from them, so it is never spelled.
@@ -1695,6 +1727,47 @@ TEST_F(DBDialectTest, unwindRoundTripsThroughTextualForm) {
 
 TEST_F(DBDialectTest, verifierRejectsUnwindRetypingACarriedColumn) {
     const mlir::OwningOpRef<mlir::ModuleOp> module = parse(retypedCarryUnwindProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, parsesMakeList) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(makeListProgram);
+    ASSERT_TRUE(module);
+
+    mlir::db::MakeList makeList;
+    module.get().walk([&](mlir::db::MakeList op) {
+        makeList = op;
+    });
+    ASSERT_TRUE(makeList);
+
+    // One operand per element, and the result the list of the type they share.
+    ASSERT_EQ(makeList.getElements().size(), 2u);
+
+    const mlir::Type nodeIDType = mlir::storage::NodeIDType::get(&_context);
+    const mlir::Type listColumnType = mlir::db::ColumnType::get(&_context, mlir::storage::ListType::get(&_context, nodeIDType));
+    EXPECT_EQ(makeList.getResult().getType(), listColumnType);
+}
+
+TEST_F(DBDialectTest, makeListRoundTripsThroughTextualForm) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(makeListProgram);
+    ASSERT_TRUE(module);
+
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module.get().print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed = parse(printed.c_str());
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
+TEST_F(DBDialectTest, verifierRejectsMakeListProducingAScalarColumn) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(scalarMakeListProgram);
+    EXPECT_FALSE(module);
+}
+
+TEST_F(DBDialectTest, verifierRejectsMakeListWithoutElementColumns) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(emptyMakeListProgram);
     EXPECT_FALSE(module);
 }
 

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -701,6 +701,31 @@ TEST_F(NLDialectTest, makeListBuildsAListChunkOfTheSharedElementType) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
+// An nl.make_list reading no chunk has no cell to build a list out of, and nothing to size
+// its step from either: the verifier turns it away rather than leaving the interpreter to
+// read the first of no element chunks.
+TEST_F(NLDialectTest, verifierRejectsMakeListWithoutElementChunks) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type listChunkType = mlir::nl::ChunkType::get(&_context, mlir::storage::ListType::get(&_context, int64Type));
+
+    builder.create<mlir::nl::MakeList>(loc, listChunkType, mlir::ValueRange {});
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    // Swallow the verifier's diagnostic so the deliberate failure does not print.
+    const mlir::ScopedDiagnosticHandler handler(&_context, [](mlir::Diagnostic&) {
+        return mlir::success();
+    });
+    EXPECT_TRUE(mlir::failed(mlir::verify(function)));
+}
+
 // A list literal is an nl.constant value: it holds the whole list rather than spreading it
 // over rows, so it produces a chunk of that list type - inferred from the elements, since an
 // array attribute carries none of its own. A nested list rides one element as an array.

--- a/test/query/ir/NLDialectTest.cpp
+++ b/test/query/ir/NLDialectTest.cpp
@@ -663,6 +663,44 @@ TEST_F(NLDialectTest, unwindBuildsElementAndCarriedChunkIterator) {
     EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
 }
 
+// nl.make_list spells its chunk type as well: the cells it writes are lists of the type
+// its element chunks share, so the type is read off the operands rather than inferred.
+TEST_F(NLDialectTest, makeListBuildsAListChunkOfTheSharedElementType) {
+    mlir::OpBuilder builder(&_context);
+    const mlir::Location loc = builder.getUnknownLoc();
+
+    mlir::OwningOpRef<mlir::ModuleOp> module = mlir::ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module->getBody());
+    auto function = builder.create<mlir::func::FuncOp>(loc, "main", mlir::FunctionType::get(&_context, {}, {}));
+    builder.setInsertionPointToStart(function.addEntryBlock());
+
+    mlir::nl::Constant first = builder.create<mlir::nl::Constant>(loc, builder.getI64IntegerAttr(1));
+    mlir::nl::Constant second = builder.create<mlir::nl::Constant>(loc, builder.getI64IntegerAttr(2));
+
+    const mlir::Type int64Type = mlir::IntegerType::get(&_context, 64);
+    const mlir::Type listChunkType = mlir::nl::ChunkType::get(&_context, mlir::storage::ListType::get(&_context, int64Type));
+
+    mlir::nl::MakeList makeList = builder.create<mlir::nl::MakeList>(loc,
+                                                                     listChunkType,
+                                                                     mlir::ValueRange {first.getResult(), second.getResult()});
+    builder.create<mlir::func::ReturnOp>(loc);
+
+    EXPECT_EQ(makeList.getResult().getType(), listChunkType);
+    EXPECT_EQ(makeList.getElements().size(), 2u);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(function)));
+
+    // Printing then re-parsing yields a module that still verifies, so the nl.make_list
+    // printer and parser are inverses.
+    std::string printed;
+    llvm::raw_string_ostream stream(printed);
+    module->print(stream);
+
+    const mlir::OwningOpRef<mlir::ModuleOp> reparsed =
+        mlir::parseSourceString<mlir::ModuleOp>(printed, mlir::ParserConfig(&_context));
+    ASSERT_TRUE(reparsed);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*reparsed)));
+}
+
 // A list literal is an nl.constant value: it holds the whole list rather than spreading it
 // over rows, so it produces a chunk of that list type - inferred from the elements, since an
 // array attribute carries none of its own. A nested list rides one element as an array.

--- a/test/query/ir/NestedAggregateProjectionTest.cpp
+++ b/test/query/ir/NestedAggregateProjectionTest.cpp
@@ -36,7 +36,6 @@ using namespace turing::test;
 namespace {
 
 const std::string_view nestedAggregateReason = "Nested aggregates are not supported";
-const std::string_view nonLiteralListElementReason = "Non-literal list elements are not yet supported";
 
 }
 
@@ -139,5 +138,5 @@ TEST_F(NestedAggregateProjectionTest, generatesAnAggregateInsideAnExpression) {
 }
 
 TEST_F(NestedAggregateProjectionTest, rejectsAListHoldingAnAggregateBesideAGroupingKey) {
-    expectRejected("MATCH (n) RETURN DISTINCT n, [count(n.age)]", nonLiteralListElementReason);
+    expectRejected("MATCH (n) RETURN DISTINCT n, [count(n.age)]", nestedAggregateReason);
 }

--- a/test/query/ir/NestedAggregateProjectionTest.cpp
+++ b/test/query/ir/NestedAggregateProjectionTest.cpp
@@ -137,6 +137,10 @@ TEST_F(NestedAggregateProjectionTest, generatesAnAggregateInsideAnExpression) {
     EXPECT_NO_THROW(generateProgram("MATCH (n:Person) RETURN n.name, 2 * count(n) + 20"));
 }
 
-TEST_F(NestedAggregateProjectionTest, rejectsAListHoldingAnAggregateBesideAGroupingKey) {
-    expectRejected("MATCH (n) RETURN DISTINCT n, [count(n.age)]", nestedAggregateReason);
+// Unlike a map, a list is a value this codegen builds a column of, so the aggregate it
+// holds is registered with the grouped aggregate and the list is built over the result -
+// the same route an aggregate inside arithmetic takes.
+TEST_F(NestedAggregateProjectionTest, generatesAListHoldingAnAggregateBesideAGroupingKey) {
+    EXPECT_NO_THROW(generateProgram("MATCH (n) RETURN DISTINCT n, [count(n.age)]"));
+    EXPECT_NO_THROW(generateProgram("MATCH (n) RETURN n.age, [count(n.name)]"));
 }

--- a/test/query/ir/OrderByAggregateUnprojectedKeyTest.cpp
+++ b/test/query/ir/OrderByAggregateUnprojectedKeyTest.cpp
@@ -348,6 +348,24 @@ TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByADeeperKeyOverAGrouping
                        durationGroupsAscending);
 }
 
+// A list of the grouping key: an element holding one value per group makes the list hold
+// one too, so the key is built over the grouped column. Built over the ungrouped one it
+// would be as long as the edges rather than as the groups.
+TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAListOverAGroupingKey) {
+    expectDurationRows("MATCH (a)-[e]->(b) RETURN e.duration, count(b.name) ORDER BY [e.duration]",
+                       durationGroupsAscending);
+}
+
+// The elements are what the key holds, so a list is group-wise only where all of them are:
+// b.name is one name per edge inside a list as much as outside one.
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAListOverADroppedVariable) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY [b.name]");
+}
+
+TEST_F(OrderByAggregateUnprojectedKeyTest, rejectsAListMixingAGroupingKeyWithADroppedVariable) {
+    expectRejected("MATCH (a:Person)-[e]->(b) RETURN a, a.age, count(b.name) ORDER BY [a.age, b.name]");
+}
+
 // An alias is another spelling of the item it names, so a key computing over one computes
 // over that item's grouped column just as spelling the item out does.
 TEST_F(OrderByAggregateUnprojectedKeyTest, ordersGroupsByAKeyComputedOverTheAliasOfAGroupingKey) {

--- a/test/query/ir/OrderByTest.cpp
+++ b/test/query/ir/OrderByTest.cpp
@@ -492,16 +492,25 @@ TEST_F(OrderByTest, mapKeyReadingARowIsNotDropped) {
                  TuringException);
 }
 
-// The list mirror of the case above, rejected one step earlier: the analyzer does not
-// accept a non-literal list element yet, so a list key cannot read a row today. The
-// element flags are propagated all the same, so the day it does, the key varies with
-// them instead of being taken for a constant
-TEST_F(OrderByTest, listKeyReadingARowIsRejected) {
+// The list mirror of the case above: a list holding a property reads a row through it, so
+// it is a column of one list per row and the key is kept rather than taken for a constant
+// and dropped. The projection returns n.name alone, so the list is the appended column
+TEST_F(OrderByTest, listKeyReadingARowIsAppended) {
     mlir::MLIRContext context;
     mlir::OwningOpRef<mlir::ModuleOp> module;
+    generateProgram("MATCH (n) RETURN n.name ORDER BY [1, n.age]", context, module);
 
-    EXPECT_THROW(generateProgram("MATCH (n) RETURN n.name ORDER BY [1, n.age]", context, module),
-                 TuringException);
+    size_t sortCount = 0;
+
+    module->walk([&](mlir::db::Sort sortOp) {
+        sortCount++;
+
+        EXPECT_EQ(sortOp.getColumns().size(), 2u);
+        ASSERT_EQ(sortOp.getKeyColumns().size(), 1u);
+        EXPECT_EQ(sortOp.getKeyColumns()[0], 1);
+    });
+
+    EXPECT_EQ(sortCount, 1u);
 }
 
 // A map is a literal, so a list may hold one and reach the propagation the case above

--- a/test/query/ir/UnwindVariablesTest.cpp
+++ b/test/query/ir/UnwindVariablesTest.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "StringRowSink.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+using Rows = std::vector<StringRowSink::Row>;
+
+}
+
+// UNWIND of a list whose elements are read per row: MATCH (n)-->(m) UNWIND [n, m] AS x.
+// The list is no longer a value known at plan time, so it is built one cell per row out of
+// the column each element rides (db.make_list) and spread by the ordinary db.unwind - two
+// rows per input row for a pair, interleaved, with everything else in flight repeated
+// beside them.
+//
+// Remy (0) is the anchor throughout: its four out-edges reach Adam (1), Ghosts (6),
+// Computers (2) and Eighties (3), in that order.
+class UnwindVariablesTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    void runQuery(std::string_view query, StringRowSink& sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              &sink);
+
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        EXPECT_EQ(sink.getRows(), expected) << "query: " << query;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+// The headline case: each matched pair spreads into the two rows its two nodes are, the
+// source ahead of the target, so the four edges out of Remy give eight rows.
+TEST_F(UnwindVariablesTest, spreadsAMatchedPairIntoTwoRows) {
+    const Rows expected = {{"0"}, {"1"}, {"0"}, {"6"}, {"0"}, {"2"}, {"0"}, {"3"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN x", expected);
+}
+
+// The unwound cell is a node, not a tagged scalar, so a property reads off it
+TEST_F(UnwindVariablesTest, readsAPropertyOfTheUnwoundNode) {
+    const Rows expected = {{"Remy"}, {"Adam"}, {"Remy"}, {"Ghosts"},
+                           {"Remy"}, {"Computers"}, {"Remy"}, {"Eighties"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN x.name", expected);
+}
+
+// What was in flight rides through the carry set, repeated once per element, so the pair
+// the element came from is still readable beside it
+TEST_F(UnwindVariablesTest, repeatsTheMatchedRowBesideEachElement) {
+    const Rows expected = {{"Remy", "Adam", "Remy"},
+                           {"Remy", "Adam", "Adam"},
+                           {"Remy", "Ghosts", "Remy"},
+                           {"Remy", "Ghosts", "Ghosts"},
+                           {"Remy", "Computers", "Remy"},
+                           {"Remy", "Computers", "Computers"},
+                           {"Remy", "Eighties", "Remy"},
+                           {"Remy", "Eighties", "Eighties"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN n.name, m.name, x.name",
+               expected);
+}
+
+// A singleton list of an edge: the four out-edges of Remy are edges 0 through 3
+TEST_F(UnwindVariablesTest, spreadsASingletonListOfAnEdge) {
+    const Rows expected = {{"0"}, {"1"}, {"2"}, {"3"}};
+    expectRows("MATCH (n)-[e]->(m) WHERE n.name = 'Remy' UNWIND [e] AS x RETURN x", expected);
+}
+
+// A variable beside a literal: the literal stands for every row, so it is laid out over
+// the rows the variable carries and each of them gets a two-element list
+TEST_F(UnwindVariablesTest, spreadsAVariableBesideALiteral) {
+    const Rows expected = {{"32"}, {"1"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [n.age, 1] AS x RETURN x", expected);
+}
+
+// Elements of differing types make the list type-erased, so the cells come back as the
+// tagged scalars they were put in as: Remy's name then its age
+TEST_F(UnwindVariablesTest, spreadsPropertiesOfDifferingTypes) {
+    const Rows expected = {{"Remy"}, {"32"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [n.name, n.age] AS x RETURN x", expected);
+}
+
+// A row with no value for one element still contributes it: UNWIND drops the null the
+// whole list is, never the null one of its cells holds
+TEST_F(UnwindVariablesTest, keepsTheNullOfAnAbsentProperty) {
+    const Rows expected = {{"32"}, {"null"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [n.age, n.height] AS x RETURN x", expected);
+}
+
+// One level deeper: the elements are lists of their own, so each cell unwinds into the
+// list it is rather than into the nodes inside it
+TEST_F(UnwindVariablesTest, spreadsAListOfLists) {
+    const Rows expected = {{"0"}, {"0, 0"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [[n], [n, n]] AS x RETURN x", expected);
+}
+
+// The unwound node drives the pattern that follows, as a matched one does
+TEST_F(UnwindVariablesTest, walksOutOfTheUnwoundNode) {
+    const Rows expected = {{"Adam"}, {"Ghosts"}, {"Computers"}, {"Eighties"}};
+    expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [n] AS x MATCH (x)-->(y) RETURN y.name", expected);
+}
+
+TEST_F(UnwindVariablesTest, countsTheUnwoundRows) {
+    const Rows expected = {{"8"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN count(x)", expected);
+}
+
+// Remy repeats once per edge and each target appears once, so five names survive the dedup
+TEST_F(UnwindVariablesTest, dedupsTheUnwoundNames) {
+    const Rows expected = {{"Remy"}, {"Adam"}, {"Ghosts"}, {"Computers"}, {"Eighties"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN DISTINCT x.name", expected);
+}
+
+// The same list as a value rather than a source: one cell per matched row, holding the
+// pair instead of spreading it
+TEST_F(UnwindVariablesTest, returnsThePairAsOneCell) {
+    const Rows expected = {{"0, 1"}, {"0, 6"}, {"0, 2"}, {"0, 3"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' RETURN [n, m] AS pair", expected);
+}
+
+// Published through a barrier and unwound on the other side: the list is built before the
+// WITH and spread after it, to the rows the pair gave directly
+TEST_F(UnwindVariablesTest, spreadsAPairPublishedByAWith) {
+    const Rows expected = {{"Remy"}, {"Adam"}, {"Remy"}, {"Ghosts"},
+                           {"Remy"}, {"Computers"}, {"Remy"}, {"Eighties"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' WITH [n, m] AS pair UNWIND pair AS x RETURN x.name",
+               expected);
+}
+
+// The list carries rows rather than standing for all of them, so a reduction over it
+// tallies one per matched pair
+TEST_F(UnwindVariablesTest, countsThePairOfEveryMatchedRow) {
+    const Rows expected = {{"4"}};
+    expectRows("MATCH (n)-->(m) WHERE n.name = 'Remy' RETURN count([n, m])", expected);
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/UnwindVariablesTest.cpp
+++ b/test/query/ir/UnwindVariablesTest.cpp
@@ -128,6 +128,25 @@ TEST_F(UnwindVariablesTest, keepsTheNullOfAnAbsentProperty) {
     expectRows("MATCH (n) WHERE n.name = 'Remy' UNWIND [n.age, n.height] AS x RETURN x", expected);
 }
 
+// An OPTIONAL MATCH that matched nothing leaves an invalid ID, which is how a null entity
+// is spelled, so the list holds a null where the element is - not the 2^64-1 the invalid
+// ID reads as. Computers (2) has no out-edge of any type.
+TEST_F(UnwindVariablesTest, holdsTheNullOfAnUnmatchedOptionalNode) {
+    const Rows expected = {{"2, null"}};
+    expectRows("MATCH (n) WHERE n.name = 'Computers' OPTIONAL MATCH (n)-[:KNOWS_WELL]->(m) "
+               "RETURN [n, m]",
+               expected);
+}
+
+// The null drains back out as the invalid ID an entity column spells it with, so the
+// unwound variable is null and a property read off it is null too
+TEST_F(UnwindVariablesTest, spreadsTheNullOfAnUnmatchedOptionalNode) {
+    const Rows expected = {{"2", "Computers"}, {"null", "null"}};
+    expectRows("MATCH (n) WHERE n.name = 'Computers' OPTIONAL MATCH (n)-[:KNOWS_WELL]->(m) "
+               "UNWIND [n, m] AS x RETURN x, x.name",
+               expected);
+}
+
 // One level deeper: the elements are lists of their own, so each cell unwinds into the
 // list it is rather than into the nodes inside it
 TEST_F(UnwindVariablesTest, spreadsAListOfLists) {

--- a/test/query/ir/WithTest.cpp
+++ b/test/query/ir/WithTest.cpp
@@ -608,6 +608,13 @@ TEST_F(WithTest, rejectsAVariableTheBarrierDropped) {
                    QueryStatus::Status::ANALYZE_ERROR);
 }
 
+// A list key is read in the scope the projection opens like any other: what it holds has
+// to be a published column, and n is not one.
+TEST_F(WithTest, rejectsAListKeyOverAVariableTheBarrierDropped) {
+    expectRejected("MATCH (n:Person) WITH n.name AS name ORDER BY [n.age] RETURN name",
+                   QueryStatus::Status::ANALYZE_ERROR);
+}
+
 // A name the barrier dropped is free again below it, so a pattern spelling it declares a
 // variable of its own rather than joining onto what the name used to hold - which makes
 // this the cross product above, not a traversal of the published rows: Remy's name


### PR DESCRIPTION
Implement UNWIND of variables.

```
MATCH (n)-->(m) WHERE n.name = 'Remy' UNWIND [n, m] AS x RETURN x.name

Remy
Adam
Remy
Ghosts
Remy
Computers
Remy
Eighties
```
