### PR TITLE
CI: run ctest in parallel, remove repeats and other fixes

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -205,7 +205,7 @@ jobs:
         # per-OS key, which later cache-hit jobs then restored and failed on at
         # find_package. Bump the salt to discard them and re-save a clean tree
         # (with fail-fast disabled, jobs now run to completion so caches stay clean).
-        key: ${{ matrix.os }}-dependencies-v3-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh') }}
+        key: ${{ matrix.os }}-dependencies-v3-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules') }}
 
     # The macOS minis share one cache base across several runner instances, and
     # corca-ai/local-cache symlinks external/dependencies straight into that
@@ -220,7 +220,7 @@ jobs:
         python3 scripts/with_host_lock.py /tmp/turingdb-depcache.lock \
           bash scripts/dep_cache.sh restore \
           /Users/m1/actions-local-cache \
-          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh', 'scripts/dep_cache.sh') }}"
+          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'scripts/dep_cache.sh') }}"
 
     - name: Install build tools
       run: ./install_build_tools.sh
@@ -236,7 +236,7 @@ jobs:
         python3 scripts/with_host_lock.py /tmp/turingdb-depcache.lock \
           bash scripts/dep_cache.sh publish \
           /Users/m1/actions-local-cache \
-          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'build.sh', 'scripts/dep_cache.sh') }}"
+          "${{ matrix.os }}-dependencies-${{ hashFiles('install_build_tools.sh', 'dependencies.sh', '.gitmodules', 'scripts/dep_cache.sh') }}"
 
     - name: Setup Python
       run: uv python install ${{ matrix.python_version }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -92,14 +92,15 @@ jobs:
     # and macos*-turing labels are self-hosted runners; ubuntu-*-arm are GitHub-hosted.
     runs-on: ${{ matrix.os }}
 
-    # Cap build parallelism at 4 across every step. The shared self-hosted runners
+    # Cap parallelism at 4 across every step. The shared self-hosted runners
     # share host memory across instances, so -j nproc on the heavy LLVM/MLIR (and
     # wheel) compiles trips the OOM killer ("Killed signal terminated program
     # cc1plus"). BUILD_JOBS feeds dependencies.sh; CMAKE_BUILD_PARALLEL_LEVEL caps
-    # the scikit-build-core wheel build.
+    # the scikit-build-core wheel build; CTEST_PARALLEL_LEVEL caps the test run.
     env:
       BUILD_JOBS: 4
       CMAKE_BUILD_PARALLEL_LEVEL: 4
+      CTEST_PARALLEL_LEVEL: 4
 
     steps:
     # Only the disk-constrained GitHub-hosted Linux runners (the -arm labels)

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,6 @@ fi
 # Build
 echo "PYTHON_VERSION=$PYTHON_VERSION"
 uv build --wheel $UV_PYTHON_FLAG
-cd build && make install && cd ..
 
 if [[ "$(uname)" == "Darwin" ]]; then
     uv add delocate

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -183,6 +183,10 @@ OPENBLAS_CMAKE_ARGS=(
     -DBUILD_SHARED_LIBS=OFF
     -DBUILD_TESTING=OFF
     -DNOFORTRAN=1
+    # NUM_THREADS defaults to the build machine's core count; 1 makes the build
+    # single-threaded, which needs USE_LOCKING to stay safe under concurrent calls.
+    -DNUM_THREADS=1
+    -DUSE_LOCKING=ON
 )
 
 if [[ $USE_CLANG -eq 1 ]]; then

--- a/jobs/JobQueue.h
+++ b/jobs/JobQueue.h
@@ -4,7 +4,6 @@
 #include <mutex>
 #include <optional>
 #include <queue>
-#include <thread>
 
 #include "Job.h"
 
@@ -34,6 +33,10 @@ public:
 
             _finished++;
             _runningCount--;
+
+            if (_finished == _submitted) {
+                _doneCondition.notify_all();
+            }
 
         } else {
             _jobs.emplace(std::move(job));
@@ -84,17 +87,18 @@ public:
         std::scoped_lock lock(_mutex);
         _finished++;
         _runningCount--;
+
+        if (_finished == _submitted) {
+            _doneCondition.notify_all();
+        }
     }
 
     void wait() {
         std::unique_lock lock(_mutex);
 
-        while (_finished != _submitted) {
-            lock.unlock();
-            _wakeCondition.notify_one();
-            std::this_thread::yield();
-            lock.lock();
-        }
+        _doneCondition.wait(lock, [&] {
+            return _finished == _submitted;
+        });
 
         _wakeCondition.notify_all();
     }
@@ -104,6 +108,7 @@ private:
 
     size_t _threadCount {1};
     std::condition_variable _wakeCondition;
+    std::condition_variable _doneCondition;
     mutable std::mutex _mutex;
     std::queue<Job> _jobs;
     size_t _finished {0};

--- a/jobs/JobSystem.cpp
+++ b/jobs/JobSystem.cpp
@@ -13,24 +13,32 @@ namespace {
 
 constexpr const char* THREAD_NAME = "turingdb.worker";
 
-size_t getThreadCount(size_t requestedThreads) {
-    if (requestedThreads == 0) {
-        return std::thread::hardware_concurrency();
-    } else {
+}
+
+size_t JobSystem::_defaultThreadCount {0};
+
+void JobSystem::setDefaultThreadCount(size_t threadCount) {
+    _defaultThreadCount = threadCount;
+}
+
+size_t JobSystem::resolveThreadCount(size_t requestedThreads) {
+    if (requestedThreads > 0) {
         return requestedThreads;
+    } else if (_defaultThreadCount > 0) {
+        return _defaultThreadCount;
+    } else {
+        return std::thread::hardware_concurrency();
     }
 }
 
-}
-
 JobSystem::JobSystem()
-    : _nThreads(getThreadCount(0)),
+    : _nThreads(resolveThreadCount(0)),
     _jobs(_nThreads)
 {
 }
 
 JobSystem::JobSystem(size_t nthreads)
-    : _nThreads(getThreadCount(nthreads)),
+    : _nThreads(resolveThreadCount(nthreads)),
     _jobs(_nThreads)
 {
 }

--- a/jobs/JobSystem.h
+++ b/jobs/JobSystem.h
@@ -75,12 +75,25 @@ public:
     void wait();
     void terminate();
 
+    /* @brief Thread count used by every JobSystem built without an explicit one
+     *
+     * Set by the test harness so a test never stands up a pool sized to the
+     * host's core count. Zero restores hardware_concurrency().
+     * */
+    static void setDefaultThreadCount(size_t threadCount);
+
+    size_t getThreadCount() const { return _nThreads; }
+
 private:
+    static size_t _defaultThreadCount;
+
     size_t _nThreads {0};
     JobQueue _jobs;
     std::vector<std::jthread> _workers;
     std::atomic<bool> _stopRequested {false};
     bool _terminated {false};
+
+    static size_t resolveThreadCount(size_t requestedThreads);
 };
 
 }

--- a/test/common/PerfStatTest.cpp
+++ b/test/common/PerfStatTest.cpp
@@ -82,7 +82,5 @@ TEST_F(PerfStatTest, MeasurePerfs) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 10;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/import/parquet/ParquetImporterTest.cpp
+++ b/test/import/parquet/ParquetImporterTest.cpp
@@ -282,7 +282,5 @@ TEST_F(ParquetImporterTest, ImportsStringPropertySpanningManyPages) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 5;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/AgingRingCacheTest.cpp
+++ b/test/io/AgingRingCacheTest.cpp
@@ -659,7 +659,5 @@ TEST_F(AgingRingCacheTest, SaveFailure_ErrorCodeInResult) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 40;
-    });
+    return turingTestMain(argc, argv);
 }

--- a/test/io/ByteBufferIteratorTest.cpp
+++ b/test/io/ByteBufferIteratorTest.cpp
@@ -66,7 +66,5 @@ TEST_F(ByteBufferIteratorTest, General) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/FileCacheTest.cpp
+++ b/test/io/FileCacheTest.cpp
@@ -820,7 +820,5 @@ TEST_F(FileCacheTest, UnsuccesfulLoadDataDirectory) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/FilePageReaderTest.cpp
+++ b/test/io/FilePageReaderTest.cpp
@@ -69,7 +69,5 @@ TEST_F(FilePageReaderTest, Pages) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 2;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/FilePageWriterTest.cpp
+++ b/test/io/FilePageWriterTest.cpp
@@ -122,7 +122,5 @@ TEST_F(FilePageWriterTest, Types) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 2;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/FileResultTest.cpp
+++ b/test/io/FileResultTest.cpp
@@ -99,7 +99,5 @@ TEST_F(FileResultTest, CannotMkdir) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/FileWriterTest.cpp
+++ b/test/io/FileWriterTest.cpp
@@ -39,7 +39,5 @@ TEST_F(FileWriterTest, General) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/io/PathTest.cpp
+++ b/test/io/PathTest.cpp
@@ -99,7 +99,5 @@ TEST_F(PathTest, IsSubDirectory) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/jobs/CMakeLists.txt
+++ b/test/jobs/CMakeLists.txt
@@ -6,3 +6,10 @@ target_link_libraries(jobs_test
 target_include_directories(jobs_test
     PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
+add_turing_test(jobs_queue_wait_test JobQueueWaitTest.cpp)
+
+target_link_libraries(jobs_queue_wait_test
+    PRIVATE turing_db_jobs_s)
+
+target_include_directories(jobs_queue_wait_test
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/test/jobs/CMakeLists.txt
+++ b/test/jobs/CMakeLists.txt
@@ -13,3 +13,11 @@ target_link_libraries(jobs_queue_wait_test
 
 target_include_directories(jobs_queue_wait_test
     PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+add_turing_test(jobs_default_threads_test JobSystemDefaultThreadsTest.cpp)
+
+target_link_libraries(jobs_default_threads_test
+    PRIVATE turing_db_jobs_s)
+
+target_include_directories(jobs_default_threads_test
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/test/jobs/JobQueueWaitTest.cpp
+++ b/test/jobs/JobQueueWaitTest.cpp
@@ -1,0 +1,47 @@
+#include <time.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "TuringTest.h"
+
+#include "JobSystem.h"
+
+using namespace turing::test;
+using namespace db;
+
+class JobQueueWaitTest : public TuringTest {
+protected:
+    void initialize() override {}
+
+    void terminate() override {}
+
+    static constexpr size_t WORKER_COUNT = 8;
+    static constexpr std::chrono::milliseconds JOB_DURATION {300};
+};
+
+TEST_F(JobQueueWaitTest, WaitingForAJobConsumesNoCpu) {
+    const std::unique_ptr<JobSystem> jobSystem = std::make_unique<JobSystem>(WORKER_COUNT);
+    jobSystem->init();
+
+    jobSystem->submit<void>([](Promise*) {
+        std::this_thread::sleep_for(JOB_DURATION);
+    });
+
+    const clock_t cpuStart = clock();
+    const std::chrono::steady_clock::time_point wallStart = std::chrono::steady_clock::now();
+
+    jobSystem->wait();
+
+    const double cpuSeconds = double(clock() - cpuStart) / CLOCKS_PER_SEC;
+    const double wallSeconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - wallStart).count();
+
+    // The job only sleeps, so every thread should be blocked for the whole wait.
+    // A spinning wait burns at least a full core over that span, which is what
+    // the ratio catches; a blocking one costs near zero whatever the core count.
+    EXPECT_GE(wallSeconds, 0.2);
+    EXPECT_LT(cpuSeconds, wallSeconds / 2.0);
+
+    jobSystem->terminate();
+}

--- a/test/jobs/JobSystemDefaultThreadsTest.cpp
+++ b/test/jobs/JobSystemDefaultThreadsTest.cpp
@@ -1,0 +1,27 @@
+#include <memory>
+
+#include "TuringTest.h"
+
+#include "JobSystem.h"
+
+using namespace turing::test;
+using namespace db;
+
+class JobSystemDefaultThreadsTest : public TuringTest {
+protected:
+    void initialize() override {}
+
+    void terminate() override {}
+};
+
+TEST_F(JobSystemDefaultThreadsTest, DefaultConstructedSystemRunsOnOneThread) {
+    const JobSystem jobSystem;
+
+    EXPECT_EQ(jobSystem.getThreadCount(), 1);
+}
+
+TEST_F(JobSystemDefaultThreadsTest, AnExplicitThreadCountStillWins) {
+    const JobSystem jobSystem(4);
+
+    EXPECT_EQ(jobSystem.getThreadCount(), 4);
+}

--- a/test/jobs/JobSystemTest.cpp
+++ b/test/jobs/JobSystemTest.cpp
@@ -265,7 +265,5 @@ TEST_F(JobSystemTest, ManyJobSystems) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 50;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query-test-suite/CMakeLists.txt
+++ b/test/query-test-suite/CMakeLists.txt
@@ -22,9 +22,7 @@ add_query_suite_target(test_query_test_suite
     QueryTestRunner.cpp
     QueryResultFormatter.cpp)
 
-gtest_discover_tests(test_query_test_suite
-      DISCOVERY_TIMEOUT 60
-      DISCOVERY_MODE PRE_TEST)
+add_test(NAME test_query_test_suite COMMAND test_query_test_suite)
 
 add_query_suite_target(test_remote_query_test_suite
     RemoteQueryTestSuite.cpp
@@ -36,9 +34,7 @@ target_link_libraries(test_remote_query_test_suite
     PRIVATE turing_db_server_s
             turing_db_proto_client_s)
 
-gtest_discover_tests(test_remote_query_test_suite
-      DISCOVERY_TIMEOUT 60
-      DISCOVERY_MODE PRE_TEST)
+add_test(NAME test_remote_query_test_suite COMMAND test_remote_query_test_suite)
 
 add_query_suite_target(query_test_suite_cli
     QueryTestSuiteCLI.cpp

--- a/test/query-test-suite/CMakeLists.txt
+++ b/test/query-test-suite/CMakeLists.txt
@@ -23,6 +23,8 @@ add_query_suite_target(test_query_test_suite
     QueryResultFormatter.cpp)
 
 add_test(NAME test_query_test_suite COMMAND test_query_test_suite)
+set_tests_properties(test_query_test_suite PROPERTIES
+    ENVIRONMENT "OPENBLAS_NUM_THREADS=1")
 
 add_query_suite_target(test_remote_query_test_suite
     RemoteQueryTestSuite.cpp
@@ -35,6 +37,8 @@ target_link_libraries(test_remote_query_test_suite
             turing_db_proto_client_s)
 
 add_test(NAME test_remote_query_test_suite COMMAND test_remote_query_test_suite)
+set_tests_properties(test_remote_query_test_suite PROPERTIES
+    ENVIRONMENT "OPENBLAS_NUM_THREADS=1")
 
 add_query_suite_target(query_test_suite_cli
     QueryTestSuiteCLI.cpp

--- a/test/query-test-suite/QueryTestSuite.cpp
+++ b/test/query-test-suite/QueryTestSuite.cpp
@@ -70,5 +70,5 @@ TEST_F(QueryTestSuite, RunAll) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 6; });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query-test-suite/RemoteQueryTestSuite.cpp
+++ b/test/query-test-suite/RemoteQueryTestSuite.cpp
@@ -50,5 +50,5 @@ TEST_F(RemoteQueryTestSuite, RunAllEnabled) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/analyzer/ExpressionTest.cpp
+++ b/test/query/analyzer/ExpressionTest.cpp
@@ -246,7 +246,5 @@ TEST_F(ExpressionTest, BinaryExpressionTest) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 20;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/ChainedCallTest.cpp
+++ b/test/query/ir/ChainedCallTest.cpp
@@ -97,7 +97,5 @@ TEST_F(ChainedCallTest, chainedCallYieldsRowsWithPersonNodes) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 100;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/ir/CreateReturnTest.cpp
+++ b/test/query/ir/CreateReturnTest.cpp
@@ -94,6 +94,5 @@ TEST_F(CreateReturnTest, returnsTheNodeTheChangeKept) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv,
-                                        [] { testing::GTEST_FLAG(repeat) = 5; });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
+++ b/test/query/pipeline/processors/CartesianProductProcessorTest.cpp
@@ -1785,7 +1785,5 @@ TEST_F(CartesianProductProcessorTest, constValueChangesAcrossChunks) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 20;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/ConstScanProcessorTest.cpp
+++ b/test/query/pipeline/processors/ConstScanProcessorTest.cpp
@@ -102,7 +102,5 @@ TEST_F(ConstScanProcessorTest, constScanGetOutEdges) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/FilterProcessorTest.cpp
+++ b/test/query/pipeline/processors/FilterProcessorTest.cpp
@@ -52,7 +52,5 @@ TEST_F(FilterProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetEdgeTypeIDProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetEdgeTypeIDProcessorTest.cpp
@@ -74,7 +74,5 @@ TEST_F(GetEdgeTypeIDProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetEdgesProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetEdgesProcessorTest.cpp
@@ -110,7 +110,5 @@ TEST_F(GetEdgesProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetInEdgesProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetInEdgesProcessorTest.cpp
@@ -108,7 +108,5 @@ TEST_F(GetInEdgesProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetLabelSetIDProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetLabelSetIDProcessorTest.cpp
@@ -72,7 +72,5 @@ TEST_F(GetLabelSetIDProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetOutEdgesProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetOutEdgesProcessorTest.cpp
@@ -108,7 +108,5 @@ TEST_F(GetOutEdgesProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetPropertiesProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetPropertiesProcessorTest.cpp
@@ -129,7 +129,5 @@ TEST_F(GetPropertiesProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/GetPropertiesWithNullProcessorTest.cpp
+++ b/test/query/pipeline/processors/GetPropertiesWithNullProcessorTest.cpp
@@ -128,7 +128,5 @@ TEST_F(GetPropertiesWithNullProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/HashJoinProcessorTest.cpp
+++ b/test/query/pipeline/processors/HashJoinProcessorTest.cpp
@@ -1684,7 +1684,5 @@ TEST_F(HashJoinProcessorTest, stringStringViewJoin) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/OrderByProcessorTest.cpp
+++ b/test/query/pipeline/processors/OrderByProcessorTest.cpp
@@ -295,7 +295,5 @@ TEST_F(OrderByProcessorTest, alternatingEmpty) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 10;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/ProjectionProcessorTest.cpp
+++ b/test/query/pipeline/processors/ProjectionProcessorTest.cpp
@@ -99,7 +99,5 @@ TEST_F(ProjectionProcessorTest, test) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/ScanNodesProcessorTest.cpp
+++ b/test/query/pipeline/processors/ScanNodesProcessorTest.cpp
@@ -78,7 +78,5 @@ TEST_F(ScanNodesProcessorTest, scanNodesVarChunk) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/pipeline/processors/UnwindProcessorTest.cpp
+++ b/test/query/pipeline/processors/UnwindProcessorTest.cpp
@@ -97,7 +97,5 @@ TEST_F(UnwindProcessorTest, listLengthsExceedingChunkSize) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/AutoCreateCommandTest.cpp
+++ b/test/query/queries/AutoCreateCommandTest.cpp
@@ -1525,6 +1525,5 @@ TEST_F(CreateCommandTest, createSegfaultProbe) {
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    testing::GTEST_FLAG(repeat) = 1;
     return RUN_ALL_TESTS();
 }

--- a/test/query/queries/AutoJoinTest.cpp
+++ b/test/query/queries/AutoJoinTest.cpp
@@ -3813,7 +3813,5 @@ TEST_F(JoinFeatureTest, commaMatch_categoryChainWithPerson) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/CallProcedureTest.cpp
+++ b/test/query/queries/CallProcedureTest.cpp
@@ -463,7 +463,5 @@ TEST_F(CallProcedureTest, DrivesItsProcedureOncePerMatchedRow) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/ChangeQueriesTest.cpp
+++ b/test/query/queries/ChangeQueriesTest.cpp
@@ -1939,7 +1939,5 @@ TEST_F(ChangeQueriesTest, threeChangesSubgraphsComplexRebase) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 100;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/ComplexNullPredicatesTest.cpp
+++ b/test/query/queries/ComplexNullPredicatesTest.cpp
@@ -407,7 +407,5 @@ TEST_F(ComplexNullPredicatesTest, noResultWhenAllHaveNull) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/ConstScanOptTest.cpp
+++ b/test/query/queries/ConstScanOptTest.cpp
@@ -873,7 +873,5 @@ TEST_F(ConstScanOptTest, nodeIndexUsedSimple) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/CreateGraphTest.cpp
+++ b/test/query/queries/CreateGraphTest.cpp
@@ -58,7 +58,5 @@ TEST_F(CreateGraphTest, createGraph) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/FilterPredicatesTest.cpp
+++ b/test/query/queries/FilterPredicatesTest.cpp
@@ -2253,7 +2253,5 @@ TEST_F(FilterPredicatesTest, largeValueFilter) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/GreeterExtensionTest.cpp
+++ b/test/query/queries/GreeterExtensionTest.cpp
@@ -58,7 +58,5 @@ TEST_F(GreeterExtensionTest, callGreeterHello) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/LoadCSVTest.cpp
+++ b/test/query/queries/LoadCSVTest.cpp
@@ -567,7 +567,5 @@ TEST_F(LoadCSVTest, exceedChunkWrites) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/LoadCommitTest.cpp
+++ b/test/query/queries/LoadCommitTest.cpp
@@ -137,7 +137,5 @@ TEST_F(LoadCommitTest, loadNonExistentHashFails) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/LoadGraphTest.cpp
+++ b/test/query/queries/LoadGraphTest.cpp
@@ -62,7 +62,5 @@ TEST_F(LoadGraphTest, loadGraph) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/MultiHopPatternTest.cpp
+++ b/test/query/queries/MultiHopPatternTest.cpp
@@ -1491,7 +1491,5 @@ TEST_F(MultiHopPatternTest, DISABLED_returnVariation_distinctMiddle) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/QueriesTest.cpp
+++ b/test/query/queries/QueriesTest.cpp
@@ -3711,7 +3711,5 @@ TEST_F(QueriesTest, matchReturnLimitZero) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/ShowExtensionsTest.cpp
+++ b/test/query/queries/ShowExtensionsTest.cpp
@@ -60,7 +60,5 @@ TEST_F(ShowExtensionsTest, showExtensions) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/ShowProceduresTest.cpp
+++ b/test/query/queries/ShowProceduresTest.cpp
@@ -109,7 +109,5 @@ TEST_F(ShowProceduresTest, showProcedures) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/VectorQueriesTest.cpp
+++ b/test/query/queries/VectorQueriesTest.cpp
@@ -742,7 +742,5 @@ TEST_F(VectorQueriesTest, vectorSearchWithMatch) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/query/queries/WriteQueriesTest.cpp
+++ b/test/query/queries/WriteQueriesTest.cpp
@@ -3523,7 +3523,5 @@ TEST_F(WriteQueriesTest, setEmbeddingCartesianOverlap) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/serialisation/CommitJournalSerialisationTest.cpp
+++ b/test/serialisation/CommitJournalSerialisationTest.cpp
@@ -225,5 +225,5 @@ TEST_F(CommitJournalSerialisationTest, createNodesAndEdgesThenLoad) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
+    return turingTestMain(argc, argv);
 }

--- a/test/serialisation/SimpleGraphSerialisationTest.cpp
+++ b/test/serialisation/SimpleGraphSerialisationTest.cpp
@@ -59,5 +59,5 @@ TEST_F(SimpleGraphSerialisationTest, indexInitialisation) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
+    return turingTestMain(argc, argv);
 }

--- a/test/serialisation/StringIndexSerialisationTest.cpp
+++ b/test/serialisation/StringIndexSerialisationTest.cpp
@@ -90,7 +90,5 @@ TEST_F(StringIndexSerialisationTest, indexInitialisation) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turingTestMain(argc, argv);
 }

--- a/test/serialisation/TombstoneSerialisationTest.cpp
+++ b/test/serialisation/TombstoneSerialisationTest.cpp
@@ -211,7 +211,5 @@ TEST_F(TombstoneSerialisationTest, deleteNodesThenLoad) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turingTestMain(argc, argv);
 }

--- a/test/storage/EmbeddingPropertyContainerTest.cpp
+++ b/test/storage/EmbeddingPropertyContainerTest.cpp
@@ -359,7 +359,5 @@ TEST_F(EmbeddingGraphTest, GetPropertiesWithNullIterator) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 3;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/dump/EdgeContainerDumpFormatTest.cpp
+++ b/test/storage/dump/EdgeContainerDumpFormatTest.cpp
@@ -71,7 +71,5 @@ TEST_F(EdgeContainerDumpFormatTest, edgeContainerDumpBytes) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/dump/EmbeddingGraphDumpLoadTest.cpp
+++ b/test/storage/dump/EmbeddingGraphDumpLoadTest.cpp
@@ -203,5 +203,5 @@ TEST_F(EmbeddingGraphDumpLoadTest, MultiCommitEmbeddings) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
+    return turingTestMain(argc, argv);
 }

--- a/test/storage/dump/GraphLoaderTest.cpp
+++ b/test/storage/dump/GraphLoaderTest.cpp
@@ -106,5 +106,5 @@ TEST_F(GraphLoaderTest, MissingHeadJournalPropagatesLoadError) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 3; });
+    return turingTestMain(argc, argv);
 }

--- a/test/storage/dump/LoadCommitDataTest.cpp
+++ b/test/storage/dump/LoadCommitDataTest.cpp
@@ -129,5 +129,5 @@ TEST_F(LoadCommitDataTest, openTransactionAfterLoadCommit) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 1; });
+    return turingTestMain(argc, argv);
 }

--- a/test/storage/dump/PropertyContainerDumperTest.cpp
+++ b/test/storage/dump/PropertyContainerDumperTest.cpp
@@ -298,7 +298,5 @@ TEST_F(PropertyContainerDumperTest, manyEmbeddingsRoundTrip) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/dump/PropertyDumpFormatTest.cpp
+++ b/test/storage/dump/PropertyDumpFormatTest.cpp
@@ -145,7 +145,5 @@ TEST_F(PropertyDumpFormatTest, embeddingDumpBytes) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/dump/StringIndexLoaderTest.cpp
+++ b/test/storage/dump/StringIndexLoaderTest.cpp
@@ -77,5 +77,5 @@ TEST_F(StringIndexLoaderTest, SimpleDumpLoad) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 3; });
+    return turingTestMain(argc, argv);
 }

--- a/test/storage/iterators/GetEdgesByTypeIteratorTest.cpp
+++ b/test/storage/iterators/GetEdgesByTypeIteratorTest.cpp
@@ -410,7 +410,5 @@ TEST_F(GetEdgesByTypeIteratorTest, emptyInputYieldsNoRows) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/iterators/IteratorsTest.cpp
+++ b/test/storage/iterators/IteratorsTest.cpp
@@ -903,7 +903,5 @@ TEST_F(IteratorsTest, GetNodePropertiesIteratorTest) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 1;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/iterators/NeighbourhoodSampleIteratorTest.cpp
+++ b/test/storage/iterators/NeighbourhoodSampleIteratorTest.cpp
@@ -175,7 +175,5 @@ TEST_F(NeighbourhoodSampleIteratorTest, deletedEdgesNotSampledAcrossMultipleNode
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 100;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/storage/iterators/ScanNodesIteratorTest.cpp
+++ b/test/storage/iterators/ScanNodesIteratorTest.cpp
@@ -244,7 +244,5 @@ TEST_F(ScanNodesIteratorTest, chunkAndALeftover) {
 }
 
 int main(int argc, char** argv) {
-    return turing::test::turingTestMain(argc, argv, [] {
-        testing::GTEST_FLAG(repeat) = 4;
-    });
+    return turing::test::turingTestMain(argc, argv);
 }

--- a/test/testutils/CMakeLists.txt
+++ b/test/testutils/CMakeLists.txt
@@ -21,5 +21,5 @@ function(add_turing_test exe_name cpp_file)
 
     add_test(NAME ${exe_name} COMMAND ${exe_name})
     set_tests_properties(${exe_name} PROPERTIES
-        ENVIRONMENT "TURING_EXTENSIONS_DIR=${CMAKE_BINARY_DIR}/lib/turingdb/extensions")
+        ENVIRONMENT "TURING_EXTENSIONS_DIR=${CMAKE_BINARY_DIR}/lib/turingdb/extensions;OPENBLAS_NUM_THREADS=1")
 endfunction()

--- a/test/testutils/CMakeLists.txt
+++ b/test/testutils/CMakeLists.txt
@@ -11,12 +11,14 @@ target_link_libraries(turing_testutils_s
 target_include_directories(turing_testutils_s
     PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR})
 
+# One ctest test per binary, not per case. gtest_discover_tests would report each
+# case separately, at the cost of relaunching the binary once per case: every launch
+# stands up a fresh SystemManager whose JobSystem costs CPU linear in core count.
 function(add_turing_test exe_name cpp_file)
     add_executable(${exe_name} ${cpp_file})
     target_link_libraries(${exe_name} PRIVATE turing_testutils_s)
-    gtest_discover_tests(${exe_name}
-          DISCOVERY_TIMEOUT 60
-          DISCOVERY_MODE PRE_TEST
-          PROPERTIES ENVIRONMENT
-              "TURING_EXTENSIONS_DIR=${CMAKE_BINARY_DIR}/lib/turingdb/extensions")
+
+    add_test(NAME ${exe_name} COMMAND ${exe_name})
+    set_tests_properties(${exe_name} PROPERTIES
+        ENVIRONMENT "TURING_EXTENSIONS_DIR=${CMAKE_BINARY_DIR}/lib/turingdb/extensions")
 endfunction()

--- a/test/testutils/CMakeLists.txt
+++ b/test/testutils/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(turing_testutils_s
     PUBLIC  GTest::gtest
             GTest::gmock
             turing_common_s
+            turing_db_jobs_s
             spdlog)
 
 target_include_directories(turing_testutils_s

--- a/test/testutils/TuringTestMain.h
+++ b/test/testutils/TuringTestMain.h
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <spdlog/fmt/bundled/core.h>
 
+#include "JobSystem.h"
 #include "TuringTime.h"
 
 namespace turing::test {
@@ -62,6 +63,8 @@ inline int turingTestMain(int argc, char** argv, TuringMainConfig config = nullp
     testing::GTEST_FLAG(print_time) = true;
     testing::GTEST_FLAG(repeat) = 50;
     testing::GTEST_FLAG(shuffle) = true;
+
+    db::JobSystem::setDefaultThreadCount(1);
 
     if (config) {
         config();

--- a/test/testutils/TuringTestMain.h
+++ b/test/testutils/TuringTestMain.h
@@ -61,7 +61,6 @@ private:
 
 inline int turingTestMain(int argc, char** argv, TuringMainConfig config = nullptr) {
     testing::GTEST_FLAG(print_time) = true;
-    testing::GTEST_FLAG(repeat) = 50;
     testing::GTEST_FLAG(shuffle) = true;
 
     db::JobSystem::setDefaultThreadCount(1);

--- a/test/vector/JsonImporterTest.cpp
+++ b/test/vector/JsonImporterTest.cpp
@@ -192,5 +192,5 @@ TEST_F(JsonImporterTest, ValidJson) {
 }
 
 int main(int argc, char** argv) {
-    return turingTestMain(argc, argv, [] { testing::GTEST_FLAG(repeat) = 2; });
+    return turingTestMain(argc, argv);
 }


### PR DESCRIPTION
* Run one ctest test per binary
* Run ctest with -j4 by default
* JobSystem: wait on a condition variable instead of spinning
* JobSystem in unit tests: use only one thread per test, not hardware_concurrency per test
* Run each unit test once: remove all repeat 50 times and repeat 10 times
* OpenBLAS: Use 1 thread at startup
* Remove redundant make install after building wheel