### PR TITLE
MLIR: sink a predicate to the column an equality holds it to

### DIFF
--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -150,7 +150,31 @@ Operation::operand_range factorYieldColumns(mlir::Region& factor) {
 // The column its variable was bound at, following every op that passes the column through.
 // Sets crossedProducer when one of those builds the rows - a hop or a cross product - as
 // opposed to a filter, which only drops them.
-Value climbToLineageAnchor(Value column, bool& crossedProducer) {
+using ColumnEquality = std::pair<Value, Value>;
+
+// A filter keeping only the rows where two node columns agree holds them to the same node
+// below it, so anything reading one of them reads the other just as well
+bool matchColumnEquality(FilterOp filter, ColumnEquality& equality) {
+    EqOp mask = filter.getMask().getDefiningOp<EqOp>();
+    if (!mask) {
+        return false;
+    }
+
+    const auto isNodeColumn = [](Value column) {
+        const auto type = dyn_cast<ColumnType>(column.getType());
+        return type && isa<storage::NodeIDType>(type.getType());
+    };
+
+    if (!isNodeColumn(mask.getLhs()) || !isNodeColumn(mask.getRhs())) {
+        return false;
+    }
+
+    equality = ColumnEquality {mask.getLhs(), mask.getRhs()};
+
+    return true;
+}
+
+Value climbToLineageAnchor(Value column, bool& crossedProducer, llvm::SmallVectorImpl<ColumnEquality>* equalities = nullptr) {
     for (;;) {
         Operation* const def = column.getDefiningOp();
         if (!def) {
@@ -163,6 +187,12 @@ Value climbToLineageAnchor(Value column, bool& crossedProducer) {
 
         if (FilterOp filter = dyn_cast<FilterOp>(def)) {
             const size_t resultIndex = cast<OpResult>(column).getResultNumber();
+
+            ColumnEquality equality;
+            if (equalities && matchColumnEquality(filter, equality)) {
+                equalities->push_back(equality);
+            }
+
             column = filter.getColumnsToFilter()[resultIndex];
 
             continue;
@@ -298,6 +328,35 @@ struct PushablePredicate {
     MaskCone _cone;
 };
 
+// The anchor a predicate can be rebuilt on instead of @param anchor: where an equality the
+// climb crossed holds that anchor to a column the graph was scanned for, the predicate reads
+// the same node off the scan, and applying it there is what spares the walk between them.
+Value scannedAnchorEqualTo(Value anchor, llvm::ArrayRef<ColumnEquality> equalities) {
+    if (!anchor || isNodeSource(anchor.getDefiningOp())) {
+        return {};
+    }
+
+    for (const ColumnEquality& equality : equalities) {
+        bool crossed = false;
+        const Value lhs = climbToLineageAnchor(equality.first, crossed);
+        crossed = false;
+        const Value rhs = climbToLineageAnchor(equality.second, crossed);
+        if (!lhs || !rhs) {
+            continue;
+        }
+
+        if (lhs == anchor && isNodeSource(rhs.getDefiningOp())) {
+            return rhs;
+        }
+
+        if (rhs == anchor && isNodeSource(lhs.getDefiningOp())) {
+            return lhs;
+        }
+    }
+
+    return {};
+}
+
 bool matchPushablePredicate(FilterOp filter, PushablePredicate& pushable) {
     Operation* const maskDef = filter.getMask().getDefiningOp();
     if (!maskDef || !isMaskComputeOp(maskDef)) {
@@ -310,8 +369,9 @@ bool matchPushablePredicate(FilterOp filter, PushablePredicate& pushable) {
     }
 
     bool crossedProducer = false;
+    llvm::SmallVector<ColumnEquality, 4> equalities;
     for (const Value input : pushable._cone._inputs) {
-        const Value inputAnchor = climbToLineageAnchor(input, crossedProducer);
+        const Value inputAnchor = climbToLineageAnchor(input, crossedProducer, &equalities);
         if (!inputAnchor) {
             return false;
         }
@@ -322,6 +382,12 @@ bool matchPushablePredicate(FilterOp filter, PushablePredicate& pushable) {
             // More than one lineage feeds the mask: not a single-variable predicate.
             return false;
         }
+    }
+
+    const Value equatedAnchor = scannedAnchorEqualTo(pushable._anchor, equalities);
+    if (equatedAnchor) {
+        pushable._anchor = equatedAnchor;
+        crossedProducer = true;
     }
 
     // Crossing only filters leaves the predicate over the rows the anchor produced already:

--- a/query/ir/dialect/db/DBPasses.cpp
+++ b/query/ir/dialect/db/DBPasses.cpp
@@ -152,26 +152,28 @@ Operation::operand_range factorYieldColumns(mlir::Region& factor) {
 // opposed to a filter, which only drops them.
 using ColumnEquality = std::pair<Value, Value>;
 
-// A filter keeping only the rows where two node columns agree holds them to the same node
-// below it, so anything reading one of them reads the other just as well
-bool matchColumnEquality(FilterOp filter, ColumnEquality& equality) {
-    EqOp mask = filter.getMask().getDefiningOp<EqOp>();
-    if (!mask) {
-        return false;
-    }
+void collectConjuncts(Value mask, llvm::SmallVectorImpl<Value>& conjuncts);
 
+// Every equality of two node columns the filter requires: it keeps only the rows where they
+// agree, so below it anything reading one of them reads the other just as well. A filter
+// whose mask is a conjunction requires each of its conjuncts, equalities among them.
+void collectColumnEqualities(FilterOp filter, llvm::SmallVectorImpl<ColumnEquality>& equalities) {
     const auto isNodeColumn = [](Value column) {
         const auto type = dyn_cast<ColumnType>(column.getType());
         return type && isa<storage::NodeIDType>(type.getType());
     };
 
-    if (!isNodeColumn(mask.getLhs()) || !isNodeColumn(mask.getRhs())) {
-        return false;
+    llvm::SmallVector<Value, 4> conjuncts;
+    collectConjuncts(filter.getMask(), conjuncts);
+
+    for (const Value conjunct : conjuncts) {
+        EqOp equality = conjunct.getDefiningOp<EqOp>();
+        if (!equality || !isNodeColumn(equality.getLhs()) || !isNodeColumn(equality.getRhs())) {
+            continue;
+        }
+
+        equalities.push_back(ColumnEquality {equality.getLhs(), equality.getRhs()});
     }
-
-    equality = ColumnEquality {mask.getLhs(), mask.getRhs()};
-
-    return true;
 }
 
 Value climbToLineageAnchor(Value column, bool& crossedProducer, llvm::SmallVectorImpl<ColumnEquality>* equalities = nullptr) {
@@ -188,9 +190,8 @@ Value climbToLineageAnchor(Value column, bool& crossedProducer, llvm::SmallVecto
         if (FilterOp filter = dyn_cast<FilterOp>(def)) {
             const size_t resultIndex = cast<OpResult>(column).getResultNumber();
 
-            ColumnEquality equality;
-            if (equalities && matchColumnEquality(filter, equality)) {
-                equalities->push_back(equality);
+            if (equalities) {
+                collectColumnEqualities(filter, *equalities);
             }
 
             column = filter.getColumnsToFilter()[resultIndex];
@@ -328,29 +329,42 @@ struct PushablePredicate {
     MaskCone _cone;
 };
 
-// The anchor a predicate can be rebuilt on instead of @param anchor: where an equality the
-// climb crossed holds that anchor to a column the graph was scanned for, the predicate reads
-// the same node off the scan, and applying it there is what spares the walk between them.
+// The anchor a predicate can be rebuilt on instead of @param anchor: the equalities the climb
+// crossed hold whole classes of columns to the same node, and where one of the class was
+// scanned for, the predicate reads that node off the scan. Applying it there is what spares
+// the walk between the two. The class is closed over the equalities rather than read a pair
+// at a time, so a column held to the scan through an intermediate is still found.
 Value scannedAnchorEqualTo(Value anchor, llvm::ArrayRef<ColumnEquality> equalities) {
     if (!anchor || isNodeSource(anchor.getDefiningOp())) {
         return {};
     }
 
-    for (const ColumnEquality& equality : equalities) {
+    llvm::SmallVector<Value, 4> anchorClass {anchor};
+    llvm::SmallPtrSet<void*, 4> seen {anchor.getAsOpaquePointer()};
+
+    const auto anchorOf = [](Value column) {
         bool crossed = false;
-        const Value lhs = climbToLineageAnchor(equality.first, crossed);
-        crossed = false;
-        const Value rhs = climbToLineageAnchor(equality.second, crossed);
-        if (!lhs || !rhs) {
-            continue;
-        }
+        return climbToLineageAnchor(column, crossed);
+    };
 
-        if (lhs == anchor && isNodeSource(rhs.getDefiningOp())) {
-            return rhs;
-        }
+    for (size_t index = 0; index < anchorClass.size(); index++) {
+        for (const ColumnEquality& equality : equalities) {
+            const Value lhs = anchorOf(equality.first);
+            const Value rhs = anchorOf(equality.second);
+            if (!lhs || !rhs) {
+                continue;
+            }
 
-        if (rhs == anchor && isNodeSource(lhs.getDefiningOp())) {
-            return lhs;
+            const Value held = lhs == anchorClass[index] ? rhs : (rhs == anchorClass[index] ? lhs : Value {});
+            if (!held || !seen.insert(held.getAsOpaquePointer()).second) {
+                continue;
+            }
+
+            if (isNodeSource(held.getDefiningOp())) {
+                return held;
+            }
+
+            anchorClass.push_back(held);
         }
     }
 

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -133,6 +133,72 @@ TEST_F(PushDownFilterTest, sinksAPredicateToTheColumnAnEqualityHoldsItTo) {
     EXPECT_TRUE(mlir::isa<mlir::db::FilterOp>(hops.front().getInputNodes().getDefiningOp()));
 }
 
+// The end of the second hop is held to that hop's seed, and that seed to the column carried
+// off the scan: a chain of two equalities, neither of which reaches the scan on its own
+const char* const chainedEqualityPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %s2, %e2, %et2, %t2, %sc = db.get_out_edges(%t, {%s}) : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %sameEnd = db.eq %t2, %s2 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %j1, %j2, %j3 = db.filter(%sameEnd, {%t2, %s2, %sc}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %sameSeed = db.eq %j2, %j3 : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %k1, %k2, %k3 = db.filter(%sameSeed, {%j1, %j2, %j3}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%k1, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %lim = db.constant(30 : i64)
+  %mask = db.gt %age, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %f1, %f2, %f3 = db.filter(%mask, {%k1, %k2, %k3}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%f1, %f2, %f3) : !db.column<!storage.node_id>, !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// Neither equality holds the predicate's column to the scan by itself; together they do
+TEST_F(PushDownFilterTest, followsAChainOfEqualitiesToTheScan) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(chainedEqualityPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
+}
+
+// The equality shares its filter with another predicate, so the mask is a conjunction
+const char* const conjoinedEqualityPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %same = db.eq %t, %s : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %rank = db.get_node_properties(%s, "rank") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %zero = db.constant(0 : i64)
+  %positive = db.gt %rank, %zero : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %both = db.and %same, %positive : (!db.column<!storage.bool>, !db.column<!storage.bool>) -> !db.column<!storage.bool>
+  %tj, %sj = db.filter(%both, {%t, %s}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%tj, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %lim = db.constant(30 : i64)
+  %mask = db.gt %age, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %tf, %sf = db.filter(%mask, {%tj, %sj}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%tf, %sf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+TEST_F(PushDownFilterTest, readsAnEqualityOutOfAConjunction) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(conjoinedEqualityPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    for (mlir::db::GetNodeProperties read : reads) {
+        if (read.getProperty() == "age") {
+            EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(read.getInputNodes().getDefiningOp()));
+        }
+    }
+}
+
 // MATCH (a) WHERE a.age > 30 RETURN a
 const char* const rootOnlyPredicate = R"mlir(
 func.func @main() {

--- a/test/query/ir/PushDownFilterTest.cpp
+++ b/test/query/ir/PushDownFilterTest.cpp
@@ -96,6 +96,43 @@ TEST_F(PushDownFilterTest, sinksRootPredicatePastHops) {
     EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(read.getInputNodes().getDefiningOp()));
 }
 
+// A walk whose end an equality filter holds to its seed - what breaking a cycle in the
+// pattern leaves behind - with the predicate written over the end
+const char* const equatedEndPredicate = R"mlir(
+func.func @main() {
+  %a = db.scan_nodes() : !db.column<!storage.node_id>
+  %s, %e, %et, %t = db.get_out_edges(%a, {}) : (!db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.edge_id>, !db.column<!storage.edge_type_id>, !db.column<!storage.node_id>)
+  %same = db.eq %t, %s : (!db.column<!storage.node_id>, !db.column<!storage.node_id>) -> !db.column<!storage.bool>
+  %tj, %sj = db.filter(%same, {%t, %s}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  %age = db.get_node_properties(%tj, "age") : (!db.column<!storage.node_id>) -> !db.column<i64>
+  %lim = db.constant(30 : i64)
+  %mask = db.gt %age, %lim : (!db.column<i64>, !db.column<i64>) -> !db.column<!storage.bool>
+  %tf, %sf = db.filter(%mask, {%tj, %sj}) : (!db.column<!storage.bool>, !db.column<!storage.node_id>, !db.column<!storage.node_id>) -> (!db.column<!storage.node_id>, !db.column<!storage.node_id>)
+  db.output(%tf, %sf) : !db.column<!storage.node_id>, !db.column<!storage.node_id>
+  return
+}
+)mlir";
+
+// The end of the walk is born at the hop, so a predicate on it sinks no further than the hop
+// on its own. The equality holds it to the seed on every row that survives, and the seed is
+// the scan, so the predicate is the scan's to apply.
+TEST_F(PushDownFilterTest, sinksAPredicateToTheColumnAnEqualityHoldsItTo) {
+    const mlir::OwningOpRef<mlir::ModuleOp> module = parse(equatedEndPredicate);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(runPushDown(*module));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*module)));
+
+    llvm::SmallVector<mlir::db::GetOutEdges> hops = collect<mlir::db::GetOutEdges>(*module);
+    ASSERT_EQ(hops.size(), 1u);
+
+    llvm::SmallVector<mlir::db::GetNodeProperties> reads = collect<mlir::db::GetNodeProperties>(*module);
+    ASSERT_EQ(reads.size(), 1u);
+    EXPECT_TRUE(mlir::isa<mlir::db::ScanNodes>(reads.front().getInputNodes().getDefiningOp()));
+
+    // The hop walks the nodes the predicate kept rather than every node of the graph
+    EXPECT_TRUE(mlir::isa<mlir::db::FilterOp>(hops.front().getInputNodes().getDefiningOp()));
+}
+
 // MATCH (a) WHERE a.age > 30 RETURN a
 const char* const rootOnlyPredicate = R"mlir(
 func.func @main() {


### PR DESCRIPTION
Teach the filter pushdown about column equivalence. 

This is the standard equijoin transitive predicate inference: for c = a AND c.age > 30 it implies a.age > 30. So the predicate c.age > 30 can be rewritten into a.age > 30 and be pushed down to the origin point of a if it is lower to get even more selectivity earlier.

This is a way to make predicate pushdown even more aggressive. 

This is necessary for optimising some fraud ring detection queries with variable length paths.

```
MATCH (a:Person)-[:KNOWS_WELL]->(b)-[:KNOWS_WELL]->(c) WHERE c = a AND c.age > 30 RETURN c.name

c is born at the second hop, the equality holds it to a, and a is the scan. 2 rows, Remy and Adam.

func.func @main() {
  %0 = db.scan_nodes_by_label(["Person"])
  %1 = db.get_node_properties(%0, "age")
  %2 = db.constant(30 : i64)
  %3 = db.gt %1, %2 
  %4 = db.filter(%3, {%0})
  %5, %6, %7, %8 = db.get_out_edges_by_type(%4, "KNOWS_WELL", {}) 
  %9, %10, %11, %12, %13 = db.get_out_edges_by_type(%8, "KNOWS_WELL", {%5})
  %14 = db.eq %12, %13
  %15 = db.filter(%14, {%12})
  %16 = db.get_node_properties(%15, "name")
  db.output(%16) names ["c.name"] 
  return
}

MATCH (a:Person)-->(b)-->(c) WHERE c = b AND b = a AND c.age > 30 RETURN c.name

Neither equality reaches the scan on its own, the class {c, b, a} does. 0 rows, simpledb has no self edge.

func.func @main() {
  %0 = db.scan_nodes_by_label(["Person"]) 
  %1 = db.get_node_properties(%0, "age") 
  %2 = db.constant(30 : i64)
  %3 = db.gt %1, %2 
  %4 = db.filter(%3, {%0}) 
  %5, %6, %7, %8 = db.get_out_edges(%4, {}) 
  %9, %10, %11, %12, %13 = db.get_out_edges(%8, {%5}) 
  %14 = db.eq %12, %9
  %15:3 = db.filter(%14, {%12, %9, %13})
  %16 = db.eq %15#1, %15#2 
  %17 = db.filter(%16, {%15#0})
  %18 = db.get_node_properties(%17, "name") 
  db.output(%18) names ["c.name"] 
  return
}
```
