### PR TITLE
Fix: concatenating two collected lists

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -94,6 +94,19 @@ ListShape sharedListShape(std::span<Expr* const> elements) {
     return ListShape::collecting(shared, first->getListShape());
 }
 
+// The shape of the list a concatenation makes: the one both sides carry, or a list of
+// tagged scalars when they carry different ones, as a mixed list literal is.
+ListShape concatenatedListShape(const ListShape& left, const ListShape& right) {
+    const bool sameDepth = left.getDepth() == right.getDepth();
+    const bool sameLeafType = left.getLeafType() == right.getLeafType();
+
+    if (!sameDepth || !sameLeafType) {
+        return ListShape(EvaluatedType::Invalid, 1);
+    }
+
+    return left;
+}
+
 }
 
 ExprAnalyzer::ExprAnalyzer(CypherAST* ast, const GraphView& graphView)
@@ -353,6 +366,7 @@ void ExprAnalyzer::analyzeBinaryExpr(BinaryExpr* expr) {
                     throwError("List concatenation is only supported in V3", expr);
                 }
                 type = EvaluatedType::List;
+                expr->setListShape(concatenatedListShape(lhs->getListShape(), rhs->getListShape()));
                 break;
             }
 

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -586,20 +586,6 @@ void collectDistinctValueIndices(llvm::ArrayRef<const FunctionInvocationExpr*> c
     }
 }
 
-void collectProjectedCollects(const Projection* projection,
-                              llvm::SmallVectorImpl<const FunctionInvocationExpr*>& found) {
-    for (const Projection::ReturnItem& returnItem : projection->items()) {
-        Expr* const* itemPtr = std::get_if<Expr*>(&returnItem);
-        if (!itemPtr) {
-            continue;
-        }
-
-        if (isCollectInvocation(*itemPtr)) {
-            found.push_back(static_cast<const FunctionInvocationExpr*>(*itemPtr));
-        }
-    }
-}
-
 }
 
 DBProgramGenerator::DBProgramGenerator(mlir::ModuleOp* mainModule, ExplainReport* explain)
@@ -5310,8 +5296,22 @@ mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> 
 }
 
 void DBProgramGenerator::generateKeylessCollect(const Projection* projection) {
+    llvm::SmallVector<const FunctionInvocationExpr*> aggregateExprs;
+    for (const Projection::ReturnItem& returnItem : projection->items()) {
+        Expr* const* itemPtr = std::get_if<Expr*>(&returnItem);
+        if (!itemPtr) {
+            continue;
+        }
+
+        collectAggregateInvocations(*itemPtr, aggregateExprs);
+    }
+
     llvm::SmallVector<const FunctionInvocationExpr*> collectExprs;
-    collectProjectedCollects(projection, collectExprs);
+    for (const FunctionInvocationExpr* aggregateExpr : aggregateExprs) {
+        if (isCollectInvocation(aggregateExpr)) {
+            collectExprs.push_back(aggregateExpr);
+        }
+    }
 
     // A lone collect is built by its own translation, keyless, as any other aggregate is
     if (collectExprs.size() < 2) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -198,6 +198,8 @@ add_call_v3_test(test_query_ir_unwind_node_seed_v3 UnwindNodeSeedV3Test.cpp)
 add_call_v3_test(test_query_ir_unwind_node_seed_call_v3 UnwindNodeSeedCallV3Test.cpp)
 add_call_v3_test(test_query_ir_scan_by_property_value_v3 ScanByPropertyValueV3Test.cpp)
 add_call_v3_test(test_query_ir_gnn_frontier_union GnnFrontierUnionTest.cpp)
+add_call_v3_test(test_query_ir_collect_concatenation CollectConcatenationTest.cpp)
+add_call_v3_test(test_query_ir_concatenated_list_seed ConcatenatedListSeedTest.cpp)
 
 # The crossing-call tests hop twice from the column a CALL yielded and then call again,
 # once with a constant argument alone and once reading the chain's tail, from the query

--- a/test/query/ir/CollectConcatenationTest.cpp
+++ b/test/query/ir/CollectConcatenationTest.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+class CollectConcatenationTest : public CallV3Test {
+};
+
+namespace {
+
+constexpr const char* barrierQuery =
+    "MATCH (n {name: 'Remy'}) "
+    "CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt "
+    "WITH collect(DISTINCT src) AS seeds, collect(DISTINCT tgt) AS sampled "
+    "RETURN seeds + sampled AS nodes";
+
+constexpr const char* returnQuery =
+    "MATCH (n {name: 'Remy'}) "
+    "CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt "
+    "RETURN collect(DISTINCT src) + collect(DISTINCT tgt) AS nodes";
+
+// Remy(0) cites Adam(1), Ghosts(6), Computers(2) and Eighties(3). A fan-out of 8 exceeds
+// his out-degree, so the sample takes the whole neighbourhood: the seed collects to [0]
+// and the targets to [1, 6, 2, 3].
+const std::vector<StringRowSink::Row> concatenatedNodes {{"0, 1, 6, 2, 3"}};
+
+}
+
+TEST_F(CollectConcatenationTest, concatenatesTwoCollectsAcrossAWithBarrier) {
+    StringRowSink sink;
+    runQuery(barrierQuery, sink);
+
+    EXPECT_EQ(sink.getRows(), concatenatedNodes);
+}
+
+// The same two collects concatenated in the RETURN itself, which the engine rejects today
+// with "db operands to deeperBlock must be bound in the same loop".
+TEST_F(CollectConcatenationTest, concatenatesTwoCollectsInTheSameReturn) {
+    StringRowSink sink;
+    runQuery(returnQuery, sink);
+
+    EXPECT_EQ(sink.getRows(), concatenatedNodes);
+}

--- a/test/query/ir/CollectConcatenationTest.cpp
+++ b/test/query/ir/CollectConcatenationTest.cpp
@@ -37,8 +37,6 @@ TEST_F(CollectConcatenationTest, concatenatesTwoCollectsAcrossAWithBarrier) {
     EXPECT_EQ(sink.getRows(), concatenatedNodes);
 }
 
-// The same two collects concatenated in the RETURN itself, which the engine rejects today
-// with "db operands to deeperBlock must be bound in the same loop".
 TEST_F(CollectConcatenationTest, concatenatesTwoCollectsInTheSameReturn) {
     StringRowSink sink;
     runQuery(returnQuery, sink);

--- a/test/query/ir/ConcatenatedListSeedTest.cpp
+++ b/test/query/ir/ConcatenatedListSeedTest.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+class ConcatenatedListSeedTest : public CallV3Test {
+};
+
+namespace {
+
+constexpr const char* collectedListQuery =
+    "MATCH (n) WHERE n = 0 OR n = 1 "
+    "CALL gnn.neighbourhoodSample(n, 8, 42) YIELD tgt "
+    "WITH collect(DISTINCT tgt) AS sampled "
+    "UNWIND sampled AS node "
+    "CALL gnn.neighbourhoodSample(node, 8, 43) YIELD src, tgt "
+    "RETURN DISTINCT src, tgt";
+
+constexpr const char* concatenatedListQuery =
+    "MATCH (n) WHERE n = 0 OR n = 1 "
+    "CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt "
+    "WITH collect(DISTINCT src) AS seeds, collect(DISTINCT tgt) AS sampled "
+    "UNWIND seeds + sampled AS node "
+    "CALL gnn.neighbourhoodSample(node, 8, 43) YIELD src, tgt "
+    "RETURN DISTINCT src, tgt";
+
+// Sampling Remy(0) and Adam(1) reaches {1, 6, 2, 3} and {0, 4, 5}, which already holds both
+// seeds, so appending them changes nothing: either frontier samples the same eight edges.
+// Remy cites Adam(1), Ghosts(6), Computers(2) and Eighties(3); Adam cites Remy, Bio(4) and
+// Cooking(5); Ghosts cites Remy; the rest cite nobody.
+const std::vector<StringRowSink::Row> frontierEdges {{"0", "1"},
+                                                     {"0", "2"},
+                                                     {"0", "3"},
+                                                     {"0", "6"},
+                                                     {"1", "0"},
+                                                     {"1", "4"},
+                                                     {"1", "5"},
+                                                     {"6", "0"}};
+
+}
+
+TEST_F(ConcatenatedListSeedTest, seedsACallFromACollectedList) {
+    StringRowSink sink;
+    runQuery(collectedListQuery, sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, frontierEdges);
+}
+
+// Concatenating the two collects drops the node element type, so the analyzer rejects the
+// call the unwound item drives with "Invalid arguments for function
+// 'gnn.neighbourhoodSample'".
+TEST_F(ConcatenatedListSeedTest, seedsACallFromTwoCollectedListsConcatenated) {
+    StringRowSink sink;
+    runQuery(concatenatedListQuery, sink);
+
+    std::vector<StringRowSink::Row> rows;
+    sink.sortedRows(rows);
+    EXPECT_EQ(rows, frontierEdges);
+}

--- a/test/query/ir/ConcatenatedListSeedTest.cpp
+++ b/test/query/ir/ConcatenatedListSeedTest.cpp
@@ -52,9 +52,6 @@ TEST_F(ConcatenatedListSeedTest, seedsACallFromACollectedList) {
     EXPECT_EQ(rows, frontierEdges);
 }
 
-// Concatenating the two collects drops the node element type, so the analyzer rejects the
-// call the unwound item drives with "Invalid arguments for function
-// 'gnn.neighbourhoodSample'".
 TEST_F(ConcatenatedListSeedTest, seedsACallFromTwoCollectedListsConcatenated) {
     StringRowSink sink;
     runQuery(concatenatedListQuery, sink);


### PR DESCRIPTION
Concatenating two collected lists fails both in a projection and as the seed of a call.

```
MATCH (n {name: 'Remy'}) CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt
RETURN collect(DISTINCT src) + collect(DISTINCT tgt) AS nodes

EXEC_ERROR: db operands to deeperBlock must be bound in the same loop

MATCH (n) WHERE n = 0 OR n = 1 CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt
WITH collect(DISTINCT src) AS seeds, collect(DISTINCT tgt) AS sampled
UNWIND seeds + sampled AS node
CALL gnn.neighbourhoodSample(node, 8, 43) YIELD src, tgt
RETURN DISTINCT src, tgt

ANALYZE_ERROR: Invalid arguments for function 'gnn.neighbourhoodSample'

MATCH (n {name: 'Remy'}) CALL gnn.neighbourhoodSample(n, 8, 42) YIELD src, tgt
WITH collect(DISTINCT src) AS seeds, collect(DISTINCT tgt) AS sampled
RETURN seeds + sampled AS nodes

0, 1, 6, 2, 3
```
