### PR TITLE
Implement the coalesce function

### DIFF
--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -295,6 +295,15 @@ void FunctionDecls::initDefault() {
     toBoolean->setArguments({EvaluatedType::String});
     toBoolean->setReturnTypes({{EvaluatedType::Bool}});
 
+    // coalesce answers the first of its arguments that is not null, so it takes any number
+    // of them and declares none: the analyzer unifies what it is given, and the type they
+    // share is what the call returns. Only the MLIR engine evaluates it.
+    FunctionSignature* coalesce = createFunction("coalesce");
+    coalesce->setReturnTypes({{EvaluatedType::Null}});
+    coalesce->setRequiredArgCount(1);
+    coalesce->setUnifiesItsArguments(true);
+    coalesce->setIsV3Only(true);
+
     // Embedding distance functions
     FunctionSignature* cosineSim = createFunction("cosine_similarity");
     cosineSim->setArguments({EvaluatedType::Embedding, EvaluatedType::Embedding});

--- a/query/AST/FunctionDecls.cpp
+++ b/query/AST/FunctionDecls.cpp
@@ -225,6 +225,23 @@ void FunctionDecls::initDefault() {
     maxBool->setReturnTypes({{EvaluatedType::Bool}});
     maxBool->setIsAggregate(true);
 
+    // An extremum of nothing is null, a sum of nothing is 0 and an average of nothing is
+    // null, so a column that is null on every row - a name no property in the graph carries,
+    // or the null literal - reduces to an answer rather than to an argument error, exactly
+    // as count(null) and collect(null) do. Only the MLIR engine reads a name the graph does
+    // not carry, so the overloads are v3-only.
+    FunctionSignature* minNulls = createFunction("min");
+    minNulls->setArguments({EvaluatedType::Null});
+    minNulls->setReturnTypes({{EvaluatedType::Null}});
+    minNulls->setIsAggregate(true);
+    minNulls->setIsV3Only(true);
+
+    FunctionSignature* maxNulls = createFunction("max");
+    maxNulls->setArguments({EvaluatedType::Null});
+    maxNulls->setReturnTypes({{EvaluatedType::Null}});
+    maxNulls->setIsAggregate(true);
+    maxNulls->setIsV3Only(true);
+
     FunctionSignature* avgInt = createFunction("avg");
     avgInt->setArguments({EvaluatedType::Integer});
     avgInt->setReturnTypes({{EvaluatedType::Double}});
@@ -245,6 +262,12 @@ void FunctionDecls::initDefault() {
     avgListItems->setIsAggregate(true);
     avgListItems->setIsV3Only(true);
 
+    FunctionSignature* avgNulls = createFunction("avg");
+    avgNulls->setArguments({EvaluatedType::Null});
+    avgNulls->setReturnTypes({{EvaluatedType::Null}});
+    avgNulls->setIsAggregate(true);
+    avgNulls->setIsV3Only(true);
+
     // sum() enabled for v3 analyzer 
     FunctionSignature* sumInt = createFunction("sum");
     sumInt->setArguments({EvaluatedType::Integer});
@@ -255,6 +278,14 @@ void FunctionDecls::initDefault() {
     sumDouble->setArguments({EvaluatedType::Double});
     sumDouble->setReturnTypes({{EvaluatedType::Double}});
     sumDouble->setIsAggregate(true);
+
+    // A sum of no value is 0 rather than null, so this one answers an integer where the
+    // extremums above answer null
+    FunctionSignature* sumNulls = createFunction("sum");
+    sumNulls->setArguments({EvaluatedType::Null});
+    sumNulls->setReturnTypes({{EvaluatedType::Integer}});
+    sumNulls->setIsAggregate(true);
+    sumNulls->setIsV3Only(true);
 
     // A type-erased cell carries its number's type per row. Mixed numeric tags are what
     // leaves a list type-erased, and Cypher sums those to a float, so this reduces to one

--- a/query/AST/FunctionSignature.h
+++ b/query/AST/FunctionSignature.h
@@ -74,6 +74,12 @@ public:
     // reading an element back knows the type it has - collect, and nothing else today.
     bool collectsItsArgument() const { return _collectsItsArgument; }
 
+    // Whether this takes any number of values of one type and answers the type they
+    // share - coalesce, and nothing else today. Such a signature declares no argument of
+    // its own: the analyzer unifies the arguments against each other, as it does the
+    // branches of a CASE, and the type they share is what the call returns.
+    bool unifiesItsArguments() const { return _unifiesItsArguments; }
+
     size_t getMinArgCount() const { return _requiredArgCount; }
 
     void setArguments(ArgumentTypes&& args) {
@@ -94,6 +100,8 @@ public:
 
     void setCollectsItsArgument(bool collects) { _collectsItsArgument = collects; }
 
+    void setUnifiesItsArguments(bool unifies) { _unifiesItsArguments = unifies; }
+
 private:
     std::string_view _fullName;
     ArgumentTypes _argumentTypes;
@@ -102,6 +110,7 @@ private:
     bool _isAggregate {false};
     bool _isProcedure {false};
     bool _collectsItsArgument {false};
+    bool _unifiesItsArguments {false};
 
     // An overload only the MLIR engine answers: the legacy planner either cannot lay its
     // argument out or reduces it over the wrong rows, so it never matches there

--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -914,23 +914,33 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
     for (FunctionSignature* signature : signatures) {
         const auto& expectedArgs = signature->argumentTypes();
 
+        // A signature unifying its arguments declares none of them, so its arity is a
+        // minimum alone and there is no expected type to match each against: they are
+        // checked against each other once the overload is settled on.
+        const bool unifiesArguments = signature->unifiesItsArguments();
+
         const size_t minArgs = signature->getMinArgCount();
         const size_t maxArgs = expectedArgs.size();
 
-        if (providedArgs.size() < minArgs || providedArgs.size() > maxArgs) {
+        const bool tooFewArgs = providedArgs.size() < minArgs;
+        const bool tooManyArgs = !unifiesArguments && providedArgs.size() > maxArgs;
+
+        if (tooFewArgs || tooManyArgs) {
             // Number of arguments does not match
             continue;
         }
 
-        const bool matchingArgs = std::equal(
-            expectedArgs.begin(), expectedArgs.begin() + providedArgs.size(),
-            providedArgs.begin(), [](const FunctionArgumentType& expected, const Expr* arg) {
-                return arg->getType() == expected.getType();
-            });
+        if (!unifiesArguments) {
+            const bool matchingArgs = std::equal(
+                expectedArgs.begin(), expectedArgs.begin() + providedArgs.size(),
+                providedArgs.begin(), [](const FunctionArgumentType& expected, const Expr* arg) {
+                    return arg->getType() == expected.getType();
+                });
 
-        if (!matchingArgs) {
-            // Argument types do not match
-            continue;
+            if (!matchingArgs) {
+                // Argument types do not match
+                continue;
+            }
         }
 
         // An overload the legacy planner cannot answer correctly is declared v3-only
@@ -944,8 +954,13 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
         // would have to be read again for every one. Turned away here rather than by the
         // procedure at runtime, once a row has already reached it - but only once every
         // overload has been tried, since another may take that argument per row.
+
+        // A signature can declare fewer arguments than were provided - one unifying them
+        // declares none - and more, when the ones behind the required count are optional
+        const size_t declaredArgs = std::min(providedArgs.size(), expectedArgs.size());
+
         bool readsARowIntoAConstant = false;
-        for (size_t argIndex = 0; argIndex < providedArgs.size(); argIndex++) {
+        for (size_t argIndex = 0; argIndex < declaredArgs; argIndex++) {
             const FunctionArgumentType& expected = expectedArgs[argIndex];
             const Expr* arg = providedArgs[argIndex];
 
@@ -981,7 +996,9 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
         }
 
         // Found a valid signature
-        if (signature->returnTypes().size() == 1) {
+        if (unifiesArguments) {
+            expr->setType(unifiedArgumentType(name, providedArgs));
+        } else if (signature->returnTypes().size() == 1) {
             expr->setType(signature->returnTypes().front().getType());
         } else {
             expr->setType(EvaluatedType::Tuple);
@@ -1024,6 +1041,29 @@ void ExprAnalyzer::analyzeFuncInvocExpr(FunctionInvocationExpr* expr, FunctionRe
 
     // Checked all overloaded signatures, none match: error
     throwError(fmt::format("Invalid arguments for function '{}'", name), expr);
+}
+
+EvaluatedType ExprAnalyzer::unifiedArgumentType(std::string_view name,
+                                                std::span<Expr* const> args) const {
+    EvaluatedType unified = EvaluatedType::Null;
+
+    for (const Expr* arg : args) {
+        const EvaluatedType argType = arg->getType();
+        const EvaluatedType folded = unifiedBranchType(unified, argType);
+
+        if (folded == EvaluatedType::Invalid) {
+            throwError(fmt::format("'{}' answers one column, so its arguments must share a "
+                                   "type: '{}' and '{}' cannot be mixed",
+                                   name,
+                                   EvaluatedTypeName::value(unified),
+                                   EvaluatedTypeName::value(argType)),
+                       arg);
+        }
+
+        unified = folded;
+    }
+
+    return unified;
 }
 
 void ExprAnalyzer::addToBeCreatedType(std::string_view name, ValueType type, const void* obj) {

--- a/query/analyzer/ExprAnalyzer.h
+++ b/query/analyzer/ExprAnalyzer.h
@@ -109,6 +109,10 @@ private:
     // and as something to compare that subject against when it has one
     void analyzeCaseTest(const CaseExpr::Branch& branch, const Expr* subject, const CaseExpr::Test& test);
 
+    // The type the arguments of a call to @param name share, folded the way a CASE folds
+    // its branches, reporting a pair no column type can hold
+    EvaluatedType unifiedArgumentType(std::string_view name, std::span<Expr* const> args) const;
+
     LoadCSVStmt* findCSVSource(const VarDecl* alias) const;
 
     // The declaration the load publishes field @param slot under, created by the first

--- a/query/ir/codegen/DBProgramGenerator.cpp
+++ b/query/ir/codegen/DBProgramGenerator.cpp
@@ -5060,9 +5060,13 @@ mlir::Value DBProgramGenerator::translateEntityTypeExpr(const EntityTypeExpr* ty
 void DBProgramGenerator::translateFunctionInvocationExpr(const Expr* expr,
                                                          const FunctionInvocationExpr* funcExpr) {
     const FunctionInvocation* invocation = funcExpr->getFunctionInvocation();
-    const std::string_view funcName = invocation->getSignature()->getFullName();
+    const FunctionSignature* signature = invocation->getSignature();
+    const std::string_view funcName = signature->getFullName();
 
-    if (!funcExpr->isAggregate()) {
+    // The expression's own aggregate flag is contaminated by its arguments, so a scalar
+    // function over a reduction - coalesce(max(n.age), 0) - carries it too. What says a
+    // call reduces its input is the signature it resolved to.
+    if (!signature->isAggregate()) {
         translateFunctionExpr(expr, invocation);
         return;
     }
@@ -5161,6 +5165,11 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
         }
     }
 
+    if (funcName == "coalesce") {
+        translateCoalesce(expr, args);
+        return;
+    }
+
     const auto unaryIt = unaryFunctionEmitters.find(funcName);
     if (unaryIt != end(unaryFunctionEmitters)) {
         if (!args || args->size() != 1) {
@@ -5185,6 +5194,53 @@ void DBProgramGenerator::translateFunctionExpr(const Expr* expr,
     }
 
     throwError(fmt::format("Unsupported function: {}", funcName), expr);
+}
+
+void DBProgramGenerator::translateCoalesce(const Expr* expr, const ExprChain* args) {
+    bioassert(args && !args->empty(), "coalesce() with no arguments.");
+
+    const ExprChain::ExprVector& argExprs = args->getExprs();
+
+    llvm::SmallVector<mlir::Value, 4> arguments;
+    for (const Expr* argExpr : argExprs) {
+        arguments.push_back(translateArg(argExpr));
+    }
+
+    if (arguments.size() == 1) {
+        _part._exprMap[expr] = arguments.front();
+        return;
+    }
+
+    const mlir::Location loc = _opBuilder.getUnknownLoc();
+    const mlir::db::ColumnType boolType = allocColumnType(mlir::storage::BoolType::get(_mlirCtxt));
+    const mlir::db::ColumnType noneType = allocColumnType(mlir::NoneType::get(_mlirCtxt));
+
+    const size_t branchCount = arguments.size() - 1;
+
+    llvm::SmallVector<mlir::Value, 4> conditions;
+    for (size_t argIndex = 0; argIndex < branchCount; argIndex++) {
+        // The null literal is absent on every row, so the branch it guards is never taken
+        if (argExprs[argIndex]->getType() == EvaluatedType::Null) {
+            conditions.push_back(constantBool(false));
+            continue;
+        }
+
+        const mlir::Value present = _opBuilder.create<mlir::db::NeqOp>(loc,
+                                                                       boolType,
+                                                                       arguments[argIndex],
+                                                                       nullConstantColumn())
+                                        .getResult();
+        conditions.push_back(present);
+    }
+
+    const llvm::ArrayRef<mlir::Value> branches = llvm::ArrayRef<mlir::Value>(arguments).drop_back();
+
+    _part._exprMap[expr] = _opBuilder.create<mlir::db::Case>(loc,
+                                                             noneType,
+                                                             conditions,
+                                                             branches,
+                                                             arguments.back())
+                               .getResult();
 }
 
 mlir::db::Collect DBProgramGenerator::createCollect(llvm::ArrayRef<mlir::Value> keyColumns,

--- a/query/ir/codegen/DBProgramGenerator.h
+++ b/query/ir/codegen/DBProgramGenerator.h
@@ -44,6 +44,7 @@ class EdgePattern;
 class EmbeddingLiteral;
 class EntityTypeExpr;
 class Expr;
+class ExprChain;
 class IndexExpr;
 class Literal;
 class ListLiteral;
@@ -679,6 +680,10 @@ private:
     void translateFunctionInvocationExpr(const Expr* expr, const FunctionInvocationExpr* funcExpr);
 
     void translateFunctionExpr(const Expr* expr, const FunctionInvocation* invocation);
+
+    // coalesce over @param args, emitted as the selection it is: every argument but the
+    // last guarded by its own presence, the last standing as the default
+    void translateCoalesce(const Expr* expr, const ExprChain* args);
 
     mlir::Value translateArg(const Expr* argExpr);
     mlir::Value translateLiteralExpr(const Literal* literal);

--- a/query/ir/dialect/db/DBOps.td
+++ b/query/ir/dialect/db/DBOps.td
@@ -1452,9 +1452,11 @@ def Case : TuringOp<"case", [Pure, AttrSizedOperandSegments]> {
     of the subject against each WHEN value as the condition.
 
     The result element type is resolved during lowering, as for the arithmetic ops: the
-    branches promote against each other into one nullable value column. A selection walks
-    rows, so - unlike the arithmetic ops - it is not constant through its operands: the
-    constants among them are laid out over the driving relation during lowering.
+    branches promote against each other into one nullable value column, or - when they are
+    all nodes, or all edges - into the entity column they already are, which carries the
+    null of an unmatched row in its ID. A selection walks rows, so - unlike the arithmetic
+    ops - it is not constant through its operands: the constants among them are laid out
+    over the driving relation during lowering.
   }];
 
   let arguments = (ins Variadic<Column>:$conditions,

--- a/query/ir/dialect/nl/NLOps.cpp
+++ b/query/ir/dialect/nl/NLOps.cpp
@@ -603,10 +603,15 @@ LogicalResult AggregateUpdate::verify() {
     // Every other input is a property value chunk; its value type is what the fold
     // reads, and sum/min/max fold into an accumulator of that type.
     if (!taggedCells) {
-        const Type inputValueType = aggregateValueType(getRows().getType());
-        if (!inputValueType) {
+        const Type declaredValueType = aggregateValueType(getRows().getType());
+        if (!declaredValueType) {
             return emitOpError("input must be a nullable value chunk (a property column)");
         }
+
+        // The null literal names no value type of its own and is carried as a null
+        // integer, which is the column the fold reads and folds nothing out of
+        const bool untypedNull = isa<NoneType>(declaredValueType);
+        const Type inputValueType = untypedNull ? IntegerType::get(getContext(), 64) : declaredValueType;
 
         if (!isAvg && inputValueType != accumulatorType) {
             return emitOpError("sum/min/max must fold into an accumulator of the input's value type");

--- a/query/ir/dialect/nl/NLOps.td
+++ b/query/ir/dialect/nl/NLOps.td
@@ -1699,9 +1699,11 @@ def Case : NLOp<"case", [Pure, RowAlignedThroughOperands, AttrSizedOperandSegmen
   let summary = "Row-wise selection of the first branch whose condition holds";
   let description = [{
       The lowered db.case: parallel condition and value chunks, an optional default, and
-      a nullable value chunk holding the branch each row took. Every operand carries
-      rows - a constant among them was laid out over the driving relation during
-      lowering - so the selection reads one cell of each per row it writes.
+      a nullable value chunk holding the branch each row took - an entity chunk when the
+      branches are nodes or edges, whose null is the invalid ID rather than an absent
+      optional. Every operand carries rows - a constant among them was laid out over the
+      driving relation during lowering - so the selection reads one cell of each per row
+      it writes.
 
       %r = nl.case({%c0}, {%v0}, %d) : (!nl.chunk<i1>, !nl.chunk<!storage.nullable<i64>>,
                                         !nl.chunk<!storage.nullable<i64>>)

--- a/query/ir/interpreter/NLExecutor.cpp
+++ b/query/ir/interpreter/NLExecutor.cpp
@@ -1061,10 +1061,24 @@ void caseWriteMaskCell(Column* result, const Column* value, size_t row) {
 void caseWriteNullCell(Column* result, const Column* value, size_t row) {
 }
 
+template <typename ID>
+void caseWriteEntityCell(Column* result, const Column* value, size_t row) {
+    std::vector<ID>& results = static_cast<ColumnVector<ID>*>(result)->getRaw();
+    results[row] = static_cast<const ColumnVector<ID>*>(value)->getRaw()[row];
+}
+
 template <typename Primitive>
 void caseResetColumn(Column* result, size_t rowCount) {
     std::vector<std::optional<Primitive>>& results = static_cast<ColumnOptVector<Primitive>*>(result)->getRaw();
     results.assign(rowCount, std::optional<Primitive> {});
+}
+
+// A default-constructed ID is the invalid one, which is how an entity column spells an
+// absent row: the reset leaves every row null, as the optional one above does
+template <typename ID>
+void caseResetEntityColumn(Column* result, size_t rowCount) {
+    std::vector<ID>& results = static_cast<ColumnVector<ID>*>(result)->getRaw();
+    results.assign(rowCount, ID {});
 }
 
 // 3-way compare two rows of a type-erased column of tagged scalars. Cells need not share
@@ -4381,6 +4395,28 @@ NLCaseTestFn NLExecutor::selectCaseTest(const Column* condition, bool nullable, 
     }
 
     return nullable ? &caseTestOptMask : &caseTestBoolColumn;
+}
+
+NLCaseResetFn NLExecutor::selectEntityCaseReset(NLChunkKind kind) {
+    if (kind == NLChunkKind::NodeID) {
+        return &caseResetEntityColumn<NodeID>;
+    } else if (kind == NLChunkKind::EdgeID) {
+        return &caseResetEntityColumn<EdgeID>;
+    }
+
+    throw IRException("Only a node or an edge column can hold a selection over entities");
+}
+
+NLCaseWriteFn NLExecutor::selectEntityCaseWrite(NLChunkKind kind, bool untypedNull) {
+    if (untypedNull) {
+        return &caseWriteNullCell;
+    } else if (kind == NLChunkKind::NodeID) {
+        return &caseWriteEntityCell<NodeID>;
+    } else if (kind == NLChunkKind::EdgeID) {
+        return &caseWriteEntityCell<EdgeID>;
+    }
+
+    throw IRException("Only a node or an edge column can hold a selection over entities");
 }
 
 NLCaseWriteFn NLExecutor::selectCaseWrite(ValueType valueType,

--- a/query/ir/interpreter/NLExecutor.h
+++ b/query/ir/interpreter/NLExecutor.h
@@ -273,6 +273,13 @@ public:
                                          bool nullable,
                                          bool untypedNull);
 
+    // The entity siblings of the two above, for a selection whose branches are nodes or
+    // edges: an entity column carries its null in the ID rather than in an optional, so
+    // the reset writes the invalid ID and the write copies the branch's ID across
+    static NLCaseResetFn selectEntityCaseReset(NLChunkKind kind);
+
+    static NLCaseWriteFn selectEntityCaseWrite(NLChunkKind kind, bool untypedNull);
+
     // Lay a constant chunk's single value out over the driving relation's rows
     // (nl.broadcast_constant), so a fold that walks rows is handed the step's rows
     // rather than the one row a constant column is.

--- a/query/ir/interpreter/NLTranslator.cpp
+++ b/query/ir/interpreter/NLTranslator.cpp
@@ -1994,9 +1994,9 @@ void NLTranslator::translateToNullable(nl::ToNullable toNullable, NLStmtContaine
 
 void NLTranslator::translateCase(nl::Case caseOp, NLStmtContainer* body) {
     const mlir::Value resultValue = caseOp.getResult();
-    const ValueType valueType = nullableChunkValueType(resultValue.getType());
+    const mlir::Type resultChunkType = resultValue.getType();
 
-    Column* const result = allocColumnForChunkType(resultValue.getType());
+    Column* const result = allocColumnForChunkType(resultChunkType);
     _valueSlots[resultValue] = result;
 
     const mlir::OperandRange conditions = caseOp.getConditions();
@@ -2006,7 +2006,7 @@ void NLTranslator::translateCase(nl::Case caseOp, NLStmtContainer* body) {
     // gives the rows this step writes
     NLCaseData* data = _program->allocFunctionData<NLCaseData>(getColumn(conditions.front()),
                                                                result,
-                                                               NLExecutor::selectCaseReset(valueType));
+                                                               selectCaseResetForChunkType(resultChunkType));
 
     for (size_t branchIndex = 0; branchIndex < conditions.size(); branchIndex++) {
         const mlir::Type conditionType = conditions[branchIndex].getType();
@@ -2018,10 +2018,7 @@ void NLTranslator::translateCase(nl::Case caseOp, NLStmtContainer* body) {
         branch._test = NLExecutor::selectCaseTest(branch._condition,
                                                   isNullableChunk(conditionType),
                                                   isUntypedNullChunk(conditionType));
-        branch._write = NLExecutor::selectCaseWrite(valueType,
-                                                    branch._value,
-                                                    isNullableChunk(valueChunkType),
-                                                    isUntypedNullChunk(valueChunkType));
+        branch._write = selectCaseWriteForChunkType(resultChunkType, branch._value, valueChunkType);
 
         data->addBranch(branch);
     }
@@ -2032,13 +2029,38 @@ void NLTranslator::translateCase(nl::Case caseOp, NLStmtContainer* body) {
         const Column* const defaultColumn = getColumn(defaultValue);
 
         data->setDefault(defaultColumn,
-                         NLExecutor::selectCaseWrite(valueType,
-                                                     defaultColumn,
-                                                     isNullableChunk(defaultType),
-                                                     isUntypedNullChunk(defaultType)));
+                         selectCaseWriteForChunkType(resultChunkType, defaultColumn, defaultType));
     }
 
     body->emplaceStmt(&NLExecutor::runCase, data);
+}
+
+NLCaseResetFn NLTranslator::selectCaseResetForChunkType(mlir::Type chunkType) {
+    const auto chunk = mlir::cast<nl::ChunkType>(chunkType);
+    const mlir::Type elementType = chunk.getElementType();
+
+    if (isEntityIDElement(elementType)) {
+        return NLExecutor::selectEntityCaseReset(chunkKindFromElementType(elementType));
+    }
+
+    return NLExecutor::selectCaseReset(nullableChunkValueType(chunkType));
+}
+
+NLCaseWriteFn NLTranslator::selectCaseWriteForChunkType(mlir::Type resultChunkType,
+                                                        const Column* value,
+                                                        mlir::Type valueChunkType) {
+    const auto resultChunk = mlir::cast<nl::ChunkType>(resultChunkType);
+    const mlir::Type resultElement = resultChunk.getElementType();
+
+    if (isEntityIDElement(resultElement)) {
+        return NLExecutor::selectEntityCaseWrite(chunkKindFromElementType(resultElement),
+                                                 isUntypedNullChunk(valueChunkType));
+    }
+
+    return NLExecutor::selectCaseWrite(nullableChunkValueType(resultChunkType),
+                                       value,
+                                       isNullableChunk(valueChunkType),
+                                       isUntypedNullChunk(valueChunkType));
 }
 
 void NLTranslator::translateUnaryFunction(mlir::Operation* op, NLStmtContainer* body) {

--- a/query/ir/interpreter/NLTranslator.h
+++ b/query/ir/interpreter/NLTranslator.h
@@ -614,6 +614,14 @@ private:
     static NLAggregateUpdateFunction selectAggregateUpdateForChunkType(AggregateKind kind,
                                                                       mlir::Type chunkType);
 
+    // The reset a selection's result column needs, and the write one of its branches
+    // needs. Both turn on what the result chunk holds: an entity column carries its null
+    // in the ID, every other column in an optional. Used by nl.case.
+    static NLCaseResetFn selectCaseResetForChunkType(mlir::Type chunkType);
+    static NLCaseWriteFn selectCaseWriteForChunkType(mlir::Type resultChunkType,
+                                                     const Column* value,
+                                                     mlir::Type valueChunkType);
+
     // Translate an nl.get_node_properties / nl.get_edge_properties: resolve the
     // property name (carried by the nl.get_property_type that produced the
     // handle) to a PropertyTypeID and value type, allocate the nullable value

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -3139,8 +3139,14 @@ mlir::Type DBLowering::caseResultElement(llvm::ArrayRef<mlir::Value> valueChunks
     const bool isBool = integerType && integerType.getWidth() == 1;
     const bool isString = mlir::isa<storage::StringType>(unified);
 
-    if (!isNumericElement(unified) && !isBool && !isString) {
-        throw IRException("db.case requires scalar branches: an entity, a list or an "
+    // A node or an edge is selected as the entity it is rather than as its ID's integer,
+    // so the selection answers a column the rest of the query still reads as an entity.
+    // Mixing one with a scalar, or a node with an edge, was already turned away above:
+    // neither pair promotes.
+    const bool isEntity = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(unified);
+
+    if (!isNumericElement(unified) && !isBool && !isString && !isEntity) {
+        throw IRException("db.case requires scalar or entity branches: a list or an "
                           "embedding is not a value a branch can select");
     }
 
@@ -3233,10 +3239,15 @@ void DBLowering::lowerCase(mlir::db::Case caseOp) {
     gatherOperands(operands);
 
     // A row matching no branch of a defaultless CASE is absent, and so is one taking a
-    // null branch, so the selection always lands in a nullable value column
+    // null branch, so the selection always lands in a column that can hold an absent row.
+    // An entity column already can - it carries its null in the ID an OPTIONAL MATCH left
+    // invalid - so entities land in a plain ID chunk and every scalar in a nullable one.
     mlir::MLIRContext* const context = _builder.getContext();
-    const nl::ChunkType resultType
-        = nl::ChunkType::get(context, storage::NullableType::get(context, resultElement));
+    const bool selectsEntities = mlir::isa<storage::NodeIDType, storage::EdgeIDType>(resultElement);
+    const mlir::Type resultChunkElement = selectsEntities
+        ? resultElement
+        : storage::NullableType::get(context, resultElement);
+    const nl::ChunkType resultType = nl::ChunkType::get(context, resultChunkElement);
 
     setInsertionForNaryOp(operands);
 

--- a/query/ir/lowering/DBLowering.cpp
+++ b/query/ir/lowering/DBLowering.cpp
@@ -286,6 +286,19 @@ mlir::Type aggregateResultElementType(mlir::OpBuilder& builder,
     const bool isString = mlir::isa<storage::StringType>(inputElement);
     const bool isTaggedCell = mlir::isa<storage::ListElementType>(inputElement);
 
+    // An untyped null holds no value to reduce - a name no property in the graph carries,
+    // or the null literal - so every reduction over it sees nothing: min, max and avg
+    // answer null and sum answers 0. It names no value type either, so the answer rides
+    // the integer column an untyped null is laid out over anywhere else, except avg's,
+    // which is a float whatever it reduced.
+    if (mlir::isa<mlir::NoneType>(inputElement)) {
+        if (kind == storage::AggregateKind::Avg) {
+            return builder.getF64Type();
+        }
+
+        return builder.getIntegerType(64);
+    }
+
     switch (kind) {
         case storage::AggregateKind::Sum: {
             if (!isNumeric && !isTaggedCell) {

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2254,6 +2254,18 @@ target_link_libraries(test_query_ir_coalesce_function PRIVATE
         turing_ir_test_rows_s)
 target_include_directories(test_query_ir_coalesce_function PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Reductions over a column that is null on every row, run end to end over SimpleGraph.
+add_turing_test(test_query_ir_null_aggregate NullAggregateTest.cpp)
+target_link_libraries(test_query_ir_null_aggregate PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_null_aggregate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 # The Cypher manual's CASE examples, run end to end against simpledb.
 add_call_v3_test(test_query_ir_neo4j_case_example Neo4jCaseExampleTest.cpp)
 

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2242,6 +2242,18 @@ target_include_directories(test_query_ir_case_expression PRIVATE ${CMAKE_CURRENT
 # The db.case dialect tests parse hand-written selections, so they need only the dialect.
 add_ir_tests(test_query_ir_case_op CaseOpTest.cpp)
 
+# coalesce, run end to end through QueryInterpreterV3 over the shared SimpleGraph fixture.
+add_turing_test(test_query_ir_coalesce_function CoalesceFunctionTest.cpp)
+target_link_libraries(test_query_ir_coalesce_function PRIVATE
+        turing_db_s
+        turing_testenv_s
+        turing_db_examples_s
+        turing_db_system_s
+        turing_db_storage_s
+        turing_db_interpreter_v3_s
+        turing_ir_test_rows_s)
+target_include_directories(test_query_ir_coalesce_function PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 # The Cypher manual's CASE examples, run end to end against simpledb.
 add_call_v3_test(test_query_ir_neo4j_case_example Neo4jCaseExampleTest.cpp)
 

--- a/test/query/ir/CaseExpressionTest.cpp
+++ b/test/query/ir/CaseExpressionTest.cpp
@@ -276,6 +276,26 @@ TEST_F(CaseExpressionTest, selectsOnAnEdgeProperty) {
                {{"Animals", "long"}, {"Computers", "short"}});
 }
 
+// A branch may select an entity. The column that comes out is still one of nodes, so the
+// query reads their properties on. simpledb's two Person-to-Person KNOWS_WELL hops are
+// Remy's and Adam's, and both select Remy
+TEST_F(CaseExpressionTest, selectsANodeBranch) {
+    expectRows("MATCH (a:Person)-[:KNOWS_WELL]->(b:Person) "
+               "WITH CASE WHEN a.name = 'Remy' THEN a ELSE b END AS chosen "
+               "RETURN chosen.name",
+               {{"Remy"}, {"Remy"}});
+}
+
+// A row matching no branch is null, which an entity column spells as an invalid ID rather
+// than as an absent optional
+TEST_F(CaseExpressionTest, leavesAnUnmatchedEntityRowNull) {
+    expectRows("MATCH (a:Person)-[:INTERESTED_IN]->(b) "
+               "WHERE a.name = 'Martina' OR a.name = 'Doruk' "
+               "WITH a, CASE WHEN a.name = 'Martina' THEN b END AS chosen "
+               "RETURN a.name, chosen.name",
+               {{"Martina", "Cooking"}, {"Doruk", "null"}});
+}
+
 // A CASE returns one column, so branches no column type can hold together are reported
 // rather than silently taking one of the two
 TEST_F(CaseExpressionTest, rejectsBranchesOfUnrelatedTypes) {

--- a/test/query/ir/CoalesceFunctionTest.cpp
+++ b/test/query/ir/CoalesceFunctionTest.cpp
@@ -262,6 +262,7 @@ TEST_F(CoalesceFunctionTest, rejectsANodeBesideAnEdge) {
 TEST_F(CoalesceFunctionTest, coalescesAReduction) {
     expectRows("MATCH (n:Person) RETURN coalesce(max(n.age), 0)", {{"32"}});
     expectRows("MATCH (n:Person) WHERE NOT n.hasPhD RETURN coalesce(max(n.age), 0)", {{"0"}});
+    expectRows("MATCH (n:Person) RETURN coalesce(max(n.shoeSize), 0)", {{"0"}});
 }
 
 // coalesce answers one column, so arguments no column type can hold together are reported

--- a/test/query/ir/CoalesceFunctionTest.cpp
+++ b/test/query/ir/CoalesceFunctionTest.cpp
@@ -214,6 +214,49 @@ TEST_F(CoalesceFunctionTest, carriesTheAnswerThroughAWith) {
                {{"32"}, {"0"}});
 }
 
+// An OPTIONAL MATCH that missed leaves a null node, which is fallen through like any other
+// null. What the selection answers is still a node, so the query reads its properties on.
+// Only Remy and Adam know someone well in simpledb; the other six fall back to themselves
+TEST_F(CoalesceFunctionTest, coalescesNodes) {
+    expectRows("MATCH (n:Person) OPTIONAL MATCH (n)-[:KNOWS_WELL]->(f) "
+               "WITH n, coalesce(f, n) AS someone RETURN n.name, someone.name",
+               {
+                   {"Remy", "Adam"}, {"Adam", "Remy"}, {"Maxime", "Maxime"}, {"Luc", "Luc"},
+                   {"Martina", "Martina"}, {"Suhas", "Suhas"}, {"Cyrus", "Cyrus"},
+                   {"Doruk", "Doruk"},
+               });
+}
+
+// Edges coalesce as nodes do, and what comes out is still an edge the query reads a
+// property from. Remy's KNOWS_WELL hop wins on each of his three interests; Martina has
+// no such hop, so her row falls back to the interest one
+TEST_F(CoalesceFunctionTest, coalescesEdges) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' OR n.name = 'Martina' "
+               "OPTIONAL MATCH (n)-[k:KNOWS_WELL]->() "
+               "OPTIONAL MATCH (n)-[i:INTERESTED_IN]->() "
+               "WITH coalesce(k, i) AS link RETURN link.name",
+               {
+                   {"Remy -> Adam"}, {"Remy -> Adam"}, {"Remy -> Adam"},
+                   {"Martina -> Cooking"},
+               });
+}
+
+// With nothing but hops that missed to choose from, the answer is the null an entity
+// column spells as an invalid ID
+TEST_F(CoalesceFunctionTest, answersANullEntityWhenNoArgumentHasOne) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Martina' "
+               "OPTIONAL MATCH (n)-[k:KNOWS_WELL]->() "
+               "WITH coalesce(k, null) AS link RETURN link.name",
+               {{"null"}});
+}
+
+// A node and an edge are no more one column than a node and a number, so neither pair is
+// held together
+TEST_F(CoalesceFunctionTest, rejectsANodeBesideAnEdge) {
+    expectError("MATCH (n:Person)-[e]->() RETURN coalesce(n, e)", "must share a type");
+    expectError("MATCH (n:Person) RETURN coalesce(n, 1)", "must share a type");
+}
+
 // A reduction answers one row, and the fallback stands in when that row is null. None of
 // the four people without a PhD carries an age, so their extremum reduces nothing
 TEST_F(CoalesceFunctionTest, coalescesAReduction) {

--- a/test/query/ir/CoalesceFunctionTest.cpp
+++ b/test/query/ir/CoalesceFunctionTest.cpp
@@ -1,0 +1,236 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+namespace {
+
+// Only Remy and Adam carry an age in simpledb, and both are 32
+const Rows agesOrZero = {
+    {"Remy", "32"}, {"Adam", "32"}, {"Maxime", "0"}, {"Luc", "0"},
+    {"Martina", "0"}, {"Suhas", "0"}, {"Cyrus", "0"}, {"Doruk", "0"},
+};
+
+// The four people simpledb gives a date of birth, and the four it does not
+const Rows datesOfBirth = {
+    {"Remy", "18/01"}, {"Adam", "18/08"}, {"Maxime", "24/07"}, {"Luc", "28/05"},
+    {"Martina", "unknown"}, {"Suhas", "unknown"}, {"Cyrus", "unknown"}, {"Doruk", "unknown"},
+};
+
+}
+
+// coalesce answers the first of its arguments that is not null, and null when they all are.
+class CoalesceFunctionTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectOrderedRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        std::string actualText;
+        describeRows(sink.rows(), actualText);
+
+        EXPECT_EQ(sink.rows(), expected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    void expectError(std::string_view query, std::string_view message) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+
+        ASSERT_FALSE(status.isOk()) << "query: " << query;
+        EXPECT_NE(status.getError().find(message), std::string::npos)
+            << "query: " << query << "\nerror: " << status.getError();
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(CoalesceFunctionTest, fallsBackToTheDefaultOnAnAbsentProperty) {
+    expectRows("MATCH (n:Person) RETURN n.name, coalesce(n.age, 0)", agesOrZero);
+}
+
+TEST_F(CoalesceFunctionTest, fallsBackToAStringDefault) {
+    expectRows("MATCH (n:Person) RETURN n.name, coalesce(n.dob, 'unknown')", datesOfBirth);
+}
+
+// The first argument that has a value wins, so the second is read only where the first is
+// absent and the third only where both are
+TEST_F(CoalesceFunctionTest, takesTheFirstArgumentThatHasAValue) {
+    expectRows("MATCH (n:Person) RETURN n.name, coalesce(n.dob, n.name, 'none')",
+               {
+                   {"Remy", "18/01"}, {"Adam", "18/08"}, {"Maxime", "24/07"}, {"Luc", "28/05"},
+                   {"Martina", "Martina"}, {"Suhas", "Suhas"},
+                   {"Cyrus", "Cyrus"}, {"Doruk", "Doruk"},
+               });
+}
+
+// A name no property in the graph carries is null on every row, so it never wins
+TEST_F(CoalesceFunctionTest, skipsAnAbsentPropertyName) {
+    expectRows("MATCH (n:Person) RETURN n.name, coalesce(n.nickname, n.name)",
+               {
+                   {"Remy", "Remy"}, {"Adam", "Adam"}, {"Maxime", "Maxime"}, {"Luc", "Luc"},
+                   {"Martina", "Martina"}, {"Suhas", "Suhas"},
+                   {"Cyrus", "Cyrus"}, {"Doruk", "Doruk"},
+               });
+}
+
+// With nothing but nulls to choose from there is no value to answer, so the answer is null
+TEST_F(CoalesceFunctionTest, answersNullWhenEveryArgumentIsNull) {
+    expectRows("MATCH (n:Person) WHERE n.name = 'Remy' RETURN coalesce(n.nickname, null)",
+               {{"null"}});
+}
+
+TEST_F(CoalesceFunctionTest, answersItsOnlyArgument) {
+    expectRows("RETURN coalesce(1)", {{"1"}});
+}
+
+// A null literal is absent on every row, so the literal behind it is what answers
+TEST_F(CoalesceFunctionTest, skipsANullLiteral) {
+    expectRows("RETURN coalesce(null, 42)", {{"42"}});
+}
+
+// An integer argument beside a double one widens the column, exactly as a CASE's branches
+// promote against each other
+TEST_F(CoalesceFunctionTest, promotesNumericArgumentsAgainstEachOther) {
+    expectRows("MATCH (n:Person) WHERE n.hasPhD RETURN n.name, coalesce(n.age, 0.5)",
+               {
+                   {"Remy", "32.000000"}, {"Adam", "32.000000"},
+                   {"Luc", "0.500000"}, {"Martina", "0.500000"},
+               });
+}
+
+// Boolean arguments give a boolean column, which reads back as one. Bio, Cooking and Padel
+// are the three simpledb interests that carry no isReal
+TEST_F(CoalesceFunctionTest, coalescesBooleans) {
+    expectRows("MATCH (n:Interest) RETURN n.name, coalesce(n.isReal, false)",
+               {
+                   {"Computers", "true"}, {"Eighties", "false"}, {"Ghosts", "true"},
+                   {"Animals", "true"}, {"Gym", "true"}, {"Travel", "true"},
+                   {"JiuJitsu", "true"}, {"Bio", "false"}, {"Cooking", "false"},
+                   {"Padel", "false"},
+               });
+}
+
+// The answer is a value like any other, so it holds where a predicate reads it
+TEST_F(CoalesceFunctionTest, filtersOnTheAnswer) {
+    expectRows("MATCH (n:Person) WHERE coalesce(n.age, 0) > 30 RETURN n.name",
+               {{"Remy"}, {"Adam"}});
+}
+
+// What coalesce returns feeds the operator around it
+TEST_F(CoalesceFunctionTest, feedsTheExpressionAroundIt) {
+    expectRows("MATCH (n:Person) WHERE n.hasPhD RETURN n.name, coalesce(n.age, 0) + 1",
+               {{"Remy", "33"}, {"Adam", "33"}, {"Luc", "1"}, {"Martina", "1"}});
+}
+
+// The answer splits the rows into groups, so it is a grouping key like any other expression
+TEST_F(CoalesceFunctionTest, groupsOnTheAnswer) {
+    expectRows("MATCH (n:Person) RETURN coalesce(n.age, 0) AS age, count(n)",
+               {{"32", "2"}, {"0", "6"}});
+}
+
+TEST_F(CoalesceFunctionTest, ordersOnTheAnswer) {
+    expectOrderedRows("MATCH (n:Person) WHERE n.hasPhD "
+                      "RETURN n.name ORDER BY coalesce(n.age, 0) DESC, n.name",
+                      {{"Adam"}, {"Remy"}, {"Luc"}, {"Martina"}});
+}
+
+// A row the fallback filled is a row the tally charges, unlike the absent value it replaced
+TEST_F(CoalesceFunctionTest, countsEveryFilledRow) {
+    expectRows("MATCH (n:Person) RETURN count(coalesce(n.age, 0))", {{"8"}});
+}
+
+// An edge property reads per matched edge, so the fallback is applied where the hop binds it
+TEST_F(CoalesceFunctionTest, coalescesAnEdgeProperty) {
+    expectRows("MATCH (a:Person)-[e:INTERESTED_IN]->(b) WHERE a.name = 'Adam' "
+               "RETURN b.name, coalesce(e.duration, 0)",
+               {{"Bio", "0"}, {"Cooking", "0"}});
+}
+
+// The answer a WITH publishes is a column the rest of the query reads by its alias
+TEST_F(CoalesceFunctionTest, carriesTheAnswerThroughAWith) {
+    expectRows("MATCH (n:Person) WITH coalesce(n.age, 0) AS age RETURN DISTINCT age",
+               {{"32"}, {"0"}});
+}
+
+// A reduction answers one row, and the fallback stands in when that row is null. None of
+// the four people without a PhD carries an age, so their extremum reduces nothing
+TEST_F(CoalesceFunctionTest, coalescesAReduction) {
+    expectRows("MATCH (n:Person) RETURN coalesce(max(n.age), 0)", {{"32"}});
+    expectRows("MATCH (n:Person) WHERE NOT n.hasPhD RETURN coalesce(max(n.age), 0)", {{"0"}});
+}
+
+// coalesce answers one column, so arguments no column type can hold together are reported
+TEST_F(CoalesceFunctionTest, rejectsArgumentsOfUnrelatedTypes) {
+    expectError("MATCH (n:Person) RETURN coalesce(n.age, 'none')", "must share a type");
+}
+
+// There is no first non-null argument to answer with when there is no argument at all
+TEST_F(CoalesceFunctionTest, rejectsACallWithNoArgument) {
+    expectError("RETURN coalesce()", "Invalid arguments for function 'coalesce'");
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}

--- a/test/query/ir/NullAggregateTest.cpp
+++ b/test/query/ir/NullAggregateTest.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "NLOutputSink.h"
+#include "QueryInterpreterV3.h"
+#include "QueryStatus.h"
+
+#include "Graph.h"
+#include "SimpleGraph.h"
+#include "SystemAccessor.h"
+#include "SystemManager.h"
+#include "versioning/ChangeID.h"
+#include "versioning/CommitHash.h"
+
+#include "IRTestRows.h"
+#include "TuringTest.h"
+#include "TuringTestEnv.h"
+
+using namespace db;
+using namespace turing::test;
+
+// Reductions over a column that is null on every row: a name no property in simpledb
+// carries, or the null literal. Nothing is reduced, so min, max and avg answer null, sum
+// answers 0, count answers 0 and collect answers the empty list.
+class NullAggregateTest : public TuringTest {
+protected:
+    void initialize() override {
+        _env = TuringTestEnv::create(fs::Path {_outDir} / "turing");
+        _interpreter = std::make_unique<QueryInterpreterV3>(&_env->getSystemManager());
+
+        SystemAccessor system = _env->getSystemManager().accessUnique();
+        Graph* graph = system.createGraph(_graphName);
+        SimpleGraph::createSimpleGraph(graph);
+    }
+
+    QueryStatus runQuery(std::string_view query, NLOutputSink* sink) {
+        QueryStatus status;
+        _interpreter->execute(status,
+                              query,
+                              _graphName,
+                              CommitHash::head(),
+                              ChangeID::head(),
+                              &_env->getMem(),
+                              sink);
+
+        return status;
+    }
+
+    void expectRows(std::string_view query, const Rows& expected) {
+        RowSink sink;
+        const QueryStatus status = runQuery(query, &sink);
+        ASSERT_TRUE(status.isOk()) << "query: " << query << "\nerror: " << status.getError();
+
+        Rows actual;
+        sink.sortedRows(actual);
+
+        Rows sortedExpected = expected;
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+
+        std::string actualText;
+        describeRows(actual, actualText);
+
+        EXPECT_EQ(actual, sortedExpected) << "query: " << query << "\ngot:\n" << actualText;
+    }
+
+    const std::string _graphName = "simpledb";
+    std::unique_ptr<TuringTestEnv> _env;
+    std::unique_ptr<QueryInterpreterV3> _interpreter;
+};
+
+TEST_F(NullAggregateTest, extremaOfNothingAreNull) {
+    expectRows("MATCH (n:Person) RETURN min(n.shoeSize)", {{"null"}});
+    expectRows("MATCH (n:Person) RETURN max(n.shoeSize)", {{"null"}});
+}
+
+TEST_F(NullAggregateTest, averageOfNothingIsNull) {
+    expectRows("MATCH (n:Person) RETURN avg(n.shoeSize)", {{"null"}});
+}
+
+// Cypher's one reduction that answers a value over no value at all
+TEST_F(NullAggregateTest, sumOfNothingIsZero) {
+    expectRows("MATCH (n:Person) RETURN sum(n.shoeSize)", {{"0"}});
+}
+
+TEST_F(NullAggregateTest, tallyOfNothingIsZeroAndTheListIsEmpty) {
+    expectRows("MATCH (n:Person) RETURN count(n.shoeSize)", {{"0"}});
+    expectRows("MATCH (n:Person) RETURN collect(n.shoeSize)", {{"[]"}});
+}
+
+// The null literal reduces as an absent property does: it is the same column of nulls
+TEST_F(NullAggregateTest, reducesTheNullLiteral) {
+    expectRows("RETURN max(null)", {{"null"}});
+    expectRows("RETURN sum(null)", {{"0"}});
+}
+
+// Each group reduces its own rows, and every one of them is null
+TEST_F(NullAggregateTest, reducesPerGroup) {
+    expectRows("MATCH (n:Person) RETURN n.hasPhD, min(n.shoeSize)",
+               {{"true", "null"}, {"false", "null"}});
+    expectRows("MATCH (n:Person) RETURN n.hasPhD, sum(n.shoeSize)",
+               {{"true", "0"}, {"false", "0"}});
+}
+
+// Dropping repeated values leaves the same nothing to reduce
+TEST_F(NullAggregateTest, reducesDistinctNothing) {
+    expectRows("MATCH (n:Person) RETURN sum(DISTINCT n.shoeSize)", {{"0"}});
+    expectRows("MATCH (n:Person) RETURN count(DISTINCT n.shoeSize)", {{"0"}});
+}
+
+// A reduction over a null column stands beside one that has values to reduce
+TEST_F(NullAggregateTest, reducesBesideAPopulatedColumn) {
+    expectRows("MATCH (n:Person) RETURN max(n.age), max(n.shoeSize)", {{"32", "null"}});
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Implement the coalesce function.

```
MATCH (n:Person) RETURN n.name, coalesce(n.age, 0)
Remy 32, Adam 32, the six with no age 0

RETURN coalesce(null, 42)
42

MATCH (n:Person) OPTIONAL MATCH (n)-[:KNOWS_WELL]->(f)
WITH n, coalesce(f, n) AS someone RETURN n.name, someone.name
Remy Adam, Adam Remy, the six with no such hop themselves

MATCH (n:Person) RETURN coalesce(max(n.shoeSize), 0)
0

MATCH (n:Person) RETURN coalesce(n.age, 'none')
'coalesce' answers one column, so its arguments must share a type: 'Integer' and 'String' cannot be mixed
```
