### PR TITLE
Implement CASE over a node or an edge

### DIFF
--- a/query/analyzer/ExprAnalyzer.cpp
+++ b/query/analyzer/ExprAnalyzer.cpp
@@ -117,6 +117,10 @@ ListShape concatenatedListShape(const ListShape& left, const ListShape& right) {
     return left;
 }
 
+bool isEntity(EvaluatedType type) {
+    return type == EvaluatedType::NodePattern || type == EvaluatedType::EdgePattern;
+}
+
 }
 
 ExprAnalyzer::ExprAnalyzer(CypherAST* ast, const GraphView& graphView)
@@ -1208,7 +1212,7 @@ void ExprAnalyzer::analyzeCaseExpr(CaseExpr* expr) {
     Expr* const subject = expr->getSubject();
     if (subject) {
         analyzeExpr(subject);
-        requireCaseComparable(subject, subject->getType());
+        requireCaseSubject(subject);
         contaminate(subject);
     }
 
@@ -1274,7 +1278,12 @@ void ExprAnalyzer::analyzeCaseTest(const CaseExpr::Branch& branch,
     }
 
     analyzeExpr(test._value);
-    requireCaseComparable(test._value, test._value->getType());
+
+    if (isEntity(subject->getType())) {
+        requireComparableToEntity(subject, test);
+    } else {
+        requireCaseValue(test._value);
+    }
 }
 
 EvaluatedType ExprAnalyzer::unifyCaseBranch(EvaluatedType carried, const Expr* branch) {
@@ -1292,15 +1301,56 @@ EvaluatedType ExprAnalyzer::unifyCaseBranch(EvaluatedType carried, const Expr* b
     return unified;
 }
 
-void ExprAnalyzer::requireCaseComparable(const Expr* expr, EvaluatedType type) const {
+void ExprAnalyzer::requireCaseSubject(const Expr* subject) const {
+    const EvaluatedType type = subject->getType();
+
+    const bool isScalar = type == EvaluatedType::Null || convertibleToValueType(type);
+
+    if (isScalar || isEntity(type)) {
+        return;
+    }
+
+    throwError(fmt::format("The subject of a CASE must be a scalar, a node or an edge, not '{}'",
+                           EvaluatedTypeName::value(type)),
+               subject);
+}
+
+void ExprAnalyzer::requireCaseValue(const Expr* value) const {
+    const EvaluatedType type = value->getType();
+
     if (type == EvaluatedType::Null || convertibleToValueType(type)) {
         return;
     }
 
-    throwError(fmt::format("The subject of a CASE and the values it is compared against "
-                           "must be scalars, not '{}'",
+    throwError(fmt::format("The values a CASE compares its subject against must be scalars, "
+                           "not '{}'",
                            EvaluatedTypeName::value(type)),
-               expr);
+               value);
+}
+
+void ExprAnalyzer::requireComparableToEntity(const Expr* subject, const CaseExpr::Test& test) const {
+    const EvaluatedType subjectType = subject->getType();
+    const EvaluatedType valueType = test._value->getType();
+
+    const bool comparesForEquality = test._kind == CaseExpr::TestKind::Value
+                                     || test._operator == BinaryOperator::Equal;
+
+    if (!comparesForEquality) {
+        throwError("A CASE compares a node or an edge for equality, so its branches cannot "
+                   "order one",
+                   test._value);
+    }
+
+    const bool comparable = valueType == EvaluatedType::Null
+                            || valueType == EvaluatedType::Integer
+                            || valueType == subjectType;
+
+    if (!comparable) {
+        throwError(fmt::format("A node or an edge is equal to one of its kind or to an id, "
+                               "not to '{}'",
+                               EvaluatedTypeName::value(valueType)),
+                   test._value);
+    }
 }
 
 void ExprAnalyzer::analyzeListExpr(ListExpr* expr) {

--- a/query/analyzer/ExprAnalyzer.h
+++ b/query/analyzer/ExprAnalyzer.h
@@ -102,8 +102,16 @@ private:
     // already share, reporting a pair no column type can hold
     EvaluatedType unifyCaseBranch(EvaluatedType carried, const Expr* branch);
 
-    // Rejects a CASE subject, or a value it is compared against, that no column holds
-    void requireCaseComparable(const Expr* expr, EvaluatedType type) const;
+    // Rejects a CASE subject no column holds. A node and an edge are subjects of their
+    // own: the MLIR engine binds one, and an OPTIONAL MATCH can leave it null
+    void requireCaseSubject(const Expr* subject) const;
+
+    // Rejects a value a CASE compares its scalar subject against that no column holds
+    void requireCaseValue(const Expr* value) const;
+
+    // Rejects a @param test the entity @param subject does not compare against: an
+    // ordering branch, or a value that is neither an entity of its kind nor an id
+    void requireComparableToEntity(const Expr* subject, const CaseExpr::Test& test) const;
 
     // One WHEN value of @param branch, read as a predicate when the CASE has no subject
     // and as something to compare that subject against when it has one

--- a/test/query/ir/CMakeLists.txt
+++ b/test/query/ir/CMakeLists.txt
@@ -2282,6 +2282,9 @@ target_include_directories(test_query_ir_null_aggregate PRIVATE ${CMAKE_CURRENT_
 # The Cypher manual's CASE examples, run end to end against simpledb.
 add_call_v3_test(test_query_ir_neo4j_case_example Neo4jCaseExampleTest.cpp)
 
+# A CASE over a node or an edge, including the ones an OPTIONAL MATCH left null.
+add_call_v3_test(test_query_ir_case_entity_subject CaseEntitySubjectTest.cpp)
+
 # type() over an edge, run end to end against simpledb.
 add_call_v3_test(test_query_ir_edge_type_function EdgeTypeFunctionTest.cpp)
 

--- a/test/query/ir/CaseEntitySubjectTest.cpp
+++ b/test/query/ir/CaseEntitySubjectTest.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "CallV3Test.h"
+#include "StringRowSink.h"
+
+using namespace turing::test;
+
+// A CASE whose subject is a node or an edge rather than a scalar. An OPTIONAL MATCH leaves
+// the variables of the pattern it missed null, and the selection over one of them is how a
+// query answers on the rows it matched and the rows it did not.
+class CaseEntitySubjectTest : public CallV3Test {
+protected:
+    void expectRows(std::string_view query, const std::vector<StringRowSink::Row>& expected) {
+        StringRowSink sink;
+        runQuery(query, sink);
+
+        std::vector<StringRowSink::Row> rows;
+        sink.sortedRows(rows);
+
+        EXPECT_EQ(rows, expected) << query;
+    }
+};
+
+// Remy and Adam know each other well; the other six people have no KNOWS_WELL edge, so the
+// OPTIONAL MATCH leaves their r null and the branch testing for one takes those rows
+TEST_F(CaseEntitySubjectTest, matchesTheUnmatchedEdgeOnANullTest) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN p.name, CASE r WHEN IS NULL THEN 'none' ELSE 'some' END",
+               {
+                   {"Adam", "some"}, {"Cyrus", "none"}, {"Doruk", "none"}, {"Luc", "none"},
+                   {"Martina", "none"}, {"Maxime", "none"}, {"Remy", "some"}, {"Suhas", "none"},
+               });
+}
+
+TEST_F(CaseEntitySubjectTest, matchesTheMatchedEdgeOnANotNullTest) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN p.name, CASE r WHEN IS NOT NULL THEN 'some' ELSE 'none' END",
+               {
+                   {"Adam", "some"}, {"Cyrus", "none"}, {"Doruk", "none"}, {"Luc", "none"},
+                   {"Martina", "none"}, {"Maxime", "none"}, {"Remy", "some"}, {"Suhas", "none"},
+               });
+}
+
+// The node the pattern binds is null on the same six rows the edge is
+TEST_F(CaseEntitySubjectTest, matchesTheUnmatchedNodeOnANullTest) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, CASE f WHEN IS NULL THEN 'nobody' ELSE 'somebody' END",
+               {
+                   {"Adam", "somebody"}, {"Cyrus", "nobody"}, {"Doruk", "nobody"},
+                   {"Luc", "nobody"}, {"Martina", "nobody"}, {"Maxime", "nobody"},
+                   {"Remy", "somebody"}, {"Suhas", "nobody"},
+               });
+}
+
+// Null is equal to nothing, itself included, so the simple form never takes a WHEN null
+// branch: all eight rows fall to the ELSE, the six null ones with them
+TEST_F(CaseEntitySubjectTest, neverMatchesTheNullLiteral) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+               "RETURN p.name, CASE r WHEN null THEN 'none' ELSE 'some' END",
+               {
+                   {"Adam", "some"}, {"Cyrus", "some"}, {"Doruk", "some"}, {"Luc", "some"},
+                   {"Martina", "some"}, {"Maxime", "some"}, {"Remy", "some"}, {"Suhas", "some"},
+               });
+}
+
+// A null test sits beside the other values of its branch, as it does over a scalar subject
+TEST_F(CaseEntitySubjectTest, mixesANullTestIntoAValueList) {
+    expectRows("MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS_WELL]->(f) "
+               "RETURN p.name, CASE f WHEN IS NULL, = 0 THEN 'nobody or Remy' ELSE 'other' END",
+               {
+                   {"Adam", "nobody or Remy"}, {"Cyrus", "nobody or Remy"},
+                   {"Doruk", "nobody or Remy"}, {"Luc", "nobody or Remy"},
+                   {"Martina", "nobody or Remy"}, {"Maxime", "nobody or Remy"},
+                   {"Remy", "other"}, {"Suhas", "nobody or Remy"},
+               });
+}
+
+// A node is equal to the node it is, which is the comparison the equality operator answers
+TEST_F(CaseEntitySubjectTest, comparesTwoEntitiesForEquality) {
+    expectRows("MATCH (a:Person)-[:KNOWS_WELL]->(b) "
+               "RETURN a.name, CASE a WHEN b THEN 'itself' ELSE 'another' END",
+               {{"Adam", "another"}, {"Remy", "another"}});
+}
+
+TEST_F(CaseEntitySubjectTest, comparesAnEntityAgainstItself) {
+    expectRows("MATCH (a:Person)-[:KNOWS_WELL]->(b) "
+               "RETURN a.name, CASE a WHEN a THEN 'itself' ELSE 'another' END",
+               {{"Adam", "itself"}, {"Remy", "itself"}});
+}
+
+// Remy is node 0, so the row Adam's edge leads to him takes the branch naming that id
+TEST_F(CaseEntitySubjectTest, comparesAnEntityAgainstAnID) {
+    expectRows("MATCH (a:Person)-[:KNOWS_WELL]->(b) "
+               "RETURN a.name, CASE b WHEN 0 THEN 'Remy' ELSE 'someone else' END",
+               {{"Adam", "Remy"}, {"Remy", "someone else"}});
+}
+
+// Nothing orders a node or an edge, so a branch that compares one with an ordering
+// operator is reported rather than answered
+TEST_F(CaseEntitySubjectTest, rejectsAnOrderingBranchOverAnEntity) {
+    runQueryExpectingError("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+                           "RETURN CASE r WHEN < 3 THEN 'low' ELSE 'high' END",
+                           "cannot order one");
+}
+
+// A node is equal to a node or to an id, and to nothing else
+TEST_F(CaseEntitySubjectTest, rejectsAValueNoEntityCompares) {
+    runQueryExpectingError("MATCH (p:Person) OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f) "
+                           "RETURN CASE r WHEN 'Remy' THEN 'low' ELSE 'high' END",
+                           "not to 'String'");
+}
+
+int main(int argc, char** argv) {
+    return turing::test::turingTestMain(argc, argv);
+}


### PR DESCRIPTION
Implement CASE over a node or an edge, including the ones an OPTIONAL MATCH left null.

```
MATCH (p:Person)
OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f)
RETURN p.name, CASE r WHEN null THEN 'none' ELSE 'some' END

(Remy, some)
(Adam, some)
(Maxime, some)
(Luc, some)
(Martina, some)
(Suhas, some)
(Cyrus, some)
(Doruk, some)

MATCH (p:Person)
OPTIONAL MATCH (p)-[r:KNOWS_WELL]->(f)
RETURN p.name, CASE r WHEN IS NULL THEN 'none' ELSE 'some' END

(Remy, some)
(Adam, some)
(Maxime, none)
(Luc, none)
(Martina, none)
(Suhas, none)
(Cyrus, none)
(Doruk, none)
```